### PR TITLE
A respawn refusal reads as a respawn failure in the thread (alp82/curia#217)

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -973,7 +973,12 @@ export class Dispatcher {
     const wayOut = where === 'respawn'
       ? 'The harness this agent was dispatched on does not load it, and the fallback harness does. Remove the file from the repo, or dispatch the ticket again once a harness that does not load it is warm'
       : 'Remove the file from the repo, or dispatch on another harness if only one harness loads it (`/start <ticket> <model>`)'
-    throw new Error(`${planted} is a config file curia did not write, and the ${harnessName} harness loads it with no prompt — hooks in it would run unreviewed, with no model in the loop. ${wayOut}`)
+    const e = new Error(`${planted} is a config file curia did not write, and the ${harnessName} harness loads it with no prompt — hooks in it would run unreviewed, with no model in the loop. ${wayOut}`)
+    // #217: this throw is curia DECLINING, not curia failing, and only here is
+    // that known — by the time it lands in a catch it is one more thrown Error.
+    // The mark is what lets the respawn callers frame it as the decision it is.
+    e.refusal = true
+    throw e
   }
 
   // Which wayfinder map, if any, owns this ticket — so the standing orders can
@@ -1520,9 +1525,10 @@ export class Dispatcher {
         this.notify(agent.ticket, `⚙️ \`${agent.session}\` reached its composer with **no curia tools** — its MCP client never connected, so nothing it did could have reached anyone. Respawned once on the same model (**${model}**); the model is not what failed.`)
         return
       } catch (e) {
-        this.log(`mute respawn of ${agent.session} on ${model} failed:`, e.message)
-        const released = await this.#releaseClaim(agent, `respawn after a mute agent failed: ${e.message}`)
-        this.notify(agent.ticket, `⚠️ \`${agent.session}\` had no curia tools and the respawn on **${model}** failed: ${e.message} — ${this.#releaseTail(agent, released)}`)
+        const verb = e.refusal ? 'refused' : 'failed'
+        this.log(`mute respawn of ${agent.session} on ${model} ${verb}:`, e.message)
+        const released = await this.#releaseClaim(agent, `respawn after a mute agent ${verb}: ${e.message}`)
+        this.notify(agent.ticket, this.#noRespawnNotify(agent, model, 'had no curia tools', e, released))
         return
       }
     }
@@ -1595,18 +1601,22 @@ export class Dispatcher {
     const cands = candidates(this.routing, agent.requestedModel, this.cooling)
     if (cands.length) {
       const next = cands[0]
+      // one name for what happened, so the respawned and the not-respawned
+      // sentence cannot drift apart
+      const cause = `hit ${limit.reason ? `the ${limit.reason}` : `a ${limit.scope} usage limit`}`
       try {
         await this.#respawnOn(agent, next, { retry_after_limit: true })
-        this.notify(agent.ticket, `⚙️ \`${agent.session}\` hit ${limit.reason ? `the ${limit.reason}` : `a ${limit.scope} usage limit`} — respawned on **${next}**`)
+        this.notify(agent.ticket, `⚙️ \`${agent.session}\` ${cause} — respawned on **${next}**`)
         return
       } catch (e) {
         // The old session is already dead. Letting this reject would strand the
         // GitHub claim in an agent record reconcile deliberately skips, making
         // it unrecoverable short of /cancel — so take the same
         // release path true exhaustion takes.
-        this.log(`respawn of ${agent.session} on ${next} failed:`, e.message)
-        const released = await this.#releaseClaim(agent, `respawn after ${limit.scope} usage limit failed: ${e.message}`)
-        this.notify(agent.ticket, `⚠️ \`${agent.session}\` hit ${limit.reason ? `the ${limit.reason}` : `a ${limit.scope} usage limit`} and the respawn on **${next}** failed: ${e.message} — ${this.#releaseTail(agent, released)}`)
+        const verb = e.refusal ? 'refused' : 'failed'
+        this.log(`respawn of ${agent.session} on ${next} ${verb}:`, e.message)
+        const released = await this.#releaseClaim(agent, `respawn after ${limit.scope} usage limit ${verb}: ${e.message}`)
+        this.notify(agent.ticket, this.#noRespawnNotify(agent, next, cause, e, released))
         // the binding stays (#140): a claim release is not a ticket-terminal state
         return
       }
@@ -1867,6 +1877,25 @@ export class Dispatcher {
     return released
       ? 'claim released, ticket re-frontiered'
       : 'claim release FAILED: the issue is still assigned; reconcile will retry'
+  }
+
+  // What the thread says when a respawn did not happen (#217). #respawnOn throws
+  // for two facts the operator must not read as one:
+  //
+  //   could not   tmux exploded, the config dir would not seed. A fault, and the
+  //               operator goes and finds it.
+  //   would not   the planted-config refusal (#174). curia declining, and there
+  //               is no fault to find — "failed" sends them hunting for one.
+  //
+  // The error already carries which one it is, so the frame is chosen HERE,
+  // where that fact is known, rather than at the two call sites — the rule
+  // #releaseTail above follows, for the same reason. Everything else is shared:
+  // one shape, one verb swapped, so the two messages stay comparable.
+  #noRespawnNotify(agent, next, cause, e, released) {
+    const head = e.refusal
+      ? `🚫 \`${agent.session}\` ${cause} and curia REFUSED to respawn it on **${next}**`
+      : `⚠️ \`${agent.session}\` ${cause} and the respawn on **${next}** failed`
+    return `${head}: ${e.message} — ${this.#releaseTail(agent, released)}`
   }
 
   // ---- the merge-gated ending (#54) ---------------------------------------------

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -982,6 +982,10 @@ describe('usage-limit respawn failure releases the claim (B3)', () => {
     assert.equal(credsRemoved.length, 1, 'the OAuth credential copy is collected on release')
     assert.equal(notifies.length, 1, 'exactly one notify')
     assert.match(notifies[0].message, /respawn on \*\*haiku\*\* failed/)
+    // #217: tmux exploding IS a fault, and this sentence must keep saying so —
+    // the refusal frame is for the other fact.
+    assert.ok(!/REFUSED/.test(notifies[0].message), 'a fault must not read as a decision')
+    assert.match(notifies[0].message, /^⚠️/)
   })
 })
 
@@ -2835,6 +2839,12 @@ describe('dispatching across two harnesses (#39)', () => {
     const msg = notifies.find((n) => /hooks\.json/.test(n.message))?.message
     assert.ok(msg, 'the operator is told which file refused the fallback')
     assert.match(msg, /once a harness that does not load it is warm/, 'the way out fits the fallback, not the dispatch')
+    // #217: curia would not, rather than curia could not. "failed" sends the
+    // operator looking for a fault that is not there.
+    assert.match(msg, /REFUSED to respawn it on \*\*gpt\*\*/)
+    assert.ok(!/failed/i.test(msg), 'a refusal is not a failure')
+    assert.match(msg, /^🚫/, 'the refusal icon, the same one the twice-mute refusal uses')
+    assert.match(msg, /claim released, ticket re-frontiered/, 'the claim tail is shared with the failure shape')
     // The lane still cooled: the refusal is about the NEXT harness, not the cap.
     assert.ok(events.some((e) => e.type === 'model_cooling' || e.type === 'provider_cooling'))
   })
@@ -2862,6 +2872,12 @@ describe('dispatching across two harnesses (#39)', () => {
     assert.ok(events.some((e) => e.type === 'agent_mute'))
     assert.ok(events.some((e) => e.type === 'dispatch_unclaimed' && /settings\.local\.json/.test(e.reason)))
     assert.equal(d.agents.has('curia-42'), false)
+    // #217: the mute lane carries the refusal too, and frames it the same way
+    // the cap lane does — one shape for one fact, on both call sites.
+    const msg = notifies.find((n) => /settings\.local\.json/.test(n.message))?.message
+    assert.ok(msg, 'the operator is told which file refused the respawn')
+    assert.match(msg, /had no curia tools and curia REFUSED to respawn it on \*\*sonnet\*\*/)
+    assert.ok(!/failed/i.test(msg), 'a refusal is not a failure')
   })
 })
 


