### PR TITLE
Pin the pitch: reader, promise, defensible claims (alp82/curia#110)

### DIFF
--- a/docs/landing-page/positioning.md
+++ b/docs/landing-page/positioning.md
@@ -1,0 +1,157 @@
+# Landing page positioning
+
+**Settled**: 2026-08-01, in [Pin the pitch: reader, promise, defensible claims](https://github.com/alp82/curia/issues/110),
+on the map [The curia landing page](https://github.com/alp82/curia/issues/109).
+Every answer below came from the operator over Discord escalations.
+
+This file is the brief the page is written against. Copy, layout and proof tickets defer to it.
+If a later ticket contradicts something here, change this file in that ticket — do not let the page
+and the brief drift apart.
+
+## The reader
+
+**A builder who already runs coding agents most days, across several repos, and keeps hitting the
+moment where the work stops because they are not at their desk.**
+
+They run Claude Code or Codex. They do not need coding agents explained, and a page that explains
+them is a page written for somebody else. They self-host by preference: their box, their
+subscription, their keys.
+
+Ruled out, on purpose:
+
+- The curious reader who runs one agent now and then. Selling parallel agents first would cost the
+  page its edge, and a page that hedges between the two is the boring one.
+- The homelab reader who wants to own infrastructure and treats agents as secondary.
+- Any portfolio audience. This page sells software the reader installs, not the operator's rig.
+
+## The one promise
+
+**Many repos, one queue, driven from a phone.**
+
+The first screen makes this promise and no other. The reader's tickets sit across every repo they
+watch; curia reads what is takeable in dependency order, runs the work, and brings every moment
+that needs a human to whatever device they are holding.
+
+The three claims below support that promise. They are not co-headlines. Presence ("curia removes
+the desk"), rigor ("a worker cannot finish by talking") and the dogfood run were each considered as
+the headline and each demoted: presence and rigor to supporting claims, the dogfood run to proof.
+
+## The three supporting claims
+
+### 1. Your tracker is the queue
+
+GitHub issues hold every ticket, claim and dependency edge. Curia reads what is takeable across
+every watched repo, in dependency order, and picks the model for each ticket by label rule. No
+second app. No board to keep in sync.
+
+Rests on:
+
+- [ADR-0001](../adr/0001-github-is-the-only-durable-state-home.md) — GitHub is the only durable
+  state home; the daemon owns no authoritative state and re-derives everything after a crash.
+- [ADR-0004](../adr/0004-label-only-routing.md) — label-only routing. No model sits in the dispatch
+  path.
+- `daemon/src/dispatch.mjs` — the frontier reads every watched repo, map lane before flat lane,
+  dropping blocked and claimed tickets.
+- `config/curia.yaml` — three repos watched today. `config/routing.yaml` — two backends, Claude Code
+  and Codex, under one contract.
+
+### 2. Any device is a full seat
+
+Five verbs over Discord. One thread per ticket. Questions arrive with buttons, results arrive as
+per-ticket HTTPS preview links, and a live worker can be attached from a phone or a desktop at the
+same time. Four or more tickets have run at once on one small box, at about 0.5 GB per worker
+measured.
+
+Rests on:
+
+- [The overseer rehearsal](../live-checks/96-overseer-rehearsal.md) — one unbroken pass driven from
+  Discord: prose dispatch, a worker question answered in the thread, a button confirm, and the
+  review gate approved.
+- The operator's memory benchmark on `coinmatica.net`: four genuinely overlapping sessions, 733 MB
+  peak total, ~0.5 GB per worker as the planning number, headroom for 40–50 concurrent workers on
+  the 30 GB box before CPU or rate limits bind.
+- The operator's own runs: four or more curia workers alive at once on real tickets.
+- [ADR-0003](../adr/0003-tmux-ttyd-tailscale-worker-host.md),
+  [ADR-0005](../adr/0005-escalation-contract.md).
+
+### 3. A worker cannot finish by talking
+
+Nothing lands without the reader's approval. Every ticket ends the same way: commit, pull request,
+live preview, review gate, merge. A rejection comes back as their own words and turns into new
+commits on the same pull request. A stop hook refuses a worker that tries to quit early.
+
+Rests on:
+
+- [ADR-0008](../adr/0008-resolved-means-merged.md) — resolved means merged; the ending is one
+  structure, rendered as both the worker's orders and the stop hook's checklist.
+- [The merge-gated ending](../live-checks/54-merge-gate.md) — written from inside the ending by the
+  worker living through it, rejection loop included.
+- The second live check, where the stop hook caught a planted protocol skip — recorded in the same
+  file, from [Live check 2 (#62)](https://github.com/alp82/curia/issues/62), commit `d3b118a`.
+
+This is the claim that keeps the page out of the agent-swarm genre. No page selling autonomy makes
+it.
+
+## Held back as proof, not claims
+
+These are evidence, and where they appear is decided in
+[Decide what proof of curia working goes on the page](https://github.com/alp82/curia/issues/114):
+
+- The rehearsal survived two daemon restarts inside one pass — one while a worker's question was
+  open, one while the review gate was open. Both recovered.
+- A question held open for almost eight hours resumed cleanly. Recorded in `README.md`; the proof
+  ticket verifies it against the journal before it goes on the page.
+- This page was charted, decided and written by curia itself: workers dispatched from a Discord
+  thread, grilling the operator, opening pull requests, and merging on approval.
+
+## What the page is honest about
+
+Three things a reader finds out sooner or later, so the page says them first:
+
+- Curia is eleven days old. First commit 2026-07-21.
+- One person runs it. There are no other users.
+- Setup is manual today: Node, tmux, Tailscale, a Discord bot, an agent CLI, a GitHub repo. It gets
+  simpler, and the page does not promise packaging it has not shipped.
+
+**Where it sits: straight after the three claims, before the guide.** The reader learns why they
+would want curia, then what it costs. Putting it on the first screen spends the opening on an
+apology; putting it only in the guide reads evasive to the sceptical reader this page is for.
+
+## What the page never sounds like
+
+### Banned words
+
+supercharge · unleash · effortless · seamless · revolutionary · game-changing · 10x · blazing-fast ·
+enterprise-grade · production-ready · vibe coding · swarm · agent army · agent workforce ·
+"while you sleep".
+
+Two with reasons worth keeping:
+
+- **"AI-powered"** — the reader already runs agents. The phrase is aimed at someone else.
+- **"autonomous"**, in every form. Curia is the opposite of autonomous by design: the human approval
+  is the point, and claim 3 says so.
+
+### Banned moves
+
+- **No "just" or "simply" in the guide.** Setup is not simple today. Pretending otherwise is what
+  makes a reader stop trusting everything else on the page.
+- **No fake proof.** No logo wall, no testimonials, no "trusted by", no star count, no "join
+  thousands of developers". Nobody but the operator runs curia yet.
+- **No first-claims.** [The landscape scan](../research/landscape-scan.md) lists OpenHands, Orca and
+  two working Discord-to-Claude-Code bridges. The page never says first, only, or the only one.
+  What it may claim is the combination — routing dispatcher, two-way Discord approval, multi-device
+  attach, self-hosted — which nothing else ships whole.
+- **No internal vocabulary as sales words.** Full loop, wayfinder, frontier, escalation, charting.
+  Precise for us, opaque to a first-time reader. Golden thread and substrate stay dead per
+  `CONTEXT.md`.
+
+### The two failure modes
+
+From the map, in the operator's words. The page is checked against both before it ships:
+
+1. **Generic and over-promising** — reading like every other AI-agent landing page, obviously
+   machine-written. The banned list, the no-first-claims rule and the honesty block exist for this.
+2. **Honest but boring** — nobody understands why they would want it. The throughput promise and
+   the concrete numbers exist for this.
+
+Polish and shipping speed are the lesser risks.


### PR DESCRIPTION
Ticket: alp82/curia#110 — [Pin the pitch: reader, promise, defensible claims](https://github.com/alp82/curia/issues/110)

Resolves #110 — the positioning brief the landing page gets written against, at `docs/landing-page/positioning.md`.

Every decision in it came from the operator over six Discord escalations; nothing was decided by the worker.

- **Reader**: a builder who already runs coding agents daily across several repos. The page assumes agents and explains none of them. Curious users, homelab-first readers and any portfolio audience are ruled out on purpose.
- **The one promise**: many repos, one queue, driven from a phone. Presence and rigor were each considered as the headline and demoted to supporting claims; the dogfood run was demoted to proof.
- **Three supporting claims**, each with its evidence: your tracker is the queue (ADR-0001/0004, the frontier code, the watch list); any device is a full seat (the overseer rehearsal, the operator's memory benchmark, 4+ real tickets alive at once); a worker cannot finish by talking (ADR-0008, both merge-gate live checks).
- **Honesty placement**: eleven days old, one user, manual setup — stated straight after the three claims, before the guide.
- **What the page never sounds like**: a banned word list, a no-fake-proof rule, a no-first-claims rule grounded in the landscape scan, and a ban on internal vocabulary as sales words.

Checked against the source before writing: the frontier really does read across watched repos in dependency order, `max_concurrent` gates only the auto-dispatch loop (which ships off), and the second live check lives inside `54-merge-gate.md` rather than its own file.

Side note for #99, not fixed here: the `max_concurrent: 6` comment in `config/curia.yaml` still reasons about an 8 GB box; the deployed box is 30 GB.

---

Dispatched by the curia daemon — session `curia-110`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `66db436` Pin the landing page's pitch (wayfinder #110)