### PR TITLE
The status line names the routing label, not the model (alp82/curia#179)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,12 @@ The ordered act: claim, prepare, spawn. A failure before the spawn releases the 
 **Routing rule**:
 The label-based model choice. A `model:<x>` label wins, else the `wayfinder:<type>` default table. No intelligence sits in the dispatch path. `wayfinder:map` is a row in that table like any other type.
 
+**Routing label**:
+A key under `models:` in `routing.yaml`. It is the dispatch vocabulary that `model:<x>` and `/start <ticket> <label>` speak. It is not a model: the label `gpt` names the model `gpt-5.6-sol`.
+
+**Model name**:
+What curia tells a human is running. Best evidence first: the model the transcript states, then `models.<label>.id`, then the routing label. The status line and the composer-ready message say this. Cooling, fallback and the `/workers` list keep the routing label, because they speak about dispatch.
+
 **Backend**:
 The agent CLI a worker runs under: claude or codex.
 _Avoid_: worker lane.
@@ -254,7 +260,7 @@ The timeline's refusal to send text while a native terminal dialog holds the pan
 One Discord message per worker, written by the daemon, that says what the worker is doing now. A state change reposts it at the thread bottom. Everything else edits it in place.
 
 **Meter**:
-A number the status line carries beside the state: the model, its reasoning effort, the context percent, and the account usage bars. Each meter has its own source and drops alone when that source is silent.
+A number the status line carries beside the state: the model name, its reasoning effort, the context percent, and the account usage bars. Each meter has its own source and drops alone when that source is silent. Meters drop from the tail when the line runs out of columns. The model is the exception: the escalation title is cut to keep it.
 
 **Account bars**:
 The 5-hour and 7-day usage windows. They are an account fact, not a worker fact, so every worker on a provider shows the same reading.

--- a/config/routing.yaml
+++ b/config/routing.yaml
@@ -59,6 +59,8 @@ models:
     backend: claude
   # `gpt` is the label vocabulary (`model:gpt` on a ticket); `id` is what the
   # CLI is actually asked for, because `codex --model gpt` is not a model.
+  # Since #179 `id` is also what a status line calls this worker, so a human
+  # reads `gpt-5.6-sol` where the line used to say `gpt`.
   #
   # There is no plain `gpt-5.6` — the release is three models. `sol` is the
   # frontier coding one (priority 1); `terra` is the everyday one and `luna` the

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -23,7 +23,10 @@ import {
   parentNumberOf, hasLabel, findPullRequest, createPullRequest, setPullRequestBody,
   deleteRemoteBranch,
 } from './github.mjs'
-import { resolveModel, candidates, buildSpawnCmd, parseUsageLimit, parseCreditGate, carriesLimitPhrase, Cooling } from './routing.mjs'
+import {
+  resolveModel, candidates, buildSpawnCmd, spawnModelId, parseUsageLimit, parseCreditGate,
+  carriesLimitPhrase, Cooling,
+} from './routing.mjs'
 import { hasSession, listSessions, newSession, capturePane, killSession } from './tmux.mjs'
 import {
   ensureBaseClone, createWorktree, createPrivateClone, isPrivateClone, removeWorktree,
@@ -907,7 +910,12 @@ export class Dispatcher {
         const links = this.attachLinks
           ? await Promise.resolve(this.attachLinks(worker.ticket)).catch(() => null)
           : null
-        this.notify(worker.ticket, `✅ \`${worker.session}\` is at the composer on **${worker.model}**${links ? '' : ` — \`/attach ${worker.ticket}\` to watch`}`, links ? { links } : {})
+        // The MODEL, not the routing label (#179). `worker.model` is the key in
+        // `routing.yaml`, so this message said `gpt` about a `gpt-5.6-sol`
+        // worker. There is no transcript yet, so the name the CLI was asked for
+        // is the best evidence there is.
+        const named = spawnModelId(this.routing, worker.model)
+        this.notify(worker.ticket, `✅ \`${worker.session}\` is at the composer on **${named}**${links ? '' : ` — \`/attach ${worker.ticket}\` to watch`}`, links ? { links } : {})
         return
       }
     }

--- a/daemon/src/routing.mjs
+++ b/daemon/src/routing.mjs
@@ -96,6 +96,9 @@ export const SAFE_SUBSTITUTION = /^[A-Za-z0-9._/-]+$/
 // broke that assumption: `model:gpt` is the label a human writes and
 // `codex --model gpt` is not a model. `models.<name>.id` is the CLI's name, and
 // the routing name stays the label vocabulary.
+//
+// It is also the best name a HUMAN has for the model before the first turn
+// lands (#179). A line that says what is running says this, not the label.
 export function spawnModelId(routing, model) {
   return routing.models?.[model]?.id ?? model
 }

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -36,10 +36,16 @@ export const GROUP_SEP = ' · '
 //
 // Set against the two real shapes. A full working line measures 86 columns and
 // always survives whole. A `waiting` line carrying an 80-character escalation
-// title starts at 116, so it keeps the model and the context and loses the
-// usage bars — which is the right thing to lose, because a worker blocked on a
-// question is burning no quota at all.
+// title starts near 116, so it loses the usage bars — which is the right thing
+// to lose, because a worker blocked on a question is burning no quota at all.
+//
+// The model is the exception, and #179 made it one. See #fit below: the title
+// yields columns to the model rather than the other way round.
 export const LINE_BUDGET = 130
+
+// The narrowest an escalation title may be cut to buy columns for the model
+// (#179). Below this a title stops being a title, and no meter is worth that.
+export const TITLE_FLOOR = 24
 
 // What the line costs a reader, not what it costs a string. Markdown syntax
 // renders to nothing, and an emoji renders about two columns wide, so
@@ -173,10 +179,13 @@ export class StatusLine {
   // state now, so it reads once, in one place, beside the effort it was picked
   // with. `dispatched` keeps it inline — there is no transcript yet, so the
   // model IS the dispatch news.
-  #base(session, state, detail) {
+  //
+  // `model` is what the meters call the model (#179), not the routing label the
+  // event carried — one line must not name the same thing two ways.
+  #base(session, state, detail, model) {
     switch (state) {
       case 'dispatched':
-        return `⚙️ \`${session}\`${GROUP_SEP}dispatched on **${detail.model}** — waiting for the composer`
+        return `⚙️ \`${session}\`${GROUP_SEP}dispatched on **${model}** — waiting for the composer`
       case 'working':
         return `▶️ \`${session}\`${GROUP_SEP}working`
       case 'stalled':
@@ -205,19 +214,48 @@ export class StatusLine {
     }
   }
 
+  // The base, cut so that the most valuable meter still fits (#179). #146
+  // appended meters to a finished base and stopped at the first one too wide,
+  // so a long escalation title pushed the MODEL group — first in value order —
+  // off the line, and every meter behind it went too. A `waiting` line then
+  // said nothing at all about the model, which is the one fact this surface
+  // exists to carry.
+  //
+  // So the base yields instead. The escalation title is the only part of any
+  // base that grows, and it is already a cut of a longer prompt, so cutting it
+  // a little further costs less than losing the model. Two guards keep the
+  // trade honest: the title never goes below TITLE_FLOOR, and a title that
+  // cannot reach that width is left whole and the meter drops as before.
+  #fit(session, state, detail, model, parts) {
+    const base = this.#base(session, state, detail, model)
+    const title = detail.esc?.title
+    if (!parts.length || !title) return base
+    const room = LINE_BUDGET - visibleWidth(`${GROUP_SEP}${parts[0]}`)
+    if (visibleWidth(base) <= room) return base
+    // One column of the allowance pays for the ellipsis promptTitle appends.
+    const max = title.length - (visibleWidth(base) - room) - 1
+    if (max < TITLE_FLOOR) return base
+    const esc = { ...detail.esc, title: promptTitle(title, max) }
+    return this.#base(session, state, { ...detail, esc }, model)
+  }
+
   #text(session, state, detail, model) {
