### PR TITLE
A respawn erases the dispatch kind, so a restart reads a charting agent as a ticket one (alp82/curia#219)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -331,6 +331,9 @@ The pass, at boot and on demand, that re-derives live state from GitHub, tmux, a
 **Epoch**:
 A ticket's latest dispatch. Journal reads count only events from the latest epoch.
 
+**Spawn line**:
+An `agent_spawned` event. It describes the agent whole, as it runs from that moment. One dispatch writes more than one of them, because a respawn down the fallback chain writes another. A respawn states every dispatch-time fact again, so the last line wins for every reader.
+
 **Orphan**:
 A live `curia-` session that every watched repo positively disowns. Reconcile sweeps it, unless it holds a result or unpushed work.
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -76,6 +76,27 @@ export const reviewSessionFor = (n) => `curia-review-${n}`
 // restarted daemon still knows which kind of agent it adopted.
 const MAP_LABEL = 'wayfinder:map'
 
+// The three kinds an `agent_spawned` line can state, in one place (#219).
+//
+// THE RULE FOR THIS EVENT: a spawn line describes the agent WHOLE, as it runs
+// from that moment. A respawn changes the PROCESS, not the dispatch, so it
+// restates every dispatch-time fact its first line carried instead of leaving
+// them to the line before. That is what makes "the last line wins" correct for
+// every reader of this event at once:
+//
+//   #epochSpawn (#187)     wants the model that is ACTUALLY running, which the
+//                          last line holds.
+//   #epochCharting (#160)  wants the ending this agent is held to, which the
+//                          dispatch fixed and no respawn changes.
+//
+// Before #219 the respawn wrote neither `kind` nor `instruction`, so those two
+// readers wanted opposite lines and the second one lost. Teaching #epochCharting
+// to take the FIRST line of the epoch was refused: it reduces over the whole
+// journal by ticket, and a respawn line is itself an epoch boundary for
+// #epochScan and for reconcile — so no READER can tell a respawn from a
+// re-dispatch. The writer can. It knows which one it is.
+const spawnKind = ({ reviewer = false, charting = false }) => (reviewer ? 'reviewer' : charting ? 'charting' : 'ticket')
+
 // The tracker doc every watched repo is meant to carry (#57 step 3). The
 // wayfinder skill reads it to learn how this repo expresses maps and tickets;
 // without it the skill follows its own instruction to fall back to the
@@ -738,7 +759,7 @@ export class Dispatcher {
       const instance = `${session}@${Date.now()}`
       this.store.logEvent('agent_spawned', {
         repo, ticket: n, agent: session, instance, model: useModel, harness: harnessName,
-        kind: charting ? 'charting' : 'ticket', instruction: charting ? instruction : null,
+        kind: spawnKind({ charting }), instruction: charting ? instruction : null,
         // The journal is the state home for what a restart cannot re-derive
         // from tmux: which image this agent runs and which ports it published.
         ...(container ? { sandbox: 'docker', image: container.image, ports: container.ports } : {}),
@@ -1171,7 +1192,7 @@ export class Dispatcher {
       // own status line in the ticket thread is what ADR-0010 asks for, and this
       // is the one event that gives it one.
       this.store.logEvent('agent_spawned', {
-        repo, ticket, agent: session, model, harness: harnessName, kind: 'reviewer',
+        repo, ticket, agent: session, model, harness: harnessName, kind: spawnKind({ reviewer: true }),
       })
 
       const agent = {
@@ -1704,9 +1725,25 @@ export class Dispatcher {
     // makes the second window a real second reading rather than an echo.
     agent.mcpSeenAt = null
     agent.readyAt = null
+    // The whole line, not the delta (#219 — see `spawnKind` for the rule). What
+    // changed is the model, the harness and the container; what did NOT change
+    // is the dispatch this agent belongs to, and a reader that takes the last
+    // line gets a description of a ticket agent unless this says otherwise.
+    //
+    // `kind` and `instruction` have live readers: #epochCharting answers the two
+    // refused tools, the ending list, the result path and `resume`, which
+    // dispatches a CHILD ticket instead of resuming the map when this says
+    // `ticket`. `instance`, `sandbox`, `image` and `ports` have none today —
+    // reconcile reads a container's ports back from docker itself. They are
+    // restated anyway, because the spawn line is their stated state home and a
+    // fact that lives here must not be erased by a respawn.
     this.store.logEvent('agent_spawned', {
       repo: agent.repo, ticket: agent.ticket, agent: agent.session,
-      model: next, harness: nextHarness, ...journalData,
+      instance: agent.instance ?? null,
+      model: next, harness: nextHarness,
+      kind: spawnKind(agent), instruction: agent.instruction ?? null,
+      ...(plan.container ? { sandbox: 'docker', image: plan.container.image, ports: plan.container.ports } : {}),
+      ...journalData,
     })
     this.#watchdog(agent).catch((e) => this.log(`watchdog ${agent.session} failed:`, e.message))
   }
@@ -2441,6 +2478,11 @@ export class Dispatcher {
   // reads `agent_spawned` only, which is the event that states the kind, and a
   // number with no such event at all is a ticket — nothing was ever charted
   // under it, so there is no map to protect.
+  //
+  // LAST wins here, exactly as it does for #epochSpawn, and #219 is why that is
+  // safe: a respawn restates the kind rather than dropping it (see `spawnKind`).
+  // Before that fix every map dispatch that fell down the fallback chain ended
+  // its life describing itself as a ticket dispatch.
   #epochCharting(ticket, agentName) {
     const w = this.agents.get(agentName)
     if (w) return { charting: Boolean(w.charting), instruction: w.instruction ?? null }
@@ -2457,6 +2499,9 @@ export class Dispatcher {
   // SESSION rather than by ticket — a re-dispatch down the fallback chain
   // writes a second `agent_spawned` for the same session, and the last one is
   // the model that is actually running.
+  //
+  // This is the reader that fixes the direction for every other one: last wins,
+  // so the writer owes every line a complete description (#219, `spawnKind`).
   //
   // The journal is the only source for the label. The harness has on-disk
   // evidence too (detectHarness), but the label names a row in `routing.yaml`

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -70,7 +70,18 @@ beforeEach(() => {
 
 afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
 
-function makeDispatcher(deps = {}, { issue = MAP_ISSUE } = {}) {
+// Poll until a condition holds — the watchdog paths below are timers, not
+// promises the caller can await.
+async function waitFor(cond, timeoutMs = 10_000) {
+  const until = Date.now() + timeoutMs
+  while (Date.now() < until) {
+    if (cond()) return
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  throw new Error('timed out waiting for a condition')
+}
+
+function makeDispatcher(deps = {}, { issue = MAP_ISSUE, routing = ROUTING } = {}) {
   const root = path.join(tmp, 'work')
   const dataDir = path.join(tmp, 'data')
   const config = {
@@ -143,7 +154,7 @@ function makeDispatcher(deps = {}, { issue = MAP_ISSUE } = {}) {
   }
   const d = new Dispatcher({
     config,
-    routing: ROUTING,
+    routing,
     store,
     notify: (ticket, message) => notifies.push({ ticket, message }),
     log: () => {},
@@ -466,6 +477,98 @@ describe('map <n> — the charting verb (#221)', () => {
     await d.start('42')
     assert.equal(events.find((e) => e.type === 'agent_spawned').kind, 'ticket')
     assert.ok(calls.includes('claim o/r#42'))
+  })
+})
+
+// ---- the respawn (#219) -------------------------------------------------------
+
+// A map dispatch that falls down the fallback chain used to lose the fact that
+// it was a map dispatch: the respawn wrote `agent_spawned` with the model and
+// the harness and nothing else, and #epochCharting keeps the LAST such line. So
+// the journal — the belt built for exactly the restart case — ended up
+// describing a charting agent as a ticket agent.
+//
+// Not an edge: while the account holds no fable credits, `map: fable` burns a
+// spawn on every map dispatch, so the respawn is the normal path. Measured live
+// on 2026-08-04 (`docs/live-checks/183-first-map-dispatch.md`).
+describe('a respawn restates the dispatch kind (#219)', () => {
+  const CHAIN = {
+    defaults: { untyped: 'sonnet', map: 'opus' },
+    models: {
+      sonnet: { provider: 'anthropic', harness: 'claude' },
+      opus: { provider: 'anthropic', harness: 'claude' },
+    },
+    fallbacks: { opus: ['sonnet'], sonnet: ['opus'] },
+    harnesses: ROUTING.harnesses,
+  }
+
+  // The first spawn hits a model-scoped cap and the second one is healthy — the
+  // shape of every map dispatch on the box today.
+  function capOnFirstSpawn() {
+    let spawns = 0
+    return {
+      newSession: async () => { spawns += 1 },
+      capturePane: async () => (spawns > 1 ? 'x' : 'Opus usage limit reached | 1800000000'),
+    }
+  }
+
+  const spawnsOf = () => events.filter((e) => e.type === 'agent_spawned')
+
+  test('the second line says charting, and carries the instruction again', async () => {
+    const d = makeDispatcher(capOnFirstSpawn(), { routing: CHAIN })
+    await d.chart('147', { instruction: 'do X' })
+    await waitFor(() => spawnsOf().length === 2)
+
+    const [first, second] = spawnsOf()
+    assert.equal(first.kind, 'charting')
+    assert.equal(second.model, 'sonnet', 'the respawn is the point of this test')
+    assert.equal(second.retry_after_limit, true)
+    assert.equal(second.kind, 'charting', 'the respawn erased the dispatch kind')
+    assert.equal(second.instruction, 'do X', 'the respawn erased the operator instruction')
+    // A respawn changes the process, not the dispatch, so the id that names the
+    // dispatch is restated rather than dropped.
+    assert.equal(second.instance, first.instance)
+    d.agents.delete('curia-147')
+  })
+
+  test('a restarted daemon reading only the journal still holds the map ending', async () => {
+    // The whole reason the kind is journalled: with no in-memory record left,
+    // `charting: false` here sends a map agent to the ticket ending, which
+    // CLOSES the map.
+    const d = makeDispatcher(capOnFirstSpawn(), { routing: CHAIN })
+    await d.chart('147', { instruction: 'do X' })
+    await waitFor(() => spawnsOf().length === 2)
+    d.agents.delete('curia-147') // as a restart leaves it
+    calls.length = 0
+
+    await d.onResult('curia-147', { ticket: '147', status: 'resolved', summary: 's' })
+    assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')), 'the respawned map dispatch was closed as a ticket')
+    assert.ok(calls.some((c) => c === 'comment o/r#147'))
+    assert.ok(calls.some((c) => String(c).includes('do X')), 'the summary comment lost the operator instruction')
+  })
+
+  test('resume after a respawn charts the map, and does not dispatch a child', async () => {
+    // #221 made `start <map>` dispatch the map's next takeable child, so a
+    // resume that reads `ticket` off the journal does not fail loudly — it
+    // quietly works a different issue.
+    const d = makeDispatcher({ ...capOnFirstSpawn(), mapFrontier: async () => [] }, { routing: CHAIN })
+    await d.chart('147', { instruction: 'do X' })
+    await waitFor(() => spawnsOf().length === 2)
+    d.agents.delete('curia-147')
+
+    const reply = await d.resume('147')
+    assert.match(reply, /charting agent on map o\/r#147/)
+    assert.equal(spawnsOf().at(-1).kind, 'charting')
+    d.agents.delete('curia-147')
+  })
+
+  test('a ticket dispatch respawns as a ticket — the kind is stated, never absent', async () => {
+    const d = makeDispatcher(capOnFirstSpawn(), { issue: TICKET_ISSUE, routing: { ...CHAIN, defaults: { untyped: 'opus' } } })
+    await d.start('42')
+    await waitFor(() => spawnsOf().length === 2)
+    assert.equal(spawnsOf()[1].kind, 'ticket')
+    assert.equal(spawnsOf()[1].instruction, null)
+    d.agents.delete('curia-42')
   })
 })
 

--- a/docs/live-checks/183-first-map-dispatch.md
+++ b/docs/live-checks/183-first-map-dispatch.md
@@ -114,7 +114,9 @@ dispatches inside one hour pay one burnt spawn between them, not one each.
 
 ## Fault: a respawn erases the dispatch kind
 
-**Not fixed. The largest thing this check found.**
+**The largest thing this check found. Fixed by
+[#219](https://github.com/alp82/curia/issues/219): the respawn now states the
+kind, the instruction and the rest of the dispatch-time facts again.**
 
 #160 built two belts against a charting agent being read as a ticket agent,
 because that misreading closes the map. One is the pair of refusals on
@@ -188,7 +190,9 @@ agent is worth less than closing #219.
   Anything reading spawn-time facts out of the journal must decide which line it
   wants. #187 wants the last (the model that runs). #160 wants the first (the
   kind it was dispatched as). Reducing to "the last line wins" is wrong for at
-  least one reader.
+  least one reader. **[#219](https://github.com/alp82/curia/issues/219) settled
+  this at the writer instead**: a respawn states the dispatch-time facts again,
+  so both lines carry them and the last line is right for every reader.
 - **Back-to-back map dispatches inside the hour skip the burnt spawn**, because
   fable is still cooling. A check that expects to see fable → opus must leave an
   hour, or read `model_cooling` first.


### PR DESCRIPTION
Ticket: alp82/curia#219 — [A respawn erases the dispatch kind, so a restart reads a charting agent as a ticket one](https://github.com/alp82/curia/issues/219)

Fixes #219. A respawn used to write `agent_spawned` with only the model and the harness, so `#epochCharting` — which keeps the last such line for a ticket — read a map dispatch as a ticket dispatch after any fallback hop. `map: fable` burns a spawn on every map dispatch today, so this was the normal case, not the edge.

The repair goes at the writer. A spawn line describes the agent whole, as it runs from that moment, so the respawn states every dispatch-time fact again: `kind`, `instruction`, `instance`, and `sandbox`/`image`/`ports` for a container. Last-wins then stays correct for both readers of this event — `#epochSpawn` wants the model that runs (#187), `#epochCharting` wants the ending the dispatch fixed (#160).

Fixing the reduction instead was refused: a respawn line is itself an epoch boundary for `#epochScan` and for reconcile, so no reader can tell a respawn from a re-dispatch. The writer can.

`spawnKind` names the three kinds in one place and carries the rule. Four new tests in `mapdispatch.test.mjs` pin it, and all four fail without the change.

---

Dispatched by the curia daemon — session `curia-219`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `83e7827` A respawn states the dispatch kind again, so a restart still reads the map (wayfinder #219)