### PR TITLE
A cancelled question ends nothing, and the agent asks it again (alp82/curia#200)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,6 +103,9 @@ The command brain of curia. The standing design is one brain with three skins (D
 **The five verbs**:
 `frontier`, `start`, `status`, `cancel`, `attach`. The whole command surface, identical over Discord and REST.
 
+**Cancel**:
+The one act that ends a running agent. It kills the session, removes the worktree and releases the GitHub claim. It closes every open question of that agent, and the ticket goes back to the frontier. The word has one place: `cancel <n>` in the command channel. No button on a question ends anything.
+
 ### Agents
 
 **Agent**:
@@ -204,7 +207,7 @@ The half-hour re-post of an open escalation into its thread.
 The Discord module. It renders and captures. It never interprets.
 
 **Thread-per-ticket**:
-One Discord thread per ticket. It carries the ticket's escalations, notifies, and answers. The binding outlives the agent: it releases only when the ticket itself closes, so a resumed agent lands back in the same thread.
+One Discord thread per ticket. It carries the ticket's escalations, notifies, and answers. The binding outlives the agent: it releases only when the ticket itself closes, so a resumed agent lands back in the same thread. The name carries the state at a glance: 🎫 bound, ✅ finished, ⚰️ cancelled.
 
 **Notify**:
 A fire-and-forget line of agent prose into the ticket thread.

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -209,7 +209,7 @@ export class DiscordBridge {
     if (!this.guild) throw new Error('bot is in no guild')
     this.channel = await this.#ensureChannel(this.channelName)
     await this.#registerSlashCommands()
-    this.client.on('interactionCreate', (i) => this.#onInteraction(i).catch((e) => this.log('interaction error', e)))
+    this.client.on('interactionCreate', (i) => this.handleInteraction(i).catch((e) => this.log('interaction error', e)))
     this.client.on('messageCreate', (m) => this.#onMessage(m).catch((e) => this.log('message error', e)))
     this.#watchGateway()
     this.#setHealth('up', { reason: 'ready' })
@@ -311,6 +311,15 @@ export class DiscordBridge {
   // instead of falling back to a name that no longer says what happened.
   static doneName(name) {
     return name.replace(/^🎫/, '✅')
+  }
+
+  // A cancel swaps the same signal for ⚰️ — the agent was torn down (#200).
+  // ✅ would be a lie (nothing finished) and 🎫 was the whole complaint: a
+  // cancelled ticket read exactly like a running one in the thread list. The
+  // BINDING stays (#140), so a later dispatch takes the same thread back and
+  // labelName puts 🎫 on it again.
+  static cancelledName(name) {
+    return name.replace(/^🎫/, '⚰️')
   }
 
   // The thread a ticket's traffic lands in (#93): the journalled binding first.
@@ -474,7 +483,8 @@ export class DiscordBridge {
     // the meantime — it is not this ticket's to take back
     if (!this.bindings.bind(ticket, t.id).ok) return null
     if (t.archived) await t.setArchived(false).catch(() => {})
-    // the label goes back on, and a ✅ from an earlier release goes back to 🎫
+    // the label goes back on: a ✅ from an earlier release, or a ⚰️ from a
+    // cancel (#200), goes back to 🎫 because a ticket is being worked again
     const name = DiscordBridge.labelName(ticket, type)
     if (t.name !== name) await t.setName(name).catch(() => {})
     return t
@@ -493,6 +503,19 @@ export class DiscordBridge {
     await t.setName(DiscordBridge.doneName(t.name)).catch(() => {})
   }
 
+  // The cancel counterpart (#200), and the one difference is the binding: a
+  // cancel does NOT release it (#140 keeps the ticket's history where a later
+  // dispatch will land), so this renames and nothing else. Display only, like
+  // every other rename here — the journal's `agent_cancelled` is the truth.
+  async cancelTicket(ticket) {
+    if (!this.bindings) return
+    const bound = this.bindings.get(ticket)
+    if (!bound) return
+    const t = await this.client.channels.fetch(bound).catch(() => null)
+    if (!t || !t.name.startsWith('🎫')) return
+    await t.setName(DiscordBridge.cancelledName(t.name)).catch(() => {})
+  }
+
   #buttons(record) {
     const rows = []
     let row = new ActionRowBuilder()
@@ -501,7 +524,7 @@ export class DiscordBridge {
       row.addComponents(b)
     }
     // A confirm (#94) gets ✅/❌ and nothing else: declining IS the safe exit,
-    // and the record closes by lapsing with its agent, never by 🛑 Cancel.
+    // and the record closes by lapsing with its agent.
     if (record.kind === CONFIRM_KIND) {
       push(new ButtonBuilder().setCustomId(`esc|${record.id}|opt|approve`).setLabel('✅ Approve').setStyle(ButtonStyle.Danger))
       push(new ButtonBuilder().setCustomId(`esc|${record.id}|opt|reject`).setLabel('❌ Decline').setStyle(ButtonStyle.Secondary))
@@ -518,8 +541,13 @@ export class DiscordBridge {
           .setLabel(label.slice(0, 80)).setStyle(ButtonStyle.Primary))
       })
     }
-    push(new ButtonBuilder().setCustomId(`esc|${record.id}|cancel`).setLabel('🛑 Cancel').setStyle(ButtonStyle.Secondary))
-    rows.push(row)
+    // No cancel button (#200). It said it ended the agent and ended nothing:
+    // it closed the question record and handed the model a sentence, which the
+    // model read and asked again around. Ending an agent has ONE word and one
+    // place — `cancel <n>` in the command channel — and that word runs the
+    // teardown, which cancels this record on its way past. A question a human
+    // does not want answered gets their words as a reply.
+    if (row.components.length) rows.push(row)
     return rows
   }
 
@@ -725,8 +753,23 @@ export class DiscordBridge {
     return this.#editEscalationMessage(record, `✅ **answered** by <@${record.answered_by}> via ${record.answered_via}: \`${String(record.answer).slice(0, 200)}\``)
   }
 
+  // The mark says what HAPPENED and nothing else (#200). It used to promise a
+  // teardown no press ever ran — "ticket re-frontiers" under a button that
+  // only closed this record. Every remaining path here closes a question
+  // because its agent is gone, so the mark names which ending it was; only a
+  // Discord user id becomes a mention.
+  static cancelWords(by) {
+    switch (by) {
+      case 'cancel': return 'its agent was cancelled'
+      case 'agent-death': return 'its agent is gone'
+      case 'reconcile': return 'the daemon reconciled it away'
+      case 'rest': return 'it was cancelled over the REST seam'
+      default: return /^\d+$/.test(String(by)) ? `cancelled by <@${by}>` : `cancelled (${by})`
+    }
+  }
+
   markCancelled(record) {
-    return this.#editEscalationMessage(record, `❌ **cancelled** by <@${record.cancelled_by}> — agent gets an "aborted" result, ticket re-frontiers`)
+    return this.#editEscalationMessage(record, `⚰️ **cancelled** — ${DiscordBridge.cancelWords(record.cancelled_by)}. Nothing is waiting on this question.`)
   }
 
   markSuperseded(record) {
@@ -822,7 +865,9 @@ export class DiscordBridge {
     return saved
   }
 
-  async #onInteraction(i) {
+  // Public because a button press is a decision path worth testing (#200) —
+  // `start` wires it to the gateway, and a test hands it an interaction.
+  async handleInteraction(i) {
     if (!this.authorized(i.user.id)) {
       if (i.isRepliable()) await i.reply({ content: 'not authorized', ephemeral: true })
       return
@@ -847,11 +892,16 @@ export class DiscordBridge {
 
     if (i.isButton() && i.customId.startsWith('esc|')) {
       const [, id, action, value] = i.customId.split('|')
+      // A message posted before #200 still carries the old cancel button, and
+      // Discord keeps it pressable forever. The act it named is gone, so the
+      // press does NOTHING and names the one word that ends an agent. Doing
+      // the old thing quietly is what the ticket exists to stop.
       if (action === 'cancel') {
-        const result = this.handlers.cancel(id, { by: i.user.id })
-        await i.reply(result.ok
-          ? { content: `❌ cancelled **${result.record.id}**` }
-          : { content: `already closed (${result.reason})`, ephemeral: true })
+        const ticket = this.handlers.get(id)?.ticket
+        await i.reply({
+          content: `⚠️ this button is gone — say \`cancel ${ticket ?? '<n>'}\` in <#${this.channel.id}> to end the agent, or reply here to answer`,
+          ephemeral: true,
+        })
         return
       }
       const record = this.handlers.get(id)

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -206,7 +206,7 @@ export class Dispatcher {
     // explicit thread, or a fresh one); release(ticket, reason) takes it off —
     // called on every terminal state. Inert by default so tests and a
     // bridgeless daemon run unchanged.
-    this.threads = threads ?? { bind: async () => ({ ok: true }), release: async () => {} }
+    this.threads = threads ?? { bind: async () => ({ ok: true }), release: async () => {}, cancelled: async () => {} }
     this.log = log
     this.cooling = cooling ?? new Cooling()
     this.dataDir = dataDir
@@ -2201,6 +2201,10 @@ export class Dispatcher {
     // claim, but the ticket goes back to the frontier — a later dispatch
     // belongs in the thread its history lives in. The label comes off when
     // the ticket itself closes (reconcile's sweep reads GitHub for that).
+    //
+    // The NAME does change (#200): 🎫 → ⚰️, so the thread list says a cancel
+    // happened without a message opened. A later dispatch relabels it 🎫.
+    await Promise.resolve(this.threads.cancelled?.(ticket)).catch((e) => this.log(`thread rename for ${session} failed:`, e.message))
     return msg
   }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -299,11 +299,19 @@ const gate = {
     }
     return result
   },
+  // The record-level void: a question closes because nothing can receive its
+  // answer any more. Every caller is a death — the cancel teardown, the
+  // agent-death sweep, reconcile, the REST seam. #200 took the 🛑 button
+  // away, so no human reaches this against a LIVE agent, and the settled text
+  // is a fact for whatever transport is still holding the promise rather than
+  // an instruction to a model. Prose in a tool result was the whole fault:
+  // the agent read "stop this line of work", and asked the same question
+  // again a minute later.
   cancel(id, { by }) {
     const result = store.cancel(id, { by })
     if (result.ok) {
       log(`escalation ${result.record.id} cancelled`)
-      settle(result.record, `aborted: a human cancelled this escalation — stop this line of work and end the turn; the ticket will be re-dispatched`)
+      settle(result.record, `aborted: this question was cancelled — nobody is waiting for an answer to it`)
       if (bridge) bridge.markCancelled(result.record).catch(() => {})
     }
     return result
@@ -397,8 +405,9 @@ function lapseEscalation(id, reason) {
 // who was merely asleep would drop the work on the floor.
 function askReview(agent, ticket, promptText) {
   const { record, answered } = openEscalation({ agent, ticket, kind: REVIEW_KIND, prompt: promptText })
-  // The final status separates an approval-or-rejection from a 🛑 Cancel, which
-  // settles the same promise with an "aborted" text.
+  // The final status separates an approval-or-rejection from a cancel — a
+  // gate whose agent was torn down (#200) settles the same promise with an
+  // "aborted" text, and the status is what tells the two apart.
   return answered.then(({ text }) => ({ text, status: store.get(record.id)?.status ?? 'answered' }))
 }
 
@@ -415,6 +424,12 @@ const threads = {
   async release(ticket, reason) {
     if (bridge) return bridge.releaseTicket(ticket, reason)
     store.releaseTicketThread(ticket, reason)
+  },
+  // A cancel renames and keeps the binding (#200, #140). With the bridge down
+  // there is nothing to do: no journal line carries a thread NAME, and the
+  // next dispatch relabels the thread anyway.
+  async cancelled(ticket) {
+    if (bridge) return bridge.cancelTicket(ticket)
   },
 }
 

--- a/daemon/src/messaging.mjs
+++ b/daemon/src/messaging.mjs
@@ -11,8 +11,8 @@
 //   🔗 link                                            down, a lapsed confirm
 //
 // Button LABELS are UI chrome, not messages: the ✅/❌ confirm pair is fixed
-// by #94, and the 🛑 Cancel withdraw button stays visually distinct from
-// ❌ Reject on purpose.
+// by #94. There is no cancel button any more (#200) — ending an agent is
+// `cancel <n>` in the command channel, and nowhere else.
 
 export const SIGNALS = {
   work: '⚙️',

--- a/daemon/test/cancel.test.mjs
+++ b/daemon/test/cancel.test.mjs
@@ -1,0 +1,221 @@
+// Tests for what a cancel is (#200). The 🛑 Cancel button under every question
+// claimed to end the agent and re-frontier the ticket, and ended nothing: it
+// closed the escalation record and handed the model a sentence. The model read
+// the sentence and asked the same question again a minute later.
+//
+// The shape settled here:
+//   - no cancel button on any escalation — questions, choices, review gates;
+//   - a press on a message posted BEFORE this change does nothing and names
+//     `cancel <n>`, the one word that ends an agent;
+//   - the teardown renames the thread 🎫 → ⚰️ and keeps the binding (#140), so
+//     the thread list shows the cancel with no message opened;
+//   - the mark on the message says what happened and nothing else.
+
+import { test, describe, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { EscalationStore, CONFIRM_KIND } from '../src/store.mjs'
+import { REVIEW_KIND } from '../src/lifecycle.mjs'
+import { DiscordBridge } from '../src/bridge.mjs'
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'curia-cancel-test-'))
+
+// The custom ids of every non-link button on a rendered escalation.
+const idsOf = (components) => components
+  .flatMap((row) => row.toJSON().components)
+  .map((c) => c.custom_id)
+  .filter(Boolean)
+
+describe('no cancel button on an escalation (#200)', () => {
+  let bridge, sent, thread
+
+  beforeEach(() => {
+    sent = []
+    thread = {
+      id: 't-1',
+      name: '🎫 200 · task',
+      send: async (payload) => { sent.push(payload); return { id: 'm-1' } },
+      setName: async () => {},
+    }
+    bridge = new DiscordBridge({
+      token: 'x', allowedUsers: [], dataDir: tmp(), handlers: {}, log: () => {},
+    })
+    bridge.channel = { id: 'C' }
+    bridge.client = { channels: { fetch: async () => thread } }
+    bridge.ensureThread = async () => thread
+  })
+
+  const render = async (record) => {
+    await bridge.renderEscalation(record)
+    return idsOf(sent.at(-1).components)
+  }
+
+  test('a free-text question renders with no buttons at all', async () => {
+    const ids = await render({ id: 'esc-1', ticket: '200', agent: 'curia-200', kind: 'free-text', prompt: 'which?' })
+    assert.deepEqual(ids, [], 'the answer is a reply in the thread; nothing here ends an agent')
+  })
+
+  test('a choice keeps its options and loses the cancel', async () => {
+    const ids = await render({
+      id: 'esc-2', ticket: '200', agent: 'curia-200', kind: 'choice', prompt: 'a or b?', options: ['a', 'b'],
+    })
+    assert.deepEqual(ids, ['esc|esc-2|idx|0', 'esc|esc-2|idx|1'])
+  })
+
+  test('a review gate keeps ✅/❌ and loses the cancel', async () => {
+    const ids = await render({ id: 'esc-3', ticket: '200', agent: 'curia-200', kind: REVIEW_KIND, prompt: 'done?' })
+    assert.deepEqual(ids, ['esc|esc-3|opt|approve', 'esc|esc-3|opt|reject'],
+      'a rejection is the "no" a gate already had; ending the agent is `cancel <n>`')
+  })
+
+  test('a confirm is unchanged — ✅/❌ and nothing else (#94)', async () => {
+    const ids = await render({ id: 'esc-4', ticket: '200', agent: 'overseer', kind: CONFIRM_KIND, prompt: 'cancel it?' })
+    assert.deepEqual(ids, ['esc|esc-4|opt|approve', 'esc|esc-4|opt|reject'])
+  })
+})
+
+describe('a press on an old cancel button (#200)', () => {
+  let bridge, replies, cancelled
+
+  beforeEach(() => {
+    replies = []
+    cancelled = []
+    bridge = new DiscordBridge({
+      token: 'x',
+      allowedUsers: ['u1'],
+      dataDir: tmp(),
+      handlers: {
+        get: (id) => (id === 'esc-9' ? { id, ticket: '200' } : null),
+        cancel: (id) => { cancelled.push(id); return { ok: true, record: { id } } },
+      },
+      log: () => {},
+    })
+    bridge.channel = { id: 'C' }
+  })
+
+  const press = async (customId, userId = 'u1') => {
+    await bridge.handleInteraction({
+      customId,
+      user: { id: userId },
+      isButton: () => true,
+      isChatInputCommand: () => false,
+      isRepliable: () => true,
+      reply: async (payload) => { replies.push(payload) },
+    })
+  }
+
+  test('it executes nothing and names the word that ends an agent', async () => {
+    await press('esc|esc-9|cancel')
+    assert.deepEqual(cancelled, [], 'the old act is gone — a quiet half-cancel is the fault itself')
+    assert.equal(replies.length, 1)
+    assert.equal(replies[0].ephemeral, true)
+    assert.match(replies[0].content, /this button is gone/)
+    assert.match(replies[0].content, /`cancel 200`/, 'the ticket comes from the record')
+    assert.match(replies[0].content, /<#C>/, 'commands run in the command channel, never in a thread')
+  })
+
+  test('a record the daemon no longer knows still gets the pointer', async () => {
+    await press('esc|esc-gone|cancel')
+    assert.match(replies[0].content, /`cancel <n>`/)
+  })
+})
+
+describe('the thread name after a cancel (#200)', () => {
+  let store, bridge, threads
+
+  const makeThread = (id, name, renames) => ({
+    id, name, send: async () => {}, setName: async (n) => { renames.push(n) },
+  })
+
+  beforeEach(() => {
+    store = new EscalationStore(tmp())
+    threads = new Map()
+    bridge = new DiscordBridge({
+      token: 'x', allowedUsers: [], dataDir: tmp(), handlers: {}, log: () => {},
+      bindings: {
+        get: (t) => store.threadForTicket(t),
+        bind: (t, id) => store.bindTicketThread(t, id),
+        release: (t, r) => store.releaseTicketThread(t, r),
+        last: (t) => store.lastThreadForTicket(t),
+      },
+    })
+    bridge.guild = { id: 'G' }
+    bridge.channel = { id: 'C', threads: { create: async () => { throw new Error('no fresh thread expected') } } }
+    bridge.client = { channels: { fetch: async (id) => threads.get(id) ?? null } }
+  })
+
+  test('cancelledName swaps the ticket signal for the grave and keeps the rest', () => {
+    assert.equal(DiscordBridge.cancelledName('🎫 200 · task'), '⚰️ 200 · task')
+    assert.equal(DiscordBridge.cancelledName(DiscordBridge.labelName('200')), '⚰️ 200')
+    assert.equal(DiscordBridge.cancelledName('deploy talk'), 'deploy talk')
+  })
+
+  test('a cancel renames the thread and KEEPS the binding (#140)', async () => {
+    const renames = []
+    const t = makeThread('t-c', '🎫 200 · task', renames)
+    threads.set(t.id, t)
+    store.bindTicketThread('200', 't-c')
+
+    await bridge.cancelTicket('200')
+    assert.deepEqual(renames, ['⚰️ 200 · task'])
+    assert.equal(store.threadForTicket('200'), 't-c', 'the ticket keeps its history where a re-dispatch will land')
+  })
+
+  test('a cancel leaves an unlabeled thread alone and survives a deleted one', async () => {
+    const renames = []
+    const t = makeThread('t-plain', 'deploy talk', renames)
+    threads.set(t.id, t)
+    store.bindTicketThread('201', 't-plain')
+    await bridge.cancelTicket('201')
+    assert.deepEqual(renames, [])
+
+    store.bindTicketThread('202', 't-gone') // never registered ⇒ the fetch misses
+    await bridge.cancelTicket('202') // no throw
+    assert.equal(store.threadForTicket('202'), 't-gone')
+  })
+
+  test('a re-dispatch takes the same thread back and puts 🎫 on it again', async () => {
+    const renames = []
+    const t = makeThread('t-again', '⚰️ 203 · task', renames)
+    threads.set(t.id, t)
+    store.bindTicketThread('203', 't-again')
+
+    const r = await bridge.bindTicket('203', { threadId: 't-again', type: 'task' })
+    assert.equal(r.ok, true)
+    assert.deepEqual(renames, ['🎫 203 · task'], 'work is running again, so the thread reads as open again')
+  })
+})
+
+describe('the mark on a cancelled question (#200)', () => {
+  test('it names the ending, and only a Discord user id becomes a mention', () => {
+    assert.equal(DiscordBridge.cancelWords('cancel'), 'its agent was cancelled')
+    assert.equal(DiscordBridge.cancelWords('agent-death'), 'its agent is gone')
+    assert.equal(DiscordBridge.cancelWords('reconcile'), 'the daemon reconciled it away')
+    assert.equal(DiscordBridge.cancelWords('rest'), 'it was cancelled over the REST seam')
+    assert.equal(DiscordBridge.cancelWords('4207'), 'cancelled by <@4207>')
+    assert.equal(DiscordBridge.cancelWords('somebody'), 'cancelled (somebody)')
+  })
+
+  test('the mark makes no promise the daemon did not keep', async () => {
+    let edited = null
+    const bridge = new DiscordBridge({
+      token: 'x', allowedUsers: [], dataDir: tmp(), handlers: {}, log: () => {},
+    })
+    bridge.client = {
+      channels: {
+        fetch: async () => ({
+          messages: { fetch: async () => ({ edit: async (payload) => { edited = payload } }) },
+        }),
+      },
+    }
+    await bridge.markCancelled({
+      id: 'esc-81', ticket: '200', agent: 'curia-200', kind: 'free-text', prompt: 'which?',
+      cancelled_by: 'cancel', discord: { threadId: 't-1', messageId: 'm-1' },
+    })
+    assert.match(edited.content, /⚰️ \*\*cancelled\*\* — its agent was cancelled/)
+    assert.doesNotMatch(edited.content, /re-frontiers/, 'the button never did that; the mark stops saying it did')
+    assert.deepEqual(edited.components, [], 'a closed record has no buttons left')
+  })
+})

--- a/daemon/test/threads.test.mjs
+++ b/daemon/test/threads.test.mjs
@@ -390,6 +390,7 @@ const OPEN_ISSUE = {
 let dir
 let binds
 let releases
+let cancels
 let escalations
 
 beforeEach(() => {
@@ -397,6 +398,7 @@ beforeEach(() => {
   fs.mkdirSync(path.join(dir, 'data', 'results'), { recursive: true })
   binds = []
   releases = []
+  cancels = []
   escalations = []
 })
 
@@ -443,6 +445,7 @@ function makeDispatcher(deps = {}, { confirm = async () => true, bound = [] } = 
     threads: {
       bind: async (ticket, opts) => { binds.push({ ticket, ...opts }); return { ok: true } },
       release: async (ticket, reason) => { releases.push({ ticket, reason }) },
+      cancelled: async (ticket) => { cancels.push(ticket) },
     },
     log: () => {},
     dataDir: path.join(dir, 'data'),
@@ -509,6 +512,20 @@ describe('Dispatcher thread binding (#93)', () => {
     await d.start('42', { repo: 'o/r' })
     assert.match(await d.cancel('42', { by: 'test' }), /cancelled/)
     assert.deepEqual(releases, [], 'a later dispatch belongs in the thread its history lives in')
+  })
+
+  test('a cancel renames the thread so the list shows it, with no message opened (#200)', async () => {
+    const d = makeDispatcher()
+    await d.start('42', { repo: 'o/r' })
+    await d.cancel('42', { by: 'test' })
+    assert.deepEqual(cancels, ['42'], 'the binding stays and the signal changes: 🎫 → ⚰️')
+  })
+
+  test('a rename that fails does not fail the cancel (#200)', async () => {
+    const d = makeDispatcher()
+    d.threads.cancelled = async () => { throw new Error('discord is down') }
+    await d.start('42', { repo: 'o/r' })
+    assert.match(await d.cancel('42', { by: 'test' }), /cancelled/, 'the agent is dead either way')
   })
 
   test('a finished agent (result recorded) releases the label; an abnormal exit keeps it', async () => {

--- a/docs/adr/0005-escalation-contract.md
+++ b/docs/adr/0005-escalation-contract.md
@@ -1,7 +1,7 @@
 # ADR-0005: The escalation contract
 
 **Status**: accepted (2026-07)
-**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47)
+**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200)
 
 ## Context
 
@@ -10,7 +10,8 @@ Agents need human answers from any device, with waits measured in hours, and the
 ## Decision
 
 - The agent's surface is MCP tools served by the daemon: `ask_human` (blocking, kinds free-text, choice, approve-reject, preview-review) and `notify` (fire-and-forget). The agent never touches Discord.
-- `ask_human` blocks indefinitely. No timer cancels it. A human cancel returns a distinct aborted result. A parked agent is nearly free.
+- `ask_human` blocks indefinitely. No timer cancels it. A parked agent is nearly free.
+- A question has no cancel of its own (#200). A record closes early only because its agent ended, and it settles as aborted into a transport nobody reads. Ending an agent is `cancel <n>`, and that word has one place: the command channel.
 - One Discord thread per ticket carries the ticket's escalations, notifies, and answers. Buttons capture closed shapes, thread replies capture open ones. Images ride the contract in both directions.
 - The first valid answer wins and closes the escalation atomically. Any device may answer. A later answer gets a clear refusal.
 - The escalation is a durable record in the journal. It survives restarts and bridge post-failures. The half-hour nudge re-posts an open escalation and re-renders any the bridge failed to post.
@@ -22,5 +23,5 @@ Agents need human answers from any device, with waits measured in hours, and the
 
 - The bridge renders and captures, and it never interprets. All routing keys on the escalation id, not on who or where.
 - A box reboot loses the in-flight turn. The ticket re-frontiers, per [ADR-0001](0001-github-is-the-only-durable-state-home.md).
-- An agent that dies without a Stop leaves its question asking until reconcile or `/cancel` cleans it up. Cancel also closes the orphaned question.
+- An agent that dies without a Stop leaves its question asking until reconcile or `cancel <n>` cleans it up. Cancel also closes the orphaned question, and it renames the thread to ⚰️.
 - The review gate of [ADR-0008](0008-resolved-means-merged.md) is one more escalation kind and inherits all of this behavior.


### PR DESCRIPTION
Ticket: alp82/curia#200 — [A cancelled question ends nothing, and the agent asks it again](https://github.com/alp82/curia/issues/200)

#200 — the 🛑 Cancel button ends nothing, so it goes.

The button closed the escalation record and settled the resolver with a sentence. The agent read the sentence and asked the same question again. Nothing killed the session, nothing unclaimed the issue, and the mark said both had happened.

- No cancel button on a question, a choice, or a review gate. A gate keeps ✅ Approve and ❌ Reject.
- Ending an agent has one word and one place: `cancel <n>` in the command channel, which runs the teardown it always ran.
- A press on a message posted before this change does nothing and names `cancel <n>`.
- The teardown renames the thread 🎫 → ⚰️ and keeps the binding (#140). A later dispatch puts 🎫 back.
- The mark on the message names which ending closed the question, and stops promising a teardown no press ever ran.
- The settled text is a fact, not an instruction to a model.

ADR-0005 and CONTEXT.md carry the decision. 14 new tests, 1106 pass.

---

Dispatched by the curia daemon — session `curia-200`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `aa5bc0b` The cancel button ends nothing, so it goes (wayfinder #200)