### PR TITLE
The daemon's real-boot tests cannot run inside an agent container (alp82/curia#212)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ The five canonical triage roles, using default label strings (`needs-triage`, `n
 ### Domain docs
 
 Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+## Daemon tests
+
+Run `npm test` in `daemon/`. The suite must be green. Never read a failure or a cancelled test as pre-existing. A cancelled test is a suite that died before it started, and it proves nothing. See [the daemon README](daemon/README.md#the-test-suite).

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -36,6 +36,16 @@ npm test           # unit tests
 
 One boot brings up everything: the HTTP surface, ttyd, the Discord bridge, the reconcile pass, and the overseer host. There is no second process. To verify a boot, look for `ready: guild=<guild> channel=#curia` in the log, then send a top-level message in `#curia` — a thread opens and the overseer answers in it.
 
+### The test suite
+
+`npm test` must be green. No failure here is expected. No count in the summary is a baseline to read past.
+
+**A cancelled test is not a skipped test.** A cancelled test is one whose suite died in its `before` hook. For a real-boot suite this means the daemon child never started, so the test proves nothing at all. Since #212 the boot wait watches the child as well as the port. A child that refuses to boot fails the wait in about one second. The message starts with `the real-boot fixture never got a daemon`, and the child's own stderr comes below it. See `test/fixtures/real-boot.mjs`.
+
+**No suite reads `$HOME`.** `loadCuriaConfig` checks `skills.install` against `skills.root`, and that root defaults to `~/.claude/skills`. So a fixture config that says nothing about skills asks the host a question the test cannot control. Every fixture config now names a skills root that the test seeds. See `test/fixtures/skills.mjs`. The two tests that pin the default root swap in a home directory they own. The suite gives the same answer on the operator's box, in an agent container, and on a stranger's machine.
+
+**Two host binaries stay optional.** The tmux describes in `tmux.test.mjs` need `tmux`. One version reader in `attach.test.mjs` needs `ttyd` at `TTYD_BIN`. Each one states why it skipped. An agent container carries neither binary, so a green run there shows one skipped test and three skipped describes.
+
 ## Surfaces
 
 Two of these routes are the AGENT's, and since #159 they are gated: `/mcp` and `/agent_done` take a per-agent token in the `X-Curia-Agent-Token` header, minted at spawn and written into that agent's own connection settings. Everything else is the operator's own and answers on loopback only. An agent container reaches the daemon on the docker bridge gateway, and that listener serves the two agent routes and nothing else.

--- a/daemon/test/config.test.mjs
+++ b/daemon/test/config.test.mjs
@@ -13,12 +13,31 @@ import { loadCuriaConfig, loadRoutingConfig } from '../src/config.mjs'
 import { DEFAULT_SKILLS, defaultSkillsRoot } from '../src/workspace.mjs'
  import { DEFAULT_INDEX } from '../src/attach.mjs'
 import { DEFAULT_TIMELINE_INDEX } from '../src/timeline.mjs'
+import { seedSkillsRoot, skillsYaml, withSeededHome } from './fixtures/skills.mjs'
 
 let tmp
 let root
 
+// The one caller that needs a config with NO skills section at all: the test
+// that pins what the DEFAULT root is. Everyone else gets the fixture root.
+const OMIT_SKILLS = Symbol('omit the skills section')
+
+// The skills root the fixtures own (#212). Seeded per `tmp`, because each
+// describe below makes its own temp dir and tears it down again.
+const seeded = new Map()
+function fixtureSkills() {
+  if (!seeded.has(tmp)) seeded.set(tmp, seedSkillsRoot(tmp))
+  return skillsYaml(seeded.get(tmp)).join('\n')
+}
+
 // Base config with every other section valid, so a failure names the skills.
-function writeConfig(skillsYaml, attachExtra = '') {
+function writeConfig(extraYaml, attachExtra = '') {
+  const extra = extraYaml === OMIT_SKILLS ? '' : (extraYaml ?? '')
+  // A config that names no skills root reads the HOST's home directory, and
+  // the answer differs on the operator's box, in an agent container, and on a
+  // stranger's. So every fixture here names a root the test owns — but never
+  // over one the caller wrote, which is what the skills describe pins.
+  const skills = extraYaml === OMIT_SKILLS || /^skills:/m.test(extra) ? '' : fixtureSkills()
   const file = path.join(tmp, `curia-${Math.random().toString(36).slice(2)}.yaml`)
   fs.writeFileSync(file, [
     'watch:',
@@ -36,7 +55,8 @@ function writeConfig(skillsYaml, attachExtra = '') {
     attachExtra,
     'identity:',
     '  allow: [tester@example.com]',
-    skillsYaml ?? '',
+    extra,
+    skills,
     '',
   ].join('\n'))
   return file
@@ -82,18 +102,16 @@ describe('skills config (#57)', () => {
   })
 
   test('an omitted section takes the full default list, not silence', () => {
-    // Validated against the real host root, so this asserts the DEFAULT
-    // behaviour is loud — either it loads the nine, or it names the one
-    // missing skill. What it must never do is quietly install nothing.
-    let cfg = null
-    try {
-      cfg = loadCuriaConfig(writeConfig(null))
-    } catch (e) {
-      assert.match(e.message, /skills\.install names/)
-      return
-    }
-    assert.deepEqual(cfg.skills.install, DEFAULT_SKILLS)
-    assert.equal(cfg.skills.root, defaultSkillsRoot())
+    // Validated against a HOME the test owns, seeded at the path
+    // `defaultSkillsRoot()` names, so the DEFAULT is pinned on every box — the
+    // operator's, an agent container, a stranger's (#212). Before that this
+    // test had to tolerate its own failure, because the host might not carry
+    // the nine, and a tolerant test proves nothing.
+    withSeededHome(() => {
+      const cfg = loadCuriaConfig(writeConfig(OMIT_SKILLS))
+      assert.deepEqual(cfg.skills.install, DEFAULT_SKILLS)
+      assert.equal(cfg.skills.root, defaultSkillsRoot())
+    })
   })
 
   test('a leading ~ in the root is expanded, since YAML does not', () => {

--- a/daemon/test/fixtures/induce-fault.mjs
+++ b/daemon/test/fixtures/induce-fault.mjs
@@ -30,6 +30,30 @@ import { WebSocket } from 'ws'
 const mode = process.env.CURIA_INDUCE
 const after = Number(process.env.CURIA_INDUCE_AFTER_MS ?? 1500)
 
+// The `after` clock starts when the daemon IS UP, not at preload (#212).
+// `--import` runs this file before the daemon's module graph even loads, so a
+// 600 ms timer used to be a race against the boot: measured in an agent
+// container the fault landed 18 ms after the listen, and a slower box would put
+// it BEFORE the listen. Both induced suites need the boot to have finished
+// first, so the clock waits for the daemon's own port to accept a connection.
+function armAfterBoot(fn) {
+  const port = Number(process.env.PORT)
+  if (!Number.isInteger(port) || port <= 0) return setTimeout(fn, after)
+  const tick = () => {
+    const probe = net.connect(port, '127.0.0.1')
+    probe.once('connect', () => {
+      probe.destroy()
+      console.log(`[induce] daemon is listening on ${port}; the fault is armed for ${after} ms from now`)
+      setTimeout(fn, after)
+    })
+    probe.once('error', () => {
+      probe.destroy()
+      setTimeout(tick, 25)
+    })
+  }
+  return tick()
+}
+
 // The exact shape WebSocketShard.destroy() leaves behind on a CONNECTING socket.
 function abandonConnectingSocket(onReady) {
   const blackhole = net.createServer(() => {})
@@ -47,11 +71,11 @@ function abandonConnectingSocket(onReady) {
 }
 
 if (mode === 'ws-handshake') {
-  setTimeout(() => abandonConnectingSocket(), after)
+  armAfterBoot(() => abandonConnectingSocket())
 } else if (mode === 'bug') {
-  setTimeout(() => {
+  armAfterBoot(() => {
     throw new TypeError('planted logic bug: this is not a network failure')
-  }, after)
+  })
 } else if (mode === 'live') {
   const require = createRequire(import.meta.url)
   const wsModule = require('ws')

--- a/daemon/test/fixtures/real-boot.mjs
+++ b/daemon/test/fixtures/real-boot.mjs
@@ -16,7 +16,7 @@ import net from 'node:net'
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
 // The phrase every real-boot failure carries, so one grep finds all of them.
-export const NO_DAEMON = 'the real-boot fixture never got a daemon'
+const NO_DAEMON = 'the real-boot fixture never got a daemon'
 
 const AND_SO = 'Nothing under this hook ran against a live daemon. A cancelled test here is a boot that FAILED, never a test that was skipped.'
 

--- a/daemon/test/fixtures/real-boot.mjs
+++ b/daemon/test/fixtures/real-boot.mjs
@@ -1,0 +1,67 @@
+// Waiting on a real daemon boot (#212).
+//
+// A boot either listens or dies. A wait that polls only the port turns a child
+// that refused to boot into ten silent seconds and then a `before`-hook
+// timeout, and node reports every test under that hook as `cancelled`. That
+// word reads exactly like `skipped`, and a cancelled test proves nothing — so
+// the count folds into a baseline an agent learns to ignore, which is how a
+// whole real-boot suite goes unrun without anybody noticing.
+//
+// So the wait watches the CHILD as well as the port. The moment the child
+// exits, the failure is its own output, said out loud and named as a boot that
+// never happened.
+
+import net from 'node:net'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+// The phrase every real-boot failure carries, so one grep finds all of them.
+export const NO_DAEMON = 'the real-boot fixture never got a daemon'
+
+const AND_SO = 'Nothing under this hook ran against a live daemon. A cancelled test here is a boot that FAILED, never a test that was skipped.'
+
+export function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address()
+      srv.close(() => resolve(port))
+    })
+    srv.once('error', reject)
+  })
+}
+
+// Collects everything the daemon child says and notices when it dies.
+// `close`, not `exit`: it fires once the stdio streams are drained, so the log
+// is whole before a failure message reads it.
+export function watchDaemon(child) {
+  let log = ''
+  let end = null
+  child.stdout.on('data', (c) => { log += c })
+  child.stderr.on('data', (c) => { log += c })
+  child.once('close', (code, signal) => { end = { code, signal } })
+  return { log: () => log, end: () => end }
+}
+
+function report(headline, log) {
+  return [headline, AND_SO, 'The child said:', log.trim() || '(nothing at all)'].join('\n')
+}
+
+// Polls `ready` until it answers truthily. Fails at once if the child dies
+// first, and gives up loudly if neither happens in time. `what` completes the
+// sentence "the child never reached ..." — say "the /state route", not "ready".
+export async function waitForBoot(watch, ready, what, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (await ready()) return
+    const end = watch.end()
+    if (end) {
+      const how = end.signal ? `on ${end.signal}` : `with code ${end.code}`
+      throw new Error(report(`${NO_DAEMON}: the child exited ${how} before it reached ${what}.`, watch.log()))
+    }
+    if (Date.now() > deadline) {
+      throw new Error(report(`${NO_DAEMON}: ${timeoutMs} ms passed, the child never reached ${what}, and it is still running.`, watch.log()))
+    }
+    await sleep(50)
+  }
+}

--- a/daemon/test/fixtures/skills.mjs
+++ b/daemon/test/fixtures/skills.mjs
@@ -1,0 +1,62 @@
+// A skills root the tests own (#212).
+//
+// `loadCuriaConfig` checks every name in `skills.install` against a `SKILL.md`
+// on disk, and `skills.root` defaults to `~/.claude/skills`. So a fixture
+// config that says nothing about skills reads the HOST's home directory, and
+// the answer depends on the box: the operator's box has the nine, an agent
+// container keeps its skills somewhere else, and a stranger's box has none.
+// Every suite that spawns a real daemon then died at its `before` hook and
+// node reported its tests as `cancelled` — a word that reads exactly like
+// `skipped`, so an agent verifying its own daemon change learned to ignore it.
+//
+// The root is DERIVED from `DEFAULT_SKILLS` rather than committed as nine
+// files, so adding a tenth default skill cannot bring the fault back.
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { DEFAULT_SKILLS } from '../../src/workspace.mjs'
+
+// Writes `<dir>/skills/<name>/SKILL.md` for every default skill and returns
+// the root. Nothing reads a manifest body — the validator only asks whether
+// the file is there — so the body says what the file is for instead.
+export function seedSkillsRoot(dir, names = DEFAULT_SKILLS) {
+  const root = path.join(dir, 'skills')
+  fs.mkdirSync(root, { recursive: true })
+  for (const name of names) {
+    fs.mkdirSync(path.join(root, name), { recursive: true })
+    fs.writeFileSync(
+      path.join(root, name, 'SKILL.md'),
+      `# ${name}\n\nA fixture stand-in for the ${name} skill (#212). Only its existence is read.\n`,
+    )
+  }
+  return root
+}
+
+// The config lines a fixture yaml needs. `install` is left out on purpose: the
+// seeded root carries the whole default list, so the fixture takes the same
+// branch the shipped config takes instead of the empty-list opt-out.
+export function skillsYaml(root) {
+  return ['skills:', `  root: ${root}`]
+}
+
+// A HOME the test owns, seeded with the default skills where
+// `defaultSkillsRoot()` looks for them. `os.homedir()` reads $HOME on POSIX,
+// which is what lets a test pin the DEFAULT root on a box that does not carry
+// it — the same trick the codex credential tests use (#158).
+//
+// `fn` must be synchronous: there is no await between the swap and the
+// restore, so no other test can observe the changed HOME. Pass `names` when
+// the config under test installs something other than the default list.
+export function withSeededHome(fn, names = DEFAULT_SKILLS) {
+  const saved = process.env.HOME
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-skills-home-'))
+  try {
+    process.env.HOME = home
+    seedSkillsRoot(path.join(home, '.claude'), names)
+    return fn(home)
+  } finally {
+    process.env.HOME = saved
+    fs.rmSync(home, { recursive: true, force: true })
+  }
+}

--- a/daemon/test/health.test.mjs
+++ b/daemon/test/health.test.mjs
@@ -12,28 +12,18 @@ import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import http from 'node:http'
-import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { classifyFault, installCrashGuard } from '../src/health.mjs'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
 const INDUCE = pathToFileURL(path.join(DIR, 'fixtures', 'induce-fault.mjs')).href
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-
-function freePort() {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer()
-    srv.listen(0, '127.0.0.1', () => {
-      const { port } = srv.address()
-      srv.close(() => resolve(port))
-    })
-    srv.once('error', reject)
-  })
-}
 
 function request(port, method, urlPath, { headers = {}, body = null } = {}) {
   return new Promise((resolve, reject) => {
@@ -207,6 +197,9 @@ async function writeConfig(cfgDir, tmp) {
     'identity:',
     '  allow: [tester@example.com]',
     `  proxy_port: ${proxyPort}`,
+    // #212: the fixture owns its skills root, so this boot depends on nothing
+    // under the host's HOME.
+    ...skillsYaml(seedSkillsRoot(tmp)),
     '',
   ].join('\n'))
   fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
@@ -223,19 +216,14 @@ async function writeConfig(cfgDir, tmp) {
   ].join('\n'))
 }
 
