### PR TITLE
Codex cooling waits blind while the reset sits in its transcript (alp82/curia#175)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,6 +91,9 @@ _Avoid_: worker lane.
 **Cooling**:
 A temporary hold on a model or provider after a usage-limit signal, until the stated reset.
 
+**Stated reset**:
+The instant a cooling ends. Two surfaces state it, and curia reads both: the anthropic pane text carries an epoch beside the reached-text, and the codex transcript carries `resets_at` beside the rate-limit window that is spent. A cap is account-level, so any live worker on that provider states it for the lane. With neither surface stating one, cooling holds for one hour.
+
 **Exhaustion**:
 The state where every candidate model is cooling. The frontier stays the queue, and a wake timer fires at the earliest reset.
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -36,6 +36,7 @@ import {
   untrustedProjectConfig,
 } from './workspace.mjs'
 import { ensureWorkerImage } from './image.mjs'
+import { transcriptReset } from './usage.mjs'
 import { mintWorkerToken, forgetWorkerToken, sweepWorkerTokens } from './workertoken.mjs'
 import {
   GUEST_WT, GUEST_CFG, GUEST_DAEMON_HOST, ENV_FILE, PORTS_PER_WORKER,
@@ -946,19 +947,47 @@ export class Dispatcher {
     this.notify(worker.ticket, `⚠️ \`${worker.session}\` ${headline}${ignored} — session and claim kept for inspection (\`/attach ${worker.ticket}\`)${why}`)
   }
 
+  // When does this cooling end? Two lanes state it in two places, so both are
+  // read, best evidence first (#175):
+  //
+  //   pane        the anthropic lane puts an epoch on the reached-text itself,
+  //               and parseUsageLimit has already taken it.
+  //   transcript  the codex lane states none in the pane and states one in its
+  //               transcript, beside the numbers the status bars read.
+  //   the floor   neither stated one ⇒ the conservative hour, journalled
+  //               (stated deviation 2). A worker capped before its first turn
+  //               has written no transcript yet, and this is that case.
+  #resetFor(worker, limit) {
+    if (limit.resetAt) return { at: limit.resetAt, source: 'pane' }
+    // The cap is ACCOUNT-level, so the reset belongs to the PROVIDER and not to
+    // the worker that ran into it. Every live worker on this provider reads the
+    // same account, and the one that just spawned is the one least likely to
+    // have written a reading — so its siblings are asked too, and the latest
+    // stated reset wins for the reason spentReset takes the latest slot.
+    let best = null
+    const read = new Set()
+    for (const w of [worker, ...this.workers.values()]) {
+      if (w.provider !== worker.provider || !w.backend || !w.cfgDir || read.has(w.cfgDir)) continue
+      read.add(w.cfgDir)
+      const at = transcriptReset(w.backend, w.cfgDir)
+      if (at && (!best || at > best)) best = at
+    }
+    if (best) return { at: best, source: 'transcript' }
+    return { at: new Date(Date.now() + 3600_000), source: 'floor' }
+  }
+
   async #handleLimit(worker, limit) {
-    // Unparseable reset ⇒ journalled conservative 1 h cooldown (stated deviation 2).
-    const resetAt = limit.resetAt ?? new Date(Date.now() + 3600_000)
-    if (!limit.resetAt) {
+    const { at: resetAt, source } = this.#resetFor(worker, limit)
+    if (source === 'floor') {
       this.store.logEvent('reset_unparseable', { worker: worker.session, scope: limit.scope, applied_cooldown_h: 1 })
     }
     if (limit.scope === 'model') {
       // Fable's own weekly sub-cap: cool only the model, provider stays warm.
       this.cooling.coolModel(worker.model, resetAt)
-      this.store.logEvent('model_cooling', { model: worker.model, reset_at: resetAt.toISOString() })
+      this.store.logEvent('model_cooling', { model: worker.model, reset_at: resetAt.toISOString(), reset_source: source })
     } else {
       this.cooling.coolProvider(worker.provider, resetAt)
-      this.store.logEvent('provider_cooling', { provider: worker.provider, reset_at: resetAt.toISOString() })
+      this.store.logEvent('provider_cooling', { provider: worker.provider, reset_at: resetAt.toISOString(), reset_source: source })
     }
     await this.deps.killSession(worker.session).catch(() => {})
 

--- a/daemon/src/routing.mjs
+++ b/daemon/src/routing.mjs
@@ -148,7 +148,9 @@ export const LIMIT_PATTERNS = {
   // weekly, 5-hour, monthly and annual limits and no per-model sub-cap — so the
   // scope is always 'provider' and the chain crosses to the other provider.
   // No reset pattern: codex states no reset time in any of these messages, so
-  // resetAt stays null and the caller applies its conservative cooldown.
+  // resetAt stays null HERE. It is not unknown, though — this lane states the
+  // instant in its transcript, and #handleLimit reads it there (#175). What
+  // stays conservative is the case neither surface states: an hour.
   openai: {
     reached: new RegExp(
       `you${AP}ve (?:hit|reached) your (?:usage limit|workspace credit limit)`

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -85,6 +85,14 @@
 //
 // The read path costs nothing and always runs; the probe is what
 // `usage.account_bars` turns off.
+//
+// THE COOLING PATH READS THE SAME LINE (#175). A codex cap hit cooled a blind
+// hour, because the codex CLI states no reset instant in the pane text the
+// limit classifier reads (`LIMIT_PATTERNS.openai.reset` is null). It states one
+// in the transcript: `resets_at`, beside every `rate_limits` slot, which is the
+// field these bars already take their pace from. `transcriptReset` is that same
+// reading asked a different question — not "how far through the window are we"
+// but "when does the window that is SPENT roll".
 
 import crypto from 'node:crypto'
 import fs from 'node:fs'
@@ -162,9 +170,17 @@ function claudeTail(lines) {
       + (u.cache_creation_input_tokens ?? 0)
     if (!tokens) continue
     const model = typeof e.message.model === 'string' ? e.message.model : null
-    return { ctx: { tokens, window: null, model }, windows: null }
+    return { ctx: { tokens, window: null, model }, windows: null, limits: null }
   }
-  return { ctx: null, windows: null }
+  return { ctx: null, windows: null, limits: null }
+}
+
+// A reset instant in either lane's vocabulary, as epoch milliseconds. The codex
+// lane states epoch seconds and the anthropic one an ISO string; both are
+// absolute, so a stale reading still dates itself correctly. NaN when nothing
+// usable is stated, which every caller checks with Number.isFinite.
+function resetMs(resetsAt) {
+  return typeof resetsAt === 'number' ? resetsAt * 1000 : Date.parse(resetsAt ?? '')
 }
 
 // How far into a usage window the clock has got, 0-100 — the second number
@@ -179,7 +195,7 @@ function claudeTail(lines) {
 //   {expired: true}    the window already reset, so the percentage beside it
 //                      belongs to a window that no longer exists. Drop it.
 export function paceOf(resetsAt, windowMs, now = Date.now()) {
-  const at = typeof resetsAt === 'number' ? resetsAt * 1000 : Date.parse(resetsAt ?? '')
+  const at = resetMs(resetsAt)
   if (!Number.isFinite(at) || !Number.isFinite(windowMs) || windowMs <= 0) return { elapsedPct: null }
   const remaining = at - now
   if (remaining <= 0) return { expired: true }
@@ -198,13 +214,31 @@ export function windowLabel(minutes) {
   return `${Math.round(minutes / 60)}h`
 }
 
+// The bars, from the raw slot readings. A worker that has been idle for hours
+// may hold a reading whose window has since reset. The percentage beside it is
+// then about a window that no longer exists, so the entry goes rather than
+// lying.
+function barsOf(limits, now) {
+  const found = []
+  for (const l of limits ?? []) {
+    const pace = paceOf(l.resetsAt, l.windowMs, now)
+    if (pace.expired) continue
+    found.push({ label: l.label, pct: Math.round(l.usedPct), elapsedPct: pace.elapsedPct })
+  }
+  return found.length ? found : null
+}
+
 // The codex lane states all three numbers itself, on the `token_count` event it
 // writes after every turn: the last request's input tokens, the model's own
 // context window, and the account rate limits. Context and limits are taken
 // from the newest line that carries each — not every token_count carries both.
+//
+// `limits` is the slot reading itself, kept beside the bars it renders (#175):
+// the bars round the percentage and drop an expired window, and the cooling
+// path needs both of those facts unrounded and undropped.
 function codexTail(lines, now) {
   let ctx = null
-  let windows = null
+  let limits = null
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     const line = lines[i]
     if (!line.includes('"token_count"')) continue
@@ -218,34 +252,79 @@ function codexTail(lines, now) {
         ctx = { tokens, window: p.info?.model_context_window ?? null }
       }
     }
-    if (!windows) {
+    if (!limits) {
       const found = []
       for (const slot of ['primary', 'secondary']) {
         const r = p.rate_limits?.[slot]
         if (!r || !Number.isFinite(r.used_percent)) continue
         const label = windowLabel(r.window_minutes)
         if (!label) continue
-        // A worker that has been idle for hours may hold a reading whose window
-        // has since reset. The percentage beside it is then about a window that
-        // no longer exists, so the entry goes rather than lying.
-        const pace = paceOf(r.resets_at, r.window_minutes * 60 * 1000, now)
-        if (pace.expired) continue
-        found.push({ label, pct: Math.round(r.used_percent), elapsedPct: pace.elapsedPct })
+        found.push({
+          label, usedPct: r.used_percent, windowMs: r.window_minutes * 60 * 1000, resetsAt: r.resets_at ?? null,
+        })
       }
-      if (found.length) windows = found
+      if (found.length) limits = found
     }
-    if (ctx && windows) break
+    if (ctx && limits) break
   }
-  return { ctx, windows }
+  return { ctx, windows: barsOf(limits, now), limits }
 }
 
 const TAILS = { claude: claudeTail, codex: codexTail }
 
-// { ctx: {tokens, window} | null, windows: [{label, pct, elapsedPct}] | null }
+// { ctx: {tokens, window} | null, windows: [{label, pct, elapsedPct}] | null,
+//   limits: [{label, usedPct, windowMs, resetsAt}] | null }
 export function readTranscriptMeters(backend, file, now = Date.now()) {
   const tail = TAILS[backend]
-  if (!tail || !file) return { ctx: null, windows: null }
+  if (!tail || !file) return { ctx: null, windows: null, limits: null }
   return tail(tailLines(file), now)
+}
+
+// ---------------------------------------------------------------------------
+// the cooling reset (#175)
+// ---------------------------------------------------------------------------
+
+// A window this full is the one the cap hit. The threshold is not 100 because
+// the reading is taken at the worker's last turn and the cap is hit on the
+// next one, so the last number below the ceiling is what the transcript holds.
+export const SPENT_PCT = 95
+
+// When does the spent window roll? Null means the transcript states nothing
+// usable, and the caller keeps its conservative floor.
+//
+// Four rules, and each one keeps a wrong answer out:
+//
+//   1. Only a SPENT window counts. A window at 40% is not what the pane just
+//      refused a turn for, and cooling until its reset would wait for nothing.
+//   2. A reset already past is dropped. That window rolled; there is nothing
+//      left to wait for.
+//   3. A reset further out than its own window is not that window's reset —
+//      the same rule paceOf runs on the same field, for the same reason.
+//   4. The LATEST surviving reset wins. Two spent windows mean two caps, and
+//      waiting only for the earlier one respawns straight into the later.
+//
+// A STALE reading is still evidence, which is what makes rule 2 the only
+// freshness check needed: `resets_at` names one instant for the whole window,
+// so a reset still in the future proves the reading belongs to the window that
+// is live now — and usage inside one window never falls.
+export function spentReset(limits, now = Date.now()) {
+  let best = null
+  for (const l of limits ?? []) {
+    if (!Number.isFinite(l.usedPct) || l.usedPct < SPENT_PCT) continue
+    const at = resetMs(l.resetsAt)
+    if (!Number.isFinite(at) || at <= now || at - now > l.windowMs) continue
+    if (!best || at > best) best = at
+  }
+  return best === null ? null : new Date(best)
+}
+
+// The instant this config dir's transcript says a cap hit has to wait for.
+// Date | null. The claude lane always answers null: its transcript states no
+// rate limits anywhere, which is why its reset rides the pane text instead.
+export function transcriptReset(backend, cfgDir, now = Date.now()) {
+  if (!backend || !cfgDir) return null
+  const { limits } = readTranscriptMeters(backend, findTranscript(backend, cfgDir), now)
+  return spentReset(limits, now)
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -2286,6 +2286,105 @@ describe('dispatching across two backends (#39)', () => {
     assert.ok(events.some((e) => e.type === 'worker_spawned' && e.backend === 'claude'))
   })
 
+  // #175: the codex pane states no reset instant, so this lane cooled a blind
+  // hour. Its transcript states one, on the `token_count` event the status bars
+  // already read. The shape below is the one usage.test.mjs pins.
+  const CAP_PANE = "You've hit your usage limit. Upgrade to Plus to continue using Codex\n"
+  const HOUR = 3600_000
+
+  const writeRollout = (cfgDir, { usedPct, windowMinutes, resetsInMinutes }) => {
+    const day = path.join(cfgDir, 'sessions', '2026', '08', '03')
+    fs.mkdirSync(day, { recursive: true })
+    fs.writeFileSync(path.join(day, 'rollout-2026-08-03T11-00-00-a.jsonl'), `${JSON.stringify({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { last_token_usage: { input_tokens: 4000 }, model_context_window: 258400 },
+        rate_limits: {
+          primary: {
+            used_percent: usedPct,
+            window_minutes: windowMinutes,
+            resets_at: Math.round((Date.now() + resetsInMinutes * 60_000) / 1000),
+          },
+        },
+      },
+    })}\n`)
+  }
+
+  test('a codex cap hit cools until the reset its own transcript states', async () => {
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      // The transcript the capped worker has already written, taken at its last
+      // turn: the 5 h window is spent and states when it rolls.
+      seedConfigDir: (cfgDir, wt, s, backend) => {
+        if (backend === 'codex') writeRollout(cfgDir, { usedPct: 100, windowMinutes: 300, resetsInMinutes: 12 })
+      },
+      capturePane: async () => CAP_PANE,
+    }, { routing: TWO_LANE, readyTimeoutS: 6 })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => events.some((e) => e.type === 'provider_cooling'))
+
+    const cooled = events.find((e) => e.type === 'provider_cooling')
+    assert.equal(cooled.reset_source, 'transcript')
+    const waited = Date.parse(cooled.reset_at) - Date.now()
+    assert.ok(waited > 10 * 60_000 && waited < 14 * 60_000, `cooled for ${Math.round(waited / 60_000)} min, not the stated 12`)
+    assert.equal(events.some((e) => e.type === 'reset_unparseable'), false)
+  })
+
+  test('a worker capped before its first turn keeps the one-hour floor', async () => {
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      capturePane: async () => CAP_PANE,
+    }, { routing: TWO_LANE, readyTimeoutS: 6 })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => events.some((e) => e.type === 'provider_cooling'))
+
+    const cooled = events.find((e) => e.type === 'provider_cooling')
+    assert.equal(cooled.reset_source, 'floor')
+    assert.ok(Math.abs(Date.parse(cooled.reset_at) - (Date.now() + HOUR)) < 5000)
+    assert.ok(events.some((e) => e.type === 'reset_unparseable' && e.applied_cooldown_h === 1))
+  })
+
+  test('a window with room states nothing, so the floor stands', async () => {
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      // 41% is not what the pane just refused a turn for.
+      seedConfigDir: (cfgDir, wt, s, backend) => {
+        if (backend === 'codex') writeRollout(cfgDir, { usedPct: 41, windowMinutes: 300, resetsInMinutes: 12 })
+      },
+      capturePane: async () => CAP_PANE,
+    }, { routing: TWO_LANE, readyTimeoutS: 6 })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => events.some((e) => e.type === 'provider_cooling'))
+
+    assert.equal(events.find((e) => e.type === 'provider_cooling').reset_source, 'floor')
+  })
+
+  // The cap is account-level, so a sibling's reading is about the same account
+  // — and the worker that just spawned is the one least likely to hold one.
+  test('a sibling worker on the same provider supplies the reset', async () => {
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      capturePane: async () => CAP_PANE,
+    }, { routing: TWO_LANE, readyTimeoutS: 6 })
+
+    const siblingCfg = path.join(tmp, 'work', 'cfg', 'curia-41')
+    writeRollout(siblingCfg, { usedPct: 99.6, windowMinutes: 10080, resetsInMinutes: 300 })
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    d.workers.set('curia-41', {
+      session: 'curia-41', ticket: '41', repo: 'o/r', backend: 'codex', provider: 'openai', cfgDir: siblingCfg,
+    })
+    await waitFor(() => events.some((e) => e.type === 'provider_cooling'))
+
+    const cooled = events.find((e) => e.type === 'provider_cooling')
+    assert.equal(cooled.reset_source, 'transcript')
+    const waited = Date.parse(cooled.reset_at) - Date.now()
+    assert.ok(waited > 4 * HOUR && waited < 6 * HOUR, `cooled for ${Math.round(waited / 60_000)} min, not the stated 300`)
+  })
+
   // The codex lane spawns with hook trust bypassed, so a hook the repo carries
   // would run unreviewed with no model in the loop.
   test('a repo-planted .codex/hooks.json refuses the dispatch and releases the claim', async () => {

--- a/daemon/test/usage.test.mjs
+++ b/daemon/test/usage.test.mjs
@@ -26,6 +26,7 @@ import path from 'node:path'
 import {
   AccountUsage, ModelWindows, accountWindows, bar, meterParts, paceMark, paceOf, payloadFromHeaders,
   readTranscriptMeters, modelName, windowFromModel, windowLabel, workerMeters,
+  spentReset, transcriptReset,
   USAGE_ATTEMPT_MS, USAGE_STALE_MS, WINDOW_STALE_MS,
 } from '../src/usage.mjs'
 
@@ -177,12 +178,97 @@ describe('transcript meters', () => {
   })
 
   test('a missing, empty or unreadable transcript reads as no meters, never as a throw', () => {
-    assert.deepEqual(readTranscriptMeters('claude', null), { ctx: null, windows: null })
-    assert.deepEqual(readTranscriptMeters('claude', path.join(dir, 'nope.jsonl')), { ctx: null, windows: null })
-    assert.deepEqual(readTranscriptMeters('gemini', write('g.jsonl', [{}])), { ctx: null, windows: null })
+    const none = { ctx: null, windows: null, limits: null }
+    assert.deepEqual(readTranscriptMeters('claude', null), none)
+    assert.deepEqual(readTranscriptMeters('claude', path.join(dir, 'nope.jsonl')), none)
+    assert.deepEqual(readTranscriptMeters('gemini', write('g.jsonl', [{}])), none)
     const half = path.join(dir, 'half.jsonl')
     fs.writeFileSync(half, '{"type":"assistant","message":{"usa')
-    assert.deepEqual(readTranscriptMeters('claude', half), { ctx: null, windows: null })
+    assert.deepEqual(readTranscriptMeters('claude', half), none)
+  })
+
+  // The reading the cooling path takes (#175): the same slots the bars render,
+  // unrounded and with the expired ones still on them.
+  test('the raw slot readings ride beside the bars they render', () => {
+    const file = write('x.jsonl', [
+      codexCount({
+        input: 10,
+        window: 100,
+        primary: { used_percent: 99.4, window_minutes: 300, resets_at: resetsInSec(-30) },
+        secondary: { used_percent: 41, window_minutes: 10080, resets_at: resetsInSec(1000) },
+      }),
+    ])
+    const { windows, limits } = readTranscriptMeters('codex', file, NOW)
+    assert.deepEqual(windows, [{ label: '7d', pct: 41, elapsedPct: 90 }], 'the expired window is dropped from the bars')
+    assert.deepEqual(limits, [
+      { label: '5h', usedPct: 99.4, windowMs: 300 * MIN, resetsAt: resetsInSec(-30) },
+      { label: '7d', usedPct: 41, windowMs: 10080 * MIN, resetsAt: resetsInSec(1000) },
+    ])
+  })
+})
+
+// The instant a codex cap hit waits for, which used to be a blind hour.
+describe('the cooling reset (#175)', () => {
+  const slot = (label, usedPct, windowMinutes, resetsInMinutes) => ({
+    label, usedPct, windowMs: windowMinutes * MIN, resetsAt: resetsInSec(resetsInMinutes),
+  })
+
+  test('the spent window is the one to wait for, and a window with room is not', () => {
+    assert.deepEqual(
+      spentReset([slot('5h', 100, 300, 42), slot('7d', 41, 10080, 5000)], NOW),
+      new Date(NOW + 42 * MIN),
+    )
+    // 94% is not a cap hit. Nothing here states when this cooling ends.
+    assert.equal(spentReset([slot('5h', 94, 300, 42)], NOW), null)
+  })
+
+  test('two spent windows mean two caps, so the LATER reset wins', () => {
+    // Waiting only for the 5 h window respawns straight into the weekly one.
+    assert.deepEqual(
+      spentReset([slot('5h', 100, 300, 42), slot('7d', 99, 10080, 4000)], NOW),
+      new Date(NOW + 4000 * MIN),
+    )
+  })
+
+  test('a reset already past states nothing: that window has rolled', () => {
+    assert.equal(spentReset([slot('5h', 100, 300, -1)], NOW), null)
+  })
+
+  test('a reset further out than its own window is not that window\'s reset', () => {
+    assert.equal(spentReset([slot('5h', 100, 300, 600)], NOW), null)
+  })
+
+  test('no reading at all keeps the caller on its floor', () => {
+    assert.equal(spentReset(null, NOW), null)
+    assert.equal(spentReset([], NOW), null)
+    assert.equal(spentReset([{ label: '5h', usedPct: 100, windowMs: 300 * MIN, resetsAt: null }], NOW), null)
+  })
+
+  test('transcriptReset reads the worker config dir, and the claude lane states nothing', () => {
+    const codexDir = path.join(dir, 'cfg-codex')
+    const day = path.join(codexDir, 'sessions', '2026', '08', '03')
+    fs.mkdirSync(day, { recursive: true })
+    fs.writeFileSync(
+      path.join(day, 'rollout-2026-08-03T11-00-00-a.jsonl'),
+      JSON.stringify(codexCount({
+        input: 10,
+        window: 258400,
+        primary: { used_percent: 100, window_minutes: 300, resets_at: resetsInSec(90) },
+      })),
+    )
+    assert.deepEqual(transcriptReset('codex', codexDir, NOW), new Date(NOW + 90 * MIN))
+
+    // The claude lane states its rate limits nowhere, so its reset stays the
+    // one on the pane text — this reader must not invent one.
+    const claudeDir = path.join(dir, 'cfg-claude')
+    const proj = path.join(claudeDir, 'projects', 'p')
+    fs.mkdirSync(proj, { recursive: true })
+    fs.writeFileSync(path.join(proj, 's.jsonl'), JSON.stringify(claudeTurn(1, 100, 0)))
+    assert.equal(transcriptReset('claude', claudeDir, NOW), null)
+
+    // A worker capped before its first turn has written no transcript at all.
+    assert.equal(transcriptReset('codex', path.join(dir, 'cfg-empty'), NOW), null)
+    assert.equal(transcriptReset(null, codexDir, NOW), null)
   })
 })
 


