### PR TITLE
The status line drops the model and the usage bars after a daemon restart (alp82/curia#187)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -263,7 +263,7 @@ One Discord message per worker, written by the daemon, that says what the worker
 A number the status line carries beside the state: the model name, its reasoning effort, the context percent, and the account usage bars. Each meter has its own source and drops alone when that source is silent. Meters drop from the tail when the line runs out of columns. The model is the exception: the escalation title is cut to keep it.
 
 **Account bars**:
-The 5-hour and 7-day usage windows. They are an account fact, not a worker fact, so every worker on a provider shows the same reading.
+The 5-hour and 7-day usage windows. They are an account fact, not a worker fact, so every worker on a provider shows the same reading. The provider follows from the worker's backend, never from the routing label: a label is a spawn-time fact and a backend has on-disk evidence. A window whose reset has passed rolls over — the bar shows the fresh window at 0%, and that reading counts as stale at once, so the next probe measures it.
 
 **Pace**:
 Usage measured against the time already gone from its window. A bar shows the window's clock as `┃` and renders spending past it as overshoot. The square before the bar states the same fact at a glance: 🟩 behind the clock, 🟨 on it, 🟥 ahead.
@@ -281,7 +281,7 @@ How full a worker's context window is. The numerator is the last request's input
 The one durable place a fact lives. GitHub holds ticket truth. The journal holds curia's events. Everything in memory is a disposable cache.
 
 **Reconcile**:
-The pass, at boot and on demand, that re-derives live state from GitHub, tmux, and the journal, and asserts the surfaces.
+The pass, at boot and on demand, that re-derives live state from GitHub, tmux, and the journal, and asserts the surfaces. A worker it re-adopts gets its spawn-time facts back from the journal: the routing label it runs on, and the backend under it.
 
 **Epoch**:
 A ticket's latest dispatch. Journal reads count only events from the latest epoch.

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -1461,6 +1461,24 @@ export class Dispatcher {
     return out
   }
 
+  // What this session was last spawned ON (#187): the routing label and the
+  // backend. Same journal reduction as #epochRepo and #epochCharting, keyed by
+  // SESSION rather than by ticket — a re-dispatch down the fallback chain
+  // writes a second `worker_spawned` for the same session, and the last one is
+  // the model that is actually running.
+  //
+  // The journal is the only source for the label. The backend has on-disk
+  // evidence too (detectBackend), but the label names a row in `routing.yaml`
+  // that nothing on disk points back to.
+  #epochSpawn(journal, session) {
+    let out = null
+    for (const ev of journal) {
+      if (ev.type !== 'worker_spawned' || ev.worker !== session) continue
+      out = { model: ev.model ?? null, backend: ev.backend ?? null }
+    }
+    return out
+  }
+
   async #resolveTicket(workerName, repo, ticket, result, w) {
     const wtPath = w?.wtPath ?? worktreePathFor(this.root, repo, ticket)
     const login = await this.deps.viewerLogin().catch(() => null)
@@ -2380,12 +2398,21 @@ export class Dispatcher {
               return []
             })
             : []
