### PR TITLE
A command typed at an agent thread dies as prose (alp82/curia#170)

### DIFF
--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -39,19 +39,47 @@ const MAX_BUTTON_OPTIONS = 23 // 25 buttons max, minus cancel; keep rows tidy
 // `cancel 166` was not, so the operator who typed the surface's OWN syntax got
 // no hint at all and waited an hour. A false positive here costs one extra
 // line under a queued note, so the shape is drawn wide on purpose.
-export const COMMAND_SHAPED = /^\s*(cancel|stop|pause|resume|status|start|attach)(\s+(#?\d+|all))?\s*[.!?]*\s*$/i
+//
+// Every argument form the router takes is a form the operator types, so every
+// one of them belongs here: the bare number, `all`, the repo-qualified
+// `curia#170` and `alp82/curia#170` that `start` accepts (see parseCommand),
+// and the trailing `model=`/`harness=` overrides. The repo-qualified form is
+// what this map's own notes tell the operator to type, so missing it repeated
+// the exact miss the ticket is about.
+export const COMMAND_SHAPED =
+  /^\s*(cancel|stop|pause|resume|status|start|attach)(?:\s+(all|#?\d+|[\w.-]+(?:\/[\w.-]+)?#\d+))?(?:\s+(?:model|harness)=[\w.-]+)*\s*[.!?]*\s*$/i
 
 // The command the operator meant. `stop` and `pause` are not verbs the surface
 // has — at an agent, cancel is what they ask for. `status` is the only one
 // that takes no ticket.
 const MEANT_VERB = { cancel: 'cancel', stop: 'cancel', pause: 'cancel', resume: 'resume', status: 'status', start: 'start', attach: 'attach' }
 
+// The argument the hint names, in the syntax the channel accepts.
+//
+// The operator's OWN argument wins over the thread's ticket. `cancel 138` typed
+// in the ticket-166 thread asks about 138, and the journal shows that exact
+// shape — a hint that answers `cancel 166` names the wrong ticket in the one
+// line that exists to fix the miss.
+//
+// What it names must also parse. `start` is the only verb that takes a
+// repo-qualified ticket, so `curia#170` survives there and reduces to its
+// number for the rest. A leading `#` goes everywhere: `cancel #166` is not a
+// command parseCommand accepts. `attach all` is not one either, so that falls
+// back to the thread's ticket.
+function hintArg(verb, typed, ticket) {
+  if (verb === 'status') return ''
+  const t = (typed ?? '').trim()
+  if (/^all$/i.test(t)) return verb === 'attach' ? ` ${ticket ?? '<n>'}` : ' all'
+  if (verb === 'start' && /#\d+$/.test(t)) return ` ${t}`
+  return ` ${/(\d+)$/.exec(t)?.[1] ?? ticket ?? '<n>'}`
+}
+
 // What to say under a note whose text was a command. The channel is the whole
 // point: commands are interpreted there and nowhere else.
 export function commandHint(text, ticket, channelId) {
-  const verb = MEANT_VERB[/^\s*([a-z]+)/i.exec(text ?? '')?.[1]?.toLowerCase()] ?? 'cancel'
-  const arg = verb === 'status' ? '' : ` ${ticket ?? '<n>'}`
-  return `commands run in <#${channelId}>, never in a ticket thread — say \`${verb}${arg}\` there`
+  const m = COMMAND_SHAPED.exec(text ?? '')
+  const verb = MEANT_VERB[m?.[1]?.toLowerCase()] ?? 'cancel'
+  return `commands run in <#${channelId}>, never in a ticket thread — say \`${verb}${hintArg(verb, m?.[2], ticket)}\` there`
 }
 
 // The whole reply under a queued note, as lines. Pure, and exported, because

--- a/daemon/test/agentnotes.test.mjs
+++ b/daemon/test/agentnotes.test.mjs
@@ -10,6 +10,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { EscalationStore } from '../src/store.mjs'
 import { COMMAND_SHAPED, commandHint, queuedNoteReply } from '../src/bridge.mjs'
+import { parseCommand } from '../src/commands.mjs'
 
 describe('agent-note queue', () => {
   let dir, store
@@ -79,9 +80,57 @@ describe('agent-note queue', () => {
     }
   })
 
+  // Every argument form parseCommand takes is a form the operator types. The
+  // repo-qualified one is what this map's notes tell them to type, so a guard
+  // that missed it repeated the miss the ticket is about.
+  test('the repo-qualified ticket and the option overrides are commands too', () => {
+    for (const s of ['start curia#170', 'start alp82/curia#170', 'start 170 model=sonnet', 'start curia#170 harness=codex', 'cancel curia#166']) {
+      assert.ok(COMMAND_SHAPED.test(s), `"${s}" should read as a command`)
+    }
+  })
+
   test('a verb inside a sentence is a real note, not a swallowed command', () => {
-    for (const s of ['cancel the deploy', 'please stop', 'status of the tests?', 'do not pause here', 'ok', 'cancel 166 once the tests pass']) {
+    for (const s of ['cancel the deploy', 'please stop', 'status of the tests?', 'do not pause here', 'ok', 'cancel 166 once the tests pass', 'start curia#170 after lunch']) {
       assert.ok(!COMMAND_SHAPED.test(s), `"${s}" should read as prose`)
+    }
+  })
+
+  // The hint names a command the channel accepts, about the ticket the operator
+  // asked about — not the one whose thread they happened to type it in.
+  test('the operator\'s own argument wins over the thread it was typed in', () => {
+    assert.match(commandHint('cancel 138', '166', 'C1'), /say `cancel 138` there/)
+    assert.match(commandHint('stop 138', '166', 'C1'), /say `cancel 138` there/)
+    // a bare verb still falls back to the thread's ticket
+    assert.match(commandHint('cancel', '166', 'C1'), /say `cancel 166` there/)
+  })
+
+  test('the hint names a form the router parses', () => {
+    // `#166` and `curia#166` are not forms `cancel` takes — the number is
+    assert.match(commandHint('cancel #166', '166', 'C1'), /say `cancel 166` there/)
+    assert.match(commandHint('cancel curia#166', '166', 'C1'), /say `cancel 166` there/)
+    // `start` is the one verb that does take the repo-qualified ticket
+    assert.match(commandHint('start curia#170', '166', 'C1'), /say `start curia#170` there/)
+    assert.match(commandHint('start alp82/curia#170', '166', 'C1'), /say `start alp82\/curia#170` there/)
+    // `all` rides through on the verbs that take it, and not on the one that does not
+    assert.match(commandHint('cancel all', '166', 'C1'), /say `cancel all` there/)
+    assert.match(commandHint('attach all', '166', 'C1'), /say `attach 166` there/)
+  })
+
+  // The claim above is the router's to make, not the hint's: every command the
+  // hint tells the operator to type goes through the real parseCommand. A hint
+  // that names a command the channel refuses is the same dead end in one more
+  // step.
+  test('every command the hint names parses — checked against the real router', () => {
+    const typed = [
+      'cancel', 'Cancel', 'stop', 'pause', 'resume', 'status', 'cancel 166', 'cancel #166',
+      'cancel curia#166', 'cancel all', 'resume 12', 'resume all', 'attach 166', 'attach all',
+      'start 170', 'start curia#170', 'start alp82/curia#170', 'start 170 model=sonnet',
+    ]
+    for (const t of typed) {
+      assert.ok(COMMAND_SHAPED.test(t), `"${t}" should read as a command`)
+      const said = /say `([^`]+)` there/.exec(commandHint(t, '166', 'C1'))?.[1]
+      assert.ok(said, `no command named for "${t}"`)
+      assert.ok(parseCommand(said), `the hint for "${t}" names \`${said}\`, which the router refuses`)
     }
   })
 


### PR DESCRIPTION
Ticket: alp82/curia#170 — [A command typed at an agent thread dies as prose](https://github.com/alp82/curia/issues/170)

#170's guard shipped with 6370dea and no resolution. Read against the ticket, two things still miss.

**The repo-qualified ticket.** `start curia#170` and `start alp82/curia#170` are forms `parseCommand` accepts, and the map's notes tell the operator to type them. Neither matched `COMMAND_SHAPED`, so the surface's own syntax got no hint — the ticket's own miss, one form later. `model=` and `harness=` join for the same reason.

**The hint named the wrong ticket.** It took the verb from the text and the number from the thread, so `cancel 138` typed in the ticket-166 thread answered `cancel 166`. The journal holds that exact shape. The operator's argument now wins; the thread's ticket is the fallback for a bare verb.

What the hint names must also parse. `cancel #166` and `cancel curia#166` are not commands the router takes, so the argument reduces to its number for every verb but `start`. A test runs each hint back through the real `parseCommand`, so the claim is the router's, not the hint's.

Interpretation is unchanged: text in an agent thread still queues as a note.

977 tests, 952 pass. The 6 failures are this container — it has no `~/.claude/skills`, so every real-boot test refuses the shipped config. They fail the same way before this change.

---

Dispatched by the curia daemon — session `curia-170`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `f662bf7` The way-out line covers the syntax the operator was told to type (wayfinder #170)