### PR TITLE
Provision GitHub Pages and fix the public URL (alp82/curia#113)

### DIFF
--- a/docs/landing-page/build.md
+++ b/docs/landing-page/build.md
@@ -31,13 +31,14 @@ The layout:
 
 ```
 docs/
-  index.html      the page — alp82.github.io/curia/
+  index.html      the page — https://curia.sh/
   .nojekyll       serve the tree as-is, no Jekyll build
+  CNAME           the custom domain, written by GitHub when it was set in repo settings
   adr/ agents/ research/ live-checks/ deploy.md   the repo's own docs, unchanged
 ```
 
 **Known and accepted: everything under `docs/` becomes part of the site.** `docs/adr/0001-....md`
-is reachable at `alp82.github.io/curia/adr/0001-....md` as raw markdown. The repo is public, so
+is reachable at `https://curia.sh/adr/0001-....md` as raw markdown. The repo is public, so
 those files were already readable on GitHub — Pages changes the URL they answer on, not who can read
 them. Nothing secret lives here. Anything that must not be published does not go in `docs/`.
 
@@ -97,8 +98,9 @@ Agreement is on framing — who curia is for, what state it is in. Not on wordin
 ## What this hands the next tickets
 
 - [Provision GitHub Pages and fix the public URL](https://github.com/alp82/curia/issues/113):
-  the source is branch `main`, folder `/docs`. The URL question and HTTPS enforcement are still that
-  ticket's to answer.
+  **answered** — the site is live at `https://curia.sh`, served from branch `main` folder `/docs`,
+  with HTTPS enforced. The URL, the DNS records and how to verify them are in
+  [`pages.md`](pages.md).
 - [Prototype the landing page](https://github.com/alp82/curia/issues/115) and every later build
   ticket: write `docs/index.html` and any CSS beside it, preview with the command above.
 

--- a/docs/landing-page/pages.md
+++ b/docs/landing-page/pages.md
@@ -77,9 +77,15 @@ if they ever change, that page is the source of truth, not this one.
 to 2026-10-31 and renewed automatically. The setting stays greyed out until that certificate exists,
 which is why it is the last step rather than part of the same visit to the settings page.
 
-Enforcement does not take effect the moment it is ticked — the plain-HTTP edge keeps answering 200
-for a few minutes before it starts 301ing. A `http://curia.sh` that has not flipped yet is a stale
-edge, not a failed setting; check `https_enforced` on the API before believing otherwise.
+**Enforcement lags the setting.** With `https_enforced: true` on the API, all four edges still
+answered plain `http://curia.sh` with a 200 rather than a 301 — checked repeatedly over the ten
+minutes after it was ticked, and against each of the four addresses directly. `http://www.curia.sh`
+301s correctly in the same window, because the `www`-to-apex redirect is a different mechanism from
+the HTTP-to-HTTPS one.
+
+This is propagation, not a broken setting. The API is the authority on whether enforcement is on;
+the edge catches up on its own. If plain HTTP is still serving 200 a day later, that is worth
+chasing — before then it is not.
 
 ## Verifying it
 
@@ -93,9 +99,10 @@ dig +short A curia.sh                       # the four 185.199.x.153 addresses
 gh api repos/alp82/curia/pages --jq '{cname,status,https_enforced,source}'
 ```
 
-Checked 2026-08-02, all passing: `https://curia.sh/` serves 200; `www.curia.sh` and
-`alp82.github.io/curia` both 301 to the apex; the API reports `status: built`, `cname: curia.sh`,
-source `main` `/docs`, `https_enforced: true`.
+Checked 2026-08-02: `https://curia.sh/` serves 200; `www.curia.sh` and `alp82.github.io/curia` both
+301 to the apex; the API reports `status: built`, `cname: curia.sh`, source `main` `/docs`,
+`https_enforced: true`. The one line not yet true at that moment is the plain-HTTP apex redirect —
+see the note above.
 
 A fresh push to `main` takes about a minute to appear. If the site 404s after a push, check that
 `docs/.nojekyll` and `docs/index.html` are both still in the tree — those two files are the whole

--- a/docs/landing-page/pages.md
+++ b/docs/landing-page/pages.md
@@ -1,0 +1,113 @@
+# Landing page: the public URL and the Pages source
+
+**Settled**: 2026-08-02, in [Provision GitHub Pages and fix the public URL](https://github.com/alp82/curia/issues/113),
+on the map [The curia landing page](https://github.com/alp82/curia/issues/109).
+The URL was the operator's call; the DNS and repo-settings work was the operator's to run, from the
+checklist below.
+
+This file records what is live and how to get back to it. It is the companion to
+[`build.md`](build.md), which fixes what gets built and where it lives.
+
+## The URL
+
+**`https://curia.sh`** — apex, custom domain.
+
+`www.curia.sh` redirects to it.
+
+The alternative was the project page, `alp82.github.io/curia`. It ships without touching a
+registrar, but the page would sit under a `/curia/` subpath forever — every link and asset in
+`index.html` prefixed or relative — and the URL reads as a repository, not a product. The domain was
+already registered (Namecheap, 2026-07-25), so the only cost of the custom domain was the DNS work
+below, done once.
+
+The apex is the canonical URL. Write links to `https://curia.sh`, never to
+`alp82.github.io/curia` — that host still answers, but it 301s to the custom domain once the domain
+is set, and hard-coding it means the page stops being portable off GitHub.
+
+## The Pages source
+
+| | |
+| --- | --- |
+| Source | Deploy from a branch |
+| Branch | `main` |
+| Folder | `/docs` |
+| Build | none — served as committed ([`build.md`](build.md)) |
+| Custom domain | `curia.sh` |
+| Enforce HTTPS | on |
+
+Setting the custom domain in repo settings makes GitHub commit a `CNAME` file to the publishing
+source on `main`. **That file is load-bearing** — deleting it drops the custom domain and the site
+falls back to `alp82.github.io/curia`. It was written by GitHub, not by a worker; leave it where it
+sits.
+
+## The DNS records
+
+At Namecheap, `curia.sh` → Advanced DNS. The parking records that shipped with the registration —
+an A record on `@` pointing at `192.64.119.209`, and the `www` parking entry — were deleted first.
+
+Four **A** records, Host `@`:
+
+```
+185.199.108.153
+185.199.109.153
+185.199.110.153
+185.199.111.153
+```
+
+Four **AAAA** records, Host `@`:
+
+```
+2606:50c0:8000::153
+2606:50c0:8001::153
+2606:50c0:8002::153
+2606:50c0:8003::153
+```
+
+One **CNAME**, Host `www`, value `alp82.github.io.`
+
+All four A records and all four AAAA records are required — GitHub serves Pages from that whole set,
+and a partial set gives an intermittently reachable site rather than an obviously broken one, which
+is worse. The addresses are GitHub's published apex set
+([GitHub docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site));
+if they ever change, that page is the source of truth, not this one.
+
+## HTTPS
+
+**Enforce HTTPS is on.** GitHub issued a certificate covering `curia.sh` and `www.curia.sh`, valid
+to 2026-10-31 and renewed automatically. The setting stays greyed out until that certificate exists,
+which is why it is the last step rather than part of the same visit to the settings page.
+
+Enforcement does not take effect the moment it is ticked — the plain-HTTP edge keeps answering 200
+for a few minutes before it starts 301ing. A `http://curia.sh` that has not flipped yet is a stale
+edge, not a failed setting; check `https_enforced` on the API before believing otherwise.
+
+## Verifying it
+
+From any box:
+
+```
+curl -sSI https://curia.sh | head -1        # HTTP/2 200
+curl -sSI http://curia.sh | head -1         # HTTP/1.1 301 -> https://curia.sh/
+curl -sSI https://www.curia.sh | head -1    # HTTP/2 301 -> https://curia.sh/
+dig +short A curia.sh                       # the four 185.199.x.153 addresses
+gh api repos/alp82/curia/pages --jq '{cname,status,https_enforced,source}'
+```
+
+Checked 2026-08-02, all passing: `https://curia.sh/` serves 200; `www.curia.sh` and
+`alp82.github.io/curia` both 301 to the apex; the API reports `status: built`, `cname: curia.sh`,
+source `main` `/docs`, `https_enforced: true`.
+
+A fresh push to `main` takes about a minute to appear. If the site 404s after a push, check that
+`docs/.nojekyll` and `docs/index.html` are both still in the tree — those two files are the whole
+publishing contract.
+
+## What this hands the next tickets
+
+- [Prototype the landing page](https://github.com/alp82/curia/issues/115) and every later build
+  ticket: the page ships to `https://curia.sh`, at the root. Internal links are root-relative
+  (`/foo`), not `/curia/`-prefixed.
+- `docs/index.html` today carries `<meta name="robots" content="noindex">`, put there while it was a
+  placeholder. **The ticket that writes the real page removes it** — the domain is live and
+  indexable now, and shipping the finished page with a noindex is a silent way to publish nothing.
+- Anywhere the repo names a URL for the page — `README.md`, the self-host guide, the repo's
+  About/homepage field — it is `https://curia.sh`.


### PR DESCRIPTION
Ticket: alp82/curia#113 — [Provision GitHub Pages and fix the public URL](https://github.com/alp82/curia/issues/113)

Records the outcome of [Provision GitHub Pages and fix the public URL](https://github.com/alp82/curia/issues/113).

GitHub Pages is live for `alp82/curia`: **https://curia.sh**, served from branch `main` folder `/docs`, no build step, HTTPS enforced. The operator chose the custom domain over the `alp82.github.io/curia` project page — `curia.sh` was already registered — and ran the Namecheap DNS and repo-settings work from a checklist, since both sit outside a worker's bounds. GitHub committed `docs/CNAME` to `main` itself when the custom domain was saved.

Verified from the worker: `https://curia.sh/` → 200; all four A and all four AAAA records live; `www.curia.sh` and `alp82.github.io/curia` both 301 to the apex; certificate approved for both hosts to 2026-10-31; the Pages API reports `status: built`, `cname: curia.sh`, source `main` `/docs`, `https_enforced: true`.

One thing is recorded as not-yet-true rather than glossed: with enforcement on, all four edges still answered plain `http://curia.sh` with a 200 instead of a 301 through the ten minutes after it was ticked — checked against each address directly. `http://www.curia.sh` redirects correctly in the same window, so this is edge propagation on the HTTP-to-HTTPS mechanism, not a failed setting. `pages.md` says so, and gives the threshold at which it becomes worth chasing.

**New — `docs/landing-page/pages.md`**: the URL and why the custom domain won, the Pages source table, the eight apex DNS records and the `www` CNAME with the reason all eight are required, the certificate, the enforcement lag, and the commands that re-verify the site. Closes with what it hands the next tickets — the page ships at the root so internal links are root-relative, and whoever writes the real page must strip the `noindex` meta the placeholder carries.

**Changed — `docs/landing-page/build.md`**: it said the page would live at `alp82.github.io/curia/`. Its layout block now names the real URL and lists `docs/CNAME`, and its handoff line to this ticket points at `pages.md` instead of leaving the URL open.

No change to `docs/index.html` — the placeholder it serves today is [Prototype the landing page](https://github.com/alp82/curia/issues/115)'s to replace.

---

Dispatched by the curia daemon — session `curia-113`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `29b593a` Record the HTTPS enforcement lag honestly (wayfinder #113)
- `402dbf0` Record curia.sh as the landing page's public URL (wayfinder #113)