### PR TITLE
A note queued at a dead agent outlives the instance it was addressed to (alp82/curia#208)

### DIFF
--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -87,13 +87,16 @@ export function commandHint(text, ticket, channelId) {
 // the note, and where the operator's words would have been a command.
 //
 // `q.reads === false` is positive evidence the agent is not running — the
-// early exit (#169), the ready timeout, the result-less exit. The note still
-// queues: the queue is session-keyed, so whatever resumes on this session gets
-// it (see store.queueRecordedAnswer). Anything else keeps the old promise.
+// early exit (#169), the ready timeout, the result-less exit. Nothing queues
+// then (#208): words typed at an agent die with that agent, so a dead one is
+// the end of them, and the line says that rather than promising a successor
+// will read them. The #139 hand-off is the one note that does cross, and it
+// comes from the daemon, not from this surface. Anything else keeps the old
+// promise.
 export function queuedNoteReply({ owner, q, text, channelId }) {
   const lines = [
     q.reads === false
-      ? `queued for \`${owner}\`, which is NOT running — nothing reads this until \`resume ${q.ticket ?? '<n>'}\``
+      ? `\`${owner}\` is NOT running, so nothing was queued: these words reached nobody. Start a fresh agent with \`resume ${q.ticket ?? '<n>'}\`, then say them again.`
       : `queued for \`${owner}\` — it reads this with its next tool result${q.after ? ` (noted as after ${q.after})` : ''}`,
   ]
   if (COMMAND_SHAPED.test(text ?? '')) lines.push(commandHint(text, q.ticket, channelId))
@@ -1001,7 +1004,9 @@ export class DiscordBridge {
       if (owner) {
         const q = this.handlers.queueAgentNote?.(m.channel.id, m.content ?? '', m.author.id)
         if (q) {
-          await m.react('📨').catch(() => {})
+          // 📨 means the words are in a queue. A dead agent queues nothing
+          // (#208), so the reaction says the same thing the reply does.
+          await m.react(q.reads === false ? '⚠️' : '📨').catch(() => {})
           // A command still queues — the operator may mean the word for the
           // agent — but the reply names the way out, so `cancel 166` typed at
           // an agent never dies silently as a note (#108 item 23, #170).

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -2311,6 +2311,7 @@ export class Dispatcher {
       const lease = await this.#endWorkspaceLease(agentName, ticket, w?.repo ?? this.#epochRepo(ticket))
       this.notify(ticket, `✅ \`${agentName}\` finished with a recorded result — session closed; ${lease}`)
       this.lapseConfirmsFor(agentName, `\`${agentName}\` finished`)
+      this.expireNotesFor(agentName, ticket, 'finished')
       // terminal state ⇒ the ticket label comes off the thread (#93)
       await this.threads.release(ticket, 'finished').catch(() => {})
     } else {
@@ -2320,6 +2321,7 @@ export class Dispatcher {
       this.notify(ticket, `⚠️ \`${agentName}\` stopped WITHOUT reporting a result — session kept for post-mortem (\`/attach ${ticket}\`)`)
       // the agent the confirm described has exited, whatever the pane holds (#94)
       this.lapseConfirmsFor(agentName, `\`${agentName}\` stopped without a result`)
+      this.expireNotesFor(agentName, ticket, 'stopped without a result')
     }
   }
 
@@ -2594,6 +2596,29 @@ export class Dispatcher {
     }
   }
 
+  // The same rule for operator notes (#208), and every exit path calls this
+  // the way it calls lapseConfirmsFor above: the words were about what THAT
+  // agent was doing, so a successor on the session must never read them. The
+  // #139 hand-off carries no instance stamp and is untouched, because
+  // reaching the successor is its whole point.
+  //
+  // The count, never the words: the journal keeps the text, and the thread
+  // says how many died so the operator knows to say them again. A note that
+  // vanishes with no line is the dead end #170 was about.
+  //
+  // `liveInstance` is null at every death. Adoption after a restart passes
+  // the FRESH instance instead, which expires the pre-restart words on the
+  // same rule that lapses a pre-restart confirm.
+  expireNotesFor(session, ticket, why, liveInstance = null) {
+    const n = this.store.expireAgentNotes(session, liveInstance)
+    if (!n) return
+    this.log(`${n} operator note(s) for ${session} expired — ${why}`)
+    const again = liveInstance
+      ? 'Say them again in this thread.'
+      : `Say them again after \`resume ${ticket}\`.`
+    this.notify(ticket, `📭 \`${session}\` ${why} with ${n} operator note${n === 1 ? '' : 's'} it never read. A note dies with the agent it was typed at, so nothing carries these words to a successor. ${again}`)
+  }
+
   // The teardown a confirmed cancel runs — shared verbatim by cancel and
   // cancelAll, so the bulk verb can never drift from the single one.
   async #teardown(ticket, { by } = {}) {
@@ -2654,6 +2679,7 @@ export class Dispatcher {
     this.notify(ticket, msg)
     // the agent is positively gone ⇒ any OTHER open confirm on it lapses (#94)
     this.lapseConfirmsFor(session, `\`${session}\` was cancelled`)
+    this.expireNotesFor(session, ticket, 'was cancelled')
     // The binding stays (#140): a cancel ends the AGENT and releases the
     // claim, but the ticket goes back to the frontier — a later dispatch
     // belongs in the thread its history lives in. The label comes off when
@@ -2872,6 +2898,7 @@ export class Dispatcher {
     await this.#withdrawPreview(ticket, 'agent died')
     // an open confirm describes an instance that no longer exists (#94)
     this.lapseConfirmsFor(session, `\`${session}\` died`)
+    this.expireNotesFor(session, ticket, 'died')
     // the session is positively gone, so nothing later collects the copy
     this.deps.removeCredentials(w.cfgDir ?? cfgDirFor(this.root, session))
 
@@ -3126,10 +3153,11 @@ export class Dispatcher {
           // state home for what a restart cannot re-derive, so it answers here
           // exactly as it does for the repo and the charting kind.
           const spawn = this.#epochSpawn(journal, session)
+          // a FRESH instance id: any confirm bound before the restart lapses
+          // at boot rather than matching an adopted agent it never described
+          const instance = `${session}@adopted-${Date.now()}`
           this.agents.set(session, {
-            // a FRESH instance id: any confirm bound before the restart lapses
-            // at boot rather than matching an adopted agent it never described
-            repo, ticket: n, title: issue.title, session, instance: `${session}@adopted-${Date.now()}`,
+            repo, ticket: n, title: issue.title, session, instance,
             wtPath, cfgDir: cfgDirFor(this.root, session), promptFile: path.join(cfgDirFor(this.root, session), 'prompt.md'),
             model: spawn?.model ?? null, requestedModel: null,
             harness: spawn?.harness ?? null,
@@ -3140,6 +3168,10 @@ export class Dispatcher {
             resultReceived: fs.existsSync(path.join(this.dataDir, 'results', `${session}.json`)),
           })
           this.log(`reconcile: re-adopted live agent ${session} (${repo}#${n})`)
+          // The same reason the confirms lapse here (#208): a pre-restart note
+          // named a pre-restart instance, and this one is new. The agent IS
+          // running, so the way out is the thread rather than a resume.
+          this.expireNotesFor(session, String(n), 'was adopted after a daemon restart', instance)
           adopted = true
           break
         }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -27,7 +27,7 @@ import { fileURLToPath } from 'node:url'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { z } from 'zod'
-import { EscalationStore, CONFIRM_KIND } from './store.mjs'
+import { EscalationStore, CONFIRM_KIND, noteDisposition } from './store.mjs'
 import { DiscordBridge } from './bridge.mjs'
 import { installCrashGuard } from './health.mjs'
 import { readable } from './logline.mjs'
@@ -354,17 +354,20 @@ const gate = {
   queueAgentNote(threadId, text, by) {
     const agent = gate.agentForThread(threadId)
     if (!agent || !text?.trim()) return null
-    const { after } = store.queueAgentNote(agent, text.trim(), { by })
-    // `reads` is what the bridge promises the operator (#170). A `failed`
-    // agent — the early exit (#169), the ready timeout, the result-less exit
-    // — calls no more tools, so "it reads this with its next tool result" is a
-    // promise nothing can keep. The note still queues: the session-keyed queue
-    // hands it to whatever resumes on this session.
-    const reads = dispatcher.agents.get(agent)?.state !== 'failed'
-    log(`agent note queued for ${agent}${after ? ` (after ${after})` : ''}${reads ? '' : ' — that agent is not running'}`)
+    // `reads` is what the bridge promises the operator (#170), and #208 makes
+    // it the same flag that decides whether anything queues at all.
+    const { reads, instance } = noteDisposition(dispatcher.agents.get(agent))
     // the ticket rides along so the bridge can spell out `cancel <n>` when the
     // note is command-shaped (#108 item 23, #170)
-    return { agent, after, reads, ticket: store.ticketForThread(threadId) ?? null }
+    const ticket = store.ticketForThread(threadId) ?? null
+    if (!reads) {
+      log(`agent note refused for ${agent} — that agent is not running, so nothing was queued`)
+      store.logEvent('agent_note_refused', { agent, ticket, by, reason: 'agent not running' })
+      return { agent, after: null, reads, ticket }
+    }
+    const { after } = store.queueAgentNote(agent, text.trim(), { by, instance })
+    log(`agent note queued for ${agent}${after ? ` (after ${after})` : ''}`)
+    return { agent, after, reads, ticket }
   },
 }
 
@@ -725,7 +728,11 @@ function buildMcpServer(agent, ticket) {
   // every tool below appends the drain, so a note is never older than one
   // round-trip. A note tagged `after esc-N` is the follow-up the operator
   // typed just after answering that escalation.
-  const drainNotes = () => store.takeAgentNotes(agent).map((n) => ({
+  //
+  // The instance is read LIVE, never captured here: this server is built once
+  // per session and #208 makes the queue instance-addressed, so a note stamped
+  // for a predecessor must not ride out on a successor's tool result.
+  const drainNotes = () => store.takeAgentNotes(agent, dispatcher.agents.get(agent)?.instance ?? null).map((n) => ({
     type: 'text',
     text: `[operator note${n.after ? `, after ${n.after}` : ''}] ${n.text}`,
   }))

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -56,6 +56,25 @@ export function normalizeEvent(ev) {
   return out
 }
 
+// #208, the caller's half of the rule — pure, so it can be checked without a
+// live gateway, for the reason queuedNoteReply is pure (#170). What operator
+// text typed in an agent's thread becomes, given the record the dispatcher
+// holds for the agent that owns the thread:
+//
+//   not running → nothing queues. The words were about what THAT agent was
+//                 doing, and it is gone. A queued one waits for a successor
+//                 that never heard them — the `cancel 166` typed at 15:13
+//                 and still pending against a 16:36 agent (#170).
+//   running     → it queues, stamped with the instance it was typed at, and
+//                 dies with that instance.
+//
+// `reads` keeps its one meaning (#170): the agent is running. A `failed`
+// record is the early exit (#169), the ready timeout, the result-less exit.
+export function noteDisposition(agent) {
+  const reads = agent?.state !== 'failed'
+  return { reads, instance: reads ? agent?.instance ?? null : null }
+}
+
 export class EscalationStore {
   constructor(dataDir) {
     this.dir = dataDir
@@ -166,13 +185,21 @@ export class EscalationStore {
       }
       case 'agent_note': {
         const arr = this.agentNotes.get(ev.agent) ?? []
-        arr.push({ text: ev.text, after: ev.after ?? null })
+        // An absent stamp is session-keyed on purpose (#208): the #139
+        // hand-off, and every note journalled before #208 was decided.
+        arr.push({ text: ev.text, after: ev.after ?? null, instance: ev.instance ?? null })
         this.agentNotes.set(ev.agent, arr)
         break
       }
       case 'agent_notes_drained': {
         const arr = this.agentNotes.get(ev.agent) ?? []
         arr.splice(0, ev.count)
+        break
+      }
+      case 'agent_notes_expired': {
+        const live = ev.live_instance ?? null
+        const arr = this.agentNotes.get(ev.agent) ?? []
+        this.agentNotes.set(ev.agent, arr.filter((n) => !n.instance || n.instance === live))
         break
       }
       case 'overseer_notes_drained': {
@@ -322,14 +349,20 @@ export class EscalationStore {
   // tagged with that escalation's id — "operator added, after esc-13" — the
   // follow-up-to-a-button case the finding measured. Journalled, so a daemon
   // restart keeps every undelivered note.
-  queueAgentNote(agent, text, { by = null, graceMs = 120_000, now = Date.now() } = {}) {
+  //
+  // `instance` is the #208 ruling: words typed at an agent die with THAT
+  // agent. The caller is what marks the two kinds apart, because the caller
+  // is the only one who knows who the words were for. Thread text names the
+  // instance that owned the thread; the #139 hand-off names none, because
+  // reaching the successor is its whole point.
+  queueAgentNote(agent, text, { by = null, instance = null, graceMs = 120_000, now = Date.now() } = {}) {
     const recent = [...this.escalations.values()]
       .filter((r) => r.agent === agent && r.status !== 'open' && r.closed_at)
       .sort((a, b) => String(a.closed_at).localeCompare(String(b.closed_at)))
       .at(-1)
     const closedMs = recent ? now - Date.parse(recent.closed_at) : Infinity
     const after = Number.isFinite(closedMs) && closedMs <= graceMs ? recent.id : null
-    this._append({ type: 'agent_note', agent, text, after, by })
+    this._append({ type: 'agent_note', agent, text, after, by, instance })
     return { after }
   }
 
@@ -348,7 +381,24 @@ export class EscalationStore {
     return this.queueAgentNote(record.agent, text, { by: record.answered_by ?? null })
   }
 
-  takeAgentNotes(agent) {
+  // The #208 rule, in one predicate: a note stamped with an instance belongs
+  // to that instance and to nothing else. This drops every note naming an
+  // instance OTHER than the one now live on the session. Pass null when
+  // nothing is live, which is what every exit path does — then every stamped
+  // note goes. An unstamped note is session-keyed and never expires here.
+  //
+  // Two callers, one rule. The exit paths call it so the operator is told at
+  // the moment the words die. The drain calls it so a successor can never
+  // read them even if some exit path was missed.
+  expireAgentNotes(agent, liveInstance = null) {
+    const arr = this.agentNotes.get(agent) ?? []
+    const stale = arr.filter((n) => n.instance && n.instance !== liveInstance).length
+    if (stale) this._append({ type: 'agent_notes_expired', agent, live_instance: liveInstance, count: stale })
+    return stale
+  }
+
+  takeAgentNotes(agent, instance = null) {
+    this.expireAgentNotes(agent, instance)
     const notes = [...(this.agentNotes.get(agent) ?? [])]
     if (notes.length) this._append({ type: 'agent_notes_drained', agent, count: notes.length })
     return notes

--- a/daemon/test/agentnotes.test.mjs
+++ b/daemon/test/agentnotes.test.mjs
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { EscalationStore } from '../src/store.mjs'
+import { EscalationStore, noteDisposition } from '../src/store.mjs'
 import { COMMAND_SHAPED, commandHint, queuedNoteReply } from '../src/bridge.mjs'
 import { parseCommand } from '../src/commands.mjs'
 
@@ -155,6 +155,9 @@ describe('agent-note queue', () => {
     assert.match(dead[0], /NOT running/)
     assert.match(dead[0], /resume 166/)
     assert.ok(!dead[0].includes('next tool result'), 'the promise must not survive on a dead agent')
+    // #208 took the queue away as well, so the line must not imply one
+    assert.match(dead[0], /nothing was queued/)
+    assert.ok(!/^queued/.test(dead[0]), 'nothing was queued, so the line may not open with "queued"')
 
     const live = queuedNoteReply({ owner: 'curia-9', q: { reads: true, ticket: '9' }, text: 'look at the logs', channelId: 'C1' })
     assert.match(live[0], /reads this with its next tool result/)
@@ -205,6 +208,68 @@ describe('agent-note queue', () => {
     store.queueRecordedAnswer(store.get(record.id))
     const [note] = store.takeAgentNotes('curia-9')
     assert.match(note.text, /\/data\/attachments\/esc-1\/image\.png/)
+  })
+
+  // #208: the ruling. Words typed at an agent are about what THAT agent was
+  // doing, so they die with it. The caller is what marks the two kinds apart:
+  // thread text names the instance it was typed at, the #139 hand-off names
+  // none, because reaching the successor is its whole point.
+  describe('a note expires with the instance it was addressed to (#208)', () => {
+    test('a stamped note dies with its instance, an unstamped one lives on', () => {
+      store.queueAgentNote('curia-166', 'cancel 166', { instance: 'curia-166@1' })
+      store.queueRecordedAnswer({ id: 'esc-3', agent: 'curia-166', prompt: 'ship it?', answer: 'yes' })
+
+      assert.equal(store.expireAgentNotes('curia-166', null), 1, 'one stamped note died')
+      const [survivor, ...rest] = store.takeAgentNotes('curia-166')
+      assert.deepEqual(rest, [], 'exactly one note survived')
+      assert.match(survivor.text, /a human answered esc-3/)
+    })
+
+    test('the successor never reads its predecessor\'s words, even if no exit path ran', () => {
+      store.queueAgentNote('curia-166', 'cancel 166', { instance: 'curia-166@15:13' })
+      // the #170 run: a fresh agent takes the session name an hour later
+      assert.deepEqual(store.takeAgentNotes('curia-166', 'curia-166@16:36'), [])
+    })
+
+    test('the instance that WAS addressed still reads its own notes', () => {
+      store.queueAgentNote('curia-166', 'look at the tail', { instance: 'curia-166@1' })
+      assert.deepEqual(store.takeAgentNotes('curia-166', 'curia-166@1').map((n) => n.text), ['look at the tail'])
+    })
+
+    test('expiry is journalled, so a restart does not resurrect the words', () => {
+      store.queueAgentNote('curia-166', 'cancel 166', { instance: 'curia-166@1' })
+      store.expireAgentNotes('curia-166', null)
+      assert.deepEqual(new EscalationStore(dir).takeAgentNotes('curia-166'), [])
+    })
+
+    test('expiring nothing writes nothing — an empty sweep is not an event', () => {
+      store.queueAgentNote('curia-166', 'a note for whoever resumes', {})
+      assert.equal(store.expireAgentNotes('curia-166', null), 0)
+      assert.deepEqual(store.takeAgentNotes('curia-166').map((n) => n.text), ['a note for whoever resumes'])
+    })
+
+    // The gate's own decision, pure for the reason queuedNoteReply is pure:
+    // the daemon seam needs a live gateway, and this rule is the one that
+    // closes the #170 case.
+    test('a dead agent queues nothing at all — the #170 note never exists', () => {
+      assert.deepEqual(noteDisposition({ state: 'failed', instance: 'curia-166@1' }), { reads: false, instance: null })
+    })
+
+    test('a running agent queues, stamped with the instance the words were typed at', () => {
+      assert.deepEqual(noteDisposition({ state: 'ready', instance: 'curia-166@1' }), { reads: true, instance: 'curia-166@1' })
+      assert.deepEqual(noteDisposition({ state: 'spawning', instance: 'curia-166@2' }), { reads: true, instance: 'curia-166@2' })
+    })
+
+    test('an agent with no instance still queues — an unstamped note is the old rule, not a refusal', () => {
+      assert.deepEqual(noteDisposition({ state: 'ready' }), { reads: true, instance: null })
+    })
+
+    test('a note journalled before #208 carries no stamp, so it keeps the old rule', () => {
+      fs.appendFileSync(path.join(dir, 'events.jsonl'),
+        JSON.stringify({ ts: '2026-08-01T00:00:00Z', type: 'agent_note', agent: 'curia-166', text: 'from before', after: null }) + '\n')
+      const reborn = new EscalationStore(dir)
+      assert.deepEqual(reborn.takeAgentNotes('curia-166', 'curia-166@2').map((n) => n.text), ['from before'])
+    })
   })
 
   test('the queue survives a daemon restart — journal, not memory', () => {

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -46,6 +46,7 @@ let confirms // confirm records opened through the injected openConfirm (#94)
 let lapses // {id, reason} lapsed through the injected lapseEscalation (#94)
 let confirmNotes // {id, text} posted next to a confirm's buttons (#94)
 let overseerNotes // {threadId, text} synthetic session lines (#94)
+let agentNotes // session -> queued operator notes the exit sweep expires (#208)
 const dispatchers = [] // every Dispatcher a test built, so afterEach can end its watches
 
 beforeEach(() => {
@@ -59,6 +60,7 @@ beforeEach(() => {
   lapses = []
   confirmNotes = []
   overseerNotes = []
+  agentNotes = new Map()
 })
 
 afterEach(() => {
@@ -107,6 +109,15 @@ function makeDispatcher(deps = {}, {
     logEvent: (type, data) => { const rec = { type, ...data }; events.push(rec); return rec },
     openEscalations: () => escalations.filter((r) => r.status === 'open'),
     cancel: () => ({ ok: true }),
+    // #208, the real EscalationStore predicate: a note stamped with an
+    // instance dies when that instance is no longer the live one. An
+    // unstamped note is session-keyed and stays (the #139 hand-off).
+    expireAgentNotes: (agent, live = null) => {
+      const arr = agentNotes.get(agent) ?? []
+      const keep = arr.filter((n) => !n.instance || n.instance === live)
+      agentNotes.set(agent, keep)
+      return arr.length - keep.length
+    },
   }
   const base = {
     viewerLogin: async () => 'me',
@@ -1207,6 +1218,84 @@ describe('Dispatcher.cancel (criterion 6, the destructive half — W8; immediate
     // dispatch_unclaimed as "this ticket is settled" and would skip it forever
     assert.ok(!typesOf().includes('dispatch_unclaimed'), 'no unclaim happened ⇒ none may be journalled')
     assert.ok(!typesOf().includes('unclaim_failed'), 'no unclaim was even attempted ⇒ no event at all')
+  })
+})
+
+// #208: words typed at an agent die with that agent. The confirm rule of #94,
+// applied to the note queue — same exit paths, same reason, and the operator
+// is told at the moment the words die rather than left to find out when a
+// successor acts on them an hour later (#170).
+describe('operator notes die with the instance they were typed at (#208)', () => {
+  const noted = (instance) => ({ text: 'cancel 42', instance })
+  const writeJournal = (lines) =>
+    fs.writeFileSync(path.join(tmp, 'data', 'events.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')
+  const agentAt = (instance) => ({
+    repo: 'o/r', ticket: '42', session: 'curia-42', instance,
+    wtPath: '/w/42', cfgDir: '/c/curia-42', state: 'ready', resultReceived: false,
+  })
+
+  test('a finished agent takes its unread notes with it, and the thread gets the count', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+    agentNotes.set('curia-42', [noted('curia-42@1'), noted('curia-42@1')])
+    fs.writeFileSync(path.join(tmp, 'data', 'results', 'curia-42.json'), '{}')
+
+    await d.onAgentDone('curia-42')
+
+    assert.deepEqual(agentNotes.get('curia-42'), [], 'nothing survives to a successor')
+    const line = notifies.find((n) => /operator note/.test(n.message))
+    assert.ok(line, 'a note that vanishes with no line is the dead end #170 was about')
+    assert.match(line.message, /2 operator notes it never read/)
+    assert.match(line.message, /resume 42/)
+    assert.ok(!line.message.includes('cancel 42'), 'the count, never the words')
+  })
+
+  test('a result-less exit expires them too — that is the #170 shape exactly', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+    agentNotes.set('curia-42', [noted('curia-42@1')])
+
+    await d.onAgentDone('curia-42')
+
+    assert.deepEqual(agentNotes.get('curia-42'), [])
+    assert.match(notifies.find((n) => /operator note/.test(n.message)).message, /1 operator note it never read/)
+  })
+
+  test('the #139 hand-off carries no instance, so it survives every exit', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+    const handOff = { text: 'a human answered esc-3', instance: null }
+    agentNotes.set('curia-42', [noted('curia-42@1'), handOff])
+
+    await d.onAgentDone('curia-42')
+
+    assert.deepEqual(agentNotes.get('curia-42'), [handOff], 'the successor is the whole point of that one')
+    assert.match(notifies.find((n) => /operator note/.test(n.message)).message, /1 operator note it never read/)
+  })
+
+  test('an exit with nothing queued says nothing — no empty line in the thread', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+
+    await d.onAgentDone('curia-42')
+
+    assert.equal(notifies.filter((n) => /operator note/.test(n.message)).length, 0)
+  })
+
+  test('adoption after a restart mints a fresh instance, so pre-restart words expire there too', async () => {
+    writeJournal([{ type: 'dispatch_claimed', repo: 'o/r', ticket: '42', agent: 'curia-42' }])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-42'],
+      fetchIssue: async () => ({ ...OPEN_ISSUE, assignees: [{ login: 'me' }] }),
+    })
+    agentNotes.set('curia-42', [noted('curia-42@before-the-restart')])
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(agentNotes.get('curia-42'), [])
+    const line = notifies.find((n) => /operator note/.test(n.message))
+    // this agent IS running, so the way out is the thread, not a resume
+    assert.match(line.message, /Say them again in this thread/)
   })
 })
 

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -90,6 +90,8 @@ function makeDispatcher(deps = {}, { issue = MAP_ISSUE } = {}) {
     },
     openEscalations: () => [],
     cancel: () => ({ ok: true }),
+    // #208: no test here queues an operator note, so nothing ever expires
+    expireAgentNotes: () => 0,
   }
   const base = {
     viewerLogin: async () => 'me',

--- a/daemon/test/reviewer.test.mjs
+++ b/daemon/test/reviewer.test.mjs
@@ -94,6 +94,8 @@ function makeDispatcher(deps = {}, { routing = ROUTING } = {}) {
     },
     openEscalations: () => [],
     cancel: () => ({ ok: true }),
+    // #208: no test here queues an operator note, so nothing ever expires
+    expireAgentNotes: () => 0,
   }
   const base = {
     viewerLogin: async () => 'me',

--- a/daemon/test/sandbox.test.mjs
+++ b/daemon/test/sandbox.test.mjs
@@ -494,7 +494,8 @@ function makeDispatcher(deps = {}, { routing = SANDBOXED_ROUTING, sandbox = PINS
       sandbox,
     },
     routing,
-    store: { logEvent: (type, data) => { events.push({ type, ...data }); return { type } }, openEscalations: () => [], cancel: () => ({ ok: true }) },
+    // expireAgentNotes (#208): no test here queues a note, so nothing expires
+    store: { logEvent: (type, data) => { events.push({ type, ...data }); return { type } }, openEscalations: () => [], cancel: () => ({ ok: true }), expireAgentNotes: () => 0 },
     notify: (ticket, message) => notifies.push({ ticket, message }),
     log: (...a) => log.push(a.join(' ')),
     dataDir: path.join(tmp, 'data'),

--- a/daemon/test/threads.test.mjs
+++ b/daemon/test/threads.test.mjs
@@ -439,6 +439,8 @@ function makeDispatcher(deps = {}, { confirm = async () => true, bound = [] } = 
       openEscalations: () => escalations,
       cancel: () => ({ ok: true }),
       boundTickets: () => bound,
+      // #208: no test here queues an operator note, so nothing ever expires
+      expireAgentNotes: () => 0,
     },
     notify: () => {},
     confirm,


### PR DESCRIPTION
Ticket: alp82/curia#208 — [A note queued at a dead agent outlives the instance it was addressed to](https://github.com/alp82/curia/issues/208)

A note dies with the agent it was typed at (#208).

Operator notes were keyed by session name, so a note typed at a dead agent reached its successor. That is how a `cancel 166` typed at 15:13 was still pending against a research agent spawned at 16:36 (#170).

The operator ruled: words typed at an agent die with that agent. The caller marks the two kinds apart. Thread text carries the instance that owned the thread. The #139 hand-off carries none, because reaching the successor is its whole point.

- `queueAgentNote` takes an instance stamp. An unstamped note stays session-keyed, so every note journalled before this change keeps the old rule.
- Every exit path calls `expireNotesFor`, next to the `lapseConfirmsFor` it mirrors. Adoption after a restart expires pre-restart words on the same rule that lapses a pre-restart confirm.
- The drain applies the same predicate as a backstop, so a successor reads no predecessor's note even if an exit path is missed.
- An agent that is not running queues nothing at all. That is the #170 shape exactly, because the agent was already a dead shell when the words were typed.
- The operator ruled the surface: the count, never the words. The thread says how many notes died and how to say them again. The journal keeps the text.

Not closed and said so: the gate seam and the drain live in `index.mjs`, which only the real-boot tests reach, and this container refuses every one of them. The queue rule is checked through the pure `noteDisposition` export instead. Nothing was checked against a live Discord gateway.

1028 tests, 1001 pass. The 8 failures are this container (no `~/.claude/skills`) and the set matches the clean tree exactly.

---

Dispatched by the curia daemon — session `curia-208`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `983a364` A note dies with the agent it was typed at (wayfinder #208)