### PR DESCRIPTION
Ticket: alp82/curia#217 — [A respawn refusal reads as a respawn failure in the thread](https://github.com/alp82/curia/issues/217)

`#respawnOn` throws for two different facts, and the thread framed both as "the respawn on **gpt** failed". That is right for tmux exploding. It is wrong for the planted-config refusal (#174), which is curia declining to spawn rather than curia failing to.

The refusal now gets its own sentence: `🚫 \`curia-42\` hit a model usage limit and curia REFUSED to respawn it on **gpt**: <reason> — claim released, ticket re-frontiered`. The session, the cause, the reason text and the claim tail are unchanged, so the two messages stay comparable.

- `#assertNoPlantedConfig` marks its error `refusal`. Only there is that fact known.
- `#noRespawnNotify` picks the frame from the mark. It sits next to `#releaseTail`, the prior art for choosing a sentence where the fact is known.
- Both call sites (`#handleLimit`, `#muteAgent`) use it. The journal reason and the daemon log take the same verb.

Tests: the cap-lane refusal and the mute-lane refusal both assert the new frame and assert the word "failed" is absent. The tmux failure asserts it still reads as a fault. All 175 tests in `dispatch.test.mjs` pass. The 13 failures elsewhere in `npm test` are missing `node_modules` and are the same on a clean tree.

---

Dispatched by the curia daemon — session `curia-217`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `23c1977` A refusal to respawn stops reading as a failed respawn (wayfinder #217)