-    const base = this.#base(session, state, detail)
-    if (!METERED.has(state)) return base
+    if (!METERED.has(state)) return this.#base(session, state, detail, model)
     let parts
+    let named = model
     try {
-      parts = meterParts(this.meters(session, model))
+      const m = this.meters(session, model)
+      // What the meters call the model wins over the routing label the event
+      // carried, on the meter run AND in the base sentence (#179).
+      named = m?.model ?? model
+      parts = meterParts(m)
     } catch (e) {
       this.log(`status line meters for ${session} failed: ${e.message}`)
-      return base
+      return this.#base(session, state, detail, model)
     }
     // `dispatched` already names the model in its own sentence.
-    if (state === 'dispatched') parts = parts.filter((p) => !p.startsWith(`**${model}**`))
-    let text = base
+    if (state === 'dispatched') parts = parts.filter((p) => !p.startsWith(`**${named}**`))
+    let text = this.#fit(session, state, detail, named, parts)
     for (const part of parts) {
       const next = `${text}${GROUP_SEP}${part}`
       if (visibleWidth(next) > LINE_BUDGET) break // value order: the tail goes first

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -599,17 +599,48 @@ export function bar(pct, elapsedPct = null, width = BAR_WIDTH) {
   return clock >= width ? `${out}┃` : out
 }
 
+// What a line a human reads CALLS the model (#179). #146 rendered the routing
+// label, which is the key in `routing.yaml` and not a model at all. On the
+// claude lane the key `opus` reads like one and hid the mismatch. On the codex
+// lane the key is `gpt` while the model is `gpt-5.6-sol`, so the status line
+// said `gpt` about a Sol 5.6 worker.
+//
+// Three sources, best evidence first — the same order #178 settled for the
+// context denominator, because it is the same question asked about the same
+// fact:
+//
+//   1. what the transcript states about ITSELF: the concrete id the CLI
+//      resolved (`claude-opus-5`). An alias that moves under us corrects
+//      itself on the next turn.
+//   2. `models.<label>.id`: the name the CLI was ASKED for. This is the codex
+//      lane's whole fault, and `id` was already sitting beside the label.
+//   3. the routing label. Last resort, for a lane that states neither — which
+//      is the claude lane before its first turn lands. `opus` is an alias the
+//      CLI accepts, and pinning an `id` there would undo the alias-following
+//      #178 depends on, so the label stands for those first seconds.
+//
+// The label does not ride along beside the id. It is the DISPATCH vocabulary
+// (`model:gpt`, `/start 179 opus`) and the surfaces that speak it — cooling,
+// fallback, the `/workers` list — go on saying it. The status line answers
+// "what is running", and one name for that is the point.
+export function modelName(model, spec, stated = null) {
+  return stated ?? spec?.id ?? model ?? null
+}
+
 // Everything the status line can say about one worker beyond its state. Every
 // field is independently nullable — a missing source drops its meter, never the
 // line.
 export function workerMeters({ backend, cfgDir, model, routing, account, models, now = Date.now() }) {
   const spec = routing?.models?.[model] ?? null
   const out = {
-    model: model ?? null, effort: spec?.reasoning_effort ?? null, ctxPct: null, ctxOver: false, windows: null,
+    model: modelName(model, spec), effort: spec?.reasoning_effort ?? null, ctxPct: null, ctxOver: false, windows: null,
   }
   if (!backend || !cfgDir) return out
 
   const { ctx, windows } = readTranscriptMeters(backend, findTranscript(backend, cfgDir), now)
+  // The transcript's own word beats the config's, exactly as it does for the
+  // window on the line below.
+  out.model = modelName(model, spec, ctx?.model)
   // Best evidence first (#178). What the transcript states about ITSELF beats
   // what the API says about the model, which beats what a human wrote in a file
   // months ago and cannot be corrected by anything.

--- a/daemon/test/statusline.test.mjs
+++ b/daemon/test/statusline.test.mjs
@@ -36,6 +36,10 @@ describe('StatusLine', () => {
       // The meter source the daemon injects (#146). Fed by hand here so the
       // suite never reads a transcript or an account cache; `meters` returns
       // the model the line was told about, plus whatever the tests set.
+      //
+      // The label passes straight through, which is workerMeters' last-resort
+      // branch (#179): a lane that states no model of its own keeps its routing
+      // label. The test below covers the branch where the two differ.
       meters: (session, model) => ({ model, ...meters }),
     })
   })
