### PR TITLE
An agent's reported ticket id steers its status line into a stray thread (alp82/curia#202)

### DIFF
--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -879,12 +879,25 @@ function buildMcpServer(agent, ticket) {
       details: z.record(z.string(), z.any()).optional(),
     },
     async (result, extra) => {
-      const rec = store.logEvent('result', { agent, ...result })
+      // The BOUND ticket is this event's ticket, not `result.ticket` (#202).
+      // The spread wrote the agent's own argument onto the journal line, and
+      // every surface keyed on that field then followed the agent's spelling:
+      // the status line reposted `resolving` under a thread named `owner/repo#164`,
+      // and reconcile's "did this ticket see a result" scans read the wrong
+      // number. The reported id is kept beside the bound one when the two
+      // disagree, because the disagreement is a fact worth journalling — it is
+      // just not a fact worth acting on.
+      const reported = result.ticket == null ? null : String(result.ticket)
+      const bound = ticket || reported
+      const disagrees = reported !== null && reported !== bound
+      const rec = store.logEvent('result', {
+        agent, ...result, ticket: bound, ...(disagrees ? { reported_ticket: reported } : {}),
+      })
       fs.writeFileSync(path.join(DATA, 'results', `${agent}.json`), JSON.stringify(rec, null, 2))
-      // Route by the BOUND ticket, not `result.ticket` — the agent-supplied id
-      // may be repo-qualified or a URL, which ensureThread would send to a
-      // stray named thread instead of the ticket's bound thread (#103).
-      if (bridge) bridge.notify(ticket || result.ticket, `✅ reports **${result.status}**: ${result.summary}`, { as: speaker() }).catch(() => {})
+      // Route by that same bound ticket: an agent-supplied id may be
+      // repo-qualified or a URL, which ensureThread would send to a stray named
+      // thread instead of the ticket's bound thread (#103).
+      if (bridge) bridge.notify(bound, `✅ reports **${result.status}**: ${result.summary}`, { as: speaker() }).catch(() => {})
       const stopKeepAlive = startKeepAlive(extra, `${agent}/result`)
       try {
         return { content: [{ type: 'text', text: await dispatcher.onResult(agent, result) }, ...drainNotes()] }

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -158,8 +158,17 @@ export class StatusLine {
         if (!r || r.kind === CONFIRM_KIND) return
         return this.#set(r.agent, r.ticket, 'working', {})
       }
-      case 'result':
-        return this.#set(ev.agent, ev.ticket, 'resolving', { status: ev.status })
+      case 'result': {
+        // The one event whose ticket the AGENT used to write (#202). The write
+        // edge binds it now, but the journal is append-only, so a line written
+        // before that keeps the agent's spelling — and this line must not
+        // follow it into a stray thread. The session this line already tracks
+        // carries the bound ticket, exactly as `agent_done` relies on below, so
+        // it wins. The event is the fallback for a session first seen after a
+        // daemon restart, where there is nothing else to post under.
+        const w = this.agents.get(ev.agent)
+        return this.#set(ev.agent, w?.ticket ?? ev.ticket, 'resolving', { status: ev.status })
+      }
       case 'agent_died':
         // the liveness sweep's event (#138) — the line stops saying "working"
         // about a killed agent and names the way out

--- a/daemon/test/keepalive.test.mjs
+++ b/daemon/test/keepalive.test.mjs
@@ -309,4 +309,26 @@ describe('a blocked ask_human keeps its stream alive (index.mjs, real boot + rea
     assert.ok(fs.existsSync(path.join(tmp, 'data', 'results', 'curia-77.json')), 'and the results file still gates the lifecycle')
     assert.equal(child.exitCode, null, 'the daemon is still up')
   })
+
+  // #202: the journal line took the agent at its word, so a repo-qualified id
+  // became the ticket every reader of that line keyed on — the status line
+  // reposted under a thread named for the string, and reconcile counted a
+  // result against the wrong number.
+  test('a reported ticket id never becomes the journal event\'s ticket', async () => {
+    const client = new Client({ name: 'curia-result-bind-test', version: '0.0.0' })
+    await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp?agent=curia-88&ticket=88`), armed('curia-88')))
+    await client.callTool(
+      { name: 'report_result', arguments: { ticket: 'alp82/curia#164', status: 'resolved', summary: 'fixture' } },
+      undefined,
+      { timeout: 30_000 },
+    )
+    await client.close()
+
+    const line = fs.readFileSync(path.join(tmp, 'data', 'events.jsonl'), 'utf8')
+      .split('\n').filter(Boolean).map((l) => JSON.parse(l))
+      .findLast((ev) => ev.type === 'result' && ev.agent === 'curia-88')
+    assert.equal(line.ticket, '88', 'the bound ticket is the event\'s ticket')
+    assert.equal(line.reported_ticket, 'alp82/curia#164', 'the disagreement is journalled beside it')
+    assert.equal(child.exitCode, null, 'the daemon is still up')
+  })
 })

--- a/daemon/test/statusline.test.mjs
+++ b/daemon/test/statusline.test.mjs
@@ -158,6 +158,25 @@ describe('StatusLine', () => {
     assert.equal(posts.at(-1).text, `⚰️ \`curia-9\`${GROUP_SEP}agent gone — \`resume 9\``)
   })
 
