### PR TITLE
Map updates get their own verb: start on a map stops meaning charting (alp82/curia#221)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,13 +35,13 @@ The map section "Not yet specified": work that is coming but not yet sharp enoug
 The map changes: new tickets, graduated fog, blocking edges, scope rulings. They land two ways. A ticket agent proposes them at the review gate and writes them after the approval. A charting agent writes them as its whole job.
 
 **Map dispatch**:
-`start` on a map's own issue. The daemon spawns a charting agent instead of a ticket agent.
+`map <n>` on a map's own issue. The daemon spawns a charting agent instead of a ticket agent. It claims nothing. `start` on a map number is not this: it dispatches the map's next takeable ticket.
 
 **Charting agent**:
 The agent of a map dispatch. It edits the map and its tickets, and it never closes the map, opens a pull request, or passes a review gate.
 
 **Instruction**:
-The operator's sentence on a map dispatch, in their own words. It rides the dispatch and reaches the charting agent as the first thing it reads. With no instruction, the agent asks what should change.
+The operator's sentence on a map dispatch, in their own words. It rides the `map` verb after a bare `--`, and reaches the charting agent as the first thing it reads. With no instruction, the agent asks what should change. No other verb takes one.
 
 **Frontier**:
 The takeable tickets of a watched repo, in map order.
@@ -53,7 +53,10 @@ Open, not a pull request, no open blockers, no assignee.
 The rule that computes a repo's frontier. The map lane takes the children of open maps. The flat lane takes open `ready-for-agent` issues. A repo whose maps are all closed or deferred gets an empty frontier, never the flat fallback.
 
 **Claim**:
-The assignee on a ticket. A claim removes the ticket from every frontier. The daemon claims before it spawns. A claim on a map takes nothing off a frontier, because a map is never on one. It stops a second charting agent from editing the same body.
+The assignee on a ticket. A claim removes the ticket from every frontier. The daemon claims before it spawns. No dispatch ever claims a map: a map is never on a frontier, so a claim on one says nothing true.
+
+**Map lock**:
+What stops a second charting agent from editing one map body: the session name. A charting agent on map #147 is `curia-147`, and `map 147` is refused while that session lives. The check asks tmux, so it survives a daemon restart. It is per box, and there is one box.
 
 **Watched repo**:
 A repo on the watch list in `config/curia.yaml`. Curia dispatches only against watched repos.
@@ -100,8 +103,9 @@ The state where every candidate model is cooling. The frontier stays the queue, 
 **Overseer**:
 The command brain of curia. The standing design is one brain with three skins (Discord, text, voice). The shipped daemon uses a deterministic router instead.
 
-**The five verbs**:
-`frontier`, `start`, `status`, `cancel`, `attach`. The whole command surface, identical over Discord and REST.
+**The verbs**:
+`tickets`, `next`, `status`, `start`, `map`, `cancel`, `resume`, `attach`, `review`. The whole command surface, identical over Discord and REST. Each verb has one meaning. `start` works a thing, and `map` updates a map.
+_Avoid_: the five verbs (the pre-#81 count, wrong since `next`, `resume` and `review` joined).
 
 **Resume**:
 A fresh agent on a ticket whose agent is gone. It inherits the surviving worktree and the model of the last spawn, which the journal states. It never inherits the conversation. A live agent refuses it: `cancel <n>` is the way to end one.
@@ -242,7 +246,7 @@ _Avoid_: status line (that names the daemon's own line, below).
 The ordered close-out of a ticket: commit, pull request, preview, review gate, merge, resolve, result. One structure drives both the prompt and the Stop hook checklist.
 
 **Charting ending**:
-The ending of a map dispatch: edit the map, then report the result. Curia posts the summary on the map and unassigns it. No pull request, no review gate, no close.
+The ending of a map dispatch: edit the map, then report the result. Curia posts the summary on the map. No unassign, no pull request, no review gate, no close.
 
 **Stop hook**:
 The enforcement hook that fires at the end of every agent turn. It refuses a stop that leaves ending steps open, up to the stop budget, then lets go and reports the ticket unfinished.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Test it: send a normal message in `#curia`. A thread opens and answers you.
 Then use the commands, as Discord slash commands or as plain English in a thread:
 
 - `tickets` — what is takeable
-- `start <n>` — send an agent
+- `start <n>` — send an agent. On a map number, this sends one to the map's next takeable ticket.
+- `map <n> -- <what should change>` — send an agent that updates the map itself
 - `status` — who is running
 - `attach <n>` — that agent's terminal in your browser
 - `resume <n>` / `cancel <n>`

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -51,13 +51,17 @@ const MAX_BUTTON_OPTIONS = 23 // 25 buttons max, minus cancel; keep rows tidy
 // that is the "drawn wide" rule doing its job: an operator typing it in a thread
 // gets the hint that sends them to #curia, where the router names the rule. The
 // note queue swallowing it silently is the miss this regex exists to stop.
+// `map` joined the alternation with #221, for the reason every other verb is
+// here: it is a command now, and a command typed at an agent must not vanish
+// into the note queue. Only the bare form matches — `map 147 -- <sentence>`
+// runs past the end of this shape, and a sentence is what a note IS.
 export const COMMAND_SHAPED =
-  /^\s*(cancel|stop|pause|resume|status|start|attach)(?:\s+(all|#?\d+|[\w.-]+(?:\/[\w.-]+)?#\d+))?(?:\s+(?:model|harness)=[\w.-]+)*\s*[.!?]*\s*$/i
+  /^\s*(cancel|stop|pause|resume|status|start|map|attach)(?:\s+(all|#?\d+|[\w.-]+(?:\/[\w.-]+)?#\d+))?(?:\s+(?:model|harness)=[\w.-]+)*\s*[.!?]*\s*$/i
 
 // The command the operator meant. `stop` and `pause` are not verbs the surface
 // has — at an agent, cancel is what they ask for. `status` is the only one
 // that takes no ticket.
-const MEANT_VERB = { cancel: 'cancel', stop: 'cancel', pause: 'cancel', resume: 'resume', status: 'status', start: 'start', attach: 'attach' }
+const MEANT_VERB = { cancel: 'cancel', stop: 'cancel', pause: 'cancel', resume: 'resume', status: 'status', start: 'start', map: 'map', attach: 'attach' }
 
 // The argument the hint names, in the syntax the channel accepts.
 //
@@ -66,7 +70,7 @@ const MEANT_VERB = { cancel: 'cancel', stop: 'cancel', pause: 'cancel', resume: 
 // shape — a hint that answers `cancel 166` names the wrong ticket in the one
 // line that exists to fix the miss.
 //
-// What it names must also parse. `start` is the only verb that takes a
+// What it names must also parse. `start` and `map` are the verbs that take a
 // repo-qualified ticket, so `curia#170` survives there and reduces to its
 // number for the rest. A leading `#` goes everywhere: `cancel #166` is not a
 // command parseCommand accepts. `attach all` is not one either, so that falls
@@ -74,8 +78,14 @@ const MEANT_VERB = { cancel: 'cancel', stop: 'cancel', pause: 'cancel', resume: 
 function hintArg(verb, typed, ticket) {
   if (verb === 'status') return ''
   const t = (typed ?? '').trim()
-  if (/^all$/i.test(t)) return verb === 'attach' ? ` ${ticket ?? '<n>'}` : ' all'
-  if (verb === 'start' && /#\d+$/.test(t)) return ` ${t}`
+  // `cancel all` and `resume all` parse; `attach all` and `map all` do not, so
+  // those fall back to the thread's own ticket rather than name a line the
+  // router would refuse.
+  if (/^all$/i.test(t)) return (verb === 'attach' || verb === 'map') ? ` ${ticket ?? '<n>'}` : ' all'
+  // The repo-qualified form needs a REPO in front of the `#`. `/#\d+$/` also
+  // matched a bare `#170`, which no verb parses — found by #221's `map #147`
+  // case, and `start #170` had carried it since the hint shipped.
+  if ((verb === 'start' || verb === 'map') && /^[\w.-]+(?:\/[\w.-]+)?#\d+$/.test(t)) return ` ${t}`
   return ` ${/(\d+)$/.exec(t)?.[1] ?? ticket ?? '<n>'}`
 }
 
@@ -116,15 +126,21 @@ const SLASH_MANIFEST = [
   new SlashCommandBuilder().setName('next').setDescription('Dispatch the next takeable ticket')
     .addStringOption((o) => o.setName('repo').setDescription('Limit to one repo (any unambiguous part of the name)')),
   new SlashCommandBuilder().setName('status').setDescription('Agents running, waiting on input, and recent endings'),
-  new SlashCommandBuilder().setName('start').setDescription('Dispatch an agent on a ticket, or a charting agent on a map')
-    .addStringOption((o) => o.setName('ticket').setDescription('Ticket number, or a map number').setRequired(true))
+  new SlashCommandBuilder().setName('start').setDescription('Dispatch an agent on a ticket, or on a map\'s next takeable ticket')
+    .addStringOption((o) => o.setName('ticket').setDescription('Ticket number, or a map number for its next ticket').setRequired(true))
     // #177 removed the `harness` option: the harness follows the model, so the
     // only values this could carry were a no-op or a broken spawn.
-    .addStringOption((o) => o.setName('model').setDescription('Model override'))
-    // #160. Optional, so an old client-side manifest still sends a valid
-    // `/start` — it just cannot carry a sentence, and the charting agent then
-    // asks what should change, which is the right degradation.
-    .addStringOption((o) => o.setName('instruction').setDescription('MAP ONLY: what should change on the map')),
+    // #221 removed `instruction`: `start` no longer charts, so it carries no
+    // sentence. A stale client-side manifest can still SEND one (#65), and the
+    // expansion drops it — see expandCommand.
+    .addStringOption((o) => o.setName('model').setDescription('Model override')),
+  // #221: charting's own verb, in the operator's own word. `instruction` stays
+  // optional, so a dispatch with no sentence opens with the "what should
+  // change?" escalation (#160) instead of being refused at the client.
+  new SlashCommandBuilder().setName('map').setDescription('Dispatch a charting agent that updates a map')
+    .addStringOption((o) => o.setName('ticket').setDescription('Map number').setRequired(true))
+    .addStringOption((o) => o.setName('instruction').setDescription('What should change on the map, in your own words'))
+    .addStringOption((o) => o.setName('model').setDescription('Model override')),
   new SlashCommandBuilder().setName('cancel').setDescription('Cancel a running ticket, or all of them')
     .addStringOption((o) => o.setName('ticket').setDescription('Ticket number, or "all"').setRequired(true)),
   new SlashCommandBuilder().setName('resume').setDescription('Fresh agent on a ticket, inheriting its worktree and its model')
@@ -162,16 +178,25 @@ export function expandCommand(i) {
     case 'tickets': return `tickets${opt('repo') ? ' ' + opt('repo') : ''}`
     case 'next': return `next${opt('repo') ? ' ' + opt('repo') : ''}`
     case 'status': return 'status'
+    // #221: `start` takes no instruction any more. A stale client-side manifest
+    // still sends the option, and putting it back into the canonical text would
+    // expand to a line the router refuses — so it is dropped here, exactly as
+    // #177 drops `harness`.
     case 'start': {
+      const ticket = need('ticket')
+      if (!ticket) return { error: 'missing' }
+      return `start ${ticket}${opt('model') ? ' model=' + opt('model') : ''}`
+    }
+    case 'map': {
       const ticket = need('ticket')
       if (!ticket) return { error: 'missing' }
       // The instruction rides LAST, after a bare `--` (#160), and its
       // whitespace is collapsed for the same reason canonicalFor collapses it:
       // this line is one line, and the router splits it on whitespace. This is
       // still expansion, not interpretation — the text is passed through, and
-      // whether a map may carry it is the dispatcher's ruling.
+      // whether the issue is a map is the dispatcher's ruling.
       const instruction = (need('instruction') ?? '').replace(/\s+/g, ' ').trim()
-      return `start ${ticket}`
+      return `map ${ticket}`
         + (opt('model') ? ' model=' + opt('model') : '')
         + (instruction ? ` -- ${instruction}` : '')
     }

--- a/daemon/src/commands.mjs
+++ b/daemon/src/commands.mjs
@@ -13,10 +13,11 @@ import { clampList } from './messaging.mjs'
 // against the watch list (see #matchRepo), so `cur` is as valid as `alp82/curia`.
 const REPOISH_RE = /^[\w./-]+$/
 
-// The instruction separator on `start` (#160). Every other argument on this
-// seam is one whitespace-free token, because the seam itself is one line of
-// text that gets split on whitespace — and a map dispatch has to carry a whole
-// operator sentence ("update the landing page map so that X").
+// The instruction separator on `map` (#160, moved off `start` by #221). Every
+// other argument on this seam is one whitespace-free token, because the seam
+// itself is one line of text that gets split on whitespace — and a map update
+// has to carry a whole operator sentence ("update the landing page map so that
+// X").
 //
 // A bare `--` is the boundary: everything before it parses as before, and
 // everything after it is the instruction, joined back with single spaces. The
@@ -24,6 +25,13 @@ const REPOISH_RE = /^[\w./-]+$/
 // so a sentence that itself contains ` -- ` survives canonicalFor → parseCommand
 // unchanged.
 const INSTRUCTION_SEP = '--'
+
+// #221: `start` carries no instruction any more, because it no longer charts.
+// The parser refuses the shape and the router names the verb that does take
+// one — the same treatment `harness=` got, and for the same reason: an operator
+// with muscle memory deserves the rule, not the whole catalogue.
+const START_INSTRUCTION_RE = /^start\b.*(^|\s)--(\s|$)/
+const START_INSTRUCTION_GONE = '`start` carries no instruction — it works a ticket. `start <map>` now dispatches that map\'s next takeable ticket, and `map <n> -- <sentence>` is how a map itself is updated.'
 
 // #177: `harness=` is gone from every surface. The harness is a FUNCTION of the
 // model — `models.<x>.harness` holds one value — so every value the daemon could
@@ -34,8 +42,50 @@ const INSTRUCTION_SEP = '--'
 const HARNESS_OPT_RE = /(^|\s)harness=/
 const HARNESS_GONE = '`harness=` is gone — the harness follows the model, so `model=` is the whole override. To run a model on another harness, add a row to `routing.yaml`.'
 
+// An issue reference plus `model=` options, shared by `start` and `map` (#221).
+// Both verbs name an issue in a watched repo and both take the model override;
+// only `map` takes a trailing instruction. Written once so the two verbs cannot
+// drift apart on the repo-qualified forms, which the ambiguity refusals
+// recommend by name and therefore have to parse back.
+function parseIssueRef(cmd, rest, { instruction: takesInstruction = false } = {}) {
+  if (!rest.length) return null
+  let m
+  if ((m = rest[0].match(/^(\d+)$/))) {
+    cmd.ticket = m[1]
+  } else if ((m = rest[0].match(/^([\w.-]+\/[\w.-]+)#(\d+)$/))) {
+    // field-notes contract 6: the repo-qualified form the ambiguity
+    // refusal recommends must itself parse
+    cmd.repo = m[1]
+    cmd.ticket = m[2]
+  } else if ((m = rest[0].match(/^([\w.-]+)#(\d+)$/))) {
+    // the fuzzy form `tickets`/`next` accept — the overseer reuses it on
+    // start, so an unslashed repo resolves through the same matcher
+    cmd.repoArg = m[1]
+    cmd.ticket = m[2]
+  } else {
+    return null
+  }
+  const sep = takesInstruction ? rest.indexOf(INSTRUCTION_SEP) : -1
+  const opts = sep === -1 ? rest.slice(1) : rest.slice(1, sep)
+  for (const opt of opts) {
+    const om = opt.match(/^model=([\w.-]+)$/)
+    if (!om) return null
+    cmd.model = om[1]
+  }
+  if (sep !== -1) {
+    // `--` with nothing after it is a typo, not an empty instruction: it
+    // would dispatch the "what should change?" escalation the operator was
+    // trying to skip.
+    const instruction = rest.slice(sep + 1).join(' ').trim()
+    if (!instruction) return null
+    cmd.instruction = instruction
+  }
+  return cmd
+}
+
 // 'tickets [repo]' | 'next [repo]' | 'status'
-// | 'start <n>|<owner/repo#n> [model=x] [-- <instruction>]'
+// | 'start <n>|<owner/repo#n> [model=x]'
+// | 'map <n>|<owner/repo#n> [model=x] [-- <instruction>]'
 // | 'cancel <n>|all' | 'resume <n> [model=x]' | 'resume all' | 'attach <n>'
 // — anything else ⇒ null.
 export function parseCommand(text) {
@@ -51,42 +101,16 @@ export function parseCommand(text) {
     }
     case 'status':
       return rest.length ? null : { verb: 'status' }
-    case 'start': {
-      if (!rest.length) return null
-      const cmd = { verb: 'start' }
-      let m
-      if ((m = rest[0].match(/^(\d+)$/))) {
-        cmd.ticket = m[1]
-      } else if ((m = rest[0].match(/^([\w.-]+\/[\w.-]+)#(\d+)$/))) {
-        // field-notes contract 6: the repo-qualified form the ambiguity
-        // refusal recommends must itself parse
-        cmd.repo = m[1]
-        cmd.ticket = m[2]
-      } else if ((m = rest[0].match(/^([\w.-]+)#(\d+)$/))) {
-        // the fuzzy form `tickets`/`next` accept — the overseer reuses it on
-        // start, so an unslashed repo resolves through the same matcher
-        cmd.repoArg = m[1]
-        cmd.ticket = m[2]
-      } else {
-        return null
-      }
-      const sep = rest.indexOf(INSTRUCTION_SEP)
-      const opts = sep === -1 ? rest.slice(1) : rest.slice(1, sep)
-      for (const opt of opts) {
-        const om = opt.match(/^model=([\w.-]+)$/)
-        if (!om) return null
-        cmd.model = om[1]
-      }
-      if (sep !== -1) {
-        // `--` with nothing after it is a typo, not an empty instruction: it
-        // would dispatch the "what should change?" escalation the operator was
-        // trying to skip.
-        const instruction = rest.slice(sep + 1).join(' ').trim()
-        if (!instruction) return null
-        cmd.instruction = instruction
-      }
-      return cmd
-    }
+    // One meaning for one verb (#221): `start` works the thing. On a ticket it
+    // dispatches that ticket; on a map it dispatches the map's next takeable
+    // ticket. It never charts, and it never carries an instruction.
+    case 'start':
+      return parseIssueRef({ verb: 'start' }, rest)
+    // The map-update verb (#221), replacing `start <map> -- <instruction>`.
+    // The operator's own word, ruled over `chart` on the grounds that it is the
+    // word they already reach for.
+    case 'map':
+      return parseIssueRef({ verb: 'map' }, rest, { instruction: true })
     case 'cancel': {
       if (rest.length !== 1) return null
       if (rest[0] === 'all') return { verb, all: true }
@@ -142,7 +166,8 @@ const USAGE = [
   '`next [repo]` — dispatch the next takeable ticket',
   '`status` — agents running, agents waiting on input, recent cancelled and finished',
   '`start <n>|repo#<n> [model=x]` — claim + dispatch an agent (repo: any unambiguous part of the name)',
-  '`start <map> -- <instruction>` — dispatch a charting agent on a `wayfinder:map` issue; the sentence after `--` is what it should change',
+  '`start <map>` — dispatch that map\'s next takeable ticket',
+  '`map <n> [-- <instruction>]` — dispatch a charting agent on a `wayfinder:map` issue; the sentence after `--` is what it should change',
   '`cancel <n>|all` — immediate teardown (the overseer\'s interpreted cancel posts a ✅/❌ confirm instead)',
   '`resume <n> [model=x]|resume all` — fresh agent on a ticket, inheriting its surviving worktree and the model it last ran on',
   '`attach <n>` — timeline + browser-terminal links for a live agent',
@@ -168,7 +193,9 @@ export class CommandRouter {
   async handle(canonical, userId, { threadId = null, interpreted = false } = {}) {
     const cmd = parseCommand(canonical)
     if (!cmd) {
-      const why = HARNESS_OPT_RE.test(canonical) ? `${HARNESS_GONE}\n` : ''
+      let why = ''
+      if (HARNESS_OPT_RE.test(canonical)) why = `${HARNESS_GONE}\n`
+      else if (START_INSTRUCTION_RE.test(canonical)) why = `${START_INSTRUCTION_GONE}\n`
       return `❌ could not parse \`${canonical}\`\n${why}${USAGE}`
     }
     try {
@@ -189,13 +216,17 @@ export class CommandRouter {
         case 'status':
           return await this.#status()
         case 'start': {
-          if (cmd.repoArg) {
-            const repo = this.#matchRepo(cmd.repoArg)
-            if (repo.error) return repo.error
-            cmd.repo = repo.repo
-          }
+          const repo = this.#dispatchRepo(cmd)
+          if (repo.error) return repo.error
           return await this.dispatcher.start(cmd.ticket, {
-            repo: cmd.repo, model: cmd.model, instruction: cmd.instruction,
+            repo: repo.repo, model: cmd.model, by: userId, threadId,
+          })
+        }
+        case 'map': {
+          const repo = this.#dispatchRepo(cmd)
+          if (repo.error) return repo.error
+          return await this.dispatcher.chart(cmd.ticket, {
+            repo: repo.repo, model: cmd.model, instruction: cmd.instruction,
             by: userId, threadId,
           })
         }
@@ -218,6 +249,14 @@ export class CommandRouter {
       this.log(`command "${canonical}" failed:`, e.message)
       return `⚠️ \`${cmd.verb}\` failed: ${e.message}`
     }
+  }
+
+  // The repo a dispatch verb runs against: the qualified form as typed, or the
+  // fuzzy one resolved against the watch list. `start` and `map` share it
+  // (#221) so one verb cannot accept a repo shape the other refuses.
+  #dispatchRepo(cmd) {
+    if (!cmd.repoArg) return { repo: cmd.repo }
+    return this.#matchRepo(cmd.repoArg)
   }
 
   // #81: a repo argument matches on any unambiguous substring of a watched

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -19,7 +19,7 @@ import crypto from 'node:crypto'
 import { setTimeout as sleepFor } from 'node:timers/promises'
 import {
   viewerLogin, repoMaps, mapFrontier, flatFrontier, fetchIssue, claim, unclaim, blockedByOf,
-  selectLane, frontierForRepo, agentOnlyChainCount, commentIssue, closeIssue, setIssueBody, issueComments,
+  selectLane, frontierForRepo, filterTakeable, agentOnlyChainCount, commentIssue, closeIssue, setIssueBody, issueComments,
   parentNumberOf, hasLabel, findPullRequest, createPullRequest, setPullRequestBody,
   deleteRemoteBranch,
 } from './github.mjs'
@@ -65,11 +65,12 @@ const SESSION_RE = /^curia-(\d+)$/
 const REVIEW_SESSION_RE = /^curia-review-(\d+)$/
 export const reviewSessionFor = (n) => `curia-review-${n}`
 
-// The label that makes a dispatch a CHARTING one (#160): `start curia#<map>` on
-// the map's own issue spawns an agent that updates the map, not one that
-// resolves a ticket under it. Everything that branches on it reads this
-// constant, and the journal records the answer per spawn so a restarted daemon
-// still knows which kind of agent it adopted.
+// The label a CHARTING dispatch needs (#160): `map curia#<n>` on a map's own
+// issue spawns an agent that updates the map, not one that resolves a ticket
+// under it. Since #221 the VERB decides the kind and this label is the check on
+// it — `start` never charts, whatever the label says. Everything that branches
+// on it reads this constant, and the journal records the answer per spawn so a
+// restarted daemon still knows which kind of agent it adopted.
 const MAP_LABEL = 'wayfinder:map'
 
 // The tracker doc every watched repo is meant to carry (#57 step 3). The
@@ -383,9 +384,14 @@ export class Dispatcher {
 
   // ---- start -----------------------------------------------------------------
 
+  // `start` has ONE meaning (#221): work the thing. On a ticket it dispatches
+  // that ticket. On a map it dispatches the map's next takeable ticket, which
+  // is what an operator reaching for `start` on a map wants — it never charts,
+  // and charting has its own verb (`map <n>`, see chart below).
+  //
   // `reuse` is the resume contract (#81): inherit the surviving worktree
   // instead of recreating it — see #dispatch.
-  async start(ticketArg, { repo, model, instruction = null, by, reuse = false, threadId = null } = {}) {
+  async start(ticketArg, { repo, model, by, reuse = false, threadId = null } = {}) {
     const n = String(ticketArg)
     const session = `curia-${n}`
     // Admission guard: synchronous check + insert BEFORE the first await, so a
@@ -410,20 +416,15 @@ export class Dispatcher {
       const { repo: theRepo, issue } = resolved
 
       if (issue.state !== 'open') return `❌ ${theRepo}#${n} is ${issue.state} — nothing to dispatch`
-      // An instruction rides a MAP dispatch and nothing else (#160/#149). A
-      // ticket agent's brief is its ticket body, which a human wrote and other
-      // sessions can read — an operator sentence that only exists in one spawn
-      // prompt would steer the work with no durable record of it. Refuse rather
-      // than drop it silently, and name where the sentence does belong.
+      // `start` on a MAP number (#221). It used to spawn a charting agent, which
+      // gave one verb two meanings — the fault class #184 exists to kill, on the
+      // command surface itself. It now means what it means everywhere else:
+      // work the next thing. The map's own frontier is that thing.
       //
-      // `!reuse` scopes it to an instruction a human actually typed. A resume
-      // carries the previous dispatch's instruction forward from the journal,
-      // and a map that has lost its label since then must degrade to an ordinary
-      // dispatch — not refuse a verb the operator typed no instruction on. The
-      // stale sentence is dropped rather than used: writePrompt renders one only
-      // on a charting dispatch.
-      if (instruction && !reuse && !hasLabel(issue, MAP_LABEL)) {
-        return `❌ ${theRepo}#${n} is not a \`${MAP_LABEL}\` issue, and an instruction rides a map dispatch only — put it in the ticket body, or send it as a note in the ticket's thread once the agent is up`
+      // A resume is exempt. It names a session, not a subject, so redirecting it
+      // to another number would resume the wrong agent.
+      if (!reuse && hasLabel(issue, MAP_LABEL)) {
+        return await this.#startNextOfMap(theRepo, n, issue, { model, by, threadId })
       }
       const anomalies = []
       const assignees = (issue.assignees ?? []).map((a) => a.login)
@@ -436,7 +437,92 @@ export class Dispatcher {
 
       // #dispatch returns null only on exhaustion whose latched notify just
       // fired; the slash caller still deserves a reply.
-      return (await this.#dispatch(theRepo, n, issue, { model, instruction, by, reuse, threadId })) ?? this.#exhaustedReply()
+      return (await this.#dispatch(theRepo, n, issue, { model, by, reuse, threadId })) ?? this.#exhaustedReply()
+    } finally {
+      this.inFlight.delete(session)
+    }
+  }
+
+  // `start <map>` → the map's next takeable ticket (#221). The ordering is the
+  // frontier's own — ascending issue number, the order `tickets` prints and the
+  // auto loop walks — so "next" means the same thing on every surface.
+  //
+  // The candidates are filtered exactly as `next` filters them: a number whose
+  // session is already live or already starting is skipped rather than refused,
+  // because the operator asked for the next takeable one and that one is taken.
+  // A ticket the frontier offers can still refuse itself further down (`start`
+  // re-reads the issue), and that refusal is returned as it stands — inventing a
+  // second candidate would dispatch a ticket the operator never saw named.
+  async #startNextOfMap(repo, mapNo, mapIssue, { model, by, threadId }) {
+    let items
+    try {
+      items = filterTakeable(await this.deps.mapFrontier(repo, mapNo))
+    } catch (e) {
+      return `❌ could not read the frontier of ${repo}#${mapNo} (${e.message}) — try again, or \`start\` one of its tickets by number`
+    }
+    for (const item of items.sort((a, b) => a.number - b.number)) {
+      const session = `curia-${item.number}`
+      if (this.agents.has(session) || this.inFlight.has(session)) continue
+      if (await this.deps.hasSession(session).catch(() => false)) continue
+      // The operator typed a map number and gets an agent on a different one.
+      // Which ticket, and why, rides the REPLY — it belongs where they typed
+      // the command (#218's rule), and a notify here would open a Discord
+      // thread on the map, which nothing else in curia ever does.
+      const picked = `🗺️ next takeable ticket of **${mapIssue.title}** is ${repo}#${item.number} **${item.title}**`
+      return `${picked}\n${await this.start(String(item.number), { repo, model, by, threadId })}`
+    }
+    // Nothing takeable is the ordinary end of a map, not a fault. Name the other
+    // verb here: an operator who typed `start <map>` meaning "update the map" is
+    // exactly the operator standing in front of this message.
+    return `❌ ${repo}#${mapNo} **${mapIssue.title}** has no takeable ticket — every child is closed, blocked, or already claimed. \`tickets\` shows the frontier, and \`map ${mapNo} -- <what should change>\` updates the map itself`
+  }
+
+  // ---- map (the charting dispatch) ---------------------------------------------
+
+  // `map <n> [-- <instruction>]` (#221, carrying #160's mechanics): the operator's
+  // own verb for updating a map. It spawns a CHARTING agent on the map issue,
+  // which edits the map and its tickets and ends on its edits plus one
+  // `report_result` — no close, no pull request, no review gate.
+  //
+  // Three things it does NOT do, each on purpose:
+  //
+  //   1. **It never claims the map** (#221). #160 claimed it to serialise the
+  //      body edits, and the operator ruled that wrong: a map is never on a
+  //      frontier, so the assignee bought nothing but a lie on the issue. The
+  //      lock that replaces it was already here — a charting agent on map #147
+  //      runs in session `curia-147`, and the two guards below refuse a second
+  //      one. The `tmux has-session` guard is the load-bearing half: it asks
+  //      tmux rather than daemon memory, so it survives a restart and catches a
+  //      session reconcile has not adopted yet.
+  //   2. **It reads no assignee or blocked-by anomaly.** Those are frontier
+  //      facts and a map is never on one. A map left assigned by a pre-#221
+  //      dispatch must not lock charting out forever.
+  //   3. **It refuses a non-map** rather than degrading to a ticket dispatch.
+  //      The two verbs mean different things now, so guessing which one the
+  //      operator meant is the ambiguity this ticket removed.
+  async chart(mapArg, { repo, model, instruction = null, by, reuse = false, threadId = null } = {}) {
+    const n = String(mapArg)
+    const session = `curia-${n}`
+    // The whole lock, in the same shape and the same order `start` uses.
+    if (this.inFlight.has(session)) return `⚙️ \`${session}\` is already starting`
+    if (this.agents.has(session)) {
+      const w = this.agents.get(session)
+      return `▶️ \`${session}\` is already charting ${w.repo ?? '?'}#${w.ticket ?? n} (state **${w.state ?? '?'}**) — \`cancel ${n}\` first, or \`attach ${n}\``
+    }
+    this.inFlight.add(session)
+    try {
+      if (await this.deps.hasSession(session)) {
+        return `⚠️ tmux session \`${session}\` is already live but untracked — \`cancel ${n}\` tears it down, then \`map ${n}\` again`
+      }
+      const resolved = await this.#resolveRepo(n, repo)
+      if (resolved.error) return resolved.error
+      const { repo: theRepo, issue } = resolved
+
+      if (issue.state !== 'open') return `❌ ${theRepo}#${n} is ${issue.state} — a closed map is not charted; reopen it first`
+      if (!hasLabel(issue, MAP_LABEL)) {
+        return `❌ ${theRepo}#${n} is not a \`${MAP_LABEL}\` issue — \`map\` updates a map, and \`start ${n}\` is how a ticket gets worked`
+      }
+      return (await this.#dispatch(theRepo, n, issue, { model, instruction, by, reuse, threadId, charting: true })) ?? this.#exhaustedReply()
     } finally {
       this.inFlight.delete(session)
     }
@@ -505,7 +591,7 @@ export class Dispatcher {
   // `reuse` (the resume contract, #81): a surviving worktree is inherited as it
   // stands — uncommitted files and local commits included — instead of being
   // recreated from origin; absent one, resume degrades to an ordinary dispatch.
-  async #dispatch(repo, n, issue, { model, instruction = null, by, reuse = false, threadId = null }) {
+  async #dispatch(repo, n, issue, { model, instruction = null, by, reuse = false, threadId = null, charting = false }) {
     const session = `curia-${n}`
     const labels = (issue.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name))
     // The type label, read once and used twice: it names the thread (#93) and
@@ -516,7 +602,16 @@ export class Dispatcher {
     // ROUTING — resolveModel reads `defaults.map` off the same loop — and unlike
     // any other for everything downstream of it: the prompt, the ending, the
     // tools curia will answer, and what report_result does.
-    const charting = typeLabel === MAP_LABEL
+    //
+    // The CALLER says which kind this is (#221), where #160 read it off the
+    // label: `start` never charts and `chart` always does, so a label alone can
+    // no longer answer the question. The label is still checked, as a belt —
+    // both mistakes are expensive (a charting agent on the ticket ending closes
+    // the map; a ticket agent on the charting ending lands no work), and this is
+    // the one place both are visible.
+    if (charting && typeLabel !== MAP_LABEL) {
+      return `❌ ${repo}#${n} is not a \`${MAP_LABEL}\` issue — curia dispatches no charting agent on it`
+    }
     const modelName = resolveModel(this.routing, labels, model)
     if (!this.routing.models[modelName]) {
       return `❌ unknown model \`${modelName}\` — configured models: ${Object.keys(this.routing.models).join(', ')}`
@@ -549,13 +644,25 @@ export class Dispatcher {
     }
 
     const login = await this.deps.viewerLogin()
-    // The claim on a MAP is not a claim on a ticket — nothing takes a map off a
-    // frontier, because a map is never on one. What it buys is the serialisation
-    // the map body needs: `start`'s own "already assigned" anomaly refuses a
-    // second charting agent on the same map, and #withMapLock cannot help here
-    // because the agent, not the daemon, does the writing.
-    await this.deps.claim(repo, n, login)
-    this.store.logEvent('dispatch_claimed', { repo, ticket: n, agent: session, by: by ?? 'unknown', kind: charting ? 'charting' : 'ticket' })
+    // NO DISPATCH CLAIMS A MAP (#221). #160 claimed it to serialise the body
+    // edits; the operator ruled the claim wrong, because a claim's whole meaning
+    // is "off the frontier" and a map is never on one — so on a map it said
+    // nothing true and made the issue read as worked when it was being edited.
+    //
+    // What replaces it is the session name, which was already doing the work:
+    // a charting agent on map #147 is `curia-147`, and `chart` refuses a second
+    // one on the in-memory table and then on `tmux has-session` itself. That
+    // second guard is why this is a real lock and not an optimistic one — it
+    // asks tmux, so it survives a daemon restart.
+    //
+    // The journal line goes with it: `dispatch_claimed` records a claim, and
+    // recording one that never happened would send reconcile looking for an
+    // assignee to release. `agent_spawned` marks the epoch for a map instead —
+    // every epoch reader takes either event.
+    if (!charting) {
+      await this.deps.claim(repo, n, login)
+      this.store.logEvent('dispatch_claimed', { repo, ticket: n, agent: session, by: by ?? 'unknown', kind: 'ticket' })
+    }
 
     // The ticket label goes on at the claim (#93): `start` binds the thread it
     // ran in, an autonomous dispatch opens and binds a fresh one — so every
@@ -671,17 +778,27 @@ export class Dispatcher {
       // the bot (filterTakeable drops it from every frontier) while disarming
       // the very mechanism built to release it. unclaim_failed is NOT matched
       // by closedAfterEpoch, so the next reconcile retries the release.
+      //
+      // A charting dispatch took no claim (#221), so there is none to release
+      // and an unclaim here would be a write against an issue curia never
+      // touched. The failure message says so rather than reporting a release
+      // that did not happen.
       let released = false
-      try {
-        await this.deps.unclaim(repo, n, login)
-        released = true
-        this.store.logEvent('dispatch_unclaimed', { repo, ticket: n, agent: session, reason: e.message })
-      } catch (unclaimErr) {
-        this.store.logEvent('unclaim_failed', { repo, ticket: n, agent: session, reason: e.message, error: unclaimErr.message })
+      if (!charting) {
+        try {
+          await this.deps.unclaim(repo, n, login)
+          released = true
+          this.store.logEvent('dispatch_unclaimed', { repo, ticket: n, agent: session, reason: e.message })
+        } catch (unclaimErr) {
+          this.store.logEvent('unclaim_failed', { repo, ticket: n, agent: session, reason: e.message, error: unclaimErr.message })
+        }
       }
       // The binding stays (#140): a failed dispatch is a claim release, not a
       // ticket-terminal state — the retry's traffic belongs in the same thread.
-      return `⚠️ dispatch of ${repo}#${n} failed before the agent could run: ${e.message} — ${released ? 'claim released' : 'claim release FAILED: the issue is still assigned to the bot; reconcile will retry'}`
+      const claimTail = charting
+        ? 'the map was never claimed, so nothing was released — `map ' + n + '` again when the cause is fixed'
+        : released ? 'claim released' : 'claim release FAILED: the issue is still assigned to the bot; reconcile will retry'
+      return `⚠️ dispatch of ${repo}#${n} failed before the agent could run: ${e.message} — ${claimTail}`
     }
   }
 
@@ -1682,6 +1799,15 @@ export class Dispatcher {
       this.store.logEvent('reviewer_ended', { repo: agent.repo, ticket: agent.ticket, agent: agent.session, reason })
       return true
     }
+    // #221: a charting agent holds no claim either, for the reason a reviewer
+    // holds none — nothing put one there. Unclaiming here would write to a map
+    // curia never assigned, and on a map an operator HAS assigned by hand it
+    // would quietly undo them. Same choke point, same guard, one line apart.
+    if (agent.charting) {
+      if (!keepCredentials) this.deps.removeCredentials(agent.cfgDir ?? cfgDirFor(this.root, agent.session))
+      this.store.logEvent('charting_ended', { repo: agent.repo, map: agent.ticket, ticket: agent.ticket, agent: agent.session, reason })
+      return true
+    }
     let released = false
     let failure = null
     const login = await this.deps.viewerLogin().catch((e) => { failure = e.message; return null })
@@ -1711,6 +1837,9 @@ export class Dispatcher {
   // rather than repeated at four call sites that would each have to remember.
   #releaseTail(agent, released) {
     if (agent.reviewer) return 'the cross-check ends with no verdict; the builder and its claim are untouched'
+    // #221: a map dispatch claims nothing, so there is no claim to report on.
+    // What the operator needs instead is that the map may be half-edited.
+    if (agent.charting) return 'the map was never claimed, so nothing was released — whatever the agent already wrote to the map STANDS'
     return released
       ? 'claim released, ticket re-frontiered'
       : 'claim release FAILED: the issue is still assigned; reconcile will retry'
@@ -2153,28 +2282,30 @@ export class Dispatcher {
     return text
   }
 
-  // The map dispatch's whole ending (#160). Three acts, and each one is the
-  // opposite of the ticket path's:
+  // The map dispatch's whole ending (#160, narrowed by #221). Two acts now:
   //
   //   1. COMMENT — curia posts the agent's summary on the map, so the change
   //      has a dated record beside the body it changed. The ticket path only
   //      comments as a repair; here it is the point.
-  //   2. UNCLAIM — the map goes back to unassigned. The ticket path closes; a
-  //      map is the standing artifact and closing it would take the whole effort
-  //      off every frontier.
-  //   3. Nothing else. No close, no Decisions-so-far line, no branch, no
-  //      merge check.
+  //   2. Nothing else. No unclaim (#221 took the claim away, so there is
+  //      nothing to release), no close, no Decisions-so-far line, no branch,
+  //      no merge check. A map is the standing artifact, and closing it would
+  //      take the whole effort off every frontier.
   //
   // The map edits themselves are NOT verified or repaired here, and cannot be:
   // curia has no expected value for a charting session, which is the same reason
   // #49 gave for having no verification gate at all. What the daemon can do is
   // say plainly what it did and did not check.
   async #finishCharting(agentName, repo, ticket, result, w, instruction) {
-    const record = w ?? { repo, ticket, session: agentName }
+    // `charting: true` is asserted, never inherited: this function is reached
+    // only through #epochCharting saying so, and after a restart `w` is null —
+    // the case where reading the flag off the record would silently unclaim a
+    // map curia never assigned (#221).
+    const record = { ...(w ?? { repo, ticket, session: agentName }), charting: true }
     // The agent is still alive at report_result, so its credential copy stays
     // until the session is positively gone — the #noteNonClean rule, same
     // reason (#34's snapshot bound).
-    const released = await this.#releaseClaim(record, 'charting agent reported in', { keepCredentials: true })
+    await this.#releaseClaim(record, 'charting agent reported in', { keepCredentials: true })
     let noted = false
     try {
       await this.deps.commentIssue(repo, ticket, chartingComment({
@@ -2185,12 +2316,13 @@ export class Dispatcher {
       this.log(`could not post the charting summary on ${repo}#${ticket}: ${e.message}`)
     }
     this.store.logEvent('charting_finished', {
-      repo, map: ticket, ticket, agent: agentName, status: result.status, commented: noted, released,
+      repo, map: ticket, ticket, agent: agentName, status: result.status, commented: noted,
     })
     const clean = result.status === 'resolved'
     const bits = [
       noted ? 'summary posted on the map' : '⚠️ the summary comment could NOT be posted',
-      released ? 'map unassigned' : '⚠️ the map is still assigned to the bot; reconcile will retry',
+      // #221: nothing to unassign — the dispatch never claimed the map.
+      'the map was never claimed',
       'the map stays open',
     ]
     this.notify(ticket, `${clean ? '🗺️' : '↩️'} ${repo}#${ticket} charted (**${result.status}**) — ${bits.join('; ')}. Nobody reviewed these map edits: read them.`)
@@ -2689,25 +2821,31 @@ export class Dispatcher {
     // does not match, so reconcile retries the release); and the untracked
     // branch — whose own message says the GitHub claim was untouched —
     // writes no unclaim event at all.
+    //
+    // A cancelled MAP dispatch has no claim to release (#221) — the same guard
+    // #releaseClaim carries, at the other teardown path.
+    const charting = Boolean(w?.charting) || (!w && this.#epochCharting(ticket, session).charting)
     let released = false
     let failure = null
     if (w) {
       await this.deps.removeWorktree(basePathFor(this.root, w.repo), w.wtPath).catch((e) => this.log(`worktree removal for ${session} failed:`, e.message))
-      const login = await this.deps.viewerLogin().catch((e) => { failure = e.message; return null })
-      if (login) {
-        try {
-          await this.deps.unclaim(w.repo, ticket, login)
-          released = true
-        } catch (e) {
-          failure = e.message
-          this.log(`unclaim ${w.repo}#${ticket} failed:`, e.message)
+      if (!charting) {
+        const login = await this.deps.viewerLogin().catch((e) => { failure = e.message; return null })
+        if (login) {
+          try {
+            await this.deps.unclaim(w.repo, ticket, login)
+            released = true
+          } catch (e) {
+            failure = e.message
+            this.log(`unclaim ${w.repo}#${ticket} failed:`, e.message)
+          }
         }
       }
     }
     this.deps.removeConfigDir(w?.cfgDir ?? cfgDirFor(this.root, session))
     this.deps.forgetAgentToken(this.dataDir, session)
     this.agents.delete(session)
-    if (w) {
+    if (w && !charting) {
       if (released) {
         this.store.logEvent('dispatch_unclaimed', { repo: w.repo, ticket, agent: session, reason: 'cancelled', by: by ?? 'unknown' })
       } else {
@@ -2718,7 +2856,9 @@ export class Dispatcher {
     // above cannot carry it because an untracked cancel writes none.
     this.store.logEvent('agent_cancelled', { repo: w?.repo, ticket, agent: session, by: by ?? 'unknown', tracked: Boolean(w) })
     const tail = w
-      ? (released ? ', worktree removed, ticket re-frontiered' : ', worktree removed — but the claim release FAILED: the issue is still assigned; reconcile will retry')
+      ? (charting
+        ? ', checkout removed — the map was never claimed, and whatever the agent already wrote to it STANDS'
+        : released ? ', worktree removed, ticket re-frontiered' : ', worktree removed — but the claim release FAILED: the issue is still assigned; reconcile will retry')
       : ' (was untracked; GitHub claim untouched)'
     const msg = `⚰️ \`${session}\` cancelled — session killed${tail}${reviewerLine ? `\n${reviewerLine}` : ''}`
     this.notify(ticket, msg)
@@ -2773,11 +2913,19 @@ export class Dispatcher {
     // A resumed map dispatch inherits the instruction that rode the original
     // one (#160). Without it the fresh charting agent would open by asking what
     // should change — a question the operator already answered, into a session
-    // that is gone. `start` re-reads the label and decides again, so an issue
-    // that is no longer a map degrades to an ordinary dispatch and the inherited
-    // sentence is dropped, never refused (the `!reuse` clause in start).
-    const { instruction } = this.#epochCharting(ticket, session)
-    return this.start(ticket, { repo, model: model ?? this.#inheritedModel(session), instruction, by, reuse: true, threadId })
+    // that is gone.
+    //
+    // #221 moved the decision here from the label. `resume` names a SESSION, and
+    // what that session was doing is a journal fact — reading it off the issue
+    // would send a resumed charting agent to `start`, which on a map number now
+    // dispatches a child ticket instead. So a charting epoch resumes through
+    // `chart`, and `chart` refuses an issue that has since lost the map label
+    // rather than guessing: there is no map left to chart, and `start <n>` is
+    // the verb for what the issue has become.
+    const { charting, instruction } = this.#epochCharting(ticket, session)
+    const inherited = { repo, model: model ?? this.#inheritedModel(session), by, reuse: true, threadId }
+    if (charting) return this.chart(ticket, { ...inherited, instruction })
+    return this.start(ticket, inherited)
   }
 
   // What a resume runs on (#177). Resume re-routed from the labels, so a ticket
@@ -2970,21 +3118,24 @@ export class Dispatcher {
     // request keeps the claim (awaiting review), anything else releases it.
     // Unreadable evidence decides nothing — reconcile retries.
     let claimLine
-    try {
-      const outcome = await this.#settleDeadClaim({ repo, ticket, session })
-      // A released MAP claim is not a re-frontiering: a map is never on a
-      // frontier, so nothing will pick it up again on its own (#160). Saying so
-      // matters — the operator has to know the next move is theirs.
-      const charting = this.#epochCharting(ticket, session).charting
-      claimLine = {
-        kept: 'its pull request is open and awaiting review, so the claim stays',
-        released: charting
-          ? 'the map is unassigned again, and whatever this agent already wrote to it STANDS'
-          : 'claim released, ticket re-frontiered',
-        'not-ours': charting ? 'the map is no longer claimed by curia' : 'the ticket is no longer claimed by curia',
-      }[outcome]
-    } catch (e) {
-      claimLine = `the claim decision failed (${e.message}) — reconcile will retry`
+    // A map dispatch holds no claim (#221), so there is no claim decision to
+    // take and #settleDeadClaim would read GitHub twice to answer "not ours".
+    // What the operator needs is the other fact: a map is never on a frontier,
+    // so nothing picks this up again on its own, and the half-finished edits are
+    // already live on the body.
+    if (this.#epochCharting(ticket, session).charting) {
+      claimLine = 'the map was never claimed, and whatever this agent already wrote to it STANDS'
+    } else {
+      try {
+        const outcome = await this.#settleDeadClaim({ repo, ticket, session })
+        claimLine = {
+          kept: 'its pull request is open and awaiting review, so the claim stays',
+          released: 'claim released, ticket re-frontiered',
+          'not-ours': 'the ticket is no longer claimed by curia',
+        }[outcome]
+      } catch (e) {
+        claimLine = `the claim decision failed (${e.message}) — reconcile will retry`
+      }
     }
     const escLine = open.length
       ? ` ${open.length} open question(s) — ${open.map((r) => `**${r.id}**`).join(', ')} — stay answerable: an answer there is recorded and handed to the resumed agent.`

--- a/daemon/src/overseer.mjs
+++ b/daemon/src/overseer.mjs
@@ -33,16 +33,20 @@ export function canonicalFor(verb, args = {}) {
       return `${verb}${args.repo ? ' ' + args.repo : ''}`
     case 'status':
       return 'status'
-    case 'start': {
-      let text = `start ${args.repo ? `${args.repo}#` : ''}${args.ticket}`
-      // #177 removed `harness=`: the harness follows the model.
+    // #177 removed `harness=`: the harness follows the model. #221 removed the
+    // instruction: `start` no longer charts, so it carries no sentence.
+    case 'start':
+      return `start ${args.repo ? `${args.repo}#` : ''}${args.ticket}${args.model ? ` model=${args.model}` : ''}`
+    case 'map': {
+      let text = `map ${args.repo ? `${args.repo}#` : ''}${args.ticket}`
       if (args.model) text += ` model=${args.model}`
-      // The map instruction (#160) rides LAST, after a bare `--`, because it is
-      // the one argument that is a whole sentence. Whitespace is collapsed here:
-      // the seam is one line of text, and the router splits it on whitespace, so
-      // a newline the model wrote would otherwise come back as a space anyway —
-      // collapsing it makes the canonical text the operator sees and the text
-      // the router parses the same string.
+      // The instruction (#160, moved here by #221) rides LAST, after a bare
+      // `--`, because it is the one argument that is a whole sentence.
+      // Whitespace is collapsed here: the seam is one line of text, and the
+      // router splits it on whitespace, so a newline the model wrote would
+      // otherwise come back as a space anyway — collapsing it makes the
+      // canonical text the operator sees and the text the router parses the
+      // same string.
       const instruction = String(args.instruction ?? '').replace(/\s+/g, ' ').trim()
       if (instruction) text += ` -- ${instruction}`
       return text
@@ -79,12 +83,17 @@ export function buildVerbTools(command) {
       repo: repoArg,
     }, run('next')),
     tool('status', 'Show the live agents: ticket, model, state, uptime, and who is waiting on input.', {}, run('status')),
-    tool('start', 'Claim a ticket and dispatch an agent on it. Use the repo field when the ticket number alone is ambiguous. Started on a MAP issue, this dispatches a charting agent that updates the map instead — pass the operator\'s sentence as the instruction.', {
+    tool('start', 'Claim a ticket and dispatch an agent to WORK it. Use the repo field when the ticket number alone is ambiguous. Given a MAP number, this dispatches that map\'s next takeable ticket — it does NOT update the map; the map tool does that.', {
       ticket: ticketArg,
       repo: repoArg,
       model: z.string().optional().describe('model override — the harness follows it, so there is no harness argument'),
-      instruction: z.string().optional().describe('MAP DISPATCHES ONLY: what the operator wants changed on the map, in their own words ("update the landing page map so that X"). The charting agent reads it as its first input. Leave it out and the agent asks the operator what should change. A ticket dispatch refuses it.'),
     }, run('start')),
+    tool('map', 'Dispatch a charting agent that UPDATES a map: add tickets, graduate fog, change scope, fix what the map says. Takes the map\'s own number. It edits the map and its tickets and closes nothing.', {
+      ticket: ticketArg,
+      repo: repoArg,
+      instruction: z.string().optional().describe('What the operator wants changed on the map, in their own words ("update the landing page map so that X"). The charting agent reads it as its first input. Leave it out and the agent asks the operator what should change.'),
+      model: z.string().optional().describe('model override — the harness follows it, so there is no harness argument'),
+    }, run('map')),
     tool('cancel', 'Cancel the agent on a ticket, or "all" for every agent. Destructive, so the daemon posts ✅/❌ buttons and executes ONLY after the operator presses ✅. Call this directly when asked — never seek confirmation in conversation first, and never report the cancel as done: report that the confirm was posted.', {
       ticket: bulkArg,
     }, run('cancel')),
@@ -98,7 +107,7 @@ export function buildVerbTools(command) {
   ]
 }
 
-export const ALLOWED_TOOLS = ['tickets', 'next', 'status', 'start', 'cancel', 'resume', 'attach']
+export const ALLOWED_TOOLS = ['tickets', 'next', 'status', 'start', 'map', 'cancel', 'resume', 'attach']
   .map((t) => `mcp__curia__${t}`)
 
 // ToolSearch is in here for the #83 gap, not for containment: with it
@@ -115,7 +124,7 @@ const SYSTEM_PROMPT = `You are the curia overseer. Curia is a personal orchestra
 You speak with one operator, in one Discord thread, in short Discord markdown. You act only through the curia tools. The daemon executes every effect.
 
 What you do:
-- Translate the operator's prose into the verbs: tickets, next, status, start, cancel, resume, attach.
+- Translate the operator's prose into the verbs: tickets, next, status, start, map, cancel, resume, attach.
 - Answer reasoning questions from tool output ("what should I start next?" — call tickets, then recommend one, with a one-line reason).
 - Report tool replies faithfully. Do not invent agents, tickets, or states.
 
@@ -123,7 +132,9 @@ Vocabulary the operator uses:
 - A "map" is a wayfinder map: a GitHub issue whose child tickets chart one effort. The operator names maps by topic ("the landing page map"). The \`tickets\` output groups tickets under their map's header line ("map #109 **The curia landing page**").
 - A map named in prose resolves to that map's header, never to repo-wide order: "continue with <map>" means \`start\` the FIRST ticket listed under that map's header. A repo can hold several maps — picking the repo's first takeable when the operator named a map dispatches the wrong ticket.
 - When a phrase names no repo or map you know, call \`tickets\` with no filter and match the phrase against the headers that come back before saying you cannot.
-- \`start\` on the MAP's own number is a map dispatch: a charting agent updates the map itself. Use it when the operator asks to CHANGE a map ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words — do not rewrite it and do not summarize it. "Continue with <map>" is not this: that starts the map's first ticket.
+- Two verbs take a map's own number, and they mean different things. \`start\` WORKS the map: it dispatches the map's next takeable ticket. \`map\` UPDATES the map: a charting agent edits the map itself.
+- Use \`map\` when the operator asks to CHANGE a map ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words. Do not rewrite it and do not summarize it.
+- Use \`start\` when the operator asks to work the map ("continue with <map>", "start the landing page map"). Either the map's own number or the ticket number listed under its header does this.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run \`tickets\` or \`status\` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -1043,8 +1043,10 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     `- **This is a MAP DISPATCH.** ${repo}#${n} is the map itself, not a ticket under it. Your job is to`,
     '  CHANGE THE MAP: its body sections, and its child tickets. Do not choose a frontier ticket, and do',
     '  not resolve one. The skill\'s step "choose the ticket" does not apply to this session.',
-    `- The map is ${repo}#${n} — ${ticketUrl}. curia has loaded it for you, and has assigned it to`,
-    '  you while you work, so a second charting agent cannot edit it under you.',
+    `- The map is ${repo}#${n} — ${ticketUrl}. curia has loaded it for you. It has NOT assigned the map`,
+    '  to you, and no dispatch ever does (#221): a claim means "off the frontier", and a map is never on',
+    '  one. What keeps a second charting agent off this body is the session name — curia refuses a second',
+    `  \`map ${n}\` while yours runs. So leave the map's assignee exactly as you found it.`,
     ...(instruction
       ? [
         '- **What the operator asked for**, in their own words:',

--- a/daemon/test/agentnotes.test.mjs
+++ b/daemon/test/agentnotes.test.mjs
@@ -95,6 +95,15 @@ describe('agent-note queue', () => {
     }
   })
 
+  // #221: `map` carries a whole operator sentence after `--`, and a sentence is
+  // what a note IS. Only the bare form is command-shaped, so the instruction
+  // form still queues as prose instead of being swallowed by the hint.
+  test('a map instruction is prose, and a bare map is a command', () => {
+    assert.ok(COMMAND_SHAPED.test('map 147'))
+    assert.ok(!COMMAND_SHAPED.test('map 147 -- add a ticket for the cooling signal'))
+    assert.ok(!COMMAND_SHAPED.test('map out the fallback chain before you start'))
+  })
+
   // The hint names a command the channel accepts, about the ticket the operator
   // asked about — not the one whose thread they happened to type it in.
   test('the operator\'s own argument wins over the thread it was typed in', () => {
@@ -108,9 +117,15 @@ describe('agent-note queue', () => {
     // `#166` and `curia#166` are not forms `cancel` takes — the number is
     assert.match(commandHint('cancel #166', '166', 'C1'), /say `cancel 166` there/)
     assert.match(commandHint('cancel curia#166', '166', 'C1'), /say `cancel 166` there/)
-    // `start` is the one verb that does take the repo-qualified ticket
+    // `start` and `map` are the verbs that take the repo-qualified ticket
     assert.match(commandHint('start curia#170', '166', 'C1'), /say `start curia#170` there/)
     assert.match(commandHint('start alp82/curia#170', '166', 'C1'), /say `start alp82\/curia#170` there/)
+    assert.match(commandHint('map curia#147', '166', 'C1'), /say `map curia#147` there/)
+    // A bare `#170` is not the repo-qualified form — it is the number with a
+    // `#` on it, and no verb parses that. Found by #221's `map #147` case, and
+    // `start` had carried the same miss.
+    assert.match(commandHint('start #170', '166', 'C1'), /say `start 170` there/)
+    assert.match(commandHint('map #147', '166', 'C1'), /say `map 147` there/)
     // `all` rides through on the verbs that take it, and not on the one that does not
     assert.match(commandHint('cancel all', '166', 'C1'), /say `cancel all` there/)
     assert.match(commandHint('attach all', '166', 'C1'), /say `attach 166` there/)
@@ -124,7 +139,10 @@ describe('agent-note queue', () => {
     const typed = [
       'cancel', 'Cancel', 'stop', 'pause', 'resume', 'status', 'cancel 166', 'cancel #166',
       'cancel curia#166', 'cancel all', 'resume 12', 'resume all', 'attach 166', 'attach all',
-      'start 170', 'start curia#170', 'start alp82/curia#170', 'start 170 model=sonnet',
+      'start 170', 'start curia#170', 'start alp82/curia#170', 'start 170 model=sonnet', 'start #170',
+      // #221: `map` is a verb now, so a bare one typed at an agent must reach
+      // the hint rather than the note queue.
+      'map', 'map 147', 'map #147', 'map curia#147', 'map all', 'map 147 model=opus',
     ]
     for (const t of typed) {
       assert.ok(COMMAND_SHAPED.test(t), `"${t}" should read as a command`)

--- a/daemon/test/commands.test.mjs
+++ b/daemon/test/commands.test.mjs
@@ -13,6 +13,10 @@
 //       (field-notes contract 6: the repo-qualified form, needed so a user
 //       can satisfy the ambiguity-refusal path's recommended qualified
 //       `owner/repo#n` reply -- plan.md step 8's `start`.)
+//     'map <n> [model=x] [-- <instruction>]'
+//                                       -> { verb: 'map', ticket, model?, instruction? }
+//       (#221: charting's own verb. `start` no longer means charting on a map
+//       number, so the instruction moved off it with the meaning.)
 //     'cancel <n>' | 'cancel all'      -> { verb: 'cancel', ticket } | { verb: 'cancel', all: true }
 //     'resume <n> [model=x]'           -> { verb: 'resume', ticket, model? }
 //     'resume all'                     -> { verb: 'resume', all: true }
@@ -146,18 +150,44 @@ describe('parseCommand', () => {
     assert.equal(c.model, 'opus')
   })
 
-  // #160: the map instruction. Every other argument on this seam is one
-  // whitespace-free token, because the seam is a line that gets split on
-  // whitespace — a whole operator sentence needs a boundary, and `--` is it.
-  test('start carries a free-text instruction after a bare --', () => {
-    const c = parseCommand('start 147 -- update the landing page map so that X')
-    assert.equal(c.verb, 'start')
+  // #221: `start` carries NO instruction. It stopped meaning charting, so the
+  // one argument that was a whole sentence went with the meaning.
+  test('start refuses an instruction', () => {
+    assert.equal(parseCommand('start 147 -- update the landing page map so that X'), null)
+    assert.equal(parseCommand('start 147 model=opus -- do X'), null)
+  })
+
+  test('the refusal names the verb that does take one, like harness= does', async () => {
+    const router = new CommandRouter({
+      dispatcher: { routing: { harnesses: {} }, config: { watch: [] } },
+      attach: {},
+      log: () => {},
+    })
+    const reply = await router.handle('start 147 -- update the map', 'user-1')
+    assert.match(reply, /`start` carries no instruction/)
+    assert.match(reply, /map <n> -- <sentence>/)
+  })
+
+  test('a bare -- inside a longer start line is still refused, not silently dropped', () => {
+    // The dangerous shape: parsing this as `start 147` would dispatch a ticket
+    // and throw the operator's sentence away with no word said.
+    assert.equal(parseCommand('start cur#147 model=opus -- add a ticket'), null)
+  })
+
+  // #160's instruction, moved to `map` by #221. Every other argument on this
+  // seam is one whitespace-free token, because the seam is a line that gets
+  // split on whitespace — a whole operator sentence needs a boundary, and `--`
+  // is it.
+  test('map carries a free-text instruction after a bare --', () => {
+    const c = parseCommand('map 147 -- update the landing page map so that X')
+    assert.equal(c.verb, 'map')
     assert.equal(c.ticket, '147')
     assert.equal(c.instruction, 'update the landing page map so that X')
   })
 
   test('the instruction sits after the options, and takes everything to the end', () => {
-    const c = parseCommand('start cur#147 model=opus -- add a ticket, then wire it -- and say so')
+    const c = parseCommand('map cur#147 model=opus -- add a ticket, then wire it -- and say so')
+    assert.equal(c.verb, 'map')
     assert.equal(c.repoArg, 'cur')
     assert.equal(c.model, 'opus')
     // from the FIRST `--` onward, so a sentence carrying one survives the round
@@ -165,38 +195,72 @@ describe('parseCommand', () => {
     assert.equal(c.instruction, 'add a ticket, then wire it -- and say so')
   })
 
-  test('a start with no -- carries no instruction at all', () => {
-    assert.equal(parseCommand('start 147').instruction, undefined)
-    assert.equal(parseCommand('start 147 model=opus').instruction, undefined)
+  test('map takes the same issue-reference forms start takes', () => {
+    // One parser behind both verbs (#221): the repo-qualified forms the
+    // ambiguity refusals recommend by name have to parse back on either.
+    assert.equal(parseCommand('map alp82/curia#147').repo, 'alp82/curia')
+    assert.equal(parseCommand('map alp82/curia#147').ticket, '147')
+    assert.equal(parseCommand('map cur#147').repoArg, 'cur')
+    assert.equal(parseCommand('map 147 model=opus').model, 'opus')
+    assert.equal(parseCommand('map'), null)
+    assert.equal(parseCommand('map banana'), null)
+  })
+
+  test('a map with no -- carries no instruction at all', () => {
+    // The agent then opens with the "what should change?" escalation (#160).
+    assert.equal(parseCommand('map 147').instruction, undefined)
+    assert.equal(parseCommand('map 147 model=opus').instruction, undefined)
   })
 
   test('a bare -- with nothing after it is refused, not read as an empty instruction', () => {
     // It would silently dispatch the "what should change?" escalation the
     // operator was trying to skip.
-    assert.equal(parseCommand('start 147 --'), null)
-    assert.equal(parseCommand('start 147 --   '), null)
+    assert.equal(parseCommand('map 147 --'), null)
+    assert.equal(parseCommand('map 147 --   '), null)
   })
 
   test('an option AFTER the -- is instruction text, not a refused option', () => {
-    const c = parseCommand('start 147 -- use model=opus wording in the note')
+    const c = parseCommand('map 147 -- use model=opus wording in the note')
     assert.equal(c.model, undefined)
     assert.equal(c.instruction, 'use model=opus wording in the note')
   })
 
-  test('the instruction reaches the dispatcher', async () => {
+  test('the instruction reaches the dispatcher, on chart and never on start', async () => {
     const seen = []
     const router = new CommandRouter({
       dispatcher: {
         routing: { harnesses: { claude: {} } },
         config: { watch: [{ repo: 'alp82/curia' }] },
-        start: async (ticket, opts) => { seen.push({ ticket, ...opts }); return 'ok' },
+        start: async (ticket, opts) => { seen.push({ verb: 'start', ticket, ...opts }); return 'ok' },
+        chart: async (ticket, opts) => { seen.push({ verb: 'map', ticket, ...opts }); return 'ok' },
       },
       attach: {},
       log: () => {},
     })
-    await router.handle('start 147 -- chart the cooling signal', 'user-1')
+    await router.handle('map 147 -- chart the cooling signal', 'user-1')
+    assert.equal(seen[0].verb, 'map')
     assert.equal(seen[0].ticket, '147')
     assert.equal(seen[0].instruction, 'chart the cooling signal')
+    await router.handle('start 147', 'user-1')
+    assert.equal(seen[1].verb, 'start')
+    assert.equal(seen[1].instruction, undefined)
+  })
+
+  test('map resolves a fuzzy repo through the same matcher start uses', async () => {
+    const seen = []
+    const router = new CommandRouter({
+      dispatcher: {
+        routing: { harnesses: { claude: {} } },
+        config: { watch: [{ repo: 'alp82/curia' }] },
+        chart: async (ticket, opts) => { seen.push({ ticket, ...opts }); return 'ok' },
+      },
+      attach: {},
+      log: () => {},
+    })
+    await router.handle('map cur#147 -- do X', 'user-1')
+    assert.equal(seen[0].repo, 'alp82/curia')
+    const reply = await router.handle('map nope#147', 'user-1')
+    assert.match(reply, /no watched repo matches/)
   })
 
   test('cancel', () => {

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -1,9 +1,14 @@
-// The map dispatch (#160, building #149 points 3-5): `start curia#<map>` on a
-// `wayfinder:map` issue spawns a CHARTING agent, which updates the map and
-// ends without a close, a pull request or a review gate.
+// The map dispatch (#160, building #149 points 3-5): a `wayfinder:map` issue
+// gets a CHARTING agent, which updates the map and ends without a close, a
+// pull request or a review gate.
+//
+// #221 moved the verb. `start <map>` used to spawn that agent, which gave one
+// word two meanings; it now dispatches the map's next takeable ticket, and
+// `map <n> [-- <instruction>]` is charting's own verb. The mechanics below are
+// #160's, unchanged, with one removal: NO DISPATCH CLAIMS A MAP any more.
 //
 // Four seams, tested where each one lives:
-//   1. the canonical text — `-- <instruction>` on `start` (commands.test.mjs
+//   1. the canonical text — `-- <instruction>` on `map` (commands.test.mjs
 //      and overseer.test.mjs carry the parse and the render);
 //   2. routing — a `map` row in the defaults, reached by the label;
 //   3. the prompt — a charting agent is told what it is, what the operator
@@ -273,19 +278,21 @@ describe('the charting checklist', () => {
 describe('report_result on a map dispatch', () => {
   async function chartAndReport(result, deps = {}) {
     const d = makeDispatcher(deps)
-    const reply = await d.start('147')
+    const reply = await d.chart('147')
     assert.match(reply, /charting agent on map/)
     calls.length = 0
     const text = await d.onResult('curia-147', result)
     return { d, text }
   }
 
-  test('it comments on the map, unassigns it, and CLOSES NOTHING', async () => {
+  test('it comments on the map, TOUCHES NO ASSIGNEE, and CLOSES NOTHING', async () => {
     const { text } = await chartAndReport({
       ticket: '147', status: 'resolved', summary: 'graduated two fog lines into tickets',
     })
     assert.ok(calls.some((c) => c === 'comment o/r#147'), 'no summary comment on the map')
-    assert.ok(calls.some((c) => c === 'unclaim o/r#147'), 'the map stayed assigned')
+    // #221: nothing claimed the map, so nothing releases it. An unclaim here
+    // would undo an assignee an operator had put on by hand.
+    assert.ok(!calls.some((c) => c === 'unclaim o/r#147'), 'the charting ending unclaimed a map it never claimed')
     assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')), 'a charting agent closed the map')
     assert.ok(!calls.some((c) => String(c).startsWith('setBody')), 'curia wrote a Decisions-so-far line for a charting session')
     assert.ok(!calls.includes('pushBranch') && !calls.includes('createPullRequest'), 'a charting session landed code')
@@ -301,14 +308,14 @@ describe('report_result on a map dispatch', () => {
     assert.match(body, /opened no pull request and closed nothing/)
   })
 
-  test('a blocked charting agent still leaves the map unassigned and says the edits stand', async () => {
+  test('a blocked charting agent says the edits stand, and still claims nothing', async () => {
     // The half-charted map is the dangerous state: the next operator has to
     // know that whatever it wrote is already live on the map.
     await chartAndReport({ ticket: '147', status: 'blocked', summary: 'ran out of road on the fog section' })
     const body = calls.find((c) => typeof c === 'string' && c.startsWith('## Charting'))
     assert.match(body, /\*\*blocked\*\*/)
     assert.match(body, /STANDS/)
-    assert.ok(calls.some((c) => c === 'unclaim o/r#147'))
+    assert.ok(!calls.some((c) => c === 'unclaim o/r#147'))
     assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')))
   })
 
@@ -322,19 +329,23 @@ describe('report_result on a map dispatch', () => {
     // The restart case: the in-memory record is gone and only the journal is
     // left. Falling back to "ticket" here would close the map.
     const d = makeDispatcher()
-    await d.start('147')
+    await d.chart('147')
     d.agents.delete('curia-147') // as a restart, or #releaseClaim, leaves it
     calls.length = 0
     await d.onResult('curia-147', { ticket: '147', status: 'resolved', summary: 's' })
     assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')), 'the journal fallback lost the charting kind')
     assert.ok(calls.some((c) => c === 'comment o/r#147'))
+    // #221's own restart hazard: with no in-memory record there is no
+    // `charting` flag to read off it, and #releaseClaim's default path would
+    // unclaim the map. The finish asserts the flag instead of inheriting it.
+    assert.ok(!calls.some((c) => c === 'unclaim o/r#147'), 'the restart path unclaimed a map curia never claimed')
   })
 })
 
 describe('the two tools a map dispatch refuses', () => {
   test('open_pull_request is refused, and nothing is pushed', async () => {
     const d = makeDispatcher()
-    await d.start('147')
+    await d.chart('147')
     calls.length = 0
     const reply = await d.openPullRequest('curia-147', { summary: 'x' })
     assert.match(reply, /CHARTING agent/)
@@ -347,7 +358,7 @@ describe('the two tools a map dispatch refuses', () => {
     let asked = 0
     const d = makeDispatcher()
     d.askReview = async () => { asked += 1; return { text: 'approve', status: 'answered' } }
-    await d.start('147')
+    await d.chart('147')
     const r = await d.requestReview('curia-147', { summary: 'x', charting: 'y' })
     assert.equal(r.ok, false)
     assert.match(r.text, /no review gate/)
@@ -364,58 +375,175 @@ describe('the two tools a map dispatch refuses', () => {
 
 // ---- the dispatch itself ------------------------------------------------------
 
-describe('start on a map', () => {
-  test('the map is claimed, the prompt gets the map and the instruction, and the reply says charting', async () => {
+describe('map <n> — the charting verb (#221)', () => {
+  test('the prompt gets the map and the instruction, and the reply says charting', async () => {
     let prompted = null
     const d = makeDispatcher({
       writePrompt: (cfgDir, issue, opts) => { prompted = opts; return path.join(cfgDir, 'prompt.md') },
     })
-    const reply = await d.start('147', { instruction: 'add a ticket for the cooling signal' })
+    const reply = await d.chart('147', { instruction: 'add a ticket for the cooling signal' })
     assert.match(reply, /charting agent on map o\/r#147/)
     assert.match(reply, /on \*\*opus\*\*/)
     assert.equal(prompted.charting, true)
     assert.equal(prompted.mapNumber, 147)
     assert.equal(prompted.instruction, 'add a ticket for the cooling signal')
-    assert.ok(calls.includes('claim o/r#147'))
+  })
+
+  // #221's ruling, and the one assertion this file exists to keep: a claim
+  // means "off the frontier", and a map is never on one. The claim #160 took
+  // said nothing true and made the issue read as worked.
+  test('NO DISPATCH CLAIMS THE MAP', async () => {
+    const d = makeDispatcher()
+    await d.chart('147', { instruction: 'do X' })
+    assert.ok(!calls.some((c) => String(c).startsWith('claim')), `the map was claimed: ${calls.join(', ')}`)
+    assert.ok(!events.some((e) => e.type === 'dispatch_claimed'), 'a claim that never happened was journalled')
+  })
+
+  test('the epoch survives without dispatch_claimed — agent_spawned carries it', async () => {
+    // Every epoch reader takes either event, which is what makes dropping the
+    // claim line safe: reconcile still finds the map's latest dispatch.
+    const d = makeDispatcher()
+    await d.chart('147')
+    assert.ok(events.some((e) => e.type === 'agent_spawned' && String(e.ticket) === '147'))
+  })
+
+  test('a map already assigned is charted anyway — the assignee is not the lock', async () => {
+    // A map left assigned by a pre-#221 dispatch, or by an operator's own hand,
+    // must not lock charting out forever.
+    const d = makeDispatcher({}, { issue: { ...MAP_ISSUE, assignees: [{ login: 'someone' }] } })
+    const reply = await d.chart('147')
+    assert.match(reply, /charting agent on map/)
+  })
+
+  test('the SESSION NAME is the lock: a second charting agent is refused', async () => {
+    const d = makeDispatcher()
+    await d.chart('147')
+    const second = await d.chart('147')
+    assert.match(second, /already charting/)
+    assert.equal(events.filter((e) => e.type === 'agent_spawned').length, 1)
+  })
+
+  test('the lock asks tmux, so it holds with no in-memory record at all', async () => {
+    // The restart case. This guard is why removing the claim costs nothing:
+    // it survives a daemon that has forgotten the agent it adopted.
+    const d = makeDispatcher({ hasSession: async () => true })
+    const reply = await d.chart('147')
+    assert.match(reply, /already live but untracked/)
+    assert.equal(events.filter((e) => e.type === 'agent_spawned').length, 0)
   })
 
   test('with no instruction the reply says the agent will ask', async () => {
     const d = makeDispatcher()
-    const reply = await d.start('147')
+    const reply = await d.chart('147')
     assert.match(reply, /no instruction rode this dispatch, so it will ask what should change/)
   })
 
   test('the spawn is journalled with its kind and its instruction', async () => {
     const d = makeDispatcher()
-    await d.start('147', { instruction: 'do X' })
+    await d.chart('147', { instruction: 'do X' })
     const spawn = events.find((e) => e.type === 'agent_spawned')
     assert.equal(spawn.kind, 'charting')
     assert.equal(spawn.instruction, 'do X')
   })
 
-  test('an instruction on a ticket is REFUSED, not dropped', async () => {
-    // Silently dropping it would steer nothing and say nothing. The ticket body
-    // is where a ticket agent's brief has to live, because other sessions read
-    // it and a spawn prompt is read once.
+  test('map on a NON-map issue is refused, never degraded to a ticket dispatch', async () => {
+    // The two verbs mean different things now, so guessing which one was meant
+    // is the ambiguity #221 removed.
     const d = makeDispatcher({}, { issue: TICKET_ISSUE })
-    const reply = await d.start('42', { instruction: 'focus on the routing part' })
+    const reply = await d.chart('42', { instruction: 'focus on the routing part' })
     assert.match(reply, /not a `wayfinder:map` issue/)
-    assert.equal(calls.length, 0, 'the refused dispatch still claimed the ticket')
+    assert.match(reply, /`start 42` is how a ticket gets worked/)
+    assert.equal(calls.length, 0, 'the refused dispatch still touched the tracker')
   })
 
-  test('a ticket dispatch is journalled as a ticket', async () => {
+  test('map on a closed map is refused', async () => {
+    const d = makeDispatcher({}, { issue: { ...MAP_ISSUE, state: 'closed' } })
+    assert.match(await d.chart('147'), /closed map is not charted/)
+  })
+
+  test('a ticket dispatch is journalled as a ticket, and still claims', async () => {
     const d = makeDispatcher({}, { issue: TICKET_ISSUE })
     await d.start('42')
     assert.equal(events.find((e) => e.type === 'agent_spawned').kind, 'ticket')
+    assert.ok(calls.includes('claim o/r#42'))
+  })
+})
+
+describe('start on a map — the map\'s next takeable ticket (#221)', () => {
+  const CHILD = (n, title, extra = {}) => ({
+    number: n, title, state: 'open', assignees: [], labels: [{ name: 'wayfinder:task' }], ...extra,
   })
 
-  test('a map already assigned refuses — one charting agent at a time', async () => {
-    // The map body is a read-modify-write with no compare-and-swap behind it,
-    // and the AGENT does the writing, so #withMapLock cannot serialise it.
-    // The claim is what does.
-    const d = makeDispatcher({}, { issue: { ...MAP_ISSUE, assignees: [{ login: 'me' }] } })
+  test('it dispatches the map\'s first takeable child, and charts nothing', async () => {
+    let prompted = null
+    const d = makeDispatcher({
+      mapFrontier: async () => [CHILD(51, 'the second one'), CHILD(43, 'the first one')],
+      fetchIssue: async (repo, n) => (String(n) === '147'
+        ? { ...MAP_ISSUE }
+        : CHILD(Number(n), 'the first one')),
+      writePrompt: (cfgDir, issue, opts) => { prompted = opts; return path.join(cfgDir, 'prompt.md') },
+    })
     const reply = await d.start('147')
-    assert.match(reply, /already assigned/)
+    // ascending issue number — the order `tickets` prints and the auto loop walks
+    assert.match(reply, /dispatched o\/r#43/)
+    assert.ok(!/charting/.test(reply), 'start still charted a map')
+    assert.equal(prompted.charting, false)
+    assert.ok(calls.includes('claim o/r#43'), 'the CHILD is claimed, as any ticket is')
+    assert.ok(!calls.includes('claim o/r#147'), 'start claimed the map')
+    assert.equal(events.find((e) => e.type === 'agent_spawned').kind, 'ticket')
+  })
+
+  test('the REPLY names the ticket it picked, and no thread is opened on the map', async () => {
+    // The operator typed a map number and gets an agent on a different number.
+    // Saying which one, and why, is what keeps that from reading as a fault —
+    // and it belongs in the reply, where they typed the command (#218).
+    const d = makeDispatcher({
+      mapFrontier: async () => [CHILD(43, 'the first one')],
+      fetchIssue: async (repo, n) => (String(n) === '147' ? { ...MAP_ISSUE } : CHILD(43, 'the first one')),
+    })
+    const reply = await d.start('147')
+    assert.match(reply, /next takeable ticket of \*\*Curia gets better\*\* is o\/r#43 \*\*the first one\*\*/)
+    assert.match(reply, /dispatched o\/r#43/)
+    assert.ok(!notifies.some((x) => String(x.ticket) === '147'), 'start on a map opened a thread on the map')
+  })
+
+  test('a blocked, claimed or closed child is not takeable', async () => {
+    const d = makeDispatcher({
+      mapFrontier: async () => [
+        CHILD(43, 'claimed', { assignees: [{ login: 'me' }] }),
+        CHILD(44, 'blocked', { issue_dependencies_summary: { blocked_by: 1 } }),
+        CHILD(45, 'closed', { state: 'closed' }),
+        CHILD(46, 'takeable'),
+      ],
+      fetchIssue: async (repo, n) => (String(n) === '147' ? { ...MAP_ISSUE } : CHILD(46, 'takeable')),
+    })
+    assert.match(await d.start('147'), /dispatched o\/r#46/)
+  })
+
+  test('a child whose session is already live is skipped, not refused', async () => {
+    const d = makeDispatcher({
+      mapFrontier: async () => [CHILD(43, 'running'), CHILD(44, 'free')],
+      fetchIssue: async (repo, n) => (String(n) === '147' ? { ...MAP_ISSUE } : CHILD(44, 'free')),
+      hasSession: async (s) => s === 'curia-43',
+    })
+    assert.match(await d.start('147'), /dispatched o\/r#44/)
+  })
+
+  test('an empty frontier refuses and names the OTHER verb', async () => {
+    // An operator who typed `start <map>` meaning "update the map" is exactly
+    // the operator standing in front of this message.
+    const d = makeDispatcher({ mapFrontier: async () => [] })
+    const reply = await d.start('147')
+    assert.match(reply, /has no takeable ticket/)
+    assert.match(reply, /`map 147 -- <what should change>` updates the map itself/)
+    assert.equal(events.filter((e) => e.type === 'agent_spawned').length, 0)
+  })
+
+  test('a frontier read that fails refuses rather than charting or guessing', async () => {
+    const d = makeDispatcher({ mapFrontier: async () => { throw new Error('gh exploded') } })
+    const reply = await d.start('147')
+    assert.match(reply, /could not read the frontier/)
+    assert.match(reply, /gh exploded/)
   })
 })
 
@@ -425,56 +553,104 @@ describe('resume on a map', () => {
     const d = makeDispatcher({
       writePrompt: (cfgDir, issue, opts) => { prompted = opts; return path.join(cfgDir, 'prompt.md') },
     })
-    await d.start('147', { instruction: 'graduate the cooling fog' })
+    await d.chart('147', { instruction: 'graduate the cooling fog' })
     d.agents.delete('curia-147')
     prompted = null
     await d.resume('147')
     assert.equal(prompted.instruction, 'graduate the cooling fog', 'the resumed charting agent lost the brief')
+    assert.equal(prompted.charting, true, 'the resumed map dispatch came back as a ticket one')
   })
 
-  test('a map that has since lost its label degrades instead of refusing', async () => {
-    // The operator typed no instruction on `resume`, so a refusal naming one
-    // would be a refusal for something they did not do.
+  // #221: `resume` names a SESSION, and what that session was doing is a
+  // journal fact. Reading it off the issue would send a resumed charting agent
+  // to `start`, which on a map number now dispatches a CHILD.
+  test('a resumed charting agent is never redirected to a child ticket', async () => {
+    const d = makeDispatcher({ mapFrontier: async () => [{ number: 43, title: 'a child', state: 'open', assignees: [], labels: [] }] })
+    await d.chart('147')
+    d.agents.delete('curia-147')
+    calls.length = 0
+    const reply = await d.resume('147')
+    assert.match(reply, /charting agent on map o\/r#147/)
+    assert.ok(!/#43/.test(reply), 'resume of a charting agent dispatched a child ticket')
+  })
+
+  test('a map that has since lost its label is refused, and the refusal names start', async () => {
+    // There is no map left to chart. Degrading to a ticket dispatch on a body
+    // written as a map is the guess #221 removed.
     const d = makeDispatcher()
-    await d.start('147', { instruction: 'do X' })
+    await d.chart('147', { instruction: 'do X' })
     d.agents.delete('curia-147')
     const plain = makeDispatcher({ fetchIssue: async () => ({ ...MAP_ISSUE, labels: [] }) })
     plain.dataDir = d.dataDir
     const reply = await plain.resume('147')
-    assert.ok(!/an instruction rides a map dispatch only/.test(reply), reply)
+    assert.match(reply, /not a `wayfinder:map` issue/)
+    assert.match(reply, /`start 147` is how a ticket gets worked/)
+  })
+
+  test('an ordinary ticket resume is untouched by any of it', async () => {
+    const d = makeDispatcher({}, { issue: TICKET_ISSUE })
+    await d.start('42')
+    d.agents.delete('curia-42')
+    calls.length = 0
+    const reply = await d.resume('42')
+    assert.match(reply, /dispatched o\/r#42/)
+  })
+})
+
+describe('cancel on a map dispatch (#221)', () => {
+  test('it removes the checkout, claims nothing back, and says the edits stand', async () => {
+    const d = makeDispatcher()
+    await d.chart('147', { instruction: 'do X' })
+    calls.length = 0
+    const reply = await d.cancel('147')
+    assert.ok(!calls.some((c) => String(c).startsWith('unclaim')), 'cancel unclaimed a map curia never claimed')
+    assert.ok(!events.some((e) => e.type === 'unclaim_failed'), 'a claim release that was never owed was journalled as failed')
+    assert.match(reply, /the map was never claimed/)
+    assert.match(reply, /STANDS/)
+  })
+
+  test('an ordinary ticket cancel still releases its claim', async () => {
+    const d = makeDispatcher({}, { issue: TICKET_ISSUE })
+    await d.start('42')
+    calls.length = 0
+    const reply = await d.cancel('42')
+    assert.ok(calls.some((c) => c === 'unclaim o/r#42'))
+    assert.match(reply, /re-frontiered/)
   })
 })
 
 // ---- the phone's command surface ----------------------------------------------
 
-describe('the /start slash expansion', () => {
-  const interaction = (options) => ({
-    commandName: 'start',
+describe('the /map slash expansion', () => {
+  const interaction = (commandName, options) => ({
+    commandName,
     options: { getString: (name) => options[name] ?? null },
   })
 
   test('an instruction expands to the same canonical text the overseer writes', () => {
     assert.equal(
-      expandCommand(interaction({ ticket: '147', instruction: 'add a ticket for X' })),
-      'start 147 -- add a ticket for X',
+      expandCommand(interaction('map', { ticket: '147', instruction: 'add a ticket for X' })),
+      'map 147 -- add a ticket for X',
     )
     assert.equal(
-      expandCommand(interaction({ ticket: '147', model: 'opus', instruction: 'add a ticket for X' })),
-      'start 147 model=opus -- add a ticket for X',
+      expandCommand(interaction('map', { ticket: '147', model: 'opus', instruction: 'add a ticket for X' })),
+      'map 147 model=opus -- add a ticket for X',
     )
   })
 
-  test('no instruction leaves the pre-#160 text untouched', () => {
-    // An old client-side manifest sends no such option (#65), and the dispatch
-    // must still work — the charting agent then asks what should change.
-    assert.equal(expandCommand(interaction({ ticket: '147' })), 'start 147')
-    assert.equal(expandCommand(interaction({ ticket: '147', instruction: '  ' })), 'start 147')
+  test('no instruction still dispatches — the agent then asks what should change', () => {
+    assert.equal(expandCommand(interaction('map', { ticket: '147' })), 'map 147')
+    assert.equal(expandCommand(interaction('map', { ticket: '147', instruction: '  ' })), 'map 147')
+  })
+
+  test('a /map with no ticket is the missing-option error, not `map null`', () => {
+    assert.deepEqual(expandCommand(interaction('map', {})), { error: 'missing' })
   })
 
   test('what the phone sends, the router reads back', () => {
-    const text = expandCommand(interaction({ ticket: '147', model: 'opus', instruction: 'chart\nthe fog' }))
+    const text = expandCommand(interaction('map', { ticket: '147', model: 'opus', instruction: 'chart\nthe fog' }))
     assert.deepEqual(parseCommand(text), {
-      verb: 'start', ticket: '147', model: 'opus', instruction: 'chart the fog',
+      verb: 'map', ticket: '147', model: 'opus', instruction: 'chart the fog',
     })
   })
 
@@ -482,7 +658,16 @@ describe('the /start slash expansion', () => {
   // it. A STALE client-side manifest still can, and expansion must not put it
   // back into the canonical text — the round trip above is what would break.
   test('a stale client sending harness= expands to text without it', () => {
-    assert.equal(expandCommand(interaction({ ticket: '147', harness: 'codex' })), 'start 147')
+    assert.equal(expandCommand(interaction('start', { ticket: '147', harness: 'codex' })), 'start 147')
+  })
+
+  // #221 removed `instruction` from /start's manifest. A stale client-side
+  // manifest still sends it, and putting it back into the canonical text would
+  // expand to a line the router now refuses — the same fault #177 fixed.
+  test('a stale client sending instruction= on /start expands to text without it', () => {
+    const text = expandCommand(interaction('start', { ticket: '147', instruction: 'update the map' }))
+    assert.equal(text, 'start 147')
+    assert.deepEqual(parseCommand(text), { verb: 'start', ticket: '147' })
   })
 })
 

--- a/daemon/test/overseer.test.mjs
+++ b/daemon/test/overseer.test.mjs
@@ -103,36 +103,48 @@ describe('canonicalFor', () => {
     assert.throws(() => canonicalFor('reboot', {}))
   })
 
-  // #160: the map instruction crosses the same canonical-text seam as every
-  // other argument, so the two ends are pinned against each other here and in
-  // commands.test.mjs.
-  test('a map instruction rides start last, after a bare --', () => {
+  // #160's instruction crosses the same canonical-text seam as every other
+  // argument, so the two ends are pinned against each other here and in
+  // commands.test.mjs. #221 moved it from `start` to `map`.
+  test('a map instruction rides map last, after a bare --', () => {
     assert.equal(
-      canonicalFor('start', { ticket: '147', instruction: 'update the map so that X' }),
-      'start 147 -- update the map so that X',
+      canonicalFor('map', { ticket: '147', instruction: 'update the map so that X' }),
+      'map 147 -- update the map so that X',
     )
     assert.equal(
-      canonicalFor('start', { ticket: '147', repo: 'cur', model: 'opus', instruction: 'add a ticket' }),
-      'start cur#147 model=opus -- add a ticket',
+      canonicalFor('map', { ticket: '147', repo: 'cur', model: 'opus', instruction: 'add a ticket' }),
+      'map cur#147 model=opus -- add a ticket',
     )
   })
 
   test('the instruction is collapsed to one line — the seam is one line of text', () => {
     assert.equal(
-      canonicalFor('start', { ticket: '147', instruction: '  add a ticket\nthen wire it  ' }),
-      'start 147 -- add a ticket then wire it',
+      canonicalFor('map', { ticket: '147', instruction: '  add a ticket\nthen wire it  ' }),
+      'map 147 -- add a ticket then wire it',
     )
   })
 
   test('an empty instruction posts no -- at all', () => {
-    assert.equal(canonicalFor('start', { ticket: '147', instruction: '' }), 'start 147')
-    assert.equal(canonicalFor('start', { ticket: '147', instruction: '   ' }), 'start 147')
+    assert.equal(canonicalFor('map', { ticket: '147', instruction: '' }), 'map 147')
+    assert.equal(canonicalFor('map', { ticket: '147', instruction: '   ' }), 'map 147')
+  })
+
+  // #221: `start` no longer charts, so it can no longer carry a sentence. A
+  // model that writes one anyway must not produce text the router refuses —
+  // the same treatment `harness=` gets above.
+  test('an instruction handed to start is dropped, never composed into the text', () => {
+    assert.equal(canonicalFor('start', { ticket: '147', instruction: 'update the map' }), 'start 147')
+    assert.equal(
+      canonicalFor('start', { ticket: '147', model: 'opus', instruction: 'update the map' }),
+      'start 147 model=opus',
+    )
+    assert.ok(parseCommand(canonicalFor('start', { ticket: '147', instruction: 'x' })))
   })
 
   test('what canonicalFor writes, parseCommand reads back', () => {
-    const text = canonicalFor('start', { ticket: '147', model: 'opus', instruction: 'chart the fog -- all of it' })
+    const text = canonicalFor('map', { ticket: '147', model: 'opus', instruction: 'chart the fog -- all of it' })
     assert.deepEqual(parseCommand(text), {
-      verb: 'start', ticket: '147', model: 'opus', instruction: 'chart the fog -- all of it',
+      verb: 'map', ticket: '147', model: 'opus', instruction: 'chart the fog -- all of it',
     })
   })
 })

--- a/docs/adr/0008-resolved-means-merged.md
+++ b/docs/adr/0008-resolved-means-merged.md
@@ -1,7 +1,7 @@
 # ADR-0008: Resolved means merged
 
 **Status**: accepted (2026-07)
-**Provenance**: [The PR gap (#48)](https://github.com/alp82/curia/issues/48), [Build the merge-gated resolution lifecycle (#54)](https://github.com/alp82/curia/issues/54), [Map dispatch (#160)](https://github.com/alp82/curia/issues/160)
+**Provenance**: [The PR gap (#48)](https://github.com/alp82/curia/issues/48), [Build the merge-gated resolution lifecycle (#54)](https://github.com/alp82/curia/issues/54), [Map dispatch (#160)](https://github.com/alp82/curia/issues/160), [Map updates get their own verb (#221)](https://github.com/alp82/curia/issues/221)
 
 ## Context
 
@@ -19,11 +19,13 @@ The full-loop rehearsal closed a ticket and wrote its map pointer while the code
 
 ## Deviations
 
-**The map dispatch (#160, deciding #149).** `start` on a map's own issue spawns a charting agent, and this ADR does not apply to it. A charting agent's output is the map itself — issue bodies and child issues, inside an ordinary agent's write bounds — so there is no branch to stage it in, nothing for a pull request to carry, and nothing for a review gate to show. It therefore never merges, never resolves, and never closes the map. It ends on two steps: edit the map, then `report_result`. Curia posts that summary as a comment on the map and unassigns it.
+**The map dispatch (#160, deciding #149; the verb moved by #221).** `map <n>` on a map's own issue spawns a charting agent, and this ADR does not apply to it. A charting agent's output is the map itself — issue bodies and child issues, inside an ordinary agent's write bounds — so there is no branch to stage it in, nothing for a pull request to carry, and nothing for a review gate to show. It therefore never merges, never resolves, and never closes the map. It ends on two steps: edit the map, then `report_result`. Curia posts that summary as a comment on the map.
 
 What replaces the gate is the operator, per [#149](https://github.com/alp82/curia/issues/149): the dispatch is a deliberate act carrying their own instruction, and the map routes to the strongest claude-harness model. Two things hold the exception in place rather than leaving it to the prompt. The daemon refuses `open_pull_request` and `request_review` on a charting agent, so an agent that has misread its own kind is not one call away from pushing a branch. And the dispatch's kind is journalled at the spawn, so a restarted daemon still knows which of the two endings it is holding an agent to — reading a charting agent as a ticket one would close the map, which takes a whole effort off every frontier.
 
-The claim keeps its second meaning here: assigning the map takes nothing off a frontier, and stops a second charting agent from editing the same body under the first.
+**The verb and the claim ([#221](https://github.com/alp82/curia/issues/221)).** #160 put charting on `start`, which gave one word two meanings: `start <n>` worked a ticket and `start <map>` charted. The operator ruled the overload confusing after using it. `start` now has one meaning everywhere — work the thing — and on a map number it dispatches that map's next takeable ticket. Charting has its own verb.
+
+No dispatch claims a map. #160 assigned the map to serialize the body edits, and a claim's whole meaning is "off a frontier" — a map is never on one, so the assignee said nothing true and made the issue read as worked. The lock that replaces it was already there: a charting agent on map #147 runs in session `curia-147`, and `map 147` is refused while that session lives. The check asks `tmux has-session` rather than daemon memory, so it survives a restart and catches a session reconcile has not adopted yet. It is per box, and there is one box.
 
 The #54 sketch made the gate a bare `ask_human(approve-reject)`. It shipped as its own tool and escalation kind, `request_review`, for three reasons the plain form cannot meet: the daemon composes every link from its own records so an agent cannot forge them, the daemon can tell the gate apart from any other block, and the approval becomes a durable journal fact only the daemon can stage. The gate requires a concrete `charting` field, per [ADR-0006](0006-worker-containment-and-standing-orders.md).
 


### PR DESCRIPTION
Ticket: alp82/curia#221 — [Map updates get their own verb: start on a map stops meaning charting](https://github.com/alp82/curia/issues/221)

`start` on a map number stops meaning charting. It now dispatches that map's next takeable ticket, so `start` has one meaning everywhere: work the thing.

Charting moves to its own verb, `map <n> [-- <instruction>]` — the operator's own word, ruled over `chart` in the grilling. #160's mechanics carry over unchanged: the instruction rides the spawn prompt after a bare `--`, no instruction opens with an `ask_human`, the charting ending stays (edits + `report_result`, never a close, never a PR), and the `map: fable` routing row stays.

No dispatch claims a map any more. A claim means "off the frontier" and a map is never on one, so the assignee said nothing true. The replacement lock was already there: a charting agent on map #147 runs in session `curia-147`, and `map 147` is refused while that session lives — the second guard asks `tmux has-session`, not daemon memory, so it survives a restart. The skip reaches every path that released a claim: dispatch failure, cancel, agent death, and the charting ending.

Two things the caller now decides instead of the label. `#dispatch` takes the dispatch kind as a parameter and checks the label as a belt. `resume` reads the kind from the journal, because it names a session rather than a subject.

Found while testing: the thread command hint matched a bare `#170` as the repo-qualified form, so `start #170` named a command the router refuses. Fixed.

Docs: CONTEXT.md's Map dispatch / Instruction / Claim / Charting ending entries, a new Map lock entry, the verb list (which had said "the five verbs" since before `next`, `resume` and `review` joined), ADR-0008's map-dispatch deviation, and the README command list.

1084 tests, failure set matching a clean tree.

---

Dispatched by the curia daemon — session `curia-221`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `580e25c` Map updates get their own verb: start on a map stops meaning charting (alp82/curia#221)