-async function waitForDaemon(port, child, log) {
-  const deadline = Date.now() + 10_000
-  for (;;) {
-    try {
-      if ((await request(port, 'GET', '/state')).status === 200) return
-    } catch { /* not listening yet */ }
-    if (Date.now() > deadline) throw new Error(`daemon did not come up; log:\n${log()}`)
-    await sleep(100)
-  }
-}
+const waitForDaemon = (port, watch) => waitForBoot(watch, async () => {
+  try {
+    return (await request(port, 'GET', '/state')).status === 200
+  } catch { return false }
+}, 'the /state route')
 
 describe('the daemon survives the gateway crash it died of (real boot, induced)', () => {
-  let tmp, child, port, dataDir, childLog = ''
+  let tmp, child, port, dataDir, watch
 
   before(async () => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-health-test-'))
@@ -258,9 +246,8 @@ describe('the daemon survives the gateway crash it died of (real boot, induced)'
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
-    await waitForDaemon(port, child, () => childLog)
+    watch = watchDaemon(child)
+    await waitForDaemon(port, watch)
   })
 
   after(() => {
@@ -283,10 +270,10 @@ describe('the daemon survives the gateway crash it died of (real boot, induced)'
       if (!transient) await sleep(150)
     }
 
-    assert.ok(transient, `no daemon_transient was journalled; log:\n${childLog}`)
+    assert.ok(transient, `no daemon_transient was journalled; log:\n${watch.log()}`)
     assert.match(transient.message, /Opening handshake has timed out/)
     assert.equal(transient.origin, 'uncaughtException')
-    assert.equal(child.exitCode, null, `the daemon died anyway; log:\n${childLog}`)
+    assert.equal(child.exitCode, null, `the daemon died anyway; log:\n${watch.log()}`)
 
     // the surface still works...
     const state = await request(port, 'GET', '/state')
@@ -301,7 +288,7 @@ describe('the daemon survives the gateway crash it died of (real boot, induced)'
 })
 
 describe('a planted logic bug still kills the daemon (real boot, induced)', () => {
-  let tmp, child, port, dataDir, childLog = ''
+  let tmp, child, port, dataDir, watch
 
   before(async () => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-health-fault-'))
@@ -324,9 +311,8 @@ describe('a planted logic bug still kills the daemon (real boot, induced)', () =
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
-    await waitForDaemon(port, child, () => childLog)
+    watch = watchDaemon(child)
+    await waitForDaemon(port, watch)
   })
 
   after(() => {
@@ -340,9 +326,9 @@ describe('a planted logic bug still kills the daemon (real boot, induced)', () =
       child.once('exit', (c) => resolve(c))
       setTimeout(() => resolve(null), 8_000)
     })
-    assert.equal(code, 1, `the guard must not keep a broken daemon alive; log:\n${childLog}`)
+    assert.equal(code, 1, `the guard must not keep a broken daemon alive; log:\n${watch.log()}`)
     const fault = events(dataDir).find((e) => e.type === 'daemon_fault')
-    assert.ok(fault, `no daemon_fault journalled; log:\n${childLog}`)
+    assert.ok(fault, `no daemon_fault journalled; log:\n${watch.log()}`)
     assert.match(fault.message, /planted logic bug/)
     assert.equal(fault.transient, false)
   })

--- a/daemon/test/image.test.mjs
+++ b/daemon/test/image.test.mjs
@@ -11,12 +11,14 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { parse } from 'yaml'
 
 import { loadCuriaConfig } from '../src/config.mjs'
 import {
   BUILD_CONTEXT, DEFAULT_IMAGE, DOCKERFILE, SANDBOX_KEYS,
   buildArgs, imageDigest, agentImageRef,
 } from '../src/image.mjs'
+import { withSeededHome } from './fixtures/skills.mjs'
 
 const PINS = {
   image: 'curia-agent',
@@ -184,7 +186,13 @@ describe('sandbox config (#154)', () => {
 describe('the shipped config (#154)', () => {
   test('config/curia.yaml pins the image, and its pins build the shipped ref', () => {
     const file = path.resolve(import.meta.dirname, '..', '..', 'config', 'curia.yaml')
-    const cfg = loadCuriaConfig(file)
+    // The shipped config names the OPERATOR's skills root, `~/.claude/skills`.
+    // A HOME the test owns lets the whole document load on any box (#212),
+    // instead of only on the box that carries those skills. Seeded from the
+    // config's OWN list, so this test says nothing about which skills the
+    // operator installs — it is about the image pins.
+    const installs = parse(fs.readFileSync(file, 'utf8')).skills?.install
+    const cfg = withSeededHome(() => loadCuriaConfig(file), installs)
     assert.ok(cfg.sandbox, 'the shipped config has no sandbox section')
     const ref = agentImageRef(cfg.sandbox)
     assert.match(ref.ref, /^curia-agent:\d[\w.]*-\d[\w.]*-[0-9a-f]{8}$/)

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -17,26 +17,16 @@ import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import http from 'node:http'
-import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { TOKEN_HEADER, mintAgentToken } from '../src/agenttoken.mjs'
 import { PROBE_MARK, PROBE_PATH } from '../src/sandbox.mjs'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
-
-function freePort() {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer()
-    srv.listen(0, '127.0.0.1', () => {
-      const { port } = srv.address()
-      srv.close(() => resolve(port))
-    })
-    srv.once('error', reject)
-  })
-}
 
 // http.request, not fetch: full control over Origin/Sec-Fetch-Site headers
 // with no client-side forbidden-header opinions in the way.
@@ -61,7 +51,7 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
   let tmp
   let child
   let port
-  let childLog = ''
+  let watch
 
   before(async () => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-index-test-'))
@@ -96,6 +86,9 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
       'identity:',
       '  allow: [tester@example.com]',
       `  proxy_port: ${proxyPort}`,
+      // #212: the fixture owns its skills root, so this boot depends on
+      // nothing under the host's HOME.
+      ...skillsYaml(seedSkillsRoot(tmp)),
       '',
     ].join('\n'))
     fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
@@ -123,19 +116,13 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
+    watch = watchDaemon(child)
 
-    const deadline = Date.now() + 10_000
-    // poll until the real server answers
-    for (;;) {
+    await waitForBoot(watch, async () => {
       try {
-        const res = await request(port, 'GET', '/state')
-        if (res.status === 200) break
-      } catch { /* not listening yet */ }
-      if (Date.now() > deadline) throw new Error(`daemon did not come up in time; log:\n${childLog}`)
-      await new Promise((r) => setTimeout(r, 100))
-    }
+        return (await request(port, 'GET', '/state')).status === 200
+      } catch { return false }
+    }, 'the /state route')
   })
 
   after(() => {
@@ -193,10 +180,9 @@ describe('an answer with no live resolver queues for the resumed agent (#139, re
   let tmp
   let child
   let port
-  let childLog = ''
+  let watch
 
   const bootDaemon = async () => {
-    childLog = ''
     child = spawn(process.execPath, [DAEMON], {
       env: {
         ...process.env,
@@ -209,17 +195,12 @@ describe('an answer with no live resolver queues for the resumed agent (#139, re
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
-    const deadline = Date.now() + 10_000
-    for (;;) {
+    watch = watchDaemon(child)
+    await waitForBoot(watch, async () => {
       try {
-        const res = await request(port, 'GET', '/state')
-        if (res.status === 200) return
-      } catch { /* not listening yet */ }
-      if (Date.now() > deadline) throw new Error(`daemon did not come up in time; log:\n${childLog}`)
-      await new Promise((r) => setTimeout(r, 100))
-    }
+        return (await request(port, 'GET', '/state')).status === 200
+      } catch { return false }
+    }, 'the /state route')
   }
 
   const killDaemon = () => new Promise((resolve) => {
@@ -258,6 +239,9 @@ describe('an answer with no live resolver queues for the resumed agent (#139, re
       'identity:',
       '  allow: [tester@example.com]',
       `  proxy_port: ${proxyPort}`,
+      // #212: the fixture owns its skills root, so this boot depends on
+      // nothing under the host's HOME.
+      ...skillsYaml(seedSkillsRoot(tmp)),
       '',
     ].join('\n'))
     fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
@@ -308,8 +292,10 @@ describe('an answer with no live resolver queues for the resumed agent (#139, re
     assert.equal(note.after, id, 'tagged with the escalation it answers')
 
     // the surface half: the thread hears where the answer went (bridge down ⇒ log)
-    assert.match(childLog, /`curia-7` is not running/)
-    assert.match(childLog, /resume 7/)
+    // `watch` is remade at every boot, so this reads the SECOND daemon's log
+    // and nothing the first one said.
+    assert.match(watch.log(), /`curia-7` is not running/)
+    assert.match(watch.log(), /resume 7/)
   })
 })
 
@@ -327,7 +313,7 @@ describe('attach refusal withdraws the serve rule (index.mjs, real boot)', () =>
   let port
   let servePort
   let tsLog
-  let childLog = ''
+  let watch
 
   before(async () => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-index-attach-test-'))
@@ -372,6 +358,9 @@ describe('attach refusal withdraws the serve rule (index.mjs, real boot)', () =>
       'identity:',
       '  allow: [tester@example.com]',
       `  proxy_port: ${proxyPort}`,
+      // #212: the fixture owns its skills root, so this boot depends on
+      // nothing under the host's HOME.
+      ...skillsYaml(seedSkillsRoot(tmp)),
       'timeline:',
       `  port: ${tlPort}`,
       `  serve_port: ${tlServePort}`,
@@ -402,15 +391,10 @@ describe('attach refusal withdraws the serve rule (index.mjs, real boot)', () =>
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
+    watch = watchDaemon(child)
 
     // wait past BOOT reconcile (it runs its own withdrawal), then start clean
-    const deadline = Date.now() + 20_000
-    while (!/boot reconcile done/.test(childLog)) {
-      if (Date.now() > deadline) throw new Error(`boot reconcile did not finish in time; log:\n${childLog}`)
-      await new Promise((r) => setTimeout(r, 100))
-    }
+    await waitForBoot(watch, () => /boot reconcile done/.test(watch.log()), 'the end of boot reconcile', 20_000)
     fs.writeFileSync(tsLog, '')
   })
 
@@ -455,7 +439,7 @@ describe('the per-agent token on the agent routes (#159, real boot, both listene
   let tmp
   let child
   let port
-  let childLog = ''
+  let watch
   const GATEWAY = '127.0.0.2'
 
   const mint = (agent) => mintAgentToken(path.join(tmp, 'data'), agent)
@@ -497,6 +481,9 @@ describe('the per-agent token on the agent routes (#159, real boot, both listene
       'identity:',
       '  allow: [tester@example.com]',
       `  proxy_port: ${proxyPort}`,
+      // #212: the fixture owns its skills root, so this boot depends on
+      // nothing under the host's HOME.
+      ...skillsYaml(seedSkillsRoot(tmp)),
       'sandbox:',
       '  image: curia-agent-test',
       '  claude_version: 1.0.0',
@@ -533,18 +520,14 @@ describe('the per-agent token on the agent routes (#159, real boot, both listene
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
+    watch = watchDaemon(child)
 
-    const deadline = Date.now() + 15_000
-    for (;;) {
+    await waitForBoot(watch, async () => {
       try {
-        if ((await request(port, 'GET', '/state')).status === 200
-          && (await requestOn(GATEWAY, port, 'POST', '/agent_done?agent=curia-0')).status === 403) break
-      } catch { /* not listening yet */ }
-      if (Date.now() > deadline) throw new Error(`daemon did not bring up both listeners; log:\n${childLog}`)
-      await new Promise((r) => setTimeout(r, 100))
-    }
+        return (await request(port, 'GET', '/state')).status === 200
+          && (await requestOn(GATEWAY, port, 'POST', '/agent_done?agent=curia-0')).status === 403
+      } catch { return false }
+    }, 'both listeners', 15_000)
   })
 
   after(() => {

--- a/daemon/test/keepalive.test.mjs
+++ b/daemon/test/keepalive.test.mjs
@@ -19,7 +19,6 @@ import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import http from 'node:http'
-import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -27,22 +26,13 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { TOKEN_HEADER, mintAgentToken } from '../src/agenttoken.mjs'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
 
 const KEEPALIVE_MS = 150
-
-function freePort() {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer()
-    srv.listen(0, '127.0.0.1', () => {
-      const { port } = srv.address()
-      srv.close(() => resolve(port))
-    })
-    srv.once('error', reject)
-  })
-}
 
 function request(port, method, urlPath, { headers = {}, body = null } = {}) {
   return new Promise((resolve, reject) => {
@@ -75,7 +65,7 @@ describe('a blocked ask_human keeps its stream alive (index.mjs, real boot + rea
   let tmp
   let child
   let port
-  let childLog = ''
+  let watch
 
   // Since #159 the daemon serves /mcp only to an agent that presents the token
   // it minted for that name — so every client here arms itself the way a real
@@ -118,6 +108,9 @@ describe('a blocked ask_human keeps its stream alive (index.mjs, real boot + rea
       'identity:',
       '  allow: [tester@example.com]',
       `  proxy_port: ${proxyPort}`,
+      // #212: the fixture owns its skills root, so this boot depends on
+      // nothing under the host's HOME.
+      ...skillsYaml(seedSkillsRoot(tmp)),
       '',
     ].join('\n'))
     fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
@@ -146,14 +139,13 @@ describe('a blocked ask_human keeps its stream alive (index.mjs, real boot + rea
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    child.stdout.on('data', (c) => { childLog += c })
-    child.stderr.on('data', (c) => { childLog += c })
+    watch = watchDaemon(child)
 
-    await until(async () => {
+    await waitForBoot(watch, async () => {
       try {
         return (await request(port, 'GET', '/state')).status === 200
       } catch { return false }
-    }, `the daemon to listen; log:\n${childLog}`)
+    }, 'the /state route')
   })
 
   after(() => {

--- a/daemon/test/realboot.test.mjs
+++ b/daemon/test/realboot.test.mjs
@@ -1,0 +1,208 @@
+// The real-boot fixture itself (#212).
+//
+// Six suites spawn the real daemon and wait for it in a `before` hook. When
+// that hook fails, node reports every test under it as `cancelled` — a word
+// that reads exactly like `skipped`, and a cancelled test proves nothing. An
+// agent verifying its own daemon change learned to read 19 of them as
+// pre-existing and move on. So the wait is the thing that has to be loud, and
+// nothing else in the suite would notice it going quiet again.
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot } from './fixtures/skills.mjs'
+
+const DIR = path.dirname(fileURLToPath(import.meta.url))
+const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
+
+// stdout, stderr and `close` are the whole contract `watchDaemon` needs, so a
+// plain emitter drives every branch with no process to schedule.
+function fakeChild() {
+  const child = new EventEmitter()
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+describe('waitForBoot: a child that dies is a failure, never a silence', () => {
+  test('the child exits before it is ready, and the wait says so at once', async () => {
+    const child = fakeChild()
+    const watch = watchDaemon(child)
+    child.stderr.emit('data', 'Error: bad config: skills.install names "wayfinder"\n')
+    child.emit('close', 1, null)
+
+    const started = Date.now()
+    await assert.rejects(
+      () => waitForBoot(watch, () => false, 'the /state route'),
+      (e) => {
+        assert.match(e.message, /never got a daemon/, 'the failure names itself')
+        assert.match(e.message, /exited with code 1/, 'and names how the child died')
+        assert.match(e.message, /skills\.install names "wayfinder"/, "and carries the child's own words")
+        assert.match(e.message, /cancelled test here is a boot that FAILED/, 'and refuses to read as a skip')
+        return true
+      },
+    )
+    assert.ok(Date.now() - started < 1_000, 'a dead child must not be waited out to the timeout')
+  })
+
+  test('a signalled child names its signal', async () => {
+    const child = fakeChild()
+    const watch = watchDaemon(child)
+    child.emit('close', null, 'SIGKILL')
+    await assert.rejects(
+      () => waitForBoot(watch, () => false, 'the /state route'),
+      /exited on SIGKILL/,
+    )
+  })
+
+  test('a child that says nothing at all still fails legibly', async () => {
+    const child = fakeChild()
+    const watch = watchDaemon(child)
+    child.emit('close', 1, null)
+    await assert.rejects(() => waitForBoot(watch, () => false, 'the /state route'), /\(nothing at all\)/)
+  })
+
+  test('a live child that never becomes ready gives up loudly, and says it is still running', async () => {
+    const watch = watchDaemon(fakeChild())
+    await assert.rejects(
+      () => waitForBoot(watch, () => false, 'both listeners', 200),
+      (e) => {
+        assert.match(e.message, /never reached both listeners/, 'the wait names what it wanted')
+        assert.match(e.message, /still running/, 'and separates a hang from a death')
+        return true
+      },
+    )
+  })
+
+  test('a child that becomes ready is simply awaited', async () => {
+    const watch = watchDaemon(fakeChild())
+    let polls = 0
+    await waitForBoot(watch, () => ++polls >= 3, 'the /state route', 5_000)
+    assert.equal(polls, 3)
+  })
+})
+
+// The end-to-end half, and the one that would have caught #212 itself: the
+// REAL daemon, refusing a real config, through the wait every real-boot suite
+// uses.
+describe('waitForBoot against the real daemon (real boot, refused)', () => {
+  let tmp
+
+  before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-realboot-test-')) })
+  after(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
+
+  test('a config the daemon refuses fails the wait fast, naming the key', async () => {
+    const cfgDir = path.join(tmp, 'config')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    const [port, ttydPort, servePort, proxyPort] = [await freePort(), await freePort(), await freePort(), await freePort()]
+    // A root the daemon cannot read, which is exactly the shape an agent
+    // container gave every suite before its fixtures owned their own root.
+    fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
+      'watch:',
+      '  - repo: example/fixture',
+      'dispatch:',
+      '  auto_dispatch: false',
+      '  max_concurrent: 1',
+      '  poll_interval_s: 60',
+      `  workspace_root: ${path.join(tmp, 'work')}`,
+      '  ready_timeout_s: 5',
+      'attach:',
+      `  ttyd_port: ${ttydPort}`,
+      `  serve_port: ${servePort}`,
+      'identity:',
+      '  allow: [tester@example.com]',
+      `  proxy_port: ${proxyPort}`,
+      'skills:',
+      `  root: ${path.join(tmp, 'no-such-skills-root')}`,
+      '  install: [wayfinder]',
+      '',
+    ].join('\n'))
+    fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
+      'defaults:',
+      '  untyped: sonnet',
+      'models:',
+      '  sonnet: { provider: anthropic, harness: claude }',
+      'harnesses:',
+      '  claude:',
+      '    template: claude --model {model} "$(cat {prompt_file})"',
+      "    ready: '⏵⏵|bypass permissions'",
+      '    tool_channel_grace_s: 15',
+      '',
+    ].join('\n'))
+
+    const child = spawn(process.execPath, [DAEMON], {
+      env: {
+        ...process.env,
+        PORT: String(port),
+        CURIA_CONFIG_DIR: cfgDir,
+        CURIA_DATA_DIR: path.join(tmp, 'data'),
+        DISCORD_BOT_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const watch = watchDaemon(child)
+    const started = Date.now()
+    try {
+      await assert.rejects(
+        () => waitForBoot(watch, () => false, 'the /state route'),
+        /never got a daemon[\s\S]*skills\.install names "wayfinder"/,
+        "the boot refusal reaches the reader instead of an empty log",
+      )
+      assert.ok(Date.now() - started < 9_000, 'the wait must not sit out its full timeout on a dead child')
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL')
+    }
+  })
+
+  test('and the same daemon boots once the fixture owns the root', async () => {
+    const cfgDir = path.join(tmp, 'config-ok')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    const [port, ttydPort, servePort, proxyPort] = [await freePort(), await freePort(), await freePort(), await freePort()]
+    fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
+      'watch:',
+      '  - repo: example/fixture',
+      'dispatch:',
+      '  auto_dispatch: false',
+      '  max_concurrent: 1',
+      '  poll_interval_s: 60',
+      `  workspace_root: ${path.join(tmp, 'work-ok')}`,
+      '  ready_timeout_s: 5',
+      'attach:',
+      `  ttyd_port: ${ttydPort}`,
+      `  serve_port: ${servePort}`,
+      'identity:',
+      '  allow: [tester@example.com]',
+      `  proxy_port: ${proxyPort}`,
+      'skills:',
+      `  root: ${seedSkillsRoot(path.join(tmp, 'owned'))}`,
+      '',
+    ].join('\n'))
+    fs.copyFileSync(path.join(tmp, 'config', 'routing.yaml'), path.join(cfgDir, 'routing.yaml'))
+
+    const child = spawn(process.execPath, [DAEMON], {
+      env: {
+        ...process.env,
+        PORT: String(port),
+        CURIA_CONFIG_DIR: cfgDir,
+        CURIA_DATA_DIR: path.join(tmp, 'data-ok'),
+        TTYD_BIN: path.join(tmp, 'no-such-ttyd'),
+        DISCORD_BOT_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const watch = watchDaemon(child)
+    try {
+      // The default skill list, unstated, against a root the test seeded: the
+      // whole fix in one boot.
+      await waitForBoot(watch, () => /curia daemon listening/.test(watch.log()), 'its listening line')
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL')
+    }
+  })
+})


### PR DESCRIPTION
Ticket: alp82/curia#212 — [The daemon's real-boot tests cannot run inside an agent container](https://github.com/alp82/curia/issues/212)

The daemon test suite owns its skills root, and a dead boot says so (#212).

`loadCuriaConfig` checks every name in `skills.install` against a `SKILL.md` under `skills.root`, and that root defaults to `~/.claude/skills`. No fixture config named a root, so every one of them asked the host a question the test could not control. An agent container keeps its skills elsewhere, so the daemon child refused to boot. Node then reported 19 tests as `cancelled` and 8 as failed. The same numbers came back on a clean tree, so an agent read them as pre-existing and moved on.

Measured in this container before the change: 1141 tests, 1113 pass, 8 fail, 19 cancelled. Every one of the 27 came from this single cause.

**A skills root the tests seed.** `test/fixtures/skills.mjs` writes a manifest for every name in `DEFAULT_SKILLS` and returns the root. The root is derived from the same constant the validator reads, so a tenth default skill cannot bring the fault back. Six fixture configs now name it. Two tests do pin the DEFAULT root, and they swap in a home directory they own instead. No suite reads `$HOME` any more, on any box.

**A cancelled test must not read as a skipped one.** `test/fixtures/real-boot.mjs` watches the daemon child as well as the port. A child that refuses to boot fails the wait in about one second, under the line `the real-boot fixture never got a daemon`, with its own stderr below it. Before this the keepalive suite captured its log before the child had said anything, so it timed out after ten seconds and printed an empty log. The helper also replaces three copies of `freePort` and six copies of the boot-wait loop.

**The guard has its own tests.** `test/realboot.test.mjs` drives every branch against a fake child, then drives the real daemon twice: a config it refuses fails the wait in about 1.6 s with the config error in the message, and the same daemon boots against a root the fixture seeded. That first one is the regression guard for this ticket.

**A race the green suite exposed.** `--import` runs the induced-crash fixture before the daemon loads, so its 600 ms fault clock started at preload. Measured in this container, the planted fault landed 18 ms after the listen, and a slower box would put it before. The clock now starts when the daemon's own port accepts a connection.

**The other host dependencies, checked.** Two stay optional and each states why it skipped: the tmux describes in `tmux.test.mjs` need tmux, and one version reader in `attach.test.mjs` needs ttyd. An agent container carries neither binary, so a green run there shows one skipped test and three skipped describes.

**Documented** in `daemon/README.md` and `AGENTS.md`: the suite must be green, and a cancelled test is a boot that failed.

After the change: 1148 tests, 1147 pass, 0 fail, 0 cancelled, 1 skipped.

---

Dispatched by the curia daemon — session `curia-212`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `f9be2a5` Pin the real-boot guard with its own tests (#212)
- `ee1e7d8` The daemon test suite owns its skills root, and a dead boot says so (#212)