+  test('a result event never steers the line out of the thread it is already in (#202)', async () => {
+    // The ticket on a `result` line used to be whatever the agent typed, and
+    // the journal is append-only, so an old line still says `owner/repo#164`.
+    // The spawn binding this line already tracks is the authority.
+    line.onEvent({ type: 'agent_spawned', agent: 'curia-9', ticket: '9', model: 'opus' })
+    line.onEvent({ type: 'result', agent: 'curia-9', ticket: 'alp82/curia#164', status: 'resolved' })
+    await drain()
+    assert.equal(posts.at(-1).ticket, '9', 'the resolving line posts under the BOUND ticket')
+    assert.match(posts.at(-1).text, /result received \(\*\*resolved\*\*\)/)
+  })
+
+  test('a result for a session first seen after a restart still posts (#202)', async () => {
+    // The Map dies with the process, so this line never saw the spawn. The
+    // event is all there is, and a line under it beats no line at all.
+    line.onEvent({ type: 'result', agent: 'curia-9', ticket: '9', status: 'blocked' })
+    await drain()
+    assert.equal(posts.at(-1).ticket, '9')
+  })
+
   test('a bridge that is down loses nothing: the next transition posts', async () => {
     let up = false
     const l3 = new StatusLine({


### PR DESCRIPTION
Ticket: alp82/curia#202 — [An agent's reported ticket id steers its status line into a stray thread](https://github.com/alp82/curia/issues/202)

Fixes #202: an agent's reported ticket id no longer steers its last status line into a stray thread.

The `report_result` handler spread the agent's arguments onto the journal event, so the event's `ticket` field was whatever string the agent typed. `statusline.mjs` read that field and reposted the `📦 result received — resolving the ticket` line under a thread named for the string.

Two edges, because the journal is append-only:

1. **Write edge** (`daemon/src/index.mjs`) — the bound ticket goes after the spread. A disagreeing reported id is kept beside it as `reported_ticket`, since the disagreement is a fact worth journalling. The `notify` beside it routes on the same value.
2. **Read edge** (`daemon/src/statusline.mjs`) — the line prefers the ticket the session already tracks, the same way `agent_done` does. A journal line written before this fix keeps the agent's spelling, and the status line must not follow it. The event stays as the fallback for a session first seen after a daemon restart.

The write edge also repairs two reconcile scans (`#reconcileDeadClaims` and the orphan sweep) that count a result against `ev.ticket`, where a reported id could mark the wrong ticket as reported.

Audit of the other events the status line keys on: `agent_spawned`, `agent_ready`, `agent_ready_timeout`, `agent_exited_early`, `esc_*` and `agent_died` are all composed by the dispatcher from the spawn binding. `agent_done` carries no ticket. `result` was the only one that took agent text.

Tests: two in `statusline.test.mjs` (bound ticket wins, restart fallback still posts) and one real-boot MCP test in `keepalive.test.mjs` (a repo-qualified id never becomes the event's ticket).

---

Dispatched by the curia daemon — session `curia-202`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `daacebc` The bound ticket, not the agent's, is what the result event carries (wayfinder #202)