@@ -217,10 +221,34 @@ describe('StatusLine', () => {
     assert.equal(posts.at(-1).text, `▶️ \`curia-6\`${GROUP_SEP}working`)
   })
 
-  test('the state and the escalation title win over the meters when the line runs long', async () => {
-    // A waiting line carrying a full-length title starts at 116 columns, so it
-    // keeps the model and the context and loses the usage bars — the right
-    // thing to lose, because a worker blocked on a question burns no quota.
+  test('the base sentence names the MODEL the meters state, not the routing label (#179)', async () => {
+    // The codex lane's fault: the label is `gpt` and the model is
+    // `gpt-5.6-sol`. The dispatched sentence and the meter run are one line, so
+    // both take their name from the same place — and the name arrives once.
+    const l = new StatusLine({
+      post: async (ticket, text) => { posts.push({ ticket, text }); return { threadId: 't', messageId: 'm' } },
+      edit: async () => true,
+      get: () => null,
+      log: () => {},
+      meters: () => ({ model: 'gpt-5.6-sol', effort: 'high', ctxPct: 12, windows: null }),
+    })
+    l.onEvent({ type: 'worker_spawned', worker: 'curia-4', ticket: '4', model: 'gpt' })
+    await Promise.all([...l.workers.values()].map((w) => w.chain))
+    const dispatched = posts.at(-1).text
+    assert.match(dispatched, /dispatched on \*\*gpt-5\.6-sol\*\*/)
+    assert.equal(dispatched.match(/gpt-5\.6-sol/g).length, 1, 'the model arrives once')
+    assert.ok(!dispatched.includes('**gpt**'), 'the routing label never stands in for it')
+
+    l.onEvent({ type: 'worker_ready', worker: 'curia-4', ticket: '4', model: 'gpt', ts: 'T' })
+    await Promise.all([...l.workers.values()].map((w) => w.chain))
+    assert.equal(posts.at(-1).text, `▶️ \`curia-4\`${GROUP_SEP}working${GROUP_SEP}**gpt-5.6-sol** high${GROUP_SEP}ctx 12%`)
+  })
+
+  test('the escalation title yields columns to the model, never the other way round (#179)', async () => {
+    // #146 appended meters to a finished base and stopped at the first one too
+    // wide, so a full-length title pushed the model — first in value order —
+    // off the line, and every meter behind it too. The line then said nothing
+    // at all about the model. Now the title takes the cut instead.
     meters = {
       effort: 'high',
       ctxPct: 41,
@@ -232,10 +260,37 @@ describe('StatusLine', () => {
     line.onEvent({ type: 'esc_open', id: 'esc-9', worker: 'curia-8', ticket: '8', kind: 'choice', prompt: title, ts: new Date().toISOString() })
     await drain()
     const text = posts.at(-1).text
-    assert.ok(text.includes(title), 'the escalation title survives whole')
     assert.ok(visibleWidth(text) <= LINE_BUDGET, `${visibleWidth(text)} columns is over the ${LINE_BUDGET} budget`)
-    assert.ok(!text.includes('5h') && !text.includes('7d'), 'the bars go')
-    assert.ok(!text.includes('**gpt**'), 'a maximal title leaves room for nothing else')
+    assert.ok(text.includes('**gpt** high'), 'the model survives the longest title there is')
+    assert.ok(text.includes('Which of these seven candidate shades'), 'and the title still reads as one')
+    assert.ok(text.includes('…'), 'it paid for the model in its own tail')
+    assert.ok(!text.includes('5h') && !text.includes('7d'), 'the bars still go — a blocked worker burns no quota')
+  })
+
+  test('a title that cannot reach the floor is left whole and the meter drops (#179)', async () => {
+    // The trade has a bottom. Below TITLE_FLOOR a title stops being a title, so
+    // a base with no columns to spare keeps its words and loses the meter —
+    // which is #146's behaviour, held as the floor case rather than the rule.
+    //
+    // No model name is 70 columns wide, and with a title capped at 80 no real
+    // line reaches this floor today. The guard is for the day LINE_BUDGET drops
+    // or a meter grows, so the probe drives it directly.
+    const WIDE = 'wide-'.repeat(14)
+    const l = new StatusLine({
+      post: async (ticket, text) => { posts.push({ ticket, text }); return { threadId: 't', messageId: 'm' } },
+      edit: async () => true,
+      get: (id) => records.get(id),
+      log: () => {},
+      meters: () => ({ model: WIDE, effort: null, ctxPct: null, windows: null }),
+    })
+    const title = 'Which of these seven candidate shades of blue should the launch banner use'
+    records.set('esc-7', { id: 'esc-7', worker: 'curia-7', ticket: '7', kind: 'choice' })
+    l.onEvent({ type: 'esc_open', id: 'esc-7', worker: 'curia-7', ticket: '7', kind: 'choice', prompt: title, ts: 'T' })
+    await Promise.all([...l.workers.values()].map((w) => w.chain))
+    const text = posts.at(-1).text
+    assert.ok(text.includes(title), 'the title survives whole')
+    assert.ok(!text.includes(WIDE), 'and the meter is what goes')
+    assert.ok(visibleWidth(text) <= LINE_BUDGET, `${visibleWidth(text)} columns is over the ${LINE_BUDGET} budget`)
   })
 
   test('the meters degrade one at a time, tail first, as the base grows', async () => {
@@ -267,10 +322,9 @@ describe('StatusLine', () => {
       kept.push(survivors.length)
     }
     assert.equal(kept[0], ORDER.length, 'a short title keeps every meter')
-    // promptTitle caps a title at 80 chars, cutting at a word boundary, which
-    // bounds how long the base can get. So there IS a floor, and the model —
-    // the most valuable meter — is always above it.
-    assert.ok(kept.at(-1) >= 1, 'the model survives even the longest title')
+    // The model is not one of the things a long title can cost (#179): the
+    // title gives up columns for it first. Every step keeps at least the model.
+    assert.ok(kept.every((k) => k >= 1), `a step lost the model: ${kept.join(',')}`)
     assert.ok(kept.at(-1) < ORDER.length, 'and a long title does cost meters')
     for (let i = 1; i < kept.length; i += 1) {
       assert.ok(kept[i] <= kept[i - 1], `a longer title kept MORE meters: ${kept.join(',')}`)

--- a/daemon/test/usage.test.mjs
+++ b/daemon/test/usage.test.mjs
@@ -25,7 +25,7 @@ import os from 'node:os'
 import path from 'node:path'
 import {
   AccountUsage, ModelWindows, accountWindows, bar, meterParts, paceMark, paceOf, payloadFromHeaders,
-  readTranscriptMeters, windowFromModel, windowLabel, workerMeters,
+  readTranscriptMeters, modelName, windowFromModel, windowLabel, workerMeters,
   USAGE_ATTEMPT_MS, USAGE_STALE_MS, WINDOW_STALE_MS,
 } from '../src/usage.mjs'
 
@@ -292,7 +292,9 @@ describe('workerMeters', () => {
     models: {
       opus: { provider: 'anthropic', backend: 'claude' },
       stale: { provider: 'anthropic', backend: 'claude', context_window: 200000 },
-      gpt: { provider: 'openai', backend: 'codex', reasoning_effort: 'high', context_window: 258400 },
+      // The shape routing.yaml actually carries: the key is the routing label
+      // and `id` is the model. #179 is about which of the two a human sees.
+      gpt: { provider: 'openai', backend: 'codex', id: 'gpt-5.6-sol', reasoning_effort: 'high', context_window: 258400 },
     },
   }
   // The live lookup, stubbed at the shape workerMeters uses it through. The
@@ -348,7 +350,27 @@ describe('workerMeters', () => {
       backend: 'claude', cfgDir: d, model: 'opus', routing, account: null, models: lookup({}), now: NOW,
     })
     assert.equal(m.ctxPct, null)
-    assert.equal(m.model, 'opus')
+    // A window it cannot find costs the context figure and nothing else — the
+    // transcript still named the model, so the model meter stands.
+    assert.equal(m.model, 'claude-opus-5')
+  })
+
+  test('the meter names the MODEL, not the routing label (#179)', () => {
+    // Three sources, best evidence first. The claude lane states its own model
+    // on every turn, so the label `opus` gives way to what actually ran.
+    const d = cfgDir()
+    write(path.join('cfg', 'curia-1', 'projects', 'p', 'run.jsonl'), [claudeTurn(2, 79998, 0)])
+    const m = workerMeters({
+      backend: 'claude', cfgDir: d, model: 'opus', routing, account: null, models: lookup({}), now: NOW,
+    })
+    assert.equal(m.model, 'claude-opus-5')
+    // And the codex lane states none, so `models.gpt.id` answers instead. This
+    // is the fault #179 was raised on: `gpt` about a Sol 5.6 worker.
+    assert.equal(modelName('gpt', routing.models.gpt), 'gpt-5.6-sol')
+    // Last resort: a lane that states neither keeps the label. The claude lane
+    // sits here for its first seconds, which is why no `id` is pinned for it.
+    assert.equal(modelName('opus', routing.models.opus), 'opus')
+    assert.equal(modelName(null, null), null)
   })
 
   test('an over-window request is reported at its real size, never clamped', () => {
@@ -376,13 +398,14 @@ describe('workerMeters', () => {
     const account = { windows: () => { throw new Error('must not be called') } }
     const m = workerMeters({ backend: 'codex', cfgDir: d, model: 'gpt', routing, account, now: NOW })
     assert.equal(m.ctxPct, 50)
+    assert.equal(m.model, 'gpt-5.6-sol')
     assert.equal(m.effort, 'high')
     assert.deepEqual(m.windows, [{ label: '5h', pct: 3, elapsedPct: 50 }])
   })
 
   test('the effort and the model survive a worker with no transcript yet', () => {
     const m = workerMeters({ backend: 'codex', cfgDir: cfgDir(), model: 'gpt', routing, account: null, now: NOW })
-    assert.deepEqual(m, { model: 'gpt', effort: 'high', ctxPct: null, ctxOver: false, windows: null })
+    assert.deepEqual(m, { model: 'gpt-5.6-sol', effort: 'high', ctxPct: null, ctxOver: false, windows: null })
   })
 })
 

--- a/docs/research/worker-context-budget.md
+++ b/docs/research/worker-context-budget.md
@@ -114,6 +114,13 @@ one that will not fit in `LINE_BUDGET` (130 columns). A `waiting` line carrying 
 title starts near 116 columns, so the model group — first in the order — is the one that goes,
 and everything after it goes with it. The line then says nothing about the model at all.
 
+**What shipped** ([#179](https://github.com/alp82/curia/issues/179)): both. `workerMeters` now
+resolves a model NAME from three sources, best evidence first — the model the transcript states,
+then `models.<label>.id`, then the routing label. That is the same order #178 settled for the
+context denominator, asked about the same fact. The status line and the composer-ready message
+both say it. And the meter run no longer loses to the base: a `waiting` line cuts its escalation
+title far enough to keep the model, down to a floor of 24 columns.
+
 ## 4. A bounds finding, not a context one
 
 The probe's 38 MCP tools are curia's six (`ask_human`, `notify`, `open_pull_request`,


### PR DESCRIPTION
Ticket: alp82/curia#179 — [The status line names the routing label, not the model](https://github.com/alp82/curia/issues/179)

Fixes both faults #166 found in the #146 meters.

**The label stood in for the model.** `meterParts` rendered the key in `routing.yaml`, so a Sol 5.6 worker on the codex lane was called `gpt` on the status line and in the composer-ready message. `workerMeters` now resolves a model NAME from three sources, best evidence first: the model the transcript states (`claude-opus-5`), then `models.<label>.id` (`gpt-5.6-sol`), then the routing label. That is the order #178 settled for the context denominator, asked about the same fact. The operator picked this shape over a config `display:` field and over showing both.

The label stays the dispatch vocabulary. Cooling, fallback and the `/workers` list go on speaking it, because they speak about dispatch and `/start 179 opus` has to keep working.

**The model dropped off long lines.** `#text` appended meters in value order and stopped at the first one too wide for `LINE_BUDGET`, so a long escalation title pushed the model group off and every meter behind it too. The base yields columns now: a `waiting` line cuts its title far enough to keep the model, down to a floor of 24 columns. Below that the title is left whole and the meter drops, which is #146's behavior held as the floor case rather than the rule.

Before, and the line says nothing about the model at all:

    waiting on [esc-9] - Which of these seven candidate shades of blue should the launch banner use - 1 h 05 min

After:

    waiting on [esc-9] - Which of these seven candidate shades of blue should the... - 1 h 05 min - gpt-5.6-sol high

Tests: 248 pass across statusline, usage, dispatch and routing. The full suite matches the baseline failure set on a clean tree exactly - 14 real-boot and config tests that need docker and network in this container.

Docs: CONTEXT.md gains `Routing label` and `Model name`, and the research doc gets its "What shipped" note beside the fault it recorded.

---

Dispatched by the curia daemon — session `curia-179`.

Commits (read out of git by the daemon, not reported by the worker):

- `c94ee59` The status line names the model, not the routing label (wayfinder #179)