+          // #187: the model and the backend are spawn-time facts, and the
+          // journal already wrote both down. Rebuilding the record without
+          // them cost the status line two meters: no model means no routing
+          // spec, and the account bars hang off that spec. The journal is the
+          // state home for what a restart cannot re-derive, so it answers here
+          // exactly as it does for the repo and the charting kind.
+          const spawn = this.#epochSpawn(journal, session)
           this.workers.set(session, {
             // a FRESH instance id: any confirm bound before the restart lapses
             // at boot rather than matching an adopted worker it never described
             repo, ticket: n, title: issue.title, session, instance: `${session}@adopted-${Date.now()}`,
             wtPath, cfgDir: cfgDirFor(this.root, session), promptFile: path.join(cfgDirFor(this.root, session), 'prompt.md'),
-            model: null, requestedModel: null, backend: null, provider: null,
+            model: spawn?.model ?? null, requestedModel: null,
+            backend: spawn?.backend ?? null,
+            provider: this.routing.models[spawn?.model]?.provider ?? null,
             ports: ports.length ? ports : null,
             sandbox: ports.length ? 'docker' : null,
             spawnedAt: null, state: 'ready',

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -144,11 +144,16 @@ const statusLine = new StatusLine({
   log,
   // Same backend resolution the timeline uses: the dispatcher's word on what it
   // spawned, on-disk evidence for re-adopted and lab sessions.
+  //
+  // The routing label takes the same route (#187). The status line only learns
+  // it from a spawn event, so a line first drawn after a restart carries none —
+  // and the effort meter reads off the label's routing row. The dispatcher's
+  // record answers instead, which reconcile now rebuilds from the journal.
   meters: (session, model) => workerMeters({
     backend: dispatcher?.workers.get(session)?.backend
       ?? detectBackend(path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)),
     cfgDir: path.join(curiaConfig.dispatch.workspace_root, 'cfg', session),
-    model,
+    model: model ?? dispatcher?.workers.get(session)?.model ?? null,
     routing: routingConfig,
     account: accountUsage,
     models: modelWindows,

--- a/daemon/src/routing.mjs
+++ b/daemon/src/routing.mjs
@@ -103,6 +103,27 @@ export function spawnModelId(routing, model) {
   return routing.models?.[model]?.id ?? model
 }
 
+// Which provider a backend belongs to, as `routing.yaml` states it (#187).
+//
+// A provider is normally read off the routing row of the model a worker was
+// dispatched on. That row needs a label, and a label is a spawn-time fact: a
+// lab session never had one, and a re-adopted worker holds one only because the
+// journal remembered it. The backend is weaker evidence, and it survives on
+// disk (detectBackend), so it answers when the label cannot.
+//
+// Config stays the authority — no table of backends and providers is written
+// here. The answer comes from what every configured model on that backend says,
+// and only when they all say the same thing. Two providers under one backend is
+// a config a caller must not be given a guess about.
+export function providerOf(routing, backend) {
+  if (!backend) return null
+  const found = new Set()
+  for (const spec of Object.values(routing?.models ?? {})) {
+    if (spec?.backend === backend && spec.provider) found.add(spec.provider)
+  }
+  return found.size === 1 ? [...found][0] : null
+}
+
 export function buildSpawnCmd(routing, backend, model, promptFile) {
   const b = routing.backends?.[backend]
   if (!b) {

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -285,6 +285,11 @@ export class StatusLine {
     // The model is sticky: only the spawn events carry it, and every state
     // after them still wants to say which model is running. A retry down the
     // fallback chain reposts `dispatched` with the new one (#13).
+    //
+    // Sticky is not durable, and #187 measured the difference: this Map dies
+    // with the process, so a line first drawn after a restart carries no model
+    // at all. The meters callback fills that in from the dispatcher's record,
+    // which reconcile rebuilds from the journal — see index.mjs.
     if (detail.model) w.model = detail.model
     const text = this.#text(session, state, detail, w.model)
     w.chain = w.chain.then(() => this.#apply(w, text, { fresh, move })).catch((e) => {

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -7,6 +7,9 @@
 //
 //   model + effort  the routing pick and `models.<name>.reasoning_effort`.
 //                   The daemon already knows both at dispatch; nothing is read.
+//                   A DISPATCH is not a process, though — #187 measured what a
+//                   restart cost, because the label reached this function only
+//                   through memory. Reconcile now rebuilds it from the journal.
 //
 //   context %       the worker's own transcript tail, the same file the
 //                   timeline (#74) reads. Both lanes state their last request's
@@ -48,6 +51,10 @@
 //                   `rate_limits` beside every token count. The claude lane
 //                   states them nowhere: not in the transcript, and not in any
 //                   file the CLI writes on a headless box.
+//                   WHICH provider comes from the backend (#187). It used to
+//                   come from the dispatched label's routing row, which made an
+//                   account fact depend on a spawn-time one, and both bars left
+//                   the line whenever the label did.
 //
 // WHERE THE CLAUDE NUMBERS COME FROM (#162 settled this, and it is not where
 // #146 thought). `GET /api/oauth/usage` only answers a credential carrying the
@@ -91,6 +98,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { findTranscript } from './transcript.mjs'
+import { providerOf } from './routing.mjs'
 
 // A transcript grows to megabytes and only its tail carries the live numbers.
 // Generous enough that one very large final record still lands whole.
@@ -177,12 +185,21 @@ function claudeTail(lines) {
 //   {elapsedPct}       the pace signal — how far through the window we are
 //   {elapsedPct: null} no reset stated: keep the reading, show a flat bar
 //   {expired: true}    the window already reset, so the percentage beside it
-//                      belongs to a window that no longer exists. Drop it.
+//                      belongs to a window that no longer exists. Drop the
+//                      NUMBER — the caller replaces it with the fresh window
+//                      (#187), and `elapsedPct` here is that window's clock.
+//
+// The fresh window starts at the instant the old one reset, so its clock is
+// knowable while `now` is still inside it. Past that the reading is a window or
+// more behind and which window we are in is a guess, so there is no clock.
 export function paceOf(resetsAt, windowMs, now = Date.now()) {
   const at = typeof resetsAt === 'number' ? resetsAt * 1000 : Date.parse(resetsAt ?? '')
   if (!Number.isFinite(at) || !Number.isFinite(windowMs) || windowMs <= 0) return { elapsedPct: null }
   const remaining = at - now
-  if (remaining <= 0) return { expired: true }
+  if (remaining <= 0) {
+    const since = -remaining
+    return { expired: true, elapsedPct: since < windowMs ? Math.round((since / windowMs) * 100) : null }
+  }
   // A reset further out than the window itself is not this window's reset.
   if (remaining > windowMs) return { elapsedPct: null }
   return { elapsedPct: Math.max(0, Math.min(100, Math.round(((windowMs - remaining) / windowMs) * 100))) }
@@ -227,9 +244,13 @@ function codexTail(lines, now) {
         if (!label) continue
         // A worker that has been idle for hours may hold a reading whose window
         // has since reset. The percentage beside it is then about a window that
-        // no longer exists, so the entry goes rather than lying.
+        // no longer exists, so the window rolls over to a fresh one at 0% and
+        // the bar stays on the line (#187). See accountWindows.
         const pace = paceOf(r.resets_at, r.window_minutes * 60 * 1000, now)
-        if (pace.expired) continue
+        if (pace.expired) {
+          found.push({ label, pct: 0, elapsedPct: pace.elapsedPct, fresh: true })
+          continue
+        }
         found.push({ label, pct: Math.round(r.used_percent), elapsedPct: pace.elapsedPct })
       }
       if (found.length) windows = found
@@ -422,13 +443,26 @@ export function payloadFromHeaders(headers) {
   return Object.keys(out).length ? out : null
 }
 
+// A window whose reset has passed ROLLS OVER — it does not leave the line
+// (#187, and the operator settled which of the three it is). Dropping the entry
+// took the 5 h bar off every worker line after every reset, for as long as the
+// next probe took, with no sign that the number was missing rather than zero.
+//
+// So the ended window is replaced by the one that started at its reset instant:
+// a fresh window, at 0%, with its own clock running. That is what a window
+// reset means, and it is the one reading that needs no probe to be true. The
+// entry is marked `fresh` so the probe still knows to go and measure it — see
+// AccountUsage#maybeFetch.
 export function accountWindows(payload, now = Date.now()) {
   const out = []
   for (const w of ANTHROPIC_WINDOWS) {
     const v = payload?.[w.key]
     if (!Number.isFinite(v?.utilization)) continue
     const p = paceOf(v.resets_at, w.ms, now)
-    if (p.expired) continue
+    if (p.expired) {
+      out.push({ label: w.label, pct: 0, elapsedPct: p.elapsedPct, fresh: true })
+      continue
+    }
     out.push({ label: w.label, pct: Math.round(v.utilization), elapsedPct: p.elapsedPct })
   }
   return out.length ? out : null
@@ -488,7 +522,14 @@ export class AccountUsage {
   #maybeFetch(best) {
     if (this.fetching || !this.fetchImpl) return
     const now = this.now()
-    if (best && now - best.at < USAGE_STALE_MS) return
+    // A reading goes stale at USAGE_STALE_MS, and AT ONCE when one of its
+    // windows resets: that window's number ended with it, whatever the age of
+    // the file it sits in (#187). The line shows the fresh window at 0% until
+    // the probe lands, and 0% is only true for the first minutes of it, so the
+    // measurement must not wait out another half hour. The shared attempt stamp
+    // below still bounds the probe rate, so the wait is ten minutes at most.
+    const rolled = best?.windows?.some((w) => w.fresh) ?? false
+    if (best && !rolled && now - best.at < USAGE_STALE_MS) return
     // The shared throttle: whoever touched the stamp last owns this window,
     // daemon or statusline.sh.
     if (now - mtimeMs(this.stampFile) < USAGE_ATTEMPT_MS) return
@@ -658,8 +699,16 @@ export function workerMeters({ backend, cfgDir, model, routing, account, models,
   // The transcript's own limits win — they are this provider's numbers,
   // measured at the worker's last turn. Only the anthropic lane needs the
   // account reading, because its transcript states none.
+  //
+  // The provider follows from the BACKEND when there is no routing row (#187).
+  // Keying the bars on the row made them a spawn-time fact: a worker the daemon
+  // adopted after a restart lost its label, lost its row with it, and both bars
+  // left the line while `ctx` — which reads the transcript — stayed. The bars
+  // are an account fact and have nothing to do with which label was dispatched.
   if (windows) out.windows = windows
-  else if (spec?.provider === 'anthropic') out.windows = account?.windows() ?? null
+  else if ((spec?.provider ?? providerOf(routing, backend)) === 'anthropic') {
+    out.windows = account?.windows() ?? null
+  }
   return out
 }
 

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -426,6 +426,67 @@ describe('reconcile epoch scoping (criterion 7)', () => {
     assert.deepEqual(unclaimed, [])
     assert.equal(d.workers.get('curia-42').repo, 'o/r') // re-adopted instead
   })
+
+  test('a re-adopted worker gets its model and backend back from the journal (#187)', async () => {
+    // The record used to be rebuilt with every spawn-time fact missing. The
+    // status line then had no routing row for the worker, and both account
+    // bars left the line while the context figure stayed — one missing fact,
+    // two meters gone. The journal wrote the label down at spawn.
+    writeJournal([
+      { type: 'worker_spawned', repo: 'o/r', ticket: '42', worker: 'curia-42', model: 'sonnet', backend: 'claude' },
+    ])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-42'],
+      fetchIssue: async () => ({ ...assignedToMe }),
+    })
+
+    await d.reconcile({ boot: false })
+
+    const w = d.workers.get('curia-42')
+    assert.equal(w.model, 'sonnet')
+    assert.equal(w.backend, 'claude')
+    assert.equal(w.provider, 'anthropic', 'the provider follows the label, as it does at spawn')
+  })
+
+  test('a respawn down the fallback chain is what is running, so the LAST spawn wins', async () => {
+    const routing = {
+      ...ROUTING,
+      models: { sonnet: { provider: 'anthropic', backend: 'claude' }, gpt: { provider: 'openai', backend: 'codex' } },
+    }
+    writeJournal([
+      { type: 'worker_spawned', repo: 'o/r', ticket: '42', worker: 'curia-42', model: 'sonnet', backend: 'claude' },
+      { type: 'worker_spawned', repo: 'o/r', ticket: '42', worker: 'curia-42', model: 'gpt', backend: 'codex', retry_after_limit: true },
+    ])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-42'],
+      fetchIssue: async () => ({ ...assignedToMe }),
+    }, { routing })
+
+    await d.reconcile({ boot: false })
+
+    const w = d.workers.get('curia-42')
+    assert.equal(w.model, 'gpt')
+    assert.equal(w.backend, 'codex')
+    assert.equal(w.provider, 'openai')
+  })
+
+  test('a session this daemon never spawned is adopted with no model, and nothing breaks', async () => {
+    // A lab session, or a journal that no longer reaches back that far. The
+    // meters fall to their on-disk evidence — the transcript names the model
+    // and the config dir names the backend.
+    writeJournal([{ type: 'dispatch_claimed', repo: 'o/r', ticket: '42', worker: 'curia-42' }])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-42'],
+      fetchIssue: async () => ({ ...assignedToMe }),
+    })
+
+    await d.reconcile({ boot: false })
+
+    const w = d.workers.get('curia-42')
+    assert.equal(w.model, null)
+    assert.equal(w.backend, null)
+    assert.equal(w.provider, null)
+  })
 })
 
 describe('the pane is untrusted text (B6)', () => {

--- a/daemon/test/routing.test.mjs
+++ b/daemon/test/routing.test.mjs
@@ -53,7 +53,7 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { Cooling, resolveModel, candidates, buildSpawnCmd, parseUsageLimit, parseCreditGate, carriesLimitPhrase } from '../src/routing.mjs'
+import { Cooling, resolveModel, candidates, buildSpawnCmd, parseUsageLimit, parseCreditGate, carriesLimitPhrase, providerOf } from '../src/routing.mjs'
 
 const routing = {
   defaults: { grilling: 'fable', prototype: 'fable', research: 'opus', task: 'opus', untyped: 'opus' },
@@ -354,6 +354,23 @@ describe('two providers (#39, restoring #13)', () => {
     cooling.coolProvider('anthropic', new Date(Date.now() + 3600_000))
     cooling.coolProvider('openai', new Date(Date.now() + 3600_000))
     assert.deepEqual(candidates(twoLane, 'opus', cooling), [])
+  })
+
+  // #187: the status line asks which provider a worker belongs to, and the
+  // label it used to ask with is a spawn-time fact the daemon loses on a
+  // restart. The backend survives on disk, so it answers instead.
+  test('a backend states its provider, taken from the models configured on it', () => {
+    assert.equal(providerOf(twoLane, 'claude'), 'anthropic')
+    assert.equal(providerOf(twoLane, 'codex'), 'openai')
+  })
+
+  test('an unknown backend, and a backend two providers claim, answer nothing', () => {
+    assert.equal(providerOf(twoLane, 'gemini'), null)
+    assert.equal(providerOf(twoLane, null), null)
+    assert.equal(providerOf(undefined, 'claude'), null)
+    // A guess here would put one account's bars on the other account's worker.
+    const split = { models: { ...twoLane.models, other: { provider: 'openai', backend: 'claude' } } }
+    assert.equal(providerOf(split, 'claude'), null)
   })
 
   // #13's "never upgrade bulk work to fable" is structural, not remembered:

--- a/daemon/test/usage.test.mjs
+++ b/daemon/test/usage.test.mjs
@@ -86,8 +86,12 @@ describe('paceOf', () => {
 
   test('a window that already reset is expired, not 100% elapsed', () => {
     // The percentage beside it belongs to a window that no longer exists. The
-    // caller drops the reading rather than showing a full, stale bar.
-    assert.deepEqual(paceOf(resetsInSec(-1), 300 * MIN, NOW), { expired: true })
+    // caller drops that number rather than showing a full, stale bar — and the
+    // clock it gets back is the FRESH window's, one minute old (#187).
+    assert.deepEqual(paceOf(resetsInSec(-1), 300 * MIN, NOW), { expired: true, elapsedPct: 0 })
+    assert.deepEqual(paceOf(resetsInSec(-150), 300 * MIN, NOW), { expired: true, elapsedPct: 50 })
+    // A reading a whole window behind cannot say which window we are in.
+    assert.deepEqual(paceOf(resetsInSec(-300), 300 * MIN, NOW), { expired: true, elapsedPct: null })
   })
 
   test('an unstated or nonsense reset yields no pace, and keeps the reading', () => {
@@ -149,8 +153,11 @@ describe('transcript meters', () => {
     ])
   })
 
-  test('a window whose reset has passed is dropped, not shown stale', () => {
-    // An idle worker holds a reading from a window that has since reset.
+  test('a window whose reset has passed rolls over to a fresh one, and stays on the line', () => {
+    // An idle worker holds a reading from a window that has since reset. The
+    // 88% is about a window that ended, so it goes — and the window that
+    // started at that reset takes its place, 30 minutes into its five hours
+    // (#187). The bar used to leave the line instead.
     const file = write('x.jsonl', [
       codexCount({
         input: 10,
@@ -160,7 +167,24 @@ describe('transcript meters', () => {
       }),
     ])
     assert.deepEqual(readTranscriptMeters('codex', file, NOW).windows, [
+      { label: '5h', pct: 0, elapsedPct: 10, fresh: true },
       { label: '7d', pct: 41, elapsedPct: 90 },
+    ])
+  })
+
+  test('a reading a whole window behind has no clock, and says so', () => {
+    // Six hours after a five-hour window reset, WHICH window we are in is a
+    // guess. The fresh window still stands at 0%, and it renders a flat bar
+    // rather than a made-up clock position.
+    const file = write('y.jsonl', [
+      codexCount({
+        input: 10,
+        window: 100,
+        primary: { used_percent: 88, window_minutes: 300, resets_at: resetsInSec(-360) },
+      }),
+    ])
+    assert.deepEqual(readTranscriptMeters('codex', file, NOW).windows, [
+      { label: '5h', pct: 0, elapsedPct: null, fresh: true },
     ])
   })
 
@@ -403,6 +427,37 @@ describe('workerMeters', () => {
     assert.deepEqual(m.windows, [{ label: '5h', pct: 3, elapsedPct: 50 }])
   })
 
+  test('the account bars survive a worker whose routing label is gone (#187)', () => {
+    // What a daemon restart used to cost. Reconcile rebuilt a live worker with
+    // no label, so there was no routing row, so `provider` was never
+    // `anthropic` and BOTH bars left the line. `ctx` stayed, because it reads
+    // the transcript. The backend is the evidence that survives, so it names
+    // the provider now.
+    const d = cfgDir()
+    write(path.join('cfg', 'curia-1', 'projects', 'p', 'run.jsonl'), [claudeTurn(2, 399998, 0)])
+    const account = { windows: () => [{ label: '5h', pct: 18, elapsedPct: 99 }] }
+    const m = workerMeters({
+      backend: 'claude', cfgDir: d, model: null, routing, account, models: lookup({ 'claude-opus-5': 1000000 }), now: NOW,
+    })
+    assert.deepEqual(m.windows, [{ label: '5h', pct: 18, elapsedPct: 99 }])
+    assert.equal(m.model, 'claude-opus-5', 'the transcript names it, label or no label')
+    assert.equal(m.ctxPct, 40)
+  })
+
+  test('a codex worker with no label still never takes the anthropic reading', () => {
+    // The other direction of the same change: the backend decides, and this
+    // backend is not anthropic's. A transcript with no rate limits in it yet
+    // must leave the bars empty rather than borrow another account's.
+    const d = cfgDir()
+    write(path.join('cfg', 'curia-1', 'sessions', '2026', '08', '03', 'rollout-a.jsonl'), [
+      codexCount({ input: 129200, window: 258400 }),
+    ])
+    const account = { windows: () => { throw new Error('must not be called') } }
+    const m = workerMeters({ backend: 'codex', cfgDir: d, model: null, routing, account, now: NOW })
+    assert.equal(m.windows, null)
+    assert.equal(m.ctxPct, 50)
+  })
+
   test('the effort and the model survive a worker with no transcript yet', () => {
     const m = workerMeters({ backend: 'codex', cfgDir: cfgDir(), model: 'gpt', routing, account: null, now: NOW })
     assert.deepEqual(m, { model: 'gpt-5.6-sol', effort: 'high', ctxPct: null, ctxOver: false, windows: null })
@@ -410,6 +465,13 @@ describe('workerMeters', () => {
 })
 
 describe('rendering', () => {
+  // An account reading whose 5 h window reset five minutes ago, in the shape
+  // the endpoint and the response headers both state.
+  const freshFive = {
+    five_hour: { utilization: 18, resets_at: resetsInIso(-5) },
+    seven_day: { utilization: 57, resets_at: resetsInIso(10080 * 0.4) },
+  }
+
   test('the mark reads PACE, not raw usage', () => {
     // 92% spent with the window nearly over is fine; 40% spent in the first
     // hour is not. Raw usage cannot tell those apart, which is the whole reason
@@ -466,6 +528,16 @@ describe('rendering', () => {
     // broken denominator (#178).
     assert.deepEqual(meterParts({ ctxPct: 100, ctxOver: false }), ['ctx 100%'])
     assert.deepEqual(meterParts({ ctxPct: 124, ctxOver: true }), ['ctx 124% ⚠️'])
+  })
+
+  test('a window that just reset renders as a fresh one, never as an absence (#187)', () => {
+    // The reading is five minutes into a new five-hour window: nothing spent,
+    // and the clock one cell in. The bar used to leave the line entirely here,
+    // and a reader could not tell a missing number from a zero.
+    assert.deepEqual(
+      meterParts({ model: null, ctxPct: null, windows: accountWindows(freshFive, NOW) }),
+      ['**5h** 🟨 ░┃░░░░░░░░░ 0%', '**7d** 🟨 ▓▓▓▓▓▓┃░░░░ 57%'],
+    )
   })
 
   test('a window with no clock keeps its bar and loses only its mark', () => {
@@ -543,10 +615,35 @@ describe('AccountUsage', () => {
     assert.equal(new AccountUsage({ home: dir, enabled: false, now: at() }).windows(), null)
   })
 
-  test('a window that already reset is dropped from the account reading too', () => {
+  test('a window that already reset rolls over on the account reading too', () => {
+    // #187: every 5 h reset used to take this bar off every worker line, for as
+    // long as the next probe took. Five minutes past the reset the window is
+    // five minutes old and empty, which is 2% of its clock and 0% spent.
     assert.deepEqual(accountWindows(payload(18, 57, { fiveIn: -5 }), NOW), [
+      { label: '5h', pct: 0, elapsedPct: 2, fresh: true },
       { label: '7d', pct: 57, elapsedPct: 60 },
     ])
+  })
+
+  test('a reset window makes its reading stale at once, whatever the file says', async () => {
+    // The old gate asked only how OLD the reading was, so a five-minute-old
+    // file whose 5 h window had just reset waited out USAGE_STALE_MS before
+    // anyone asked for a replacement (#187). The shared attempt stamp still
+    // bounds the probe rate — that lock is about spending quota, and it stands.
+    home()
+    creds('tok-1')
+    cache(payload(18, 57, { fiveIn: -5 }))
+    let calls = 0
+    const u = new AccountUsage({
+      home: dir,
+      now: at(),
+      env: env(),
+      fetchImpl: async () => { calls += 1; return { ok: true, status: 200, headers: limitHeaders(4, 58) } },
+    })
+    assert.deepEqual(u.windows().map((w) => w.pct), [0, 57], 'the fresh window serves while the probe runs')
+    await u.pending
+    assert.equal(calls, 1)
+    assert.deepEqual(u.windows().map((w) => w.pct), [4, 58])
   })
 
   test('a fresh reading is never refetched', () => {


### PR DESCRIPTION
Ticket: alp82/curia#187 — [The status line drops the model and the usage bars after a daemon restart](https://github.com/alp82/curia/issues/187)

Fixes #187 — the status line dropped the model and both usage bars after a daemon restart.

**The fault.** The model reached the status line only through memory. A line first drawn after a restart carried none, so there was no routing row, so `spec?.provider === 'anthropic'` was false and the account reading was never asked for. One missing fact removed two meters. The context figure survived because it reads the transcript.

**What changed.**

1. Reconcile rebuilds a re-adopted worker with the model and the backend from the journal's last `worker_spawned` for that session. A respawn down the fallback chain is what shows. The status line's meters callback reads that record when its own event carried no model.
2. The account bars key off the provider of the backend, not the routing row. `providerOf` reads the provider from the models configured on that backend, and answers nothing when two providers claim one backend.
3. A window whose reset has passed rolls over to a fresh window at 0%, with its own clock. It also counts as stale at once, so the next probe measures it inside the shared ten-minute attempt stamp. The 5h bar used to leave every worker line for up to forty minutes after each reset. The operator picked this over a pending mark and over the last reading shown stale.

**Evidence.** 258 tests pass across usage, statusline, routing and dispatch. The full suite matches the baseline failure set on a clean tree (10 real-boot and socket tests that fail without my changes too). `CONTEXT.md` updates Account bars and Reconcile.

---

Dispatched by the curia daemon — session `curia-187`, model `opus`.

Commits (read out of git by the daemon, not reported by the worker):

- `3810f33` The status line keeps its model and its bars across a restart (wayfinder #187)