### PR TITLE
Map dispatch: a charting worker updates the map on demand (alp82/curia#160)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,16 @@ A ticket whose parent issue is a map.
 The map section "Not yet specified": work that is coming but not yet sharp enough to state as a ticket.
 
 **Charting**:
-The map changes a worker proposes at the review gate: new tickets, graduated fog, blocking edges, scope rulings.
+The map changes: new tickets, graduated fog, blocking edges, scope rulings. They land two ways. A ticket worker proposes them at the review gate and writes them after the approval. A charting worker writes them as its whole job.
+
+**Map dispatch**:
+`start` on a map's own issue. The daemon spawns a charting worker instead of a ticket worker.
+
+**Charting worker**:
+The worker of a map dispatch. It edits the map and its tickets, and it never closes the map, opens a pull request, or passes a review gate.
+
+**Instruction**:
+The operator's sentence on a map dispatch, in their own words. It rides the dispatch and reaches the charting worker as the first thing it reads. With no instruction, the worker asks what should change.
 
 **Frontier**:
 The takeable tickets of a watched repo, in map order.
@@ -44,7 +53,7 @@ Open, not a pull request, no open blockers, no assignee.
 The rule that computes a repo's frontier. The map lane takes the children of open maps. The flat lane takes open `ready-for-agent` issues. A repo whose maps are all closed or deferred gets an empty frontier, never the flat fallback.
 
 **Claim**:
-The assignee on a ticket. A claim removes the ticket from every frontier. The daemon claims before it spawns.
+The assignee on a ticket. A claim removes the ticket from every frontier. The daemon claims before it spawns. A claim on a map takes nothing off a frontier, because a map is never on one. It stops a second charting worker from editing the same body.
 
 **Watched repo**:
 A repo on the watch list in `config/curia.yaml`. Curia dispatches only against watched repos.
@@ -67,7 +76,7 @@ Merged. A ticket counts as resolved only when a human approved the work and the 
 The ordered act: claim, prepare, spawn. A failure before the spawn releases the claim.
 
 **Routing rule**:
-The label-based model choice. A `model:<x>` label wins, else the `wayfinder:<type>` default table. No intelligence sits in the dispatch path.
+The label-based model choice. A `model:<x>` label wins, else the `wayfinder:<type>` default table. No intelligence sits in the dispatch path. `wayfinder:map` is a row in that table like any other type.
 
 **Backend**:
 The agent CLI a worker runs under: claude or codex.
@@ -181,6 +190,9 @@ _Avoid_: status line (that names the daemon's own line, below).
 
 **Ending**:
 The ordered close-out of a ticket: commit, pull request, preview, review gate, merge, resolve, result. One structure drives both the prompt and the Stop hook checklist.
+
+**Charting ending**:
+The ending of a map dispatch: edit the map, then report the result. Curia posts the summary on the map and unassigns it. No pull request, no review gate, no close.
 
 **Stop hook**:
 The enforcement hook that fires at the end of every worker turn. It refuses a stop that leaves ending steps open, up to the stop budget, then lets go and reports the ticket unfinished.

--- a/config/routing.yaml
+++ b/config/routing.yaml
@@ -19,14 +19,19 @@ defaults:
   # pinned it to the strongest claude-backend model, because no gate checks a
   # charting worker: the operator in the loop is the whole check.
   #
-  # That model is fable, and fable is entitlement-blocked on this account
-  # (#126 — the same reason grilling and prototype sit on opus above). A `fable`
-  # row here would burn one spawn per map dispatch and then fall to opus down
-  # the chain, so opus stands. This row flips back to fable with the other
-  # three, once the account holds fable usage credits.
+  # So this row states fable and NOT opus, unlike grilling and prototype above.
+  # Those three moved to opus in #126 to stop the burnt spawn; here the operator
+  # ruled the other way (2026-08-03), because charting is the one job worth the
+  # strongest model even at that price. While the account holds no fable usage
+  # credits, every map dispatch spends one spawn: the pane classifier reads the
+  # credits dialog, cools fable, and respawns down the chain. The row needs no
+  # edit on the day the credits arrive.
+  #
+  # The chain the operator asked for — fable, then opus, then gpt-5.6-sol — is
+  # what `fallbacks` below already gives, transitively, with sonnet at the tail.
   #
   # A `model:<x>` label on the map still beats this row (resolveModel).
-  map: opus
+  map: fable
 
 # `context_window` feeds the status line's context % (#146), and it is the LAST
 # resort for it since #178. It used to say 200000 for the three anthropic models

--- a/config/routing.yaml
+++ b/config/routing.yaml
@@ -14,6 +14,19 @@ defaults:
   research: gpt          # #13: spread quota — research is the bulk lane
   task: opus
   untyped: opus
+  # A map dispatch (#160): `start curia#<map>` on a `wayfinder:map` issue spawns
+  # a CHARTING worker, which rewrites the map every later worker reads. #149
+  # pinned it to the strongest claude-backend model, because no gate checks a
+  # charting worker: the operator in the loop is the whole check.
+  #
+  # That model is fable, and fable is entitlement-blocked on this account
+  # (#126 — the same reason grilling and prototype sit on opus above). A `fable`
+  # row here would burn one spawn per map dispatch and then fall to opus down
+  # the chain, so opus stands. This row flips back to fable with the other
+  # three, once the account holds fable usage credits.
+  #
+  # A `model:<x>` label on the map still beats this row (resolveModel).
+  map: opus
 
 # `context_window` feeds the status line's context % (#146), and it is the LAST
 # resort for it since #178. It used to say 200000 for the three anthropic models

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -80,10 +80,14 @@ const SLASH_MANIFEST = [
   new SlashCommandBuilder().setName('next').setDescription('Dispatch the next takeable ticket')
     .addStringOption((o) => o.setName('repo').setDescription('Limit to one repo (any unambiguous part of the name)')),
   new SlashCommandBuilder().setName('status').setDescription('Workers running, waiting on input, and recent endings'),
-  new SlashCommandBuilder().setName('start').setDescription('Dispatch a worker on a ticket')
-    .addStringOption((o) => o.setName('ticket').setDescription('Ticket number').setRequired(true))
+  new SlashCommandBuilder().setName('start').setDescription('Dispatch a worker on a ticket, or a charting worker on a map')
+    .addStringOption((o) => o.setName('ticket').setDescription('Ticket number, or a map number').setRequired(true))
     .addStringOption((o) => o.setName('model').setDescription('Model override'))
-    .addStringOption((o) => o.setName('backend').setDescription('Backend override')),
+    .addStringOption((o) => o.setName('backend').setDescription('Backend override'))
+    // #160. Optional, so an old client-side manifest still sends a valid
+    // `/start` — it just cannot carry a sentence, and the charting worker then
+    // asks what should change, which is the right degradation.
+    .addStringOption((o) => o.setName('instruction').setDescription('MAP ONLY: what should change on the map')),
   new SlashCommandBuilder().setName('cancel').setDescription('Cancel a running ticket, or all of them')
     .addStringOption((o) => o.setName('ticket').setDescription('Ticket number, or "all"').setRequired(true)),
   new SlashCommandBuilder().setName('resume').setDescription('Fresh worker on a ticket, inheriting its surviving worktree')
@@ -102,7 +106,10 @@ const SLASH_MANIFEST = [
 // register (a stale client-side manifest, verified live from the phone), and
 // that deserves to be said out loud rather than turned into a fake ticket id.
 // Same rule as everywhere else in the daemon: a missing read is not a value.
-function expandCommand(i) {
+// Exported for the same reason queuedNoteReply is: this is the phone's only
+// command surface (see missingOptionReply), and a pure expansion deserves a
+// test that does not need a live gateway.
+export function expandCommand(i) {
   const opt = (name) => i.options.getString(name)
   const need = (name) => {
     const v = opt(name)
@@ -118,7 +125,16 @@ function expandCommand(i) {
     case 'start': {
       const ticket = need('ticket')
       if (!ticket) return { error: 'missing' }
-      return `start ${ticket}${opt('model') ? ' model=' + opt('model') : ''}${opt('backend') ? ' backend=' + opt('backend') : ''}`
+      // The instruction rides LAST, after a bare `--` (#160), and its
+      // whitespace is collapsed for the same reason canonicalFor collapses it:
+      // this line is one line, and the router splits it on whitespace. This is
+      // still expansion, not interpretation — the text is passed through, and
+      // whether a map may carry it is the dispatcher's ruling.
+      const instruction = (need('instruction') ?? '').replace(/\s+/g, ' ').trim()
+      return `start ${ticket}`
+        + (opt('model') ? ' model=' + opt('model') : '')
+        + (opt('backend') ? ' backend=' + opt('backend') : '')
+        + (instruction ? ` -- ${instruction}` : '')
     }
     case 'cancel':
     case 'resume':

--- a/daemon/src/commands.mjs
+++ b/daemon/src/commands.mjs
@@ -13,8 +13,20 @@ import { clampList } from './messaging.mjs'
 // against the watch list (see #matchRepo), so `cur` is as valid as `alp82/curia`.
 const REPOISH_RE = /^[\w./-]+$/
 
+// The instruction separator on `start` (#160). Every other argument on this
+// seam is one whitespace-free token, because the seam itself is one line of
+// text that gets split on whitespace — and a map dispatch has to carry a whole
+// operator sentence ("update the landing page map so that X").
+//
+// A bare `--` is the boundary: everything before it parses as before, and
+// everything after it is the instruction, joined back with single spaces. The
+// round trip is stable — the instruction is taken from the FIRST `--` onward,
+// so a sentence that itself contains ` -- ` survives canonicalFor → parseCommand
+// unchanged.
+const INSTRUCTION_SEP = '--'
+
 // 'tickets [repo]' | 'next [repo]' | 'status'
-// | 'start <n>|<owner/repo#n> [model=x] [backend=y]'
+// | 'start <n>|<owner/repo#n> [model=x] [backend=y] [-- <instruction>]'
 // | 'cancel <n>|all' | 'resume <n>|all' | 'attach <n>'  — anything else ⇒ null.
 export function parseCommand(text) {
   const parts = (text ?? '').trim().split(/\s+/).filter(Boolean)
@@ -48,10 +60,20 @@ export function parseCommand(text) {
       } else {
         return null
       }
-      for (const opt of rest.slice(1)) {
+      const sep = rest.indexOf(INSTRUCTION_SEP)
+      const opts = sep === -1 ? rest.slice(1) : rest.slice(1, sep)
+      for (const opt of opts) {
         const om = opt.match(/^(model|backend)=([\w.-]+)$/)
         if (!om) return null
         cmd[om[1]] = om[2]
+      }
+      if (sep !== -1) {
+        // `--` with nothing after it is a typo, not an empty instruction: it
+        // would dispatch the "what should change?" escalation the operator was
+        // trying to skip.
+        const instruction = rest.slice(sep + 1).join(' ').trim()
+        if (!instruction) return null
+        cmd.instruction = instruction
       }
       return cmd
     }
@@ -77,6 +99,7 @@ const USAGE = [
   '`next [repo]` — dispatch the next takeable ticket',
   '`status` — workers running, workers waiting on input, recent cancelled and finished',
   '`start <n>|repo#<n> [model=x] [backend=y]` — claim + dispatch a worker (repo: any unambiguous part of the name)',
+  '`start <map> -- <instruction>` — dispatch a charting worker on a `wayfinder:map` issue; the sentence after `--` is what it should change',
   '`cancel <n>|all` — immediate teardown (the overseer\'s interpreted cancel posts a ✅/❌ confirm instead)',
   '`resume <n>|all` — fresh worker on a ticket, inheriting its surviving worktree',
   '`attach <n>` — timeline + browser-terminal links for a live worker',
@@ -129,7 +152,10 @@ export class CommandRouter {
             const configured = Object.keys(this.dispatcher.routing.backends ?? {}).map((b) => `\`${b}\``).join(', ')
             return `❌ backend \`${cmd.backend}\` is not configured — configured backends: ${configured}`
           }
-          return await this.dispatcher.start(cmd.ticket, { repo: cmd.repo, model: cmd.model, backend: cmd.backend, by: userId, threadId })
+          return await this.dispatcher.start(cmd.ticket, {
+            repo: cmd.repo, model: cmd.model, backend: cmd.backend, instruction: cmd.instruction,
+            by: userId, threadId,
+          })
         }
         case 'cancel':
           if (interpreted) {

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -31,12 +31,19 @@ import {
   branchFor, defaultBranchOf, commitsOnBranch, pushBranch, hasUnpushedWork, workerEnv,
   untrustedProjectConfig,
 } from './workspace.mjs'
-import { resolveAndLand, summariseOutcome, nonCleanComment, landBranch, prLinkComment } from './resolve.mjs'
+import { resolveAndLand, summariseOutcome, nonCleanComment, landBranch, prLinkComment, chartingComment } from './resolve.mjs'
 import { outstanding, stopReason, reviewGateText, classifyReviewAnswer, REVIEW_KIND } from './lifecycle.mjs'
 import { CONFIRM_KIND } from './store.mjs'
 import { ensureTtyd, assertServe, serveOff } from './attach.mjs'
 
 const SESSION_RE = /^curia-(\d+)$/
+
+// The label that makes a dispatch a CHARTING one (#160): `start curia#<map>` on
+// the map's own issue spawns a worker that updates the map, not one that
+// resolves a ticket under it. Everything that branches on it reads this
+// constant, and the journal records the answer per spawn so a restarted daemon
+// still knows which kind of worker it adopted.
+const MAP_LABEL = 'wayfinder:map'
 
 // The tracker doc every watched repo is meant to carry (#57 step 3). The
 // wayfinder skill reads it to learn how this repo expresses maps and tickets;
@@ -320,7 +327,7 @@ export class Dispatcher {
 
   // `reuse` is the resume contract (#81): inherit the surviving worktree
   // instead of recreating it — see #dispatch.
-  async start(ticketArg, { repo, model, backend, by, reuse = false, threadId = null } = {}) {
+  async start(ticketArg, { repo, model, backend, instruction = null, by, reuse = false, threadId = null } = {}) {
     const n = String(ticketArg)
     const session = `curia-${n}`
     // Admission guard: synchronous check + insert BEFORE the first await, so a
@@ -345,6 +352,21 @@ export class Dispatcher {
       const { repo: theRepo, issue } = resolved
 
       if (issue.state !== 'open') return `❌ ${theRepo}#${n} is ${issue.state} — nothing to dispatch`
+      // An instruction rides a MAP dispatch and nothing else (#160/#149). A
+      // ticket worker's brief is its ticket body, which a human wrote and other
+      // sessions can read — an operator sentence that only exists in one spawn
+      // prompt would steer the work with no durable record of it. Refuse rather
+      // than drop it silently, and name where the sentence does belong.
+      //
+      // `!reuse` scopes it to an instruction a human actually typed. A resume
+      // carries the previous dispatch's instruction forward from the journal,
+      // and a map that has lost its label since then must degrade to an ordinary
+      // dispatch — not refuse a verb the operator typed no instruction on. The
+      // stale sentence is dropped rather than used: writePrompt renders one only
+      // on a charting dispatch.
+      if (instruction && !reuse && !hasLabel(issue, MAP_LABEL)) {
+        return `❌ ${theRepo}#${n} is not a \`${MAP_LABEL}\` issue, and an instruction rides a map dispatch only — put it in the ticket body, or send it as a note in the ticket's thread once the worker is up`
+      }
       const anomalies = []
       const assignees = (issue.assignees ?? []).map((a) => a.login)
       if (assignees.length) anomalies.push(`already assigned to ${assignees.join(', ')}`)
@@ -356,7 +378,7 @@ export class Dispatcher {
 
       // #dispatch returns null only on exhaustion whose latched notify just
       // fired; the slash caller still deserves a reply.
-      return (await this.#dispatch(theRepo, n, issue, { model, backend, by, reuse, threadId })) ?? this.#exhaustedReply()
+      return (await this.#dispatch(theRepo, n, issue, { model, backend, instruction, by, reuse, threadId })) ?? this.#exhaustedReply()
     } finally {
       this.inFlight.delete(session)
     }
@@ -425,13 +447,18 @@ export class Dispatcher {
   // `reuse` (the resume contract, #81): a surviving worktree is inherited as it
   // stands — uncommitted files and local commits included — instead of being
   // recreated from origin; absent one, resume degrades to an ordinary dispatch.
-  async #dispatch(repo, n, issue, { model, backend, by, reuse = false, threadId = null }) {
+  async #dispatch(repo, n, issue, { model, backend, instruction = null, by, reuse = false, threadId = null }) {
     const session = `curia-${n}`
     const labels = (issue.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name))
     // The type label, read once and used twice: it names the thread (#93) and
     // it reaches the worker prompt (#49 decision 2). One read, so the thread a
     // human reads and the prompt the worker reads can never say different kinds.
     const typeLabel = labels.find((l) => l.startsWith('wayfinder:')) ?? null
+    // A map dispatch (#160). `wayfinder:map` is a type label like any other for
+    // ROUTING — resolveModel reads `defaults.map` off the same loop — and unlike
+    // any other for everything downstream of it: the prompt, the ending, the
+    // tools curia will answer, and what report_result does.
+    const charting = typeLabel === MAP_LABEL
     const modelName = resolveModel(this.routing, labels, model)
     if (!this.routing.models[modelName]) {
       return `❌ unknown model \`${modelName}\` — configured models: ${Object.keys(this.routing.models).join(', ')}`
@@ -458,8 +485,13 @@ export class Dispatcher {
     }
 
     const login = await this.deps.viewerLogin()
+    // The claim on a MAP is not a claim on a ticket — nothing takes a map off a
+    // frontier, because a map is never on one. What it buys is the serialisation
+    // the map body needs: `start`'s own "already assigned" anomaly refuses a
+    // second charting worker on the same map, and #withMapLock cannot help here
+    // because the worker, not the daemon, does the writing.
     await this.deps.claim(repo, n, login)
-    this.store.logEvent('dispatch_claimed', { repo, ticket: n, worker: session, by: by ?? 'unknown' })
+    this.store.logEvent('dispatch_claimed', { repo, ticket: n, worker: session, by: by ?? 'unknown', kind: charting ? 'charting' : 'ticket' })
 
     // The ticket label goes on at the claim (#93): `start` binds the thread it
     // ran in, an autonomous dispatch opens and binds a fresh one — so every
@@ -481,7 +513,11 @@ export class Dispatcher {
       const wtPath = reuse && fs.existsSync(surviving)
         ? surviving
         : await this.deps.createWorktree(base, n)
-      const mapNumber = await this.#mapNumberFor(repo, full)
+      // A charting worker's map is the issue in hand. Naming it as the map (and
+      // not asking #mapNumberFor for a parent) is what puts the `/wayfinder`
+      // line on the prompt and arms #assertTracker: a charting worker without
+      // the tracker doc is exactly the worker that would chart into `.scratch/`.
+      const mapNumber = charting ? Number(n) : await this.#mapNumberFor(repo, full)
       this.#assertTracker(repo, n, session, wtPath, mapNumber)
       this.#assertNoPlantedConfig(wtPath, backendName)
       this.deps.seedConfigDir(cfgDir, wtPath, this.config.skills, backendName)
@@ -493,7 +529,7 @@ export class Dispatcher {
       // that stops a dispatched `wayfinder:grilling` worker from standing in for
       // the human's side of its own ticket.
       const promptFile = this.deps.writePrompt(cfgDir, full, {
-        repo, wtPath, mapNumber, type: typeLabel,
+        repo, wtPath, mapNumber, type: typeLabel, charting, instruction,
       })
       fs.rmSync(path.join(this.dataDir, 'results', `${session}.json`), { force: true })
 
@@ -504,13 +540,20 @@ export class Dispatcher {
       // DISPATCH, not per ticket, so a confirm can never outlive the worker
       // the operator read about and hit its successor.
       const instance = `${session}@${Date.now()}`
-      this.store.logEvent('worker_spawned', { repo, ticket: n, worker: session, instance, model: useModel, backend: backendName })
+      this.store.logEvent('worker_spawned', {
+        repo, ticket: n, worker: session, instance, model: useModel, backend: backendName,
+        kind: charting ? 'charting' : 'ticket', instruction: charting ? instruction : null,
+      })
 
       const worker = {
         repo, ticket: n, title: full.title, session, instance, wtPath, cfgDir, promptFile,
         model: useModel, requestedModel: modelName, backend: backendName,
         provider: this.routing.models[useModel].provider,
         spawnedAt: Date.now(), state: 'spawning', resultReceived: false,
+        // #160: which ending this worker is held to, and what the operator
+        // asked for. Journalled beside it (worker_spawned above) so a daemon
+        // restart re-derives both — see #epochCharting.
+        charting, instruction: charting ? instruction : null,
         // this spawn's exit marker (#169) — the watchdog's fail-fast signal
         exitMarker,
         // this ticket's own text can forge the usage-limit signal ⇒ the
@@ -519,6 +562,9 @@ export class Dispatcher {
       }
       this.workers.set(session, worker)
       this.#watchdog(worker).catch((e) => this.log(`watchdog ${session} failed:`, e.message))
+      if (charting) {
+        return `⚙️ charting worker on map ${repo}#${n} → \`${session}\` on **${useModel}**${instruction ? '' : ' — no instruction rode this dispatch, so it will ask what should change'} — watching for readiness`
+      }
       return `⚙️ dispatched ${repo}#${n} → \`${session}\` on **${useModel}** — watching for readiness`
     } catch (e) {
       this.workers.delete(session)
@@ -550,16 +596,18 @@ export class Dispatcher {
   // Throws before the config dir is seeded, so the ordinary prepare-failure
   // path unclaims and tells the operator why.
   //
-  // Only a MAP CHILD is refused: that is the ticket whose worker invokes the
-  // wayfinder skill, and the one whose resolution the fallback would silently
-  // send to `.scratch/` instead of GitHub. A plain ready-for-agent ticket
-  // invokes no such skill, and #10 watches ANY plain repo through the flat
-  // lane — refusing those for a missing doc would take that lane away. It gets
-  // a journal line instead, so the absence is on the record either way.
+  // Only work THROUGH A MAP is refused: a map child, or since #160 a charting
+  // worker on the map itself. Those are the workers that invoke the wayfinder
+  // skill, and whose writes the fallback would silently send to `.scratch/`
+  // instead of GitHub. A plain ready-for-agent ticket invokes no such skill,
+  // and #10 watches ANY plain repo through the flat lane — refusing those for a
+  // missing doc would take that lane away. It gets a journal line instead, so
+  // the absence is on the record either way.
   #assertTracker(repo, n, session, wtPath, mapNumber) {
     if (fs.existsSync(path.join(wtPath, TRACKER_DOC))) return
     if (mapNumber) {
-      throw new Error(`${repo} has no ${TRACKER_DOC}, so a worker on map child #${n} would fall back to the local-markdown tracker and write .scratch/ files instead of resolving on GitHub — run \`/setup-matt-pocock-skills\` in ${repo} first`)
+      const what = String(mapNumber) === String(n) ? `map #${n}` : `map child #${n}`
+      throw new Error(`${repo} has no ${TRACKER_DOC}, so a worker on ${what} would fall back to the local-markdown tracker and write .scratch/ files instead of resolving on GitHub — run \`/setup-matt-pocock-skills\` in ${repo} first`)
     }
     this.store.logEvent('tracker_doc_missing', { repo, ticket: n, worker: session })
   }
@@ -874,6 +922,14 @@ export class Dispatcher {
     const b = this.#bindingFor(workerName)
     if (b.error) return `❌ ${b.error} — nothing was pushed`
     const { w, ticket, repo, wtPath, branch, basePath } = b
+    // #160: a map dispatch produces tracker writes, not code. Refused rather
+    // than left to the prompt, because this call PUSHES — and a charting worker
+    // that has misread its own kind must not be one tool call away from putting
+    // a branch on the remote.
+    if (this.#epochCharting(ticket, workerName).charting) {
+      this.store.logEvent('charting_tool_refused', { repo, ticket, worker: workerName, tool: 'open_pull_request' })
+      return `❌ \`${workerName}\` is a CHARTING worker on map ${repo}#${ticket}. A map dispatch opens no pull request: your work is the map itself, and it is already written. Update the map, then call report_result.`
+    }
     if (!fs.existsSync(wtPath)) return `❌ the worktree ${wtPath} is gone — nothing was pushed`
 
     let title = w?.title
@@ -913,6 +969,17 @@ export class Dispatcher {
     const b = this.#bindingFor(workerName)
     if (b.error) return { ok: false, text: `❌ ${b.error} — no review was requested` }
     const { w, ticket, repo, branch } = b
+    // #160/#149: no review gate on a map dispatch. The gate exists to put a
+    // human in front of a DIFF before it merges; a charting worker has no diff,
+    // and the operator who dispatched it is the check. Opening one here would
+    // block the worker on a question with nothing to look at.
+    if (this.#epochCharting(ticket, workerName).charting) {
+      this.store.logEvent('charting_tool_refused', { repo, ticket, worker: workerName, tool: 'request_review' })
+      return {
+        ok: false,
+        text: `❌ \`${workerName}\` is a CHARTING worker on map ${repo}#${ticket}, and a map dispatch has no review gate — there is no pull request to show and nothing to merge. The operator who dispatched you is the check. Finish the map edits and call report_result; ask_human is how you reach them with a question.`,
+      }
+    }
 
     const title = w?.title ?? `#${ticket}`
     const links = [`Ticket: https://github.com/${repo}/issues/${ticket}`]
@@ -1001,7 +1068,16 @@ export class Dispatcher {
       ...this.#epochScan(ticket, workerName),
       hasCommits: false,
       prState: null,
+      // #160: which of the two endings this worker is held to. `outstanding`
+      // picks the checklist off it, so a charting worker is never nudged toward
+      // a pull request, a review or a merge it is forbidden to reach.
+      charting: this.#epochCharting(ticket, workerName).charting,
     }
+    // A charting worker has one daemon-visible step, and it is not in git or on
+    // GitHub — so the reads below are skipped whole. The Stop hook fires at the
+    // end of every turn, and a `git log` against a checkout that will never
+    // carry a commit is pure cost.
+    if (state.charting) return state
     try {
       const commits = await this.deps.commitsOnBranch(wtPath, await this.deps.defaultBranchOf(basePath))
       state.hasCommits = commits.length > 0
@@ -1099,6 +1175,12 @@ export class Dispatcher {
     }
 
     try {
+      // #160: a map dispatch never runs the resolve protocol. resolveAndLand
+      // would close the map, append a Decisions-so-far pointer to whatever the
+      // map's own parent is, and open a pull request for a session that wrote no
+      // code — three wrong acts on the one issue every later worker reads.
+      const { charting, instruction } = this.#epochCharting(ticket, workerName)
+      if (charting) return await this.#finishCharting(workerName, repo, ticket, result, w, instruction)
       return result.status === 'resolved'
         ? await this.#resolveTicket(workerName, repo, ticket, result, w)
         : await this.#noteNonClean(workerName, repo, ticket, result, w)
@@ -1118,6 +1200,28 @@ export class Dispatcher {
         && String(ev.ticket ?? '') === String(ticket) && ev.repo) repo = ev.repo
     }
     return repo
+  }
+
+  // Was this ticket's latest dispatch a charting one, and what rode it (#160)?
+  // Same journal reduction as #epochRepo, for a worker record this process never
+  // held: a restart mid-session, or a reconcile-adopted worker. The in-memory
+  // record wins where there is one — the journal is the fallback, not a second
+  // opinion.
+  //
+  // The failure direction matters: `charting: false` on a real map worker sends
+  // it to the ticket ending, which would try to close the map. So the reduction
+  // reads `worker_spawned` only, which is the event that states the kind, and a
+  // number with no such event at all is a ticket — nothing was ever charted
+  // under it, so there is no map to protect.
+  #epochCharting(ticket, workerName) {
+    const w = this.workers.get(workerName)
+    if (w) return { charting: Boolean(w.charting), instruction: w.instruction ?? null }
+    let out = { charting: false, instruction: null }
+    for (const ev of this.#readJournal()) {
+      if (ev.type !== 'worker_spawned' || String(ev.ticket ?? '') !== String(ticket)) continue
+      out = { charting: ev.kind === 'charting', instruction: ev.instruction ?? null }
+    }
+    return out
   }
 
   async #resolveTicket(workerName, repo, ticket, result, w) {
@@ -1155,6 +1259,50 @@ export class Dispatcher {
     const text = summariseOutcome(out)
     this.notify(ticket, `✅ ${repo}#${ticket} resolved — ${text}`)
     return text
+  }
+
+  // The map dispatch's whole ending (#160). Three acts, and each one is the
+  // opposite of the ticket path's:
+  //
+  //   1. COMMENT — curia posts the worker's summary on the map, so the change
+  //      has a dated record beside the body it changed. The ticket path only
+  //      comments as a repair; here it is the point.
+  //   2. UNCLAIM — the map goes back to unassigned. The ticket path closes; a
+  //      map is the standing artifact and closing it would take the whole effort
+  //      off every frontier.
+  //   3. Nothing else. No close, no Decisions-so-far line, no branch, no
+  //      merge check.
+  //
+  // The map edits themselves are NOT verified or repaired here, and cannot be:
+  // curia has no expected value for a charting session, which is the same reason
+  // #49 gave for having no verification gate at all. What the daemon can do is
+  // say plainly what it did and did not check.
+  async #finishCharting(workerName, repo, ticket, result, w, instruction) {
+    const record = w ?? { repo, ticket, session: workerName }
+    // The worker is still alive at report_result, so its credential copy stays
+    // until the session is positively gone — the #noteNonClean rule, same
+    // reason (#34's snapshot bound).
+    const released = await this.#releaseClaim(record, 'charting worker reported in', { keepCredentials: true })
+    let noted = false
+    try {
+      await this.deps.commentIssue(repo, ticket, chartingComment({
+        worker: workerName, model: w?.model ?? null, instruction, result,
+      }))
+      noted = true
+    } catch (e) {
+      this.log(`could not post the charting summary on ${repo}#${ticket}: ${e.message}`)
+    }
+    this.store.logEvent('charting_finished', {
+      repo, map: ticket, ticket, worker: workerName, status: result.status, commented: noted, released,
+    })
+    const clean = result.status === 'resolved'
+    const bits = [
+      noted ? 'summary posted on the map' : '⚠️ the summary comment could NOT be posted',
+      released ? 'map unassigned' : '⚠️ the map is still assigned to the bot; reconcile will retry',
+      'the map stays open',
+    ]
+    this.notify(ticket, `${clean ? '🗺️' : '↩️'} ${repo}#${ticket} charted (**${result.status}**) — ${bits.join('; ')}. Nobody reviewed these map edits: read them.`)
+    return `charting recorded — ${bits.join('; ')}. Nothing was closed, resolved or pushed.`
   }
 
   // A non-clean result resolves NOTHING — and the ticket has to actually come
@@ -1607,7 +1755,14 @@ export class Dispatcher {
     if (this.workers.has(session) || this.inFlight.has(session) || await this.deps.hasSession(session).catch(() => false)) {
       return `▶️ \`${session}\` is already running — \`cancel ${ticket}\` first, or \`attach ${ticket}\``
     }
-    return this.start(ticket, { repo, model, backend, by, reuse: true, threadId })
+    // A resumed map dispatch inherits the instruction that rode the original
+    // one (#160). Without it the fresh charting worker would open by asking what
+    // should change — a question the operator already answered, into a session
+    // that is gone. `start` re-reads the label and decides again, so an issue
+    // that is no longer a map degrades to an ordinary dispatch and the inherited
+    // sentence is dropped, never refused (the `!reuse` clause in start).
+    const { instruction } = this.#epochCharting(ticket, session)
+    return this.start(ticket, { repo, model, backend, instruction, by, reuse: true, threadId })
   }
 
   // Bulk resume (#81): every surviving worktree without a live worker, behind

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -1921,10 +1921,16 @@ export class Dispatcher {
     let claimLine
     try {
       const outcome = await this.#settleDeadClaim({ repo, ticket, session })
+      // A released MAP claim is not a re-frontiering: a map is never on a
+      // frontier, so nothing will pick it up again on its own (#160). Saying so
+      // matters — the operator has to know the next move is theirs.
+      const charting = this.#epochCharting(ticket, session).charting
       claimLine = {
         kept: 'its pull request is open and awaiting review, so the claim stays',
-        released: 'claim released, ticket re-frontiered',
-        'not-ours': 'the ticket is no longer claimed by curia',
+        released: charting
+          ? 'the map is unassigned again, and whatever this worker already wrote to it STANDS'
+          : 'claim released, ticket re-frontiered',
+        'not-ours': charting ? 'the map is no longer claimed by curia' : 'the ticket is no longer claimed by curia',
       }[outcome]
     } catch (e) {
       claimLine = `the claim decision failed (${e.message}) — reconcile will retry`

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -16,6 +16,10 @@
 // `todo` is prose only: the resolve step is daemon-invisible (#49 — there is no
 // expected value to compare a charting proposal against), and committing is not
 // required at all, since a grilling ticket resolves with a comment and no code.
+//
+// Since #160 there are TWO endings, read the same two ways: `ENDING` for a
+// ticket dispatch and `CHARTING_ENDING` for a map one. `state.charting` picks,
+// in the one function each caller already goes through.
 
 // The kind the review gate opens under (#54 item 2). Its own kind rather than a
 // plain approve-reject, for three reasons: /status must read *awaiting review*
@@ -94,10 +98,66 @@ export const ENDING = [
   },
 ]
 
+// ---- the charting ending (#160) ----------------------------------------------
+//
+// A map dispatch has a different ending, because it produces a different thing.
+// A ticket worker's output is CODE, so the ending is the merge gate: pull
+// request → review → merge → resolve. A charting worker's output is the MAP
+// ITSELF — issue bodies and child issues on the tracker — which is inside a
+// worker's ordinary write bounds and cannot be staged in a branch at all. There
+// is nothing to push, so there is nothing for a review gate to show, and #149
+// settled the trade: no gate, an operator in the loop, and the strongest model.
+//
+// So four steps of ENDING are not merely skipped here — they are refused
+// (dispatch.mjs turns `open_pull_request` and `request_review` down for a
+// charting worker). What is left is the map edit, and the one call that ends
+// every dispatch.
+//
+// The summary comment is deliberately NOT a step. The daemon posts it from the
+// `report_result` summary (see chartingComment in resolve.mjs), for the same
+// reason the review gate composes its own links: a record curia writes from its
+// own knowledge of what happened is evidence, and one the worker writes about
+// itself is an account. It also keeps the Stop-hook checklist off a `gh` read
+// at the end of every turn.
+export const CHARTING_ENDING = [
+  {
+    key: 'chart',
+    prose: ({ repo, ticket }) => [
+      `Update the map: edit ${repo}#${ticket}'s body, and create, edit or close its child tickets.`,
+      'Those tracker writes ARE the work. Nothing here is staged, reviewed or merged.',
+    ],
+  },
+  {
+    key: 'report',
+    prose: () => [
+      'Call `report_result` exactly once, with `resolved` and a summary of what you changed on the map.',
+      'curia posts that summary as a comment on the map. It never closes the map.',
+    ],
+    todo: (s) => (s.hasResult ? null : 'call `report_result` exactly once'),
+  },
+]
+
+// What a charting worker must NOT do — one bullet per entry, its own lines.
+// Prose only: the refusals themselves live in dispatch.mjs, and this is the
+// copy the model reads.
+export const CHARTING_NEVER = [
+  ['Never close the map. It is the standing artifact, not a ticket you resolve.'],
+  [
+    'Never call `open_pull_request` or `request_review`, and never merge anything. curia refuses both',
+    'calls on a map dispatch. There is no review gate here: the operator who dispatched you is the check.',
+  ],
+  [
+    'The resolve protocol — resolution comment, close, Decisions-so-far line — belongs to a TICKET',
+    "worker. Do not run it, and do not resolve any of the map's children yourself.",
+  ],
+]
+
+const listFor = (state) => (state.charting ? CHARTING_ENDING : ENDING)
+
 // The prose block for the spawn prompt: a numbered list, in order.
 export function endingProse(ctx) {
   const out = []
-  ENDING.forEach((step, i) => {
+  listFor(ctx).forEach((step, i) => {
     const lines = step.prose(ctx).map((l) => l.replace('#{n}', `#${ctx.ticket}`))
     out.push(`${i + 1}. ${lines[0]}`)
     for (const l of lines.slice(1)) out.push(`   ${l}`)
@@ -111,7 +171,7 @@ export function endingProse(ctx) {
 // cannot comply — the loop #48 refused.
 export function outstanding(state) {
   if (state.hasResult) return []
-  return ENDING.map((s) => (s.todo ? s.todo(state) : null)).filter(Boolean)
+  return listFor(state).map((s) => (s.todo ? s.todo(state) : null)).filter(Boolean)
 }
 
 // The `reason` a blocked Stop hands back to the worker. It is the only text the

--- a/daemon/src/overseer.mjs
+++ b/daemon/src/overseer.mjs
@@ -37,6 +37,14 @@ export function canonicalFor(verb, args = {}) {
       let text = `start ${args.repo ? `${args.repo}#` : ''}${args.ticket}`
       if (args.model) text += ` model=${args.model}`
       if (args.backend) text += ` backend=${args.backend}`
+      // The map instruction (#160) rides LAST, after a bare `--`, because it is
+      // the one argument that is a whole sentence. Whitespace is collapsed here:
+      // the seam is one line of text, and the router splits it on whitespace, so
+      // a newline the model wrote would otherwise come back as a space anyway —
+      // collapsing it makes the canonical text the operator sees and the text
+      // the router parses the same string.
+      const instruction = String(args.instruction ?? '').replace(/\s+/g, ' ').trim()
+      if (instruction) text += ` -- ${instruction}`
       return text
     }
     case 'cancel':
@@ -67,11 +75,12 @@ export function buildVerbTools(command) {
       repo: repoArg,
     }, run('next')),
     tool('status', 'Show the live workers: ticket, model, state, uptime, and who is waiting on input.', {}, run('status')),
-    tool('start', 'Claim a ticket and dispatch a worker on it. Use the repo field when the ticket number alone is ambiguous.', {
+    tool('start', 'Claim a ticket and dispatch a worker on it. Use the repo field when the ticket number alone is ambiguous. Started on a MAP issue, this dispatches a charting worker that updates the map instead — pass the operator\'s sentence as the instruction.', {
       ticket: ticketArg,
       repo: repoArg,
       model: z.string().optional().describe('model override'),
       backend: z.string().optional().describe('backend override (claude | codex)'),
+      instruction: z.string().optional().describe('MAP DISPATCHES ONLY: what the operator wants changed on the map, in their own words ("update the landing page map so that X"). The charting worker reads it as its first input. Leave it out and the worker asks the operator what should change. A ticket dispatch refuses it.'),
     }, run('start')),
     tool('cancel', 'Cancel the worker on a ticket, or "all" for every worker. Destructive, so the daemon posts ✅/❌ buttons and executes ONLY after the operator presses ✅. Call this directly when asked — never seek confirmation in conversation first, and never report the cancel as done: report that the confirm was posted.', {
       ticket: bulkArg,
@@ -110,6 +119,7 @@ Vocabulary the operator uses:
 - A "map" is a wayfinder map: a GitHub issue whose child tickets chart one effort. The operator names maps by topic ("the landing page map"). The \`tickets\` output groups tickets under their map's header line ("map #109 **The curia landing page**").
 - A map named in prose resolves to that map's header, never to repo-wide order: "continue with <map>" means \`start\` the FIRST ticket listed under that map's header. A repo can hold several maps — picking the repo's first takeable when the operator named a map dispatches the wrong ticket.
 - When a phrase names no repo or map you know, call \`tickets\` with no filter and match the phrase against the headers that come back before saying you cannot.
+- \`start\` on the MAP's own number is a map dispatch: a charting worker updates the map itself. Use it when the operator asks to CHANGE a map ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words — do not rewrite it and do not summarize it. "Continue with <map>" is not this: that starts the map's first ticket.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run \`tickets\` or \`status\` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/src/resolve.mjs
+++ b/daemon/src/resolve.mjs
@@ -143,6 +143,36 @@ export function nonCleanComment({ worker, result, released }) {
   ])
 }
 
+// ---- the map dispatch (#160) --------------------------------------------------
+
+// What a charting worker leaves on the map. The DAEMON posts it, from the
+// `report_result` summary — the same division of labour as the review gate's
+// links (#40): a record curia writes from what it knows is evidence, and one
+// the worker writes about itself is an account. It also makes the summary
+// arrive exactly once, whatever the worker did with `gh` on its own.
+//
+// No MACHINE_MARKER: this is the substantive record of a charting session, not
+// plumbing for a later check to skip over.
+//
+// The map is never closed and its `## Decisions so far` is never touched here.
+// That section indexes the route walked — one line per RESOLVED ticket — and a
+// charting session walks no step of it.
+export function chartingComment({ worker, model, instruction, result }) {
+  const clean = result.status === 'resolved'
+  return [
+    `## ${clean ? 'Charting' : `Charting — **${result.status}**`} (curia session \`${worker}\`)`,
+    '',
+    ...(instruction ? ['The operator asked for:', '', `> ${instruction}`, ''] : ['Dispatched with no instruction.', '']),
+    result.summary ?? '(no summary)',
+    '',
+    '---',
+    '',
+    clean
+      ? `_A map dispatch: this session edited the map and its tickets. It opened no pull request and closed nothing. Model \`${model ?? '?'}\`._`
+      : `_The charting worker stopped with status **${result.status}**. Whatever it had already written to the map STANDS — read the changes above before you dispatch another one. Model \`${model ?? '?'}\`._`,
+  ].join('\n')
+}
+
 export function prLinkComment({ branch, commits, url, state }) {
   return machine([
     `🔗 curia pushed \`${branch}\` (${commits} commit${commits === 1 ? '' : 's'}) and ${state === 'updated' ? 'updated' : 'opened'} ${url}`,

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -15,7 +15,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileP } from './exec.mjs'
-import { endingProse } from './lifecycle.mjs'
+import { endingProse, CHARTING_NEVER } from './lifecycle.mjs'
 
 // The mandatory communication rules (#133): a curia-owned copy of the
 // operator's STE writing standard, seeded into every config dir as the CLI's
@@ -583,7 +583,22 @@ export function writeHarness({ wtPath, cfgDir, worker, ticket, daemonPort, backe
 // tool at all — told to invoke it in prose the call comes back "cannot be used
 // with Skill tool". A prompt whose first line is `/wayfinder` loads the full
 // skill text. That is the only working form, verified both directions.
-export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, type = null }) {
+// `charting` (#160) is the map dispatch: the issue in hand IS the map, and the
+// worker's job is to change it rather than to resolve a ticket under it. Three
+// things move — the `/wayfinder` invocation carries no ticket, the params say
+// what this dispatch is and what the operator asked for, and the ending is the
+// charting one (lifecycle.mjs). Everything else — bounds, tools, the tracker
+// line — is the same worker.
+//
+// `instruction` is the operator's own sentence, delivered HERE rather than on
+// the worker-note queue. #149 called it "the worker's first note"; a note is
+// drained by the next curia tool call, and a charting worker can read the whole
+// map and start editing before it makes one. The prompt is the only channel
+// that is guaranteed to arrive BEFORE the first turn, which is what "first"
+// has to mean for an instruction that decides what the whole session does.
+// The text is never shell-substituted — the spawn template reads this file with
+// `$(cat …)` — so it needs no quoting rules of its own.
+export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, type = null, charting = false, instruction = null }) {
   const promptFile = path.join(cfgDir, 'prompt.md')
   const n = issue.number
   const branch = branchFor(n)
@@ -593,11 +608,38 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   // A mapless ticket gets no `/wayfinder` line: the skill works THROUGH a map,
   // and invoking it with nothing to work through would invent one. The flat
   // ready-for-agent lane (#10) is exactly this case.
-  const invocation = mapNumber ? [`/wayfinder ${mapUrl} ticket #${n}`, ''] : []
+  //
+  // A map dispatch names the map and NO ticket. That is the skill's "work
+  // through the map" invocation, whose step 2 would pick a frontier ticket — so
+  // the params below cancel that step in the same breath, under the standing
+  // rule that curia's bounds beat the skill where they disagree. The skill is
+  // still what has to load: fog of war, out of scope, ticket types, the map
+  // body's shape and refer-by-name are all doctrine a charting worker needs and
+  // curia does not restate.
+  const invocation = mapNumber ? [`/wayfinder ${mapUrl}${charting ? '' : ` ticket #${n}`}`, ''] : []
 
-  const params = [
-    `- The tracker is **GitHub**, repo \`${repo}\`, reached with the \`gh\` CLI. Do not fall back to a`,
-    '  local-markdown tracker: this repo carries `docs/agents/issue-tracker.md`.',
+  const chartingParams = [
+    `- **This is a MAP DISPATCH.** ${repo}#${n} is the map itself, not a ticket under it. Your job is to`,
+    '  CHANGE THE MAP: its body sections, and its child tickets. Do not choose a frontier ticket, and do',
+    '  not resolve one. The skill\'s step "choose the ticket" does not apply to this session.',
+    `- The map is ${repo}#${n} — ${ticketUrl}. curia has loaded it for you, and has assigned it to`,
+    '  you while you work, so a second charting worker cannot edit it under you.',
+    ...(instruction
+      ? [
+        '- **What the operator asked for**, in their own words:',
+        '',
+        `  > ${instruction}`,
+        '',
+        '  This is the whole brief. Do that, and no more than that. If it is unclear, or if doing it well',
+        '  needs a decision that is theirs, use `ask_human` — one question at a time.',
+      ]
+      : [
+        '- **No instruction rode this dispatch.** Do not guess what should change. Your FIRST act is one',
+        '  `ask_human` call: what should change on this map? Then work from the answer.',
+      ]),
+  ]
+
+  const params = charting ? chartingParams : [
     ...(mapNumber
       ? [`- The map is ${repo}#${mapNumber} — ${mapUrl}. curia has loaded it for you.`]
       : ['- This ticket belongs to no map, so there is no map to work through and no map line to append.']),
@@ -606,17 +648,32 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     ...(type
       ? [`- Ticket type: \`${type}\`. The skill's Ticket Types section says what that means for how you work it.`]
       : ['- This ticket carries no `wayfinder:` type label.']),
+  ]
+
+  const allParams = [
+    `- The tracker is **GitHub**, repo \`${repo}\`, reached with the \`gh\` CLI. Do not fall back to a`,
+    '  local-markdown tracker: this repo carries `docs/agents/issue-tracker.md`.',
+    ...params,
     `- Your worktree is ${wtPath}, on branch \`${branch}\`.`,
   ]
 
   const bounds = [
     '- **Read anything.** Zoom into any issue, map, sibling or closed ticket you need. Nothing here limits',
     '  reading.',
-    `- **Write only:** files inside ${wtPath}; this ticket;${mapNumber ? ` the map ${repo}#${mapNumber} and its children;` : ''}`,
-    '  and the one merge a human has just approved. Nothing else on the tracker, and nothing outside the',
-    '  worktree on disk.',
-    "- Leave the assignee alone, and do not rewrite anyone else's text. That claim is curia's record of who",
-    '  did this work.',
+    ...(charting
+      ? [
+        `- **Write only:** the map ${repo}#${n} and its child tickets. Nothing else on the tracker, and`,
+        `  nothing on disk: ${wtPath} is a read-only checkout to you. A map dispatch produces no code, no`,
+        '  commit and no branch.',
+        "- Do not rewrite anyone else's text. A section you did not write is edited, not replaced.",
+      ]
+      : [
+        `- **Write only:** files inside ${wtPath}; this ticket;${mapNumber ? ` the map ${repo}#${mapNumber} and its children;` : ''}`,
+        '  and the one merge a human has just approved. Nothing else on the tracker, and nothing outside the',
+        '  worktree on disk.',
+        "- Leave the assignee alone, and do not rewrite anyone else's text. That claim is curia's record of who",
+        '  did this work.',
+      ]),
     // #131 (operator ruling, 2026-08-02): the browser bound is about JUDGMENT,
     // not tooling. A worker that "looks at" its own page and approves what it
     // sees has bypassed the human the review gate exists for — but a renderer
@@ -649,7 +706,14 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '- Where a skill and these bounds disagree, these win.',
   ]
 
-  const tools = [
+  const tools = charting ? [
+    '- `ask_human` — a decision you cannot make alone. Blocks until a human answers, for as long as it',
+    '  takes. This is how you reach the operator who dispatched you.',
+    '- `notify` — a status line for the human. Returns at once.',
+    '- `report_result` — exactly once, at the very end. Its summary becomes curia\'s comment on the map.',
+    '- `open_pull_request`, `request_review` and `publish_preview` belong to a ticket dispatch. curia',
+    '  refuses the first two on a map dispatch, and there is nothing here to preview.',
+  ] : [
     '- `ask_human` — a decision you cannot make alone. Blocks until a human answers, for as long as it',
     '  takes.',
     '- `notify` — a status line for the human. Returns at once.',
@@ -674,7 +738,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '',
     '## What curia already did (parameters, not procedure)',
     '',
-    ...params,
+    ...allParams,
     '',
     '## Bounds (curia daemon)',
     '',
@@ -686,13 +750,23 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '',
     '## How this ends',
     '',
-    ...endingProse({ repo, ticket: n, branch, mapNumber }),
+    ...endingProse({ repo, ticket: n, branch, mapNumber, charting }),
     '',
-    '- If you cannot finish, call `report_result` with status `blocked` and say why. Never comment-and-close',
-    '  a ticket you did not resolve.',
-    '- curia holds you at this ending: its Stop hook refuses your stop while a step is outstanding, and',
-    '  tells you which one. It also verifies the resolution afterwards and repairs what is missing, so an',
-    '  honest `report_result` matters more than a perfect run.',
+    ...(charting
+      ? [
+        ...CHARTING_NEVER.flatMap(([first, ...rest]) => [`- ${first}`, ...rest.map((l) => `  ${l}`)]),
+        '- If you cannot finish, call `report_result` with status `blocked` and say why. A half-charted map',
+        '  is worse than an unchanged one, so say which part you left alone.',
+        '- curia holds you at this ending: its Stop hook refuses your stop while a step is outstanding, and',
+        '  tells you which one.',
+      ]
+      : [
+        '- If you cannot finish, call `report_result` with status `blocked` and say why. Never comment-and-close',
+        '  a ticket you did not resolve.',
+        '- curia holds you at this ending: its Stop hook refuses your stop while a step is outstanding, and',
+        '  tells you which one. It also verifies the resolution afterwards and repairs what is missing, so an',
+        '  honest `report_result` matters more than a perfect run.',
+      ]),
     '',
   ].join('\n')
   fs.writeFileSync(promptFile, body)

--- a/daemon/test/commands.test.mjs
+++ b/daemon/test/commands.test.mjs
@@ -122,6 +122,59 @@ describe('parseCommand', () => {
     assert.equal(c.model, 'opus')
   })
 
+  // #160: the map instruction. Every other argument on this seam is one
+  // whitespace-free token, because the seam is a line that gets split on
+  // whitespace — a whole operator sentence needs a boundary, and `--` is it.
+  test('start carries a free-text instruction after a bare --', () => {
+    const c = parseCommand('start 147 -- update the landing page map so that X')
+    assert.equal(c.verb, 'start')
+    assert.equal(c.ticket, '147')
+    assert.equal(c.instruction, 'update the landing page map so that X')
+  })
+
+  test('the instruction sits after the options, and takes everything to the end', () => {
+    const c = parseCommand('start cur#147 model=opus -- add a ticket, then wire it -- and say so')
+    assert.equal(c.repoArg, 'cur')
+    assert.equal(c.model, 'opus')
+    // from the FIRST `--` onward, so a sentence carrying one survives the round
+    // trip through canonicalFor unchanged
+    assert.equal(c.instruction, 'add a ticket, then wire it -- and say so')
+  })
+
+  test('a start with no -- carries no instruction at all', () => {
+    assert.equal(parseCommand('start 147').instruction, undefined)
+    assert.equal(parseCommand('start 147 model=opus').instruction, undefined)
+  })
+
+  test('a bare -- with nothing after it is refused, not read as an empty instruction', () => {
+    // It would silently dispatch the "what should change?" escalation the
+    // operator was trying to skip.
+    assert.equal(parseCommand('start 147 --'), null)
+    assert.equal(parseCommand('start 147 --   '), null)
+  })
+
+  test('an option AFTER the -- is instruction text, not a refused option', () => {
+    const c = parseCommand('start 147 -- use model=opus wording in the note')
+    assert.equal(c.model, undefined)
+    assert.equal(c.instruction, 'use model=opus wording in the note')
+  })
+
+  test('the instruction reaches the dispatcher', async () => {
+    const seen = []
+    const router = new CommandRouter({
+      dispatcher: {
+        routing: { backends: { claude: {} } },
+        config: { watch: [{ repo: 'alp82/curia' }] },
+        start: async (ticket, opts) => { seen.push({ ticket, ...opts }); return 'ok' },
+      },
+      attach: {},
+      log: () => {},
+    })
+    await router.handle('start 147 -- chart the cooling signal', 'user-1')
+    assert.equal(seen[0].ticket, '147')
+    assert.equal(seen[0].instruction, 'chart the cooling signal')
+  })
+
   test('cancel', () => {
     const c = parseCommand('cancel 42')
     assert.equal(c.verb, 'cancel')

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -1,0 +1,488 @@
+// The map dispatch (#160, building #149 points 3-5): `start curia#<map>` on a
+// `wayfinder:map` issue spawns a CHARTING worker, which updates the map and
+// ends without a close, a pull request or a review gate.
+//
+// Four seams, tested where each one lives:
+//   1. the canonical text — `-- <instruction>` on `start` (commands.test.mjs
+//      and overseer.test.mjs carry the parse and the render);
+//   2. routing — a `map` row in the defaults, reached by the label;
+//   3. the prompt — a charting worker is told what it is, what the operator
+//      asked for, and what it must not do;
+//   4. the ending — Stop-hook checklist, the two refused tools, and what
+//      report_result does instead of resolving.
+//
+// The failure this file exists to pin: a charting worker run through the TICKET
+// ending would close the map. That is the one act nothing can undo cheaply —
+// closing a map takes a whole effort off every frontier — so the assertions on
+// #finishCharting are exact rather than "does not throw".
+
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { Dispatcher } from '../src/dispatch.mjs'
+import { writePrompt } from '../src/workspace.mjs'
+import { outstanding, CHARTING_ENDING, ENDING } from '../src/lifecycle.mjs'
+import { chartingComment } from '../src/resolve.mjs'
+import { resolveModel } from '../src/routing.mjs'
+import { loadRoutingConfig } from '../src/config.mjs'
+import { expandCommand } from '../src/bridge.mjs'
+import { parseCommand } from '../src/commands.mjs'
+
+const ROUTING = {
+  defaults: { untyped: 'sonnet', map: 'opus' },
+  models: {
+    sonnet: { provider: 'anthropic', backend: 'claude' },
+    opus: { provider: 'anthropic', backend: 'claude' },
+  },
+  fallbacks: {},
+  backends: { claude: { template: 'claude --model {model} "$(cat {prompt_file})"', ready: 'x', readyRe: /x/ } },
+}
+
+const MAP_ISSUE = {
+  number: 147, title: 'Curia gets better', body: '## Destination\n\nsomewhere', state: 'open',
+  assignees: [], labels: [{ name: 'wayfinder:map' }],
+}
+
+const TICKET_ISSUE = {
+  number: 42, title: 'a ticket', body: 'body text', state: 'open',
+  assignees: [], labels: [{ name: 'wayfinder:task' }],
+}
+
+let tmp
+let notifies
+let events
+let calls // every gh-ish effect the dispatcher ordered, in order
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-mapdispatch-test-'))
+  fs.mkdirSync(path.join(tmp, 'data', 'results'), { recursive: true })
+  notifies = []
+  events = []
+  calls = []
+})
+
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
+
+function makeDispatcher(deps = {}, { issue = MAP_ISSUE } = {}) {
+  const root = path.join(tmp, 'work')
+  const dataDir = path.join(tmp, 'data')
+  const config = {
+    watch: [{ repo: 'o/r', mode: 'auto' }],
+    dispatch: {
+      auto_dispatch: false, max_concurrent: 2, poll_interval_s: 60,
+      workspace_root: root, ready_timeout_s: 45, stop_nudge_budget: 3,
+    },
+    attach: { ttyd_port: 7681, serve_port: 8443 },
+    identity: { allow: ['tester@example.com'], proxy_port: 7682 },
+    skills: null,
+  }
+  // The journal is a real file here: #epochCharting reads it back, which is the
+  // whole point of journalling the kind — a restarted daemon must still know
+  // which ending it is holding a worker to.
+  const store = {
+    logEvent: (type, data) => {
+      const rec = { type, ...data }
+      events.push(rec)
+      fs.appendFileSync(path.join(dataDir, 'events.jsonl'), JSON.stringify(rec) + '\n')
+      return rec
+    },
+    openEscalations: () => [],
+    cancel: () => ({ ok: true }),
+  }
+  const base = {
+    viewerLogin: async () => 'me',
+    repoMaps: async () => [],
+    mapFrontier: async () => [],
+    flatFrontier: async () => [],
+    blockedByOf: async () => [],
+    fetchIssue: async () => ({ ...issue }),
+    claim: async (repo, n) => calls.push(`claim ${repo}#${n}`),
+    unclaim: async (repo, n) => calls.push(`unclaim ${repo}#${n}`),
+    hasSession: async () => false,
+    listSessions: async () => [],
+    newSession: async () => {},
+    capturePane: async () => '',
+    killSession: async () => {},
+    ensureBaseClone: async (r, repo) => path.join(r, 'repos', repo.replace('/', '__'), 'base'),
+    createWorktree: async (b, n) => {
+      const wt = path.join(path.dirname(b), 'wt', String(n))
+      fs.mkdirSync(path.join(wt, 'docs', 'agents'), { recursive: true })
+      fs.writeFileSync(path.join(wt, 'docs', 'agents', 'issue-tracker.md'), '# Issue tracker: GitHub\n')
+      return wt
+    },
+    removeWorktree: async () => {},
+    removeConfigDir: () => {},
+    removeCredentials: () => {},
+    seedConfigDir: () => {},
+    writeHarness: () => {},
+    writePrompt: (cfgDir) => path.join(cfgDir, 'prompt.md'),
+    ensureTtyd: async () => ({ verified: true }),
+    assertServe: async () => {},
+    serveOff: async () => {},
+    commentIssue: async (repo, n, body) => calls.push(`comment ${repo}#${n}`, body),
+    closeIssue: async (repo, n) => calls.push(`CLOSE ${repo}#${n}`),
+    setIssueBody: async (repo, n) => calls.push(`setBody ${repo}#${n}`),
+    issueComments: async () => [],
+    findPullRequest: async () => null,
+    createPullRequest: async () => { calls.push('createPullRequest'); return 'https://github.com/o/r/pull/1' },
+    defaultBranchOf: async () => 'main',
+    commitsOnBranch: async () => [],
+    pushBranch: async () => { calls.push('pushBranch'); return 'abc1234' },
+    hasUnpushedWork: async () => false,
+    setPullRequestBody: async () => {},
+    deleteRemoteBranch: async () => ({ deleted: true }),
+  }
+  const d = new Dispatcher({
+    config,
+    routing: ROUTING,
+    store,
+    notify: (ticket, message) => notifies.push({ ticket, message }),
+    log: () => {},
+    dataDir,
+    daemonPort: 4271,
+    deps: { ...base, ...deps },
+  })
+  d.identityProxy = { listening: true }
+  return d
+}
+
+// ---- routing (#149 point 5) ---------------------------------------------------
+
+describe('a wayfinder:map row joins the routing defaults', () => {
+  test('the shipped config routes a map to a claude-backend model', () => {
+    const routing = loadRoutingConfig(path.join(path.dirname(new URL(import.meta.url).pathname), '..', '..', 'config', 'routing.yaml'))
+    const model = resolveModel(routing, ['wayfinder:map'], null)
+    assert.ok(routing.defaults.map, 'routing.yaml states no map default')
+    assert.equal(model, routing.defaults.map)
+    assert.equal(routing.models[model].backend, 'claude', 'a map dispatch must route to the claude lane')
+  })
+
+  test('a model: label on the map still beats the row', () => {
+    // The precedence rule is resolveModel's and unchanged — pinned here because
+    // #149 named it as part of THIS decision, so a later edit to the defaults
+    // has a test that says the override outranks them.
+    assert.equal(resolveModel(ROUTING, ['wayfinder:map'], null), 'opus')
+    assert.equal(resolveModel(ROUTING, ['wayfinder:map', 'model:sonnet'], null), 'sonnet')
+  })
+})
+
+// ---- the prompt (#149 point 4) ------------------------------------------------
+
+describe('the charting prompt', () => {
+  const write = (opts) => {
+    const file = writePrompt(tmp, MAP_ISSUE, { repo: 'o/r', wtPath: '/w/147', mapNumber: 147, type: 'wayfinder:map', ...opts })
+    return fs.readFileSync(file, 'utf8')
+  }
+
+  test('the /wayfinder line names the map and NO ticket', () => {
+    // The skill still has to load — fog of war, out of scope, the body shape and
+    // refer-by-name are doctrine curia does not restate — but "ticket #147"
+    // would tell it to resolve the map as if it were its own child.
+    const p = write({ charting: true, instruction: 'add a ticket for X' })
+    assert.equal(p.split('\n')[0], '/wayfinder https://github.com/o/r/issues/147')
+  })
+
+  test('it says this is a map dispatch and cancels the skill\'s choose-a-ticket step', () => {
+    const p = write({ charting: true, instruction: 'add a ticket for X' })
+    assert.match(p, /\*\*This is a MAP DISPATCH\.\*\*/)
+    assert.match(p, /Do not choose a frontier ticket/)
+    assert.ok(!p.includes('already CLAIMED it in your name'), 'the ticket-claim wording must not reach a charting worker')
+  })
+
+  test('the operator\'s sentence rides the prompt verbatim, as the first thing it reads', () => {
+    // #149 called it "the worker's first note". The note QUEUE drains on the
+    // next curia tool call, and a charting worker can read the map and start
+    // editing before it makes one — so the prompt is the only channel that is
+    // first by construction.
+    const p = write({ charting: true, instruction: 'update the landing page map so that the proof frames come last' })
+    assert.match(p, /> update the landing page map so that the proof frames come last/)
+    assert.match(p, /This is the whole brief/)
+  })
+
+  test('with no instruction the worker is ordered to ask what should change', () => {
+    const p = write({ charting: true, instruction: null })
+    assert.match(p, /No instruction rode this dispatch/)
+    assert.match(p, /FIRST act is one\n\s*`ask_human` call: what should change on this map\?/)
+    assert.ok(!p.includes('the whole brief'))
+  })
+
+  test('the ending has no pull request, no review and no merge — and says so', () => {
+    const p = write({ charting: true, instruction: 'x' })
+    const ending = p.slice(p.indexOf('## How this ends'))
+    assert.match(ending, /Update the map/)
+    assert.match(ending, /Never close the map/)
+    assert.match(ending, /curia refuses both/)
+    assert.ok(!/Only after the approval: merge it/.test(ending), 'the merge step leaked into a map dispatch')
+    assert.ok(!/request_review`: a summary of what you did/.test(ending), 'the review step leaked into a map dispatch')
+  })
+
+  test('the write bounds are the map and its children, and nothing on disk', () => {
+    const p = write({ charting: true, instruction: 'x' })
+    assert.match(p, /\*\*Write only:\*\* the map o\/r#147 and its child tickets/)
+    assert.match(p, /read-only checkout/)
+  })
+
+  test('an ordinary ticket prompt is untouched by any of it', () => {
+    const p = writePrompt(tmp, TICKET_ISSUE, { repo: 'o/r', wtPath: '/w/42', mapNumber: 147, type: 'wayfinder:task' })
+    const text = fs.readFileSync(p, 'utf8')
+    assert.equal(text.split('\n')[0], '/wayfinder https://github.com/o/r/issues/147 ticket #42')
+    assert.match(text, /already CLAIMED it in your name/)
+    assert.match(text, /Only after the approval: merge it/)
+    assert.ok(!text.includes('MAP DISPATCH'))
+  })
+})
+
+// ---- the ending (#149 point 3) ------------------------------------------------
+
+describe('the charting checklist', () => {
+  test('a charting worker is only ever held for report_result', () => {
+    // The state below would put THREE items on a ticket worker's checklist.
+    const state = { hasResult: false, hasCommits: true, prOpened: false, reviewApproved: false, prState: null }
+    assert.equal(outstanding({ ...state, charting: false }).length, 3)
+    assert.deepEqual(outstanding({ ...state, charting: true }), ['call `report_result` exactly once'])
+  })
+
+  test('a reported result ends both endings, whatever its status', () => {
+    assert.deepEqual(outstanding({ hasResult: true, charting: true }), [])
+    assert.deepEqual(outstanding({ hasResult: true, charting: false }), [])
+  })
+
+  test('the charting ending states no step the daemon cannot see', () => {
+    // Every `todo` is a step the Stop hook will block on, so a step with no
+    // evidence behind it would trap the worker. Only `report` has one.
+    assert.deepEqual(CHARTING_ENDING.filter((s) => s.todo).map((s) => s.key), ['report'])
+    assert.ok(ENDING.filter((s) => s.todo).length > 1, 'the ticket ending should still have several')
+  })
+})
+
+describe('report_result on a map dispatch', () => {
+  async function chartAndReport(result, deps = {}) {
+    const d = makeDispatcher(deps)
+    const reply = await d.start('147')
+    assert.match(reply, /charting worker on map/)
+    calls.length = 0
+    const text = await d.onResult('curia-147', result)
+    return { d, text }
+  }
+
+  test('it comments on the map, unassigns it, and CLOSES NOTHING', async () => {
+    const { text } = await chartAndReport({
+      ticket: '147', status: 'resolved', summary: 'graduated two fog lines into tickets',
+    })
+    assert.ok(calls.some((c) => c === 'comment o/r#147'), 'no summary comment on the map')
+    assert.ok(calls.some((c) => c === 'unclaim o/r#147'), 'the map stayed assigned')
+    assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')), 'a charting worker closed the map')
+    assert.ok(!calls.some((c) => String(c).startsWith('setBody')), 'curia wrote a Decisions-so-far line for a charting session')
+    assert.ok(!calls.includes('pushBranch') && !calls.includes('createPullRequest'), 'a charting session landed code')
+    assert.match(text, /Nothing was closed, resolved or pushed/)
+  })
+
+  test('the summary comment carries the operator\'s instruction and the model', async () => {
+    await chartAndReport({ ticket: '147', status: 'resolved', summary: 'did the thing' })
+    const body = calls.find((c) => typeof c === 'string' && c.startsWith('## Charting'))
+    assert.ok(body, 'the comment body is not a charting comment')
+    assert.match(body, /curia session `curia-147`/)
+    assert.match(body, /did the thing/)
+    assert.match(body, /opened no pull request and closed nothing/)
+  })
+
+  test('a blocked charting worker still leaves the map unassigned and says the edits stand', async () => {
+    // The half-charted map is the dangerous state: the next operator has to
+    // know that whatever it wrote is already live on the map.
+    await chartAndReport({ ticket: '147', status: 'blocked', summary: 'ran out of road on the fog section' })
+    const body = calls.find((c) => typeof c === 'string' && c.startsWith('## Charting'))
+    assert.match(body, /\*\*blocked\*\*/)
+    assert.match(body, /STANDS/)
+    assert.ok(calls.some((c) => c === 'unclaim o/r#147'))
+    assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')))
+  })
+
+  test('the finish is journalled as charting, not as a resolution', async () => {
+    await chartAndReport({ ticket: '147', status: 'resolved', summary: 's' })
+    assert.ok(events.some((e) => e.type === 'charting_finished' && e.map === '147'))
+    assert.ok(!events.some((e) => e.type === 'ticket_resolved'))
+  })
+
+  test('a worker whose record this process never held is still read as charting', async () => {
+    // The restart case: the in-memory record is gone and only the journal is
+    // left. Falling back to "ticket" here would close the map.
+    const d = makeDispatcher()
+    await d.start('147')
+    d.workers.delete('curia-147') // as a restart, or #releaseClaim, leaves it
+    calls.length = 0
+    await d.onResult('curia-147', { ticket: '147', status: 'resolved', summary: 's' })
+    assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')), 'the journal fallback lost the charting kind')
+    assert.ok(calls.some((c) => c === 'comment o/r#147'))
+  })
+})
+
+describe('the two tools a map dispatch refuses', () => {
+  test('open_pull_request is refused, and nothing is pushed', async () => {
+    const d = makeDispatcher()
+    await d.start('147')
+    calls.length = 0
+    const reply = await d.openPullRequest('curia-147', { summary: 'x' })
+    assert.match(reply, /CHARTING worker/)
+    assert.match(reply, /opens no pull request/)
+    assert.equal(calls.length, 0, 'the refusal still touched the remote')
+    assert.ok(events.some((e) => e.type === 'charting_tool_refused' && e.tool === 'open_pull_request'))
+  })
+
+  test('request_review is refused, and no gate is opened', async () => {
+    let asked = 0
+    const d = makeDispatcher()
+    d.askReview = async () => { asked += 1; return { text: 'approve', status: 'answered' } }
+    await d.start('147')
+    const r = await d.requestReview('curia-147', { summary: 'x', charting: 'y' })
+    assert.equal(r.ok, false)
+    assert.match(r.text, /no review gate/)
+    assert.equal(asked, 0, 'a review gate was opened for a map dispatch')
+  })
+
+  test('an ordinary ticket worker reaches both as before', async () => {
+    const d = makeDispatcher({}, { issue: TICKET_ISSUE })
+    await d.start('42')
+    const reply = await d.openPullRequest('curia-42', { summary: 'x' })
+    assert.ok(!/CHARTING/.test(reply))
+  })
+})
+
+// ---- the dispatch itself ------------------------------------------------------
+
+describe('start on a map', () => {
+  test('the map is claimed, the prompt gets the map and the instruction, and the reply says charting', async () => {
+    let prompted = null
+    const d = makeDispatcher({
+      writePrompt: (cfgDir, issue, opts) => { prompted = opts; return path.join(cfgDir, 'prompt.md') },
+    })
+    const reply = await d.start('147', { instruction: 'add a ticket for the cooling signal' })
+    assert.match(reply, /charting worker on map o\/r#147/)
+    assert.match(reply, /on \*\*opus\*\*/)
+    assert.equal(prompted.charting, true)
+    assert.equal(prompted.mapNumber, 147)
+    assert.equal(prompted.instruction, 'add a ticket for the cooling signal')
+    assert.ok(calls.includes('claim o/r#147'))
+  })
+
+  test('with no instruction the reply says the worker will ask', async () => {
+    const d = makeDispatcher()
+    const reply = await d.start('147')
+    assert.match(reply, /no instruction rode this dispatch, so it will ask what should change/)
+  })
+
+  test('the spawn is journalled with its kind and its instruction', async () => {
+    const d = makeDispatcher()
+    await d.start('147', { instruction: 'do X' })
+    const spawn = events.find((e) => e.type === 'worker_spawned')
+    assert.equal(spawn.kind, 'charting')
+    assert.equal(spawn.instruction, 'do X')
+  })
+
+  test('an instruction on a ticket is REFUSED, not dropped', async () => {
+    // Silently dropping it would steer nothing and say nothing. The ticket body
+    // is where a ticket worker's brief has to live, because other sessions read
+    // it and a spawn prompt is read once.
+    const d = makeDispatcher({}, { issue: TICKET_ISSUE })
+    const reply = await d.start('42', { instruction: 'focus on the routing part' })
+    assert.match(reply, /not a `wayfinder:map` issue/)
+    assert.equal(calls.length, 0, 'the refused dispatch still claimed the ticket')
+  })
+
+  test('a ticket dispatch is journalled as a ticket', async () => {
+    const d = makeDispatcher({}, { issue: TICKET_ISSUE })
+    await d.start('42')
+    assert.equal(events.find((e) => e.type === 'worker_spawned').kind, 'ticket')
+  })
+
+  test('a map already assigned refuses — one charting worker at a time', async () => {
+    // The map body is a read-modify-write with no compare-and-swap behind it,
+    // and the WORKER does the writing, so #withMapLock cannot serialise it.
+    // The claim is what does.
+    const d = makeDispatcher({}, { issue: { ...MAP_ISSUE, assignees: [{ login: 'me' }] } })
+    const reply = await d.start('147')
+    assert.match(reply, /already assigned/)
+  })
+})
+
+describe('resume on a map', () => {
+  test('the instruction that rode the first dispatch rides the resumed one', async () => {
+    let prompted = null
+    const d = makeDispatcher({
+      writePrompt: (cfgDir, issue, opts) => { prompted = opts; return path.join(cfgDir, 'prompt.md') },
+    })
+    await d.start('147', { instruction: 'graduate the cooling fog' })
+    d.workers.delete('curia-147')
+    prompted = null
+    await d.resume('147')
+    assert.equal(prompted.instruction, 'graduate the cooling fog', 'the resumed charting worker lost the brief')
+  })
+
+  test('a map that has since lost its label degrades instead of refusing', async () => {
+    // The operator typed no instruction on `resume`, so a refusal naming one
+    // would be a refusal for something they did not do.
+    const d = makeDispatcher()
+    await d.start('147', { instruction: 'do X' })
+    d.workers.delete('curia-147')
+    const plain = makeDispatcher({ fetchIssue: async () => ({ ...MAP_ISSUE, labels: [] }) })
+    plain.dataDir = d.dataDir
+    const reply = await plain.resume('147')
+    assert.ok(!/an instruction rides a map dispatch only/.test(reply), reply)
+  })
+})
+
+// ---- the phone's command surface ----------------------------------------------
+
+describe('the /start slash expansion', () => {
+  const interaction = (options) => ({
+    commandName: 'start',
+    options: { getString: (name) => options[name] ?? null },
+  })
+
+  test('an instruction expands to the same canonical text the overseer writes', () => {
+    assert.equal(
+      expandCommand(interaction({ ticket: '147', instruction: 'add a ticket for X' })),
+      'start 147 -- add a ticket for X',
+    )
+    assert.equal(
+      expandCommand(interaction({ ticket: '147', model: 'opus', instruction: 'add a ticket for X' })),
+      'start 147 model=opus -- add a ticket for X',
+    )
+  })
+
+  test('no instruction leaves the pre-#160 text untouched', () => {
+    // An old client-side manifest sends no such option (#65), and the dispatch
+    // must still work — the charting worker then asks what should change.
+    assert.equal(expandCommand(interaction({ ticket: '147' })), 'start 147')
+    assert.equal(expandCommand(interaction({ ticket: '147', instruction: '  ' })), 'start 147')
+  })
+
+  test('what the phone sends, the router reads back', () => {
+    const text = expandCommand(interaction({ ticket: '147', backend: 'claude', instruction: 'chart\nthe fog' }))
+    assert.deepEqual(parseCommand(text), {
+      verb: 'start', ticket: '147', backend: 'claude', instruction: 'chart the fog',
+    })
+  })
+})
+
+// ---- the comment shape --------------------------------------------------------
+
+describe('chartingComment', () => {
+  test('it is not marked as machine plumbing — it is the record of the session', () => {
+    const body = chartingComment({
+      worker: 'curia-147', model: 'opus', instruction: 'do X',
+      result: { status: 'resolved', summary: 'did X' },
+    })
+    assert.ok(!body.includes('curia:machine'))
+    assert.match(body, /> do X/)
+  })
+
+  test('no instruction is stated as such, never left blank', () => {
+    const body = chartingComment({
+      worker: 'curia-147', model: 'opus', instruction: null,
+      result: { status: 'resolved', summary: 'did X' },
+    })
+    assert.match(body, /Dispatched with no instruction/)
+  })
+})

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -25,7 +25,7 @@ import { Dispatcher } from '../src/dispatch.mjs'
 import { writePrompt } from '../src/workspace.mjs'
 import { outstanding, CHARTING_ENDING, ENDING } from '../src/lifecycle.mjs'
 import { chartingComment } from '../src/resolve.mjs'
-import { resolveModel } from '../src/routing.mjs'
+import { resolveModel, candidates, Cooling } from '../src/routing.mjs'
 import { loadRoutingConfig } from '../src/config.mjs'
 import { expandCommand } from '../src/bridge.mjs'
 import { parseCommand } from '../src/commands.mjs'
@@ -157,6 +157,17 @@ describe('a wayfinder:map row joins the routing defaults', () => {
     assert.ok(routing.defaults.map, 'routing.yaml states no map default')
     assert.equal(model, routing.defaults.map)
     assert.equal(routing.models[model].backend, 'claude', 'a map dispatch must route to the claude lane')
+  })
+
+  test('the shipped chain is the one the operator asked for on #160', () => {
+    // "fable with fallback to opus if it's at its limit. then again fallback to
+    // gpt 5.6 sol" — ruled 2026-08-03. Pinned because it is a THREE-hop
+    // transitive walk through `fallbacks`, not a list anyone can read off one
+    // row, so an edit to opus's or fable's chain can move it silently.
+    const routing = loadRoutingConfig(path.join(path.dirname(new URL(import.meta.url).pathname), '..', '..', 'config', 'routing.yaml'))
+    const chain = candidates(routing, resolveModel(routing, ['wayfinder:map'], null), new Cooling())
+    assert.deepEqual(chain.slice(0, 3), ['fable', 'opus', 'gpt'])
+    assert.equal(routing.models.gpt.id, 'gpt-5.6-sol')
   })
 
   test('a model: label on the map still beats the row', () => {

--- a/daemon/test/overseer.test.mjs
+++ b/daemon/test/overseer.test.mjs
@@ -9,6 +9,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { EscalationStore } from '../src/store.mjs'
+import { parseCommand } from '../src/commands.mjs'
 import {
   OverseerHost, canonicalFor, buildVerbTools, ALLOWED_TOOLS, DISALLOWED_TOOLS,
 } from '../src/overseer.mjs'
@@ -88,6 +89,39 @@ describe('canonicalFor', () => {
 
   test('an unknown verb throws instead of posting garbage to /command', () => {
     assert.throws(() => canonicalFor('reboot', {}))
+  })
+
+  // #160: the map instruction crosses the same canonical-text seam as every
+  // other argument, so the two ends are pinned against each other here and in
+  // commands.test.mjs.
+  test('a map instruction rides start last, after a bare --', () => {
+    assert.equal(
+      canonicalFor('start', { ticket: '147', instruction: 'update the map so that X' }),
+      'start 147 -- update the map so that X',
+    )
+    assert.equal(
+      canonicalFor('start', { ticket: '147', repo: 'cur', model: 'opus', instruction: 'add a ticket' }),
+      'start cur#147 model=opus -- add a ticket',
+    )
+  })
+
+  test('the instruction is collapsed to one line — the seam is one line of text', () => {
+    assert.equal(
+      canonicalFor('start', { ticket: '147', instruction: '  add a ticket\nthen wire it  ' }),
+      'start 147 -- add a ticket then wire it',
+    )
+  })
+
+  test('an empty instruction posts no -- at all', () => {
+    assert.equal(canonicalFor('start', { ticket: '147', instruction: '' }), 'start 147')
+    assert.equal(canonicalFor('start', { ticket: '147', instruction: '   ' }), 'start 147')
+  })
+
+  test('what canonicalFor writes, parseCommand reads back', () => {
+    const text = canonicalFor('start', { ticket: '147', model: 'opus', instruction: 'chart the fog -- all of it' })
+    assert.deepEqual(parseCommand(text), {
+      verb: 'start', ticket: '147', model: 'opus', instruction: 'chart the fog -- all of it',
+    })
   })
 })
 

--- a/docs/adr/0008-resolved-means-merged.md
+++ b/docs/adr/0008-resolved-means-merged.md
@@ -1,7 +1,7 @@
 # ADR-0008: Resolved means merged
 
 **Status**: accepted (2026-07)
-**Provenance**: [The PR gap (#48)](https://github.com/alp82/curia/issues/48), [Build the merge-gated resolution lifecycle (#54)](https://github.com/alp82/curia/issues/54)
+**Provenance**: [The PR gap (#48)](https://github.com/alp82/curia/issues/48), [Build the merge-gated resolution lifecycle (#54)](https://github.com/alp82/curia/issues/54), [Map dispatch (#160)](https://github.com/alp82/curia/issues/160)
 
 ## Context
 
@@ -18,6 +18,12 @@ The full-loop rehearsal closed a ticket and wrote its map pointer while the code
 - CI does not change the answer. Where CI exists it is evidence on the pull request, never a second authority.
 
 ## Deviations
+
+**The map dispatch (#160, deciding #149).** `start` on a map's own issue spawns a charting worker, and this ADR does not apply to it. A charting worker's output is the map itself — issue bodies and child issues, inside an ordinary worker's write bounds — so there is no branch to stage it in, nothing for a pull request to carry, and nothing for a review gate to show. It therefore never merges, never resolves, and never closes the map. It ends on two steps: edit the map, then `report_result`. Curia posts that summary as a comment on the map and unassigns it.
+
+What replaces the gate is the operator, per [#149](https://github.com/alp82/curia/issues/149): the dispatch is a deliberate act carrying their own instruction, and the map routes to the strongest claude-backend model. Two things hold the exception in place rather than leaving it to the prompt. The daemon refuses `open_pull_request` and `request_review` on a charting worker, so a worker that has misread its own kind is not one call away from pushing a branch. And the dispatch's kind is journalled at the spawn, so a restarted daemon still knows which of the two endings it is holding a worker to — reading a charting worker as a ticket one would close the map, which takes a whole effort off every frontier.
+
+The claim keeps its second meaning here: assigning the map takes nothing off a frontier, and stops a second charting worker from editing the same body under the first.
 
 The #54 sketch made the gate a bare `ask_human(approve-reject)`. It shipped as its own tool and escalation kind, `request_review`, for three reasons the plain form cannot meet: the daemon composes every link from its own records so a worker cannot forge them, the daemon can tell the gate apart from any other block, and the approval becomes a durable journal fact only the daemon can stage. The gate requires a concrete `charting` field, per [ADR-0006](0006-worker-containment-and-standing-orders.md).
 


### PR DESCRIPTION
Ticket: alp82/curia#160 — [Map dispatch: a charting worker updates the map on demand](https://github.com/alp82/curia/issues/160)

Builds the map-update path decided at #149 (points 3-5).

`start curia#<map>` on a `wayfinder:map` issue spawns a CHARTING worker: it edits the map and its child tickets, then ends. No close, no pull request, no review gate.

- **The seam**: `start <n> [model=x] [backend=y] [-- <instruction>]`. A bare `--` is the boundary, because every other argument on that seam is one whitespace-free token. The overseer `start` tool and the Discord `/start` manifest both carry the field, and `canonicalFor` → `parseCommand` round-trips.
- **The instruction rides the PROMPT**, not the worker-note queue. A note drains on the next curia tool call, and a charting worker can read the map and start editing before it makes one. With no instruction the worker's first act is an `ask_human`. An instruction on a ticket is refused with the way out, never dropped.
- **The charting ending** is a second list beside `ENDING` in lifecycle.mjs, picked by `state.charting`. Two steps: edit the map, then `report_result`. curia posts that summary as a comment on the map and unassigns it.
- **Two belts**, because reading a charting worker as a ticket one would close the map: the daemon refuses `open_pull_request` and `request_review` on a map dispatch, and the kind is journalled at the spawn so a restarted daemon still knows which ending it holds a worker to.
- **Routing**: a `map` row pinned to `fable`, per the operator's ruling on 2026-08-03 — falling back to opus, then gpt-5.6-sol, which is what `fallbacks` already gives transitively. A `model:<x>` label on the map still wins.

Recorded as a deviation inside ADR-0008 (resolved means merged), which is the ADR a map dispatch stands outside of. 34 new tests; the suite is green.

---

Dispatched by the curia daemon — session `curia-160`.

Commits (read out of git by the daemon, not reported by the worker):

- `0d3ffd7` The map row is fable, not opus (wayfinder #160)
- `6139c44` A map updates itself on demand (wayfinder #160)