### PR TITLE
Settle cross-check semantics (alp82/curia#150)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,16 @@ The blocking tool a worker calls to ask a question. Kinds: free-text, choice, ap
 **Review gate**:
 The one approval before a merge, and its own escalation kind. Only the daemon opens it, and it composes every link from its own records.
 
+**Cross-check**:
+The operator's third choice at the review gate. Curia spawns a reviewer on the other provider, and the verdict returns to the builder.
+
+**Reviewer**:
+The worker a cross-check spawns. It reads the diff, the ticket, and a checkout it can run. It writes nothing and it ends with its verdict.
+_Avoid_: checker.
+
+**Verdict**:
+The reviewer's findings on one diff. It reaches the builder, and it lands as a pull-request comment.
+
 **First-valid-wins**:
 The answer rule. The first valid answer closes the escalation atomically. Any device may answer. Later answers get a refusal.
 

--- a/docs/adr/0010-the-cross-check.md
+++ b/docs/adr/0010-the-cross-check.md
@@ -1,0 +1,32 @@
+# ADR-0010: The cross-check
+
+**Status**: accepted (2026-08)
+**Provenance**: [Settle cross-check semantics (#150)](https://github.com/alp82/curia/issues/150), parked as out of scope on [the PoC map (#1)](https://github.com/alp82/curia/issues/1)
+
+## Context
+
+One model builds a ticket, and one human approves it. That human is the only reader of the diff. A model on the other provider can read the same diff and disagree with it. The PoC map parked this idea because the dispatch plumbing was not proven yet. The plumbing is proven now, so the semantics need a decision.
+
+## Decision
+
+- The cross-check is a third button on the review gate, beside approve and reject. The operator presses it. Nothing starts a cross-check by itself.
+- The reviewer is a full worker. It gets its own tmux session, its own status line in the ticket thread, and the sandbox any worker gets. The operator can attach to it and watch it read.
+- The reviewer reads the diff, the ticket, and a live checkout of the branch tip. It can grep the repo and run the tests, so it can prove a finding instead of guessing at it. It does not read the builder's transcript, and it does not read the thread.
+- The reviewer runs on the other provider. `routing.yaml` states the pairing: an anthropic builder gets `gpt`, and an openai builder gets `opus`. A `review-model:<name>` label on the ticket beats the table.
+- If every model on the other provider is cooling, the reviewer runs on the builder's own provider. The verdict states this at its top, because a same-provider reading is the weaker check.
+- The verdict goes to the builder, never to the operator alone. The builder judges each finding, agrees or disagrees with it, and writes a summary with a recommendation.
+- The builder sends that summary as a plain question, not as a gate. The operator says what to do. The builder then acts, and the review gate returns as a pure approve-or-reject about the final code.
+- The operator arbitrates a disagreement, and the builder gets the first word on it. There is no third model, and there is no automatic tie-break. The reviewer never gets a reply and never reads the same diff twice.
+- A finding beyond this ticket's scope becomes charting. The builder's recommendation names the new ticket, and that line rides in the charting field of the gate. No worker opens a fault ticket by itself, per [ADR-0006](0006-worker-containment-and-standing-orders.md).
+- The verdict lands as a pull-request comment, per [ADR-0001](0001-github-is-the-only-durable-state-home.md). The daemon posts it when it arrives, and it posts the builder's judgement as a second comment under it. The daemon holds both texts already: it spawned the reviewer, and the builder's summary is the escalation prompt.
+- The reviewer writes nothing. It makes no tracker write, no push, no merge, no gate, and no charting. It produces a verdict and it ends.
+
+## Consequences
+
+- The button is pressable on every gate round. [ADR-0008](0008-resolved-means-merged.md) counts no rejections, and the cross-check follows the same rule.
+- A cross-check costs two worker slots against `max_concurrent`. The builder stays idle and holds its slot while the reviewer reads.
+- The reviewer needs a session name of its own, because `curia-<n>` is the builder's identity on every surface.
+- git refuses the same branch in two worktrees, so the reviewer checks out the branch tip in its own worktree at a detached HEAD.
+- The review gate now has three outcomes, so `request_review` is no longer a two-way answer. [ADR-0005](0005-escalation-contract.md) gains a button, not a new escalation kind.
+- The cross-check adds no authority. Every tracker write still passes the one gate the operator answers.
+- A verdict the operator never asked for cannot exist, so the reviewer burns no quota on a diff the operator was happy with.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ One file per standing decision. A decision earns an ADR when it still constrains
 ## Resolution
 
 - [ADR-0008](0008-resolved-means-merged.md): Resolved means merged. The worker stays alive through the review, and the Stop hook enforces the ending.
+- [ADR-0010](0010-the-cross-check.md): The cross-check is a button on the review gate. A reviewer on the other provider returns a verdict, and the builder answers it before the operator decides.
 
 ## Attach surfaces
 


### PR DESCRIPTION
Ticket: alp82/curia#150 — [Settle cross-check semantics](https://github.com/alp82/curia/issues/150)

Settles cross-check semantics as ADR-0010, from nine answers in the #150 grilling.

The cross-check is a third button on the review gate. The operator presses it. Curia spawns a full reviewer worker on the other provider (`routing.yaml` table, `review-model:<name>` label overrides, same-provider fallback labelled weaker when the other side is cooling). The reviewer reads the diff, the ticket, and a live checkout it can run. It writes nothing.

The verdict goes to the builder. The builder judges it, then asks the operator as a plain question, not a gate. The operator arbitrates. Out-of-scope findings become charting, never a ticket a worker opens by itself. The verdict lands as a pull-request comment.

CONTEXT.md gains cross-check, reviewer, and verdict.

---

Dispatched by the curia daemon — session `curia-150`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `832f175` The cross-check becomes a button, not a policy (wayfinder #150)