### PR TITLE
The planted-config refusal skips the cross-harness respawn (alp82/curia#174)

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -827,11 +827,23 @@ export class Dispatcher {
   // loads one repo-carried config file without a prompt (codex under its
   // hook-trust bypass flag, claude by merging settings.local.json over the
   // settings curia writes), and hooks in it would run with no model in the loop.
-  #assertNoPlantedConfig(wtPath, harnessName) {
+  //
+  // #174: the dispatch is not the only spawn. The check is per HARNESS — one
+  // repo file exposes one harness — so it clears only the lane it ran against,
+  // and #respawnOn changes that lane. It runs there too, against the NEXT
+  // harness, which is what closes the hole: a claude dispatch in a repo carrying
+  // `.codex/hooks.json` passes here, and the cap-hit fallback to the codex lane
+  // would otherwise spawn codex over that file under its hook-trust bypass.
+  // `where` only picks the way out, because the two paths offer different ones:
+  // at dispatch the operator can name another harness, and on a fallback they
+  // cannot — the lane they came from is the cooling one.
+  #assertNoPlantedConfig(wtPath, harnessName, where = 'dispatch') {
     const planted = untrustedProjectConfig(wtPath, harnessName)
-    if (planted) {
-      throw new Error(`${planted} is a config file curia did not write, and the ${harnessName} harness loads it with no prompt — hooks in it would run unreviewed, with no model in the loop. Remove the file from the repo, or dispatch on another harness if only one harness loads it (\`/start <ticket> <model>\`)`)
-    }
+    if (!planted) return
+    const wayOut = where === 'respawn'
+      ? 'The harness this agent was dispatched on does not load it, and the fallback harness does. Remove the file from the repo, or dispatch the ticket again once a harness that does not load it is warm'
+      : 'Remove the file from the repo, or dispatch on another harness if only one harness loads it (`/start <ticket> <model>`)'
+    throw new Error(`${planted} is a config file curia did not write, and the ${harnessName} harness loads it with no prompt — hooks in it would run unreviewed, with no model in the loop. ${wayOut}`)
   }
 
   // Which wayfinder map, if any, owns this ticket — so the standing orders can
@@ -1489,6 +1501,22 @@ export class Dispatcher {
   // about when it matters.
   async #respawnOn(agent, next, journalData = {}) {
     const nextHarness = this.routing.models[next].harness
+    // #174: the planted-config refusal is per harness, and this is where the
+    // harness moves. It runs BEFORE #reshapeWorkspace and #armAgent, so a
+    // refusal costs the workspace and the config dir nothing — the same
+    // ordering the dispatch path keeps.
+    //
+    // Unconditional, for the reason the re-seed below is: a same-harness
+    // respawn tests a worktree the agent has been writing in since the dispatch
+    // check ran, and one path is easier to trust than a branch that has to be
+    // right about when it matters.
+    //
+    // The throw lands in the caller's catch, which is the failed-respawn path
+    // both callers already own: the old session is dead, so the claim is
+    // released, the ticket is re-frontiered and the workspace survives for a
+    // human. Falling FURTHER down the chain to a clean lane was refused
+    // deliberately — that routes around a planted file with nobody told.
+    this.#assertNoPlantedConfig(agent.wtPath, nextHarness, 'respawn')
     // The two harnesses need not agree about the sandbox (#148's rollout puts
     // claude in a container first and codex after the soak), so a fallback
     // across providers can also cross the boundary. Everything the agent reads

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -2781,6 +2781,69 @@ describe('dispatching across two harnesses (#39)', () => {
     await d.start('42', { repo: 'o/r', by: 'test' })
     assert.equal(spawned, true)
   })
+
+  // #174. The test above is the hole: that dispatch is clean BECAUSE the claude
+  // harness does not read `.codex/`, and the fallback chain hands the same
+  // worktree to codex, which does — under `--dangerously-bypass-hook-trust`.
+  test('a cap hit refuses the fallback onto the harness the repo carries a config file for', async () => {
+    const seeded = []
+    const spawns = []
+    const unclaimed = []
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [] }),
+      createWorktree: async (b, n) => {
+        const wt = path.join(path.dirname(b), 'wt', String(n))
+        fs.mkdirSync(path.join(wt, 'docs', 'agents'), { recursive: true })
+        fs.writeFileSync(path.join(wt, 'docs', 'agents', 'issue-tracker.md'), '# Issue tracker: GitHub\n')
+        fs.mkdirSync(path.join(wt, '.codex'), { recursive: true })
+        fs.writeFileSync(path.join(wt, '.codex', 'hooks.json'), '{"hooks":{"SessionStart":[]}}')
+        return wt
+      },
+      seedConfigDir: (cfg, wt, s, harness) => seeded.push(harness),
+      newSession: async (o) => { spawns.push(o) },
+      unclaim: async (repo, ticket) => { unclaimed.push(`${repo}#${ticket}`) },
+      capturePane: async () => 'Sonnet usage limit reached | 1800000000',
+    }, { routing: TWO_LANE, readyTimeoutS: 6 })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => unclaimed.length > 0, 12_000)
+
+    assert.equal(spawns.length, 1, 'codex never spawned over the planted file')
+    assert.deepEqual(seeded, ['claude'], 'refused BEFORE the config dir was re-seeded for codex')
+    assert.deepEqual(unclaimed, ['o/r#42'], 'the claim is released, exactly once')
+    assert.ok(events.some((e) => e.type === 'dispatch_unclaimed' && /config file curia did not write/.test(e.reason)))
+    assert.equal(d.agents.has('curia-42'), false, 'the agent record is dropped')
+    const msg = notifies.find((n) => /hooks\.json/.test(n.message))?.message
+    assert.ok(msg, 'the operator is told which file refused the fallback')
+    assert.match(msg, /once a harness that does not load it is warm/, 'the way out fits the fallback, not the dispatch')
+    // The lane still cooled: the refusal is about the NEXT harness, not the cap.
+    assert.ok(events.some((e) => e.type === 'model_cooling' || e.type === 'provider_cooling'))
+  })
+
+  // The check is unconditional on the respawn path, so it also covers a file
+  // that appeared AFTER the dispatch check passed — the agent writes in this
+  // worktree, and the mute respawn re-seeds the same harness over it.
+  test('a same-harness mute respawn refuses a file planted after the dispatch check', async () => {
+    const spawns = []
+    const unclaimed = []
+    const d = makeDispatcher({
+      newSession: async (o) => {
+        spawns.push(o)
+        fs.mkdirSync(path.join(o.cwd, '.claude'), { recursive: true })
+        fs.writeFileSync(path.join(o.cwd, '.claude', 'settings.local.json'), '{"hooks":{"SessionStart":[]}}')
+      },
+      unclaim: async (repo, ticket) => { unclaimed.push(`${repo}#${ticket}`) },
+      capturePane: async () => '⏵⏵ bypass permissions on',
+    }, { routing: withGrace(2) })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => unclaimed.length > 0, 12_000)
+
+    assert.equal(spawns.length, 1, 'the respawn never reached tmux')
+    assert.ok(events.some((e) => e.type === 'agent_mute'))
+    assert.ok(events.some((e) => e.type === 'dispatch_unclaimed' && /settings\.local\.json/.test(e.reason)))
+    assert.equal(d.agents.has('curia-42'), false)
+  })
 })
 
 describe('the grown verbs (#81, wayfinder #91)', () => {


### PR DESCRIPTION
Ticket: alp82/curia#174 — [The planted-config refusal skips the cross-harness respawn](https://github.com/alp82/curia/issues/174)

Gap 5 of the codex-lane inventory (#174).

`#assertNoPlantedConfig` ran once, at dispatch, against the dispatch harness. The check is per harness: one repo file exposes one harness (`.codex/hooks.json` for codex, `.claude/settings.local.json` for claude). So a repo carrying `.codex/hooks.json` cleared a claude dispatch, and a cap-hit fallback to the codex lane then spawned codex over that file under `--dangerously-bypass-hook-trust`.

**The fix.** The refusal now runs in `#respawnOn`, against the harness about to spawn. `#respawnOn` is the one choke point for both respawn paths: the usage-limit fallback (#13) and the mute respawn (#194). It runs before `#reshapeWorkspace` and `#armAgent`, so a refusal costs the workspace and the config dir nothing. It is unconditional, for the reason the re-seed is: a same-harness respawn tests a worktree the agent has been writing in since the dispatch check ran.

**What a refusal does to an agent mid-flight.** The operator chose refuse-and-release. A refusal here is what a failed respawn already is: the old session is dead, the throw lands in the caller's catch, the claim is released, the ticket is re-frontiered and the workspace survives for a human. Falling further down the chain to a clean lane was refused. That would route around a planted file with nobody told.

The refusal message states the way out that fits the path. At dispatch the operator can name another harness. On a fallback they cannot, because the lane they came from is the cooling one.

**Tests.** Two new cases in `dispatch.test.mjs`: a cap hit refusing the cross-harness fallback (no codex spawn, no re-seed for codex, one unclaim, the file named in the notify), and a same-harness mute respawn refusing a file planted after the dispatch check. 389/389 pass across the dispatch family. The 8 failures in the full suite are pre-existing and identical on the clean tree (config and real-boot tests that need the deployment box).

---

Dispatched by the curia daemon — session `curia-174`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `b3051e9` The planted-config refusal runs on the respawn path too (wayfinder #174)