### PR TITLE
Bring the README into line with the page (alp82/curia#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Curia watches your GitHub issues, sends a coding agent at the ones that are read
 everything that needs you — a question, a preview, an approval — to whatever device you are holding.
 Your box, your subscription, your repos.
 
+The page is <https://curia.sh>. It makes the same promise to a reader who has not cloned anything
+yet. This file sets curia up on your machine, and shows you around the code.
+
 ## What it does
 
 - Reads what is takeable across every watched repo, in dependency order.
@@ -20,7 +23,7 @@ Your box, your subscription, your repos.
 
 ## Where it stands
 
-- Proof of concept. First commit 2026-07-21. One person runs it.
+- First commit 2026-07-21. One person runs it. You would be the second.
 - Setup is manual and takes an evening. It gets simpler. There is no package yet.
 - Tailscale and Discord are required. There is no web UI.
 - Attach and preview links are open to anything on your tailnet.
@@ -200,4 +203,8 @@ Logs are the daemon's output. Under systemd: `journalctl -u curia -f`.
 
 - `CONTEXT.md` — the words curia uses.
 - `docs/adr/` — the decisions behind the design.
+- `daemon/src/` — the daemon itself: the dispatch loop, the Discord bridge, the MCP tools an agent
+  calls.
+- `config/` — the two files you edit: what curia watches, and which model each label gets.
+- `docs/landing-page/` — the brief, the build notes and the hosting record for <https://curia.sh>.
 - `daemon/README.md` and `docs/deploy.md` — the operator's own box, not yours.

--- a/docs/landing-page/pages.md
+++ b/docs/landing-page/pages.md
@@ -87,6 +87,22 @@ This is propagation, not a broken setting. The API is the authority on whether e
 the edge catches up on its own. If plain HTTP is still serving 200 a day later, that is worth
 chasing — before then it is not.
 
+## The repo's homepage field
+
+The repository's own **homepage** field is `https://curia.sh`. GitHub shows it in the About box at
+the top right of the repository page, and it is how a reader who arrives at the code finds the page.
+It was empty until 2026-08-04.
+
+No agent can write it. Like the custom domain and the DNS above, it is a setting outside a
+worktree, so the operator ran it from one instruction in
+[Bring the README into line with the page](https://github.com/alp82/curia/issues/117):
+
+> Open <https://github.com/alp82/curia>, click the gear next to About, put `https://curia.sh` in
+> the Website field, and click Save changes.
+
+The **Description** field beside it is a separate string, and it is not the page URL. Nothing in
+this map governs it.
+
 ## Verifying it
 
 From any box:
@@ -97,6 +113,7 @@ curl -sSI http://curia.sh | head -1         # HTTP/1.1 301 -> https://curia.sh/
 curl -sSI https://www.curia.sh | head -1    # HTTP/2 301 -> https://curia.sh/
 dig +short A curia.sh                       # the four 185.199.x.153 addresses
 gh api repos/alp82/curia/pages --jq '{cname,status,https_enforced,source}'
+gh repo view alp82/curia --json homepageUrl # https://curia.sh
 ```
 
 Checked 2026-08-02: `https://curia.sh/` serves 200; `www.curia.sh` and `alp82.github.io/curia` both


### PR DESCRIPTION
Ticket: alp82/curia#117 — [Bring the README into line with the page](https://github.com/alp82/curia/issues/117)

Closes the last gap between `README.md` and the live page at https://curia.sh.

**`README.md`**
- Names the page. Nothing in the repo pointed at it before.
- **Where it stands** drops "Proof of concept", the last line that read as "this is not for you". The page says one person runs it and you would be the second. The README now says the same.
- **Where things are** gains `daemon/src/`, `config/` and `docs/landing-page/`, which keeps the README's own job of orienting a code reader.

The rest of the README was already brought into line by [#112](https://github.com/alp82/curia/issues/112). The "not packaged for reuse" sentence the ticket quotes left `main` with that guide.

**`docs/landing-page/pages.md`**
- Records the repo's About/homepage field, which the operator set to `https://curia.sh` from a one-line instruction, the same way [#113](https://github.com/alp82/curia/issues/113) handed over the registrar work. Verified from outside with `gh repo view`.

---

Dispatched by the curia daemon — session `curia-117`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `8475a61` Record the repo's homepage field beside the DNS handover (wayfinder #117)
- `31ffb16` The README points at the page, and stops calling curia a proof of concept (wayfinder #117)