### PR DESCRIPTION
Ticket: alp82/curia#175 — [Codex cooling waits blind while the reset sits in its transcript](https://github.com/alp82/curia/issues/175)

Codex cooling now waits until the reset its transcript states, instead of a blind hour (ticket #175, gap 6 of the codex-lane inventory).

The codex pane states no reset instant, so `LIMIT_PATTERNS.openai.reset` stays null. The transcript states one: `resets_at`, beside the `rate_limits` slot the status bars already read. The cooling path and the meter path now meet at one reader.

- `codexTail` keeps the raw slot readings (`limits`) beside the bars it renders.
- `spentReset` picks the instant to wait for: only a window at or over 95% counts, a reset already past is dropped, a reset further out than its own window is not that window's reset, and the latest survivor wins because two spent windows mean two caps.
- `#handleLimit` asks every live worker on the provider, not only the one that ran into the cap: the cap is account-level, and the worker that just spawned is the one least likely to hold a reading.
- The one-hour floor stands for a worker whose transcript states nothing yet, and it still journals `reset_unparseable`. The cooling events now carry `reset_source`: pane, transcript, or floor.
- CONTEXT.md gains the term "stated reset".

Rebuilt on main after #187 landed on the same files. One conflict, in `codexTail`: the bars roll an expired window over to a fresh one at 0% (#187), and the cooling path takes the reading as stated, so a rolled window states no cap to wait for. Both now come off one read.

11 new tests, 875 in the suite. The failure set matches the baseline on a clean tree (6 real-boot and config-path tests that need the live box).

---

Dispatched by the curia daemon — session `curia-175`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `04c1d05` Merge main: the rolled-over window meets the cooling reset
- `90ccaed` Codex cooling waits until the reset its transcript states (wayfinder #175)