### PR TITLE
A dead spawn command reads as a slow start (alp82/curia#169)

### DIFF
--- a/daemon/src/tmux.mjs
+++ b/daemon/src/tmux.mjs
@@ -67,6 +67,18 @@ export async function listSessions() {
 // here rather than trusted.
 const SAFE_MARKER = /^[A-Za-z0-9_-]+$/
 
+// The script `bash -c` runs in the pane. Exported so a check can run the REAL
+// string through a real shell: the tmux live checks below skip wherever tmux is
+// absent, and a copy of this line in a test proves only the copy.
+export function wrapShellCmd(shellCmd, exitMarker = null) {
+  if (exitMarker && !SAFE_MARKER.test(exitMarker)) {
+    throw new Error(`refusing to use exit marker "${exitMarker}": it is not quote-free/shell-safe`)
+  }
+  return exitMarker
+    ? `${shellCmd}; echo "[curia] the harness command exited — ${exitMarker} $?"; exec bash`
+    : `${shellCmd}; exec bash`
+}
+
 // Detached session running `env K=V… bash -c '<shellCmd>; exec bash'` — the
 // trailing `exec bash` keeps the pane alive after the command exits, so the
 // pane content stays inspectable (spike #32 pattern).
@@ -76,14 +88,9 @@ const SAFE_MARKER = /^[A-Za-z0-9_-]+$/
 // only wait out its whole timeout. The echo is the last thing before the
 // shell, so it always sits inside the pane tail the classifiers read.
 export async function newSession({ name, cwd, env = {}, shellCmd, exitMarker = null }) {
-  if (exitMarker && !SAFE_MARKER.test(exitMarker)) {
-    throw new Error(`refusing to use exit marker "${exitMarker}": it is not quote-free/shell-safe`)
-  }
+  const wrapped = wrapShellCmd(shellCmd, exitMarker)
   const args = ['new-session', '-d', '-s', name, '-c', cwd, 'env']
   for (const [k, v] of Object.entries(env)) args.push(`${k}=${v}`)
-  const wrapped = exitMarker
-    ? `${shellCmd}; echo "[curia] the harness command exited — ${exitMarker} $?"; exec bash`
-    : `${shellCmd}; exec bash`
   args.push('bash', '-c', wrapped)
   await tmux(args)
 }

--- a/daemon/test/tmux.test.mjs
+++ b/daemon/test/tmux.test.mjs
@@ -12,7 +12,8 @@ import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { hasSession, listSessions, newSession, capturePane, killSession } from '../src/tmux.mjs'
+import { hasSession, listSessions, newSession, capturePane, killSession, wrapShellCmd } from '../src/tmux.mjs'
+import { paneTail, parseExitMarker, paneExcerpt } from '../src/dispatch.mjs'
 
 // Inside any tmux pane — every curia agent runs there — tmux exports $TMUX,
 // and a set $TMUX beats TMUX_TMPDIR: every tmux call below then targets the
@@ -191,5 +192,50 @@ describe('tmux targets survive a renamed window', { skip: !hasTmux && 'tmux not 
       /not quote-free/,
     )
     assert.equal(await hasSession(session), false, 'a refused marker must spawn nothing at all')
+  })
+})
+
+// #169 again, WITHOUT tmux. The live check above is the only place the wrapper
+// meets a real shell, and it skips wherever tmux is absent — the container this
+// was confirmed in included. So run the SAME string through bash here, and read
+// what comes back with the daemon's own classifiers. tmux only adds a pane to
+// hold the text; the exit line is bash's work, and bash is everywhere.
+describe('the exit wrapper, through a real shell', () => {
+  // stdout and stderr share ONE file descriptor, because that is what a terminal
+  // is: `command not found` goes to stderr and the marker echo to stdout, and
+  // paneExcerpt reads the reason as the line ABOVE the marker. Two separate
+  // pipes would lose exactly that order. `exec bash` reads stdin, so an empty
+  // input ends the pane shell instead of hanging the test.
+  const runWrapped = (shellCmd, marker) => {
+    const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'curia-wrap-')), 'pane.txt')
+    const fd = fs.openSync(out, 'w')
+    try {
+      spawnSync('bash', ['-c', wrapShellCmd(shellCmd, marker)], {
+        stdio: ['pipe', fd, fd], input: '', timeout: 10_000,
+      })
+    } finally {
+      fs.closeSync(fd)
+    }
+    return fs.readFileSync(out, 'utf8')
+  }
+
+  test('a missing binary reads as status 127, with the reason above the marker', () => {
+    const marker = 'curia-exit-liveshell'
+    const tail = paneTail(runWrapped('definitely-not-a-real-binary --model x', marker))
+
+    assert.equal(parseExitMarker(tail, marker), 127, 'the wrapper has to carry the shell status, not just the death')
+    assert.match(paneExcerpt(tail, marker), /command not found/, 'the reason the notify quotes must survive the real shell')
+  })
+
+  test('a command that succeeds and exits is still an exit, at status 0', () => {
+    const marker = 'curia-exit-liveshell0'
+    const tail = paneTail(runWrapped('echo the harness printed this and left', marker))
+
+    assert.equal(parseExitMarker(tail, marker), 0)
+    assert.match(paneExcerpt(tail, marker), /printed this and left/)
+  })
+
+  test('an unsafe marker is refused before it is ever nested in bash -c', () => {
+    assert.throws(() => wrapShellCmd('true', 'x"; rm -rf /; #'), /not quote-free/)
   })
 })


### PR DESCRIPTION
Ticket: alp82/curia#169 — [A dead spawn command reads as a slow start](https://github.com/alp82/curia/issues/169)

#169 was already built on main (a70ddc4): the exit marker, the watchdog fast path, the quoted pane excerpt, and the per-spawn nonce. This change adds the one check that was missing. The tmux live check skips wherever tmux is absent, so `wrapShellCmd` is now exported and a new check runs the same string through bash directly, reading the output with `paneTail`, `parseExitMarker` and `paneExcerpt`. A missing binary gives status 127 with `command not found` above the marker. Dropping `$?` from the wrapper makes both checks fail.

---

Dispatched by the curia daemon — session `curia-169`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `aaa4160` Live check: the exit wrapper against a real shell (wayfinder #169)