### PR TITLE
Decide what proof of curia working goes on the page (alp82/curia#114)

### DIFF
--- a/docs/landing-page/positioning.md
+++ b/docs/landing-page/positioning.md
@@ -94,15 +94,25 @@ it.
 
 ## Held back as proof, not claims
 
-These are evidence, and where they appear is decided in
-[Decide what proof of curia working goes on the page](https://github.com/alp82/curia/issues/114):
+Settled in [Decide what proof of curia working goes on the page](https://github.com/alp82/curia/issues/114).
+The proof brief is [`proof.md`](proof.md); what follows is what became of each item.
 
-- The rehearsal survived two daemon restarts inside one pass — one while a worker's question was
-  open, one while the review gate was open. Both recovered.
-- A question held open for almost eight hours resumed cleanly. Recorded in `README.md`; the proof
-  ticket verifies it against the journal before it goes on the page.
-- This page was charted, decided and written by curia itself: workers dispatched from a Discord
-  thread, grilling the operator, opening pull requests, and merging on approval.
+- **This page was charted, decided and written by curia itself** — workers dispatched from a Discord
+  thread, grilling the operator, opening pull requests, and merging on approval. **On the page**, as
+  a line pointing at the merged pull requests, each stamped by the daemon with its session and model.
+- **The rehearsal survived two daemon restarts inside one pass** — one while a worker's question was
+  open, one while the review gate was open. Both recovered. **Not on the page.** It stays where it is
+  above, backing claim 2.
+- **A question held open for almost eight hours resumed cleanly.** Recorded in
+  [`docs/live-checks/56-gateway-crash.md`](../live-checks/56-gateway-crash.md), not `README.md` as
+  this brief previously said. **Not on the page**, and not because it is untrue: the same file
+  records a `request_review` that dropped after about 4 hours 22 minutes in the same run, and the
+  journal no longer reaches 27 July, so neither figure can be re-verified. The pull-request trail
+  carries endurance instead.
+
+The page shows, besides those: **four frames of one real ticket** on a repo other than this one,
+captured by the operator on a phone, in a strip after the three claims; and **a dated stats line** a
+worker regenerates from GitHub and the journal. `proof.md` holds the detail.
 
 ## What the page is honest about
 

--- a/docs/landing-page/proof.md
+++ b/docs/landing-page/proof.md
@@ -1,0 +1,129 @@
+# Landing page proof
+
+**Settled**: 2026-08-02, in [Decide what proof of curia working goes on the page](https://github.com/alp82/curia/issues/114),
+on the map [The curia landing page](https://github.com/alp82/curia/issues/109).
+Every answer below came from the operator over Discord escalations.
+
+This file names each proof element, its form, and who produces it. It sits under
+[the positioning brief](positioning.md): the brief says what the page claims, this file says what
+the page shows. The brief's banned moves apply here — no logo wall, no testimonials, no star count.
+
+## Why the page carries proof at all
+
+Failure mode one is a page that reads like every other agent landing page. The defence is showing
+rather than claiming: three supporting claims, and under them a strip of a real ticket being done.
+
+The operator chose pictures over text (Q1). A page proved only by links is words about words, which
+runs straight into failure mode two.
+
+## The four frames
+
+**One ticket, four frames** — not one image per claim. The reader watches a thing get done rather
+than reading four assertions. A frame-per-claim set was considered and turned down: it argues more
+tightly but reads as a feature grid.
+
+**Source: a real ticket on a repo other than `alp82/curia`.** `getalfredo/landing-page` or
+`alp82/alperortac.com`, both already watched in `config/curia.yaml`. Photographing this map's own
+tickets was the cheaper option and was rejected — a page that only proves it can build itself
+answers the sceptic with nothing.
+
+The four frames, in order:
+
+1. The operator dispatches the ticket in a Discord thread.
+2. The worker asks a question; the operator answers in the thread.
+3. The preview link, opened on the phone.
+4. The review gate, approved.
+
+**Producer: the operator, on a phone.** Workers have no browser, so this is the one element on the
+page nobody else can make.
+
+**Redaction: the tailnet host, and nothing else.** Frame 3 shows a curia preview link, and those are
+tailnet HTTPS URLs — publishing one hands out the machine's name on the network. The operator's
+Discord handle, the server name, the repo and the ticket text stay visible on purpose: a
+redacted-to-death screenshot proves nothing, and the frames have to feel real. **The blurring
+happens at capture time.** A worker cannot judge what is still readable in an image.
+
+**Delivery: Discord attachments on an `ask_human` answer.** The daemon downloads them to
+`daemon/data/attachments/<esc-id>/`, and the answer reaches the worker with real image blocks. A
+worker copies the files out of that directory into `docs/` and commits them; the directory sits
+outside the worktree, so this is a read-then-copy, not a write. Two escalations have already carried
+images this way. `MAX_IMAGES` in `daemon/src/images.mjs` is **4**, and `MAX_INBOUND_BYTES` is 5 MB
+per file — the whole set fits one answer with nothing to spare.
+
+**Placement: one strip, after the three claims, before the honesty block.** The reader learns why
+they would want curia, sees it being done, then finds out what it costs. Distributing one frame per
+claim was rejected for the same reason the frame-per-claim set was.
+
+**Nothing blocks on the capture.** The prototype and the real build use grey placeholder boxes, and
+the page goes live with them. The frames land in a later commit. The page is public with holes in
+its proof strip for a while, and that was the operator's call over a ship date set by a camera roll.
+
+## The pull-request trail
+
+**Form: one line on the page, pointing at the merged pull requests on `alp82/curia`.**
+
+This is the "curia built this page" proof the brief held back. It costs nothing, it is public, and
+it updates itself. Every worker pull request ends with a block the daemon writes, not the worker:
+
+> Dispatched by the curia daemon — session `curia-113`, model `opus`.
+>
+> Commits (read out of git by the daemon, not reported by the worker):
+
+Four merged so far on this map — [#116](https://github.com/alp82/curia/pull/116),
+[#128](https://github.com/alp82/curia/pull/128), [#129](https://github.com/alp82/curia/pull/129),
+[#130](https://github.com/alp82/curia/pull/130) — each one a worker, each one merged after a review
+gate the operator approved from a phone.
+
+**Producer: a worker.** GitHub is the evidence; the page only points at it.
+
+## The stats line
+
+**Form: a short line of counts, split by where each number comes from, and dated.**
+
+**Producer: a worker, regenerated whenever the page is touched.** Two sources, and they are not
+equally durable:
+
+**From GitHub — permanent, and the reader can re-derive them.**
+
+```sh
+gh pr list --repo alp82/curia --state merged --limit 200 --json number --jq length
+gh issue list --repo alp82/curia --state closed --limit 200 --json number --jq length
+git log --reverse --format=%ad --date=short | head -1     # first commit, for the age
+grep -c 'repo:' config/curia.yaml                          # repos watched
+```
+
+**From the journal — only ever "since 1 Aug 2026".** `daemon/data/events.jsonl` reaches back to
+**2026-08-01T13:41:50Z** and no further; everything before that is gone. Threads, sessions,
+escalations answered and workers spawned come from here, and the line on the page must carry the
+since-date rather than read as a lifetime total.
+
+**Tokens are not on the page.** The operator asked for them; curia never journals them. They exist
+only in the agent CLI's own transcripts, for the Claude backend and not Codex, and only for projects
+still on disk — the one number a reader could not check. **Handed to the production map
+[#99](https://github.com/alp82/curia/issues/99): make the daemon journal token usage**, so a later
+page can carry it honestly. That is a change to the daemon, so it belongs to #99's fog and not to
+this map. Filing it is the operator's, not a worker's — this map's tickets cannot write to #99.
+
+## What is deliberately not on the page
+
+- **The eight-hour question.** The brief held back "a question stayed open almost 8 hours and
+  resumed cleanly" and said `README.md` records it. It does not — the record is
+  [the gateway crash live check](../live-checks/56-gateway-crash.md), and **the same file records
+  the other half**: one `request_review` dropped after about 4 hours 22 minutes in that same run.
+  The worker who wrote it says plainly it cannot tell which mechanism made the difference. Neither
+  figure can be re-verified, because the journal no longer reaches 27 July. Carrying the eight hours
+  alone is failure mode one, and it is a fact a reader can find in this repo in two clicks. Carrying
+  both was offered; the operator dropped the number entirely and let the pull-request trail carry
+  endurance instead.
+- **The live-check records.** `docs/live-checks/` is the deepest proof in the repo and the page does
+  not link it. Three hundred lines of internal detail, and the operator chose the pull-request trail
+  and the stats line over it.
+- **The two daemon restarts survived mid-pass.** Held back as proof by the brief; it lives in
+  [the overseer rehearsal](../live-checks/96-overseer-rehearsal.md), which the page does not link.
+  It stays where it already is — backing for claim 2 in the brief — and does not appear as page
+  copy.
+
+## Corrections this ticket makes to the positioning brief
+
+- The eight-hour question is recorded in `docs/live-checks/56-gateway-crash.md`, not `README.md`.
+- The brief's "Held back as proof, not claims" section is now resolved, and points here.


### PR DESCRIPTION
Ticket: alp82/curia#114 — [Decide what proof of curia working goes on the page](https://github.com/alp82/curia/issues/114)

Records the outcome of [Decide what proof of curia working goes on the page](https://github.com/alp82/curia/issues/114). Nine Discord escalations settled it.

**New — `docs/landing-page/proof.md`.** Each proof element, its form, and who produces it.

- **Four frames of one real ticket**, on a repo other than `alp82/curia` — dispatch, the worker's question answered in-thread, the preview on the phone, the review gate approved. One story rather than one image per claim. Photographing this map's own tickets was rejected: a page that only proves it can build itself answers the sceptic with nothing.
- **Producer: the operator, on a phone.** Workers have no browser, so this is the only element nobody else can make. Redaction is the tailnet host and nothing else — a preview link is a tailnet HTTPS URL, and blurring the rest would leave a stock screenshot. Blurring happens at capture time; a worker cannot judge what is still readable.
- **Delivery is already proven**: Discord attachments on an `ask_human` answer land in `daemon/data/attachments/<esc-id>/` and reach the worker as image blocks. Two escalations have carried images this way. `MAX_IMAGES` is 4 — the set fits one answer exactly.
- **Placement**: one strip after the three claims, before the honesty block. **Nothing blocks on the capture** — prototype and build ship grey placeholders, the frames land later.
- **The pull-request trail** carries "curia built this page": four merged worker PRs, each stamped by the daemon with its session and model, and the note that the commits were read out of git rather than reported by the worker. Free, public, self-updating.
- **A dated stats line**, split by source. GitHub numbers are permanent and reader-checkable; journal numbers only reach back to `2026-08-01T13:41:50Z`, so the line carries a since-date instead of reading as a lifetime total. The regeneration commands are in the file.

**Changed — `docs/landing-page/positioning.md`.** The held-back-as-proof section is resolved and now points at `proof.md`. Two corrections:

- The eight-hour question is recorded in `docs/live-checks/56-gateway-crash.md`, not `README.md` as the brief said.
- That same file records a `request_review` that **dropped after about 4h22m** in the same run, and the journal no longer reaches 27 July, so neither figure can be re-verified. Rather than carry the eight hours half-told, the number comes off the page and the pull-request trail carries endurance.

Also recorded as not-on-the-page, with reasons: the `docs/live-checks/` records, and the two daemon restarts survived mid-pass.

**Handed to [#99](https://github.com/alp82/curia/issues/99), not done here**: the daemon does not journal token usage, so the stats line cannot carry it. Making it do so is a daemon change and sits outside this map — and outside a #109 worker's write bounds, so the operator files it.

No page markup changed. `docs/index.html` is still [Prototype the landing page](https://github.com/alp82/curia/issues/115)'s to replace.

---

Dispatched by the curia daemon — session `curia-114`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `8103020` Decide what proof of curia working goes on the page (wayfinder #114)