### PR TITLE
A timeline /send into a codex pane never submits (alp82/curia#223)

### DIFF
--- a/daemon/src/tmux.mjs
+++ b/daemon/src/tmux.mjs
@@ -116,20 +116,87 @@ export async function capturePane(name) {
 
 export async function killSession(name) {
   await tmux(['kill-session', '-t', `=${name}`])
+  paneWrites.delete(name) // the pane is gone, and its pacing state goes with it
 }
 
+// ---------------------------------------------------------------------------
+// the write path, paced (#223)
+// ---------------------------------------------------------------------------
+//
 // The timeline surface's write path (#74): send-keys drives a session with
 // ZERO attached clients, so no geometry is negotiated and the pane never
 // learns how many devices exist (#72 leg 3). Same pane-scoped `=name:` target
 // as capturePane, for the same window-rename reason.
 //
-// -l sends the text LITERALLY (no key-name interpretation); the separate
-// Enter submits it.
-export async function sendText(name, text) {
-  await tmux(['send-keys', '-t', `=${name}:`, '-l', text])
-  await tmux(['send-keys', '-t', `=${name}:`, 'Enter'])
+// Every byte a caller writes into a pane goes through paneWrite, which holds
+// consecutive writes to the SAME pane at least PANE_WRITE_GAP_MS apart.
+//
+// codex 0.146 folds keystrokes that arrive inside about a second into one
+// PASTE — measured live on #176 (docs/live-checks/176-codex-attach-surfaces.md,
+// section 4). sendText used to send the text and the Enter as two send-keys
+// calls milliseconds apart, so on a codex pane the Enter landed inside that
+// window and became a NEWLINE: the message sat in the composer, no turn ever
+// started, and the timeline still reported "sent". Every timeline /send to a
+// codex agent was a silent no-op — #75's loss class again, on the write path.
+//
+// The gap is unconditional, not per-harness. A per-harness send would have to
+// pick its branch from the dispatcher's harness answer, which is null for a
+// re-adopted or lab session, and the wrong branch here fails SILENTLY — the
+// exact outcome this closes. The claude composer submits on a late Enter
+// exactly as it does on an immediate one (measured throughout #74/#75), so
+// both lanes pay the gap and neither lane can lose a message to a fold.
+//
+// The pacing also covers the fold nobody had to type by hand: two /send posts
+// from two devices, milliseconds apart, put the first message's Enter and the
+// second message's text in one burst, which loses the first submit the same
+// way. Writers are therefore QUEUED per pane as well as spaced. The queue is
+// what makes a send ATOMIC: the text and its Enter are one job, so another
+// device's Escape can no longer land between them and empty the composer the
+// Enter was about to submit.
+export const PANE_WRITE_GAP_MS = 1_500
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+// name -> { at, chain }: `at` is when the last write to this pane finished,
+// `chain` is the tail of that pane's job queue. The queue is per pane, so one
+// agent's send never delays another's.
+const paneWrites = new Map()
+
+// job(write) runs with the pane to itself; each `write` waits out the gap
+// since the previous one, whoever made it.
+function paneJob(name, job) {
+  let state = paneWrites.get(name)
+  if (!state) {
+    state = { at: 0, chain: Promise.resolve() }
+    paneWrites.set(name, state)
+  }
+  const write = async (args) => {
+    const wait = state.at + PANE_WRITE_GAP_MS - Date.now()
+    if (wait > 0) await sleep(wait)
+    try {
+      await tmux(args)
+    } finally {
+      // A failed send-keys may still have put bytes in the pane, so it starts
+      // the next gap exactly as a successful one does.
+      state.at = Date.now()
+    }
+  }
+  const done = state.chain.then(() => job(write))
+  // The queue carries the swallowed copy: one failed job must not reject every
+  // job queued behind it.
+  state.chain = done.catch(() => {})
+  return done
 }
 
-export async function sendKey(name, key) {
-  await tmux(['send-keys', '-t', `=${name}:`, key])
+// -l sends the text LITERALLY (no key-name interpretation); the separate
+// Enter, one gap later, submits it.
+export function sendText(name, text) {
+  return paneJob(name, async (write) => {
+    await write(['send-keys', '-t', `=${name}:`, '-l', text])
+    await write(['send-keys', '-t', `=${name}:`, 'Enter'])
+  })
+}
+
+export function sendKey(name, key) {
+  return paneJob(name, (write) => write(['send-keys', '-t', `=${name}:`, key]))
 }

--- a/daemon/test/tmux.test.mjs
+++ b/daemon/test/tmux.test.mjs
@@ -12,7 +12,7 @@ import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { hasSession, listSessions, newSession, capturePane, killSession, wrapShellCmd } from '../src/tmux.mjs'
+import { hasSession, listSessions, newSession, capturePane, killSession, wrapShellCmd, sendText, sendKey, PANE_WRITE_GAP_MS } from '../src/tmux.mjs'
 import { paneTail, parseExitMarker, paneExcerpt } from '../src/dispatch.mjs'
 
 // Inside any tmux pane — every curia agent runs there — tmux exports $TMUX,
@@ -237,5 +237,88 @@ describe('the exit wrapper, through a real shell', () => {
 
   test('an unsafe marker is refused before it is ever nested in bash -c', () => {
     assert.throws(() => wrapShellCmd('true', 'x"; rm -rf /; #'), /not quote-free/)
+  })
+})
+
+// #223, WITHOUT tmux, for the same reason the wrapper test above runs without
+// it: the property under test is the TIMING of the send-keys calls, and a fake
+// tmux on PATH records that timing anywhere. codex 0.146 folds keystrokes that
+// arrive inside about a second into one paste (measured live on #176), so an
+// Enter that follows its text milliseconds later becomes a newline and the
+// message never leaves the composer.
+describe('pane writes are spaced so a codex composer cannot fold them (#223)', () => {
+  // The widest fold window measured on codex 0.146. The gap must clear it.
+  const CODEX_PASTE_WINDOW_MS = 1_000
+
+  let tmp
+  let log
+  let savedPath
+
+  // Every call appends "<ms> <argv…>", so the log carries both the order and
+  // the spacing of the real execFile calls.
+  const FAKE = `#!/usr/bin/env node
+const fs = require('fs')
+fs.appendFileSync(process.env.CURIA_TMUX_LOG, Date.now() + ' ' + process.argv.slice(2).join(' ') + '\\n')
+`
+
+  const calls = () => fs.readFileSync(log, 'utf8').split('\n').filter(Boolean).map((line) => {
+    const at = line.slice(0, line.indexOf(' '))
+    return { at: Number(at), args: line.slice(at.length + 1) }
+  })
+
+  test.beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-paced-'))
+    log = path.join(tmp, 'calls.log')
+    fs.writeFileSync(path.join(tmp, 'tmux'), FAKE, { mode: 0o755 })
+    fs.writeFileSync(log, '')
+    process.env.CURIA_TMUX_LOG = log
+    savedPath = process.env.PATH
+    process.env.PATH = `${tmp}:${savedPath}`
+  })
+
+  test.afterEach(() => {
+    process.env.PATH = savedPath
+    delete process.env.CURIA_TMUX_LOG
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  test('the Enter lands a gap after the text, not milliseconds after it', async () => {
+    await sendText('curia-223a', 'ship it')
+    const c = calls()
+
+    assert.equal(c.length, 2)
+    assert.equal(c[0].args, 'send-keys -t =curia-223a: -l ship it')
+    assert.equal(c[1].args, 'send-keys -t =curia-223a: Enter')
+    assert.ok(
+      c[1].at - c[0].at > CODEX_PASTE_WINDOW_MS,
+      `the Enter landed ${c[1].at - c[0].at}ms after the text — inside codex's fold window, where it is a newline`,
+    )
+  })
+
+  test('two writers to one pane are serialised, so no write folds into another', async () => {
+    // The second fold: two devices posting /send milliseconds apart put the
+    // first message's Enter and the second message's text in one burst.
+    await Promise.all([sendText('curia-223b', 'first'), sendKey('curia-223b', 'Escape')])
+    const c = calls()
+
+    assert.deepEqual(c.map((x) => x.args), [
+      'send-keys -t =curia-223b: -l first',
+      'send-keys -t =curia-223b: Enter',
+      'send-keys -t =curia-223b: Escape',
+    ], 'writes must reach the pane in the order they were issued')
+    for (let i = 1; i < c.length; i++) {
+      assert.ok(
+        c[i].at - c[i - 1].at > CODEX_PASTE_WINDOW_MS,
+        `write ${i} landed ${c[i].at - c[i - 1].at}ms after write ${i - 1}`,
+      )
+    }
+  })
+
+  test('two panes do not wait on each other', async () => {
+    const started = Date.now()
+    await Promise.all([sendKey('curia-223c', 'Escape'), sendKey('curia-223d', 'Escape')])
+
+    assert.equal(calls().length, 2)
+    assert.ok(Date.now() - started < PANE_WRITE_GAP_MS, 'the gap is per pane; one agent must not delay another')
   })
 })


### PR DESCRIPTION
Ticket: alp82/curia#223 — [A timeline /send into a codex pane never submits](https://github.com/alp82/curia/issues/223)

Fixes the silent no-op in ticket #223: a timeline /send into a codex pane never submitted.

codex 0.146 folds keystrokes that arrive inside about a second into one paste (measured on #176, live check section 4). `sendText` sent the text and the Enter as two `send-keys` calls milliseconds apart, so on a codex pane the Enter became a newline. The message sat in the composer, no turn started, and the timeline still reported "sent".

What changed in `daemon/src/tmux.mjs`:

- Every pane write goes through a per-pane queue that holds consecutive writes 1.5 s apart (`PANE_WRITE_GAP_MS`).
- The gap is unconditional, not per-harness. A per-harness branch reads a harness answer that is null for a re-adopted or lab session, and the wrong branch fails silently. The claude composer submits on a late Enter as well as on an immediate one.
- The queue also makes a send atomic per pane. Two devices posting /send milliseconds apart used to put the first message's Enter and the second message's text in one burst. Another device's Escape could also land between a message and its Enter.
- The queue is per pane, so one agent never delays another.

Callers checked: `sendText` and `sendKey` have one caller each, the timeline surface's `/send` and `/key`. Both are covered by the change. The copy in `spikes/timeline-attach/server.mjs` is a spike, not running code.

Tests: three new cases in `daemon/test/tmux.test.mjs`. They need no tmux. A fake tmux on PATH records the argv and the timestamp of every call, so the test reads the real spacing and the real order. `npm test` in `daemon/` is green (1154 pass, 0 fail).

NOT done: the ticket also asks for one live send into each lane. This agent container has no tmux and no codex credential, so the live confirmation cannot run here.

---

Dispatched by the curia daemon — session `curia-223`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `f55a7b5` A timeline send reaches a codex composer as a submit (alp82/curia#223)