### PR TITLE
Choose the page's build path and source directory (alp82/curia#111)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>curia</title>
+<style>
+  body {
+    margin: 0;
+    padding: 3rem 1.5rem;
+    font: 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+    max-width: 34rem;
+  }
+  code { font-size: 0.9em; }
+</style>
+</head>
+<body>
+  <h1>curia</h1>
+  <p>This page is not written yet. It is a placeholder proving the publishing path works:
+  <code>docs/</code> on <code>main</code>, served by GitHub Pages with no build step.</p>
+  <p>The page being built here is charted on
+  <a href="https://github.com/alp82/curia/issues/109">The curia landing page</a>. How it is built and
+  previewed is recorded in
+  <a href="https://github.com/alp82/curia/blob/main/docs/landing-page/build.md">docs/landing-page/build.md</a>.</p>
+</body>
+</html>

--- a/docs/landing-page/build.md
+++ b/docs/landing-page/build.md
@@ -1,0 +1,106 @@
+# Landing page: build path, source directory, preview
+
+**Settled**: 2026-08-02, in [Choose the page's build path and source directory](https://github.com/alp82/curia/issues/111),
+on the map [The curia landing page](https://github.com/alp82/curia/issues/109).
+Every answer below came from the operator over Discord escalations.
+
+This file is the contract the shipping tickets build against. It fixes where the page lives, what
+turns it into a site, and the one command a worker runs before `publish_preview`.
+
+## Build path: none
+
+**Hand-written HTML and CSS, committed. No generator, no GitHub Actions, no build step at all.**
+
+The whole site is one page. A generator would add a toolchain, a lockfile and a CI workflow to this
+repo — which today has no root `package.json` and no `.github/` — to produce a file a person can
+write directly. The repo's own daemon runs unbuilt; the page matches it.
+
+`docs/` is served as it sits in `main`. Push and it is live.
+
+## Source directory: `docs/`, served from `main`
+
+GitHub Pages publishes from a branch, source `main` **`/docs`**.
+
+**Why `/docs` and not a `landing-page/` subfolder.** Branch publishing offers exactly two folders —
+the repository root or `/docs`
+([GitHub docs](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)).
+There is no third choice. Serving an arbitrary subfolder needs a GitHub Actions workflow to upload it
+as an artifact, and that workflow was the only thing standing between this map and a zero-build ship.
+
+The layout:
+
+```
+docs/
+  index.html      the page — alp82.github.io/curia/
+  .nojekyll       serve the tree as-is, no Jekyll build
+  adr/ agents/ research/ live-checks/ deploy.md   the repo's own docs, unchanged
+```
+
+**Known and accepted: everything under `docs/` becomes part of the site.** `docs/adr/0001-....md`
+is reachable at `alp82.github.io/curia/adr/0001-....md` as raw markdown. The repo is public, so
+those files were already readable on GitHub — Pages changes the URL they answer on, not who can read
+them. Nothing secret lives here. Anything that must not be published does not go in `docs/`.
+
+`.nojekyll` is required, not decoration. Without it Pages runs Jekyll over the whole folder, and a
+Liquid-looking `{{ ... }}` in any committed markdown fails the build.
+
+## Local preview
+
+One command, from the repo root:
+
+```
+python3 -m http.server 4000 --directory docs
+```
+
+Then `publish_preview(4000, "/")`.
+
+`/` is the page locally and `/` is the page live, so a worker previews the same URL shape that
+ships. No path skew between the review gate and production.
+
+**Why `http.server` and not a node dev server:**
+
+- **No install, no network, no `package.json`.** python3 is on the box. A node static server means
+  `npx serve`, which downloads on first run, and this repo has no root `package.json` to hang it off.
+- **No host check.** Tailscale Serve passes the original `Host` header through, and Vite's host check
+  answers `*.ts.net` with `Blocked request` — the repair recorded in
+  [`docs/full-loop.md`](../full-loop.md) cost an `allowedHosts` line in every watched repo.
+  `http.server` has no host check, so a preview here cannot hit that class of bug.
+- **About 10 MB**, against the ~0.3 GB per preview dev server that `config/curia.yaml` budgets.
+
+**Port 4000**, checked free on the host. It is clear of the daemon (4271, 4272), ttyd (7681), the
+attach and timeline Serve rules (8443, 8444) and the 8500–8599 preview range. `8000` and `8080` were
+both taken.
+
+**If the port is busy, move up.** `dispatch.max_concurrent` is 6, so two workers can want a preview
+at the same moment and `http.server` exits on `Address already in use`. Try 4001, 4002, and pass the
+port you **actually** bound — which is why `publish_preview` takes a port rather than reading a
+configured one (#40).
+
+## One source of truth: not wanted
+
+Asked whether the page, `README.md` and the self-host guide should render from one file, the operator
+ruled against it: they cover similar ground in their own voice, for different readers, and a build
+step to keep three copies identical would buy a sameness nobody asked for.
+
+So:
+
+- **The page** carries its own version of the setup steps, written for a stranger who has not cloned
+  the repo.
+- **[`README.md`](../../README.md)** keeps its own job — orienting someone reading the code. It must
+  stop *contradicting* the page ([Bring the README into line with the page](https://github.com/alp82/curia/issues/117));
+  it does not have to repeat it.
+- **The self-host guide** from [Write the self-host guide](https://github.com/alp82/curia/issues/112)
+  stays as markdown in the repo, as the repo-side document. Nothing renders it into the page.
+
+Agreement is on framing — who curia is for, what state it is in. Not on wording.
+
+## What this hands the next tickets
+
+- [Provision GitHub Pages and fix the public URL](https://github.com/alp82/curia/issues/113):
+  the source is branch `main`, folder `/docs`. The URL question and HTTPS enforcement are still that
+  ticket's to answer.
+- [Prototype the landing page](https://github.com/alp82/curia/issues/115) and every later build
+  ticket: write `docs/index.html` and any CSS beside it, preview with the command above.
+
+`docs/index.html` is a placeholder today — enough for the pipeline to serve a 200. The prototype
+replaces it whole.


### PR DESCRIPTION
Ticket: alp82/curia#111 — [Choose the page's build path and source directory](https://github.com/alp82/curia/issues/111)

Resolves the build-path decision for the landing page map (#111).

**No build step.** Hand-written HTML and CSS, committed under `docs/`, served from `main` by GitHub Pages. No generator, no GitHub Actions, no root `package.json`.

**Source directory: `main` / `/docs`.** GitHub Pages branch publishing offers only the repo root or `/docs` — there is no arbitrary-subfolder option. A `landing-page/` folder would have required an Actions workflow to upload it as an artifact, which was the only thing standing between this map and a zero-build ship.

Consequence accepted on purpose: everything under `docs/` becomes part of the site, so the ADRs and agent docs answer on `alp82.github.io/curia/...` as raw markdown. The repo is public, so this changes the URL those files serve on, not who can read them.

**Local preview:** `python3 -m http.server 4000 --directory docs`, then `publish_preview(4000, "/")`. Chosen over a node dev server for three reasons: no install and no network, no host check (Vite's answers `*.ts.net` with `Blocked request` behind Tailscale Serve — the repair recorded in `docs/full-loop.md`), and ~10 MB against the ~0.3 GB per preview dev server that `config/curia.yaml` budgets. Port 4000 verified free on the host; 8000 and 8080 were taken. If busy, move up and pass the port actually bound.

**Files:**
- `docs/landing-page/build.md` — the decision record, alongside `positioning.md`.
- `docs/.nojekyll` — required, not decoration: without it Pages runs Jekyll over the folder and a Liquid-looking `{{ ... }}` in any committed markdown fails the build.
- `docs/index.html` — a placeholder, `noindex`, so the pipeline serves a 200 and #113 has something to verify against. The prototype (#115) replaces it whole.

Also records the operator's ruling that the page, `README.md` and the self-host guide do **not** share one source: they cover similar ground in their own voice for different readers, and must agree on framing, not wording.

Verified locally: `GET /` → 200 with the placeholder, `GET /adr/0001-....md` → 200.

---

Dispatched by the curia daemon — session `curia-111`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `b2896d8` Fix the landing page's build path and source directory (wayfinder #111)