### PR TITLE
`map` with no issue charts a new map from prose (alp82/curia#241)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,11 +37,17 @@ The map changes: new tickets, graduated fog, blocking edges, scope rulings. They
 **Map dispatch**:
 `map <n>` on a map's own issue. The daemon spawns a charting agent instead of a ticket agent. It claims nothing. `start` on a map number is not this: it dispatches the map's next takeable ticket.
 
+**New-map dispatch**:
+`map [repo] -- <prose>` with no issue. The daemon spawns a charting agent that has no map. The agent settles the destination with the operator, then creates the `wayfinder:map` issue itself. The prose is mandatory here: it is the loose idea the charting starts from.
+
+**Adoption**:
+The act that gives a new-map dispatch its map. The agent calls `map_created` with the number. curia checks the issue is an open map in that repo, then takes it as the session's map: the thread moves onto it, `map <n>` on it is refused, and the charting summary lands there.
+
 **Charting agent**:
-The agent of a map dispatch. It edits the map and its tickets, and it never closes the map, opens a pull request, or passes a review gate.
+The agent of a map dispatch. It edits the map and its tickets, and it never closes the map, opens a pull request, or passes a review gate. On a new-map dispatch it creates the map first.
 
 **Instruction**:
-The operator's sentence on a map dispatch, in their own words. It rides the `map` verb after a bare `--`, and reaches the charting agent as the first thing it reads. With no instruction, the agent asks what should change. No other verb takes one.
+The operator's sentence on a map dispatch, in their own words. It rides the `map` verb after a bare `--`, and reaches the charting agent as the first thing it reads. On an existing map it is optional: with none, the agent asks what should change. On a new map it is mandatory, because nothing else says what to chart. No other verb takes one.
 
 **Frontier**:
 The takeable tickets of a watched repo, in map order.
@@ -121,6 +127,9 @@ _Avoid_: worker (the old name, swept in #184).
 
 **Session**:
 The tmux session `curia-<n>`. The session name is the agent's identity everywhere.
+
+**Chat handle**:
+The name of an agent no issue answers for: `chat-1`, `chat-2`, the lowest free index at dispatch. It stands where a ticket number stands — the session `curia-chat-1`, the worktree, the thread, and the argument `attach`, `cancel` and `resume` take. Today one kind of agent uses it: the new-map dispatch.
 
 **Agent host**:
 The layer that hosts agent sessions and their attach: bare tmux, one shared ttyd, Tailscale Serve.
@@ -253,6 +262,9 @@ The ordered close-out of a ticket: commit, pull request, preview, review gate, m
 
 **Charting ending**:
 The ending of a map dispatch: edit the map, then report the result. Curia posts the summary on the map. No unassign, no pull request, no review gate, no close.
+
+**New-map ending**:
+The charting ending with one step in front: create the map, adopt it with `map_created`, then report the result. The Stop hook holds the agent to the adoption, because it is the one fact the daemon cannot read for itself.
 
 **Stop hook**:
 The enforcement hook that fires at the end of every agent turn. It refuses a stop that leaves ending steps open, up to the stop budget, then lets go and reports the ticket unfinished.

--- a/README.md
+++ b/README.md
@@ -171,9 +171,13 @@ Then use the commands, as Discord slash commands or as plain English in a thread
 - `tickets` — what is takeable
 - `start <n>` — send an agent. On a map number, this sends one to the map's next takeable ticket.
 - `map <n> -- <what should change>` — send an agent that updates the map itself
+- `map -- <what to chart>` — send an agent with no map. It settles the destination with you, then creates the map issue itself. Name the repo (`map <repo> -- …`) when more than one is watched.
 - `status` — who is running
 - `attach <n>` — that agent's terminal in your browser
 - `resume <n>` / `cancel <n>`
+
+An agent that no ticket answers for gets a handle instead of a number — `chat-1`, `chat-2` — and the
+three verbs above take it: `attach chat-1`, `cancel chat-1`, `resume chat-1`. `status` lists it.
 
 ## 13. Keep it running
 

--- a/daemon/src/attach.mjs
+++ b/daemon/src/attach.mjs
@@ -32,6 +32,47 @@ export function validSessionName(s) {
   return /^curia-[A-Za-z0-9._-]+$/.test(s)
 }
 
+// ---- the chat handle: an agent with no ticket (#241) ------------------------
+//
+// Every curia agent until now was named by an issue number, because every one
+// of them was dispatched ON an issue. `map -- <prose>` breaks that: it charts a
+// map that does not exist yet, so there is no number to name the session, the
+// tmux pane, the config dir or the thread with — and the operator still has to
+// reach it with `attach`, `cancel` and `resume`.
+//
+// The operator's ruling (#241): ENUMERATE the ticketless ones. `chat-1`,
+// `chat-2`, and so on — the lowest free index at dispatch — each with its own
+// thread, all of them live at once. That is deliberately a general principle
+// and not a new-map special case: a chat is any agent curia runs that no issue
+// answers for, and the next kind of one gets its handle from here too.
+//
+// So the handle IS the identity: session `curia-chat-1`, `attach chat-1`,
+// `cancel chat-1`, `resume chat-1`, and `chat-1` in the `status` list.
+//
+// It lives HERE because attach.mjs owns the session-name vocabulary and is the
+// one module the command surface and the dispatcher both already import. The
+// regex above takes it as it stands: session names were never numeric-only.
+export const CHAT_PREFIX = 'chat-'
+export const CHAT_HANDLE_RE = /^chat-\d+$/
+export const isChatHandle = (s) => CHAT_HANDLE_RE.test(String(s ?? ''))
+export const chatHandle = (i) => `${CHAT_PREFIX}${i}`
+export const chatSession = (i) => `curia-${chatHandle(i)}`
+
+// The lowest index no live session already holds. `taken` is every session name
+// curia knows about — its own table plus what tmux reports — because the index
+// has to be free on the BOX, not merely in this process's memory: the same rule
+// that makes the dispatch locks ask tmux rather than the agents map.
+export function nextChatHandle(taken = []) {
+  const used = new Set()
+  for (const s of taken) {
+    const m = String(s).match(/^curia-chat-(\d+)$/)
+    if (m) used.add(Number(m[1]))
+  }
+  let i = 1
+  while (used.has(i)) i += 1
+  return chatHandle(i)
+}
+
 function portLive(port) {
   return new Promise((resolve) => {
     const sock = net.connect({ host: '127.0.0.1', port, timeout: 750 })

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -65,8 +65,12 @@ const LIVE_GLYPH_RE = /^(?:🎫|⏳|🔎)/u
 // here: it is a command now, and a command typed at an agent must not vanish
 // into the note queue. Only the bare form matches — `map 147 -- <sentence>`
 // runs past the end of this shape, and a sentence is what a note IS.
+// #241 adds the chat handle (`chat-1`) to the argument alternation, for the
+// same reason: it is what `cancel`, `resume` and `attach` take on an agent no
+// ticket answers for, so an operator typing it at that agent's own thread must
+// get the hint rather than have it queued as prose.
 export const COMMAND_SHAPED =
-  /^\s*(cancel|stop|pause|resume|status|start|map|attach)(?:\s+(all|#?\d+|[\w.-]+(?:\/[\w.-]+)?#\d+))?(?:\s+(?:model|harness)=[\w.-]+)*\s*[.!?]*\s*$/i
+  /^\s*(cancel|stop|pause|resume|status|start|map|attach)(?:\s+(all|#?\d+|chat-\d+|[\w.-]+(?:\/[\w.-]+)?#\d+))?(?:\s+(?:model|harness)=[\w.-]+)*\s*[.!?]*\s*$/i
 
 // The command the operator meant. `stop` and `pause` are not verbs the surface
 // has — at an agent, cancel is what they ask for. `status` is the only one
@@ -205,9 +209,14 @@ const SLASH_MANIFEST = [
   // #221: charting's own verb, in the operator's own word. `instruction` stays
   // optional, so a dispatch with no sentence opens with the "what should
   // change?" escalation (#160) instead of being refused at the client.
-  new SlashCommandBuilder().setName('map').setDescription('Dispatch a charting agent that updates a map')
-    .addStringOption((o) => o.setName('ticket').setDescription('Map number').setRequired(true))
-    .addStringOption((o) => o.setName('instruction').setDescription('What should change on the map, in your own words'))
+  // #241: `ticket` is no longer required. With one, this charts an existing
+  // map. Without one, `instruction` alone charts a NEW map — the agent settles
+  // the destination with the operator and creates the issue itself. Exactly one
+  // of the two must be present, and the expansion says which is missing.
+  new SlashCommandBuilder().setName('map').setDescription('Dispatch a charting agent on a map, or on no map yet')
+    .addStringOption((o) => o.setName('ticket').setDescription('Map number — leave empty to chart a NEW map'))
+    .addStringOption((o) => o.setName('instruction').setDescription('What should change on the map — or, with no map number, what to chart'))
+    .addStringOption((o) => o.setName('repo').setDescription('Which repo a NEW map is charted in (only needed when more than one is watched)'))
     .addStringOption((o) => o.setName('model').setDescription('Model override')),
   new SlashCommandBuilder().setName('cancel').setDescription('Cancel a running ticket, or all of them')
     .addStringOption((o) => o.setName('ticket').setDescription('Ticket number, or "all"').setRequired(true)),
@@ -257,13 +266,21 @@ export function expandCommand(i) {
     }
     case 'map': {
       const ticket = need('ticket')
-      if (!ticket) return { error: 'missing' }
       // The instruction rides LAST, after a bare `--` (#160), and its
       // whitespace is collapsed for the same reason canonicalFor collapses it:
       // this line is one line, and the router splits it on whitespace. This is
       // still expansion, not interpretation — the text is passed through, and
       // whether the issue is a map is the dispatcher's ruling.
       const instruction = (need('instruction') ?? '').replace(/\s+/g, ' ').trim()
+      // #241: no map number means the NEW-map shape, which needs the sentence.
+      // A `/map` carrying neither is the one shape no dispatcher can read, so
+      // it is refused HERE, naming both — the expansion can see it is wrong
+      // without interpreting anything.
+      if (!ticket) {
+        if (!instruction) return { error: 'map-shape' }
+        const repo = need('repo')
+        return `map${repo ? ' ' + repo : ''}${opt('model') ? ' model=' + opt('model') : ''} -- ${instruction}`
+      }
       return `map ${ticket}`
         + (opt('model') ? ' model=' + opt('model') : '')
         + (instruction ? ` -- ${instruction}` : '')
@@ -285,6 +302,19 @@ export function expandCommand(i) {
     default: return null
   }
 }
+
+// `/map` with neither a map number nor a sentence (#241). This is NOT the stale
+// manifest of missingOptionReply below: both options are optional now, and the
+// client sent exactly what it was told it could send. So the reply teaches the
+// two shapes instead of telling the operator to restart Discord.
+const MAP_SHAPE_REPLY = [
+  '❌ `/map` needs a **ticket**, an **instruction**, or both.',
+  '',
+  '• **ticket** alone — chart that existing map, and the agent asks what should change.',
+  '• **ticket** + **instruction** — chart that existing map, with your sentence as the brief.',
+  '• **instruction** alone — chart a **NEW** map: the agent settles the destination and the scope',
+  '  with you, then creates the `wayfinder:map` issue itself. Add **repo** when more than one is watched.',
+].join('\n')
 
 function missingOptionReply(commandName) {
   return [
@@ -616,6 +646,33 @@ export class DiscordBridge {
       return this.#bindFreshThread(ticket, type, repo, threadId)
     }
     return this.#bindFreshThread(ticket, type, repo, null)
+  }
+
+  // #241: the thread of a NEW-map charting session is bound to the handle
+  // `new`, because that word was the only name the session had. The moment the
+  // agent creates the map, this thread becomes THAT MAP's thread — the
+  // conversation that settled the destination is exactly the record a later
+  // `map <n>` should land back in, and #93's binding is what makes it land.
+  //
+  // Two acts, in order: the binding moves off the handle onto the number, then
+  // the name follows so the thread list reads as the map instead of as a
+  // sentence the operator typed once. A bind that refuses puts the handle back
+  // — an unbound thread would send the running agent's next notify into a
+  // fresh thread, which is worse than a stale name.
+  async adoptMapThread(handle, mapNumber, { repo = '' } = {}) {
+    if (!this.bindings) return { ok: false, reason: 'no-bindings' }
+    const threadId = this.bindings.get(handle)
+    if (!threadId) return { ok: false, reason: 'unbound' }
+    this.bindings.release(handle, 'the map this session created now names it')
+    const r = this.bindings.bind(String(mapNumber), threadId)
+    if (!r.ok) {
+      this.bindings.bind(handle, threadId)
+      return r
+    }
+    const name = DiscordBridge.labelName(mapNumber, 'map', repo)
+    const t = await this.client.channels.fetch(threadId).catch(() => null)
+    if (t && (this.renamer.desired(t.id) ?? t.name) !== name) await this.renamer.set(t.id, name)
+    return { ok: true, threadId }
   }
 
   async #bindFreshThread(ticket, type, repo, originThreadId) {
@@ -1141,7 +1198,8 @@ export class DiscordBridge {
       const canonical = expandCommand(i)
       if (!canonical) return
       if (typeof canonical === 'object') {
-        await i.reply({ content: missingOptionReply(i.commandName), ephemeral: true })
+        const content = canonical.error === 'map-shape' ? MAP_SHAPE_REPLY : missingOptionReply(i.commandName)
+        await i.reply({ content, ephemeral: true })
         return
       }
       await i.deferReply()

--- a/daemon/src/commands.mjs
+++ b/daemon/src/commands.mjs
@@ -6,7 +6,7 @@
 // so the slash reply itself stays fast (#18 seam: bridge macro-expands, this
 // router interprets — the stated deviation until the overseer session exists).
 
-import { validSessionName } from './attach.mjs'
+import { validSessionName, CHAT_HANDLE_RE } from './attach.mjs'
 import { clampList } from './messaging.mjs'
 
 // A repo argument is any single non-numeric token — #81 resolves it fuzzily
@@ -26,12 +26,32 @@ const REPOISH_RE = /^[\w./-]+$/
 // unchanged.
 const INSTRUCTION_SEP = '--'
 
+// What names ONE live agent on `cancel`, `resume` and `attach`: an issue
+// number, or a chat handle (#241). An agent no issue answers for — today, the
+// one charting a map that does not exist yet — is reached by its handle
+// instead: `cancel chat-1`. `all` is not here; it names every agent, and only
+// two of the three verbs take it.
+const AGENT_RE = new RegExp(`^(\\d+|${CHAT_HANDLE_RE.source.replace(/^\^|\$$/g, '')})$`)
+
 // #221: `start` carries no instruction any more, because it no longer charts.
 // The parser refuses the shape and the router names the verb that does take
 // one — the same treatment `harness=` got, and for the same reason: an operator
 // with muscle memory deserves the rule, not the whole catalogue.
 const START_INSTRUCTION_RE = /^start\b.*(^|\s)--(\s|$)/
 const START_INSTRUCTION_GONE = '`start` carries no instruction — it works a ticket. `start <map>` now dispatches that map\'s next takeable ticket, and `map <n> -- <sentence>` is how a map itself is updated.'
+
+// #241: `map` has two shapes, and a parse failure on the verb names both. The
+// second one carries no issue reference at all, so the FIRST shape's refusal
+// ("not a number") would be a lie about what the operator may type. Any `map`
+// that fails to parse gets this line, because both shapes are short enough to
+// state whole and the difference between them is the whole point.
+const MAP_VERB_RE = /^map(\s|$)/
+const MAP_SHAPES = [
+  '`map` takes one of two shapes:',
+  '• `map <n> [model=x] [-- <what should change>]` — chart an EXISTING map, by its own issue number.',
+  '• `map [repo] [model=x] -- <what to chart>` — chart a NEW map from your words. The sentence is',
+  '  required here, and it is the whole brief. Name the repo when more than one is watched.',
+].join('\n')
 
 // #177: `harness=` is gone from every surface. The harness is a FUNCTION of the
 // model — `models.<x>.harness` holds one value — so every value the daemon could
@@ -83,9 +103,47 @@ function parseIssueRef(cmd, rest, { instruction: takesInstruction = false } = {}
   return cmd
 }
 
+// The NEW-map shape of `map` (#241): `map [repo] [model=x] -- <prose>`. No issue
+// reference, because the issue does not exist yet — the prose is what the
+// charting agent chooses a destination and a scope from, with the operator.
+//
+// The instruction is MANDATORY here, and that asymmetry with `map <n>` is
+// deliberate. On an existing map a missing sentence has a safe meaning ("ask me
+// what should change", #160), because the map itself says what the effort is.
+// On a new map there is nothing to ask ABOUT, so a bare `map` is a refusal that
+// names both shapes rather than a session that opens with a blank question.
+//
+// The repo token is optional, and the ROUTER fills it in when exactly one repo
+// is watched (see #newMapRepo). It is parsed here as the same two forms
+// parseIssueRef takes — qualified `owner/repo` and the fuzzy part-of-a-name —
+// so the two shapes of one verb cannot drift apart on how a repo is named.
+function parseNewMap(rest) {
+  const sep = rest.indexOf(INSTRUCTION_SEP)
+  if (sep === -1) return null
+  const instruction = rest.slice(sep + 1).join(' ').trim()
+  if (!instruction) return null
+  const cmd = { verb: 'map', instruction }
+  for (const opt of rest.slice(0, sep)) {
+    const om = opt.match(/^model=([\w.-]+)$/)
+    if (om) {
+      if (cmd.model) return null
+      cmd.model = om[1]
+      continue
+    }
+    // one repo token, and never a bare number: `map 147 -- x` is the OTHER
+    // shape, and a number that failed to parse there must not silently become
+    // a new-map dispatch against a repo called "147"
+    if (cmd.repo || cmd.repoArg || /^\d+$/.test(opt) || !REPOISH_RE.test(opt)) return null
+    if (/^[\w.-]+\/[\w.-]+$/.test(opt)) cmd.repo = opt
+    else cmd.repoArg = opt
+  }
+  return cmd
+}
+
 // 'tickets [repo]' | 'next [repo]' | 'status'
 // | 'start <n>|<owner/repo#n> [model=x]'
 // | 'map <n>|<owner/repo#n> [model=x] [-- <instruction>]'
+// | 'map [repo] [model=x] -- <instruction>'
 // | 'cancel <n>|all' | 'resume <n> [model=x]' | 'resume all' | 'attach <n>'
 // — anything else ⇒ null.
 export function parseCommand(text) {
@@ -109,12 +167,15 @@ export function parseCommand(text) {
     // The map-update verb (#221), replacing `start <map> -- <instruction>`.
     // The operator's own word, ruled over `chart` on the grounds that it is the
     // word they already reach for.
+    // #241: two shapes. The issue-reference one is tried FIRST, so every form
+    // that parsed before still parses to exactly what it parsed to; the
+    // new-map one is the fallback, and it is the only shape with no number.
     case 'map':
-      return parseIssueRef({ verb: 'map' }, rest, { instruction: true })
+      return parseIssueRef({ verb: 'map' }, rest, { instruction: true }) ?? parseNewMap(rest)
     case 'cancel': {
       if (rest.length !== 1) return null
       if (rest[0] === 'all') return { verb, all: true }
-      if (/^\d+$/.test(rest[0])) return { verb, ticket: rest[0] }
+      if (AGENT_RE.test(rest[0])) return { verb, ticket: rest[0] }
       return null
     }
     // `resume` takes the same `model=` override `start` takes (#177). It needs
@@ -127,7 +188,7 @@ export function parseCommand(text) {
     case 'resume': {
       if (!rest.length) return null
       if (rest[0] === 'all') return rest.length === 1 ? { verb, all: true } : null
-      if (!/^\d+$/.test(rest[0])) return null
+      if (!AGENT_RE.test(rest[0])) return null
       const cmd = { verb, ticket: rest[0] }
       for (const opt of rest.slice(1)) {
         const om = opt.match(/^model=([\w.-]+)$/)
@@ -137,7 +198,7 @@ export function parseCommand(text) {
       return cmd
     }
     case 'attach': {
-      if (rest.length === 1 && /^\d+$/.test(rest[0])) return { verb, ticket: rest[0] }
+      if (rest.length === 1 && AGENT_RE.test(rest[0])) return { verb, ticket: rest[0] }
       return null
     }
     // The cross-check's daemon-side entry point (#164, ADR-0010). The operator
@@ -168,9 +229,11 @@ const USAGE = [
   '`start <n>|repo#<n> [model=x]` — claim + dispatch an agent (repo: any unambiguous part of the name)',
   '`start <map>` — dispatch that map\'s next takeable ticket',
   '`map <n> [-- <instruction>]` — dispatch a charting agent on a `wayfinder:map` issue; the sentence after `--` is what it should change',
+  '`map [repo] -- <instruction>` — dispatch a charting agent with NO map: it settles the destination with you and creates the `wayfinder:map` issue itself',
   '`cancel <n>|all` — immediate teardown (the overseer\'s interpreted cancel posts a ✅/❌ confirm instead)',
   '`resume <n> [model=x]|resume all` — fresh agent on a ticket, inheriting its surviving worktree and the model it last ran on',
   '`attach <n>` — timeline + browser-terminal links for a live agent',
+  '`cancel chat-1` / `resume chat-1` / `attach chat-1` — the same three verbs on an agent no ticket answers for, such as one charting a NEW map. `status` lists its handle',
   '`review <n> [model=x]` — cross-check: a reviewer on the other provider reads the pushed diff and returns a verdict',
 ].join('\n')
 
@@ -196,6 +259,7 @@ export class CommandRouter {
       let why = ''
       if (HARNESS_OPT_RE.test(canonical)) why = `${HARNESS_GONE}\n`
       else if (START_INSTRUCTION_RE.test(canonical)) why = `${START_INSTRUCTION_GONE}\n`
+      else if (MAP_VERB_RE.test(canonical.trim())) why = `${MAP_SHAPES}\n`
       return `❌ could not parse \`${canonical}\`\n${why}${USAGE}`
     }
     try {
@@ -225,6 +289,18 @@ export class CommandRouter {
         case 'map': {
           const repo = this.#dispatchRepo(cmd)
           if (repo.error) return repo.error
+          // #241: no issue reference ⇒ the new-map shape. It needs a repo
+          // BEFORE the dispatch, because there is no issue number to resolve
+          // one from — `chart <n>` finds its repo by asking which watched repo
+          // owns that number, and a map that does not exist owns nothing.
+          if (!cmd.ticket) {
+            const target = repo.repo ? repo : this.#newMapRepo()
+            if (target.error) return target.error
+            return await this.dispatcher.chartNew({
+              repo: target.repo, model: cmd.model, instruction: cmd.instruction,
+              by: userId, threadId,
+            })
+          }
           return await this.dispatcher.chart(cmd.ticket, {
             repo: repo.repo, model: cmd.model, instruction: cmd.instruction,
             by: userId, threadId,
@@ -257,6 +333,18 @@ export class CommandRouter {
   #dispatchRepo(cmd) {
     if (!cmd.repoArg) return { repo: cmd.repo }
     return this.#matchRepo(cmd.repoArg)
+  }
+
+  // The repo a NEW-map dispatch runs against when the operator named none
+  // (#241). One watched repo means there is no question to ask, and asking it
+  // anyway would put a token in the way of the shortest form of the command.
+  // Two or more, and curia refuses rather than picking the first — a map is a
+  // standing artifact, and one charted into the wrong repo is a manual move.
+  #newMapRepo() {
+    const watched = (this.dispatcher.config?.watch ?? []).map((w) => w.repo)
+    if (watched.length === 1) return { repo: watched[0] }
+    if (!watched.length) return { error: '❌ no repo is on the watch list, so there is nowhere to chart a new map' }
+    return { error: `❌ ${watched.length} repos are watched, so a new map needs one named: ${watched.map((r) => `\`map ${r} -- …\``).join(' or ')}` }
   }
 
   // #81: a repo argument matches on any unambiguous substring of a watched

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -49,9 +49,17 @@ import {
 } from './resolve.mjs'
 import { outstanding, stopReason, reviewGateText, classifyReviewAnswer, REVIEW_KIND, dutyLines } from './lifecycle.mjs'
 import { CONFIRM_KIND, normalizeEvent } from './store.mjs'
-import { ensureTtyd, assertServe, serveOff } from './attach.mjs'
+import {
+  ensureTtyd, assertServe, serveOff, CHAT_HANDLE_RE, isChatHandle, nextChatHandle,
+} from './attach.mjs'
 
-const SESSION_RE = /^curia-(\d+)$/
+// A ticket session's name. Chat handles are in here since #241: an agent no
+// issue answers for — today, the one charting a map that does not exist yet —
+// is a ticket-lane session in every way that matters to reconcile, the orphan
+// sweep and the tool bindings. It just has a handle where the others have a
+// number. Every consumer treats the capture as a STRING already, because a
+// ticket id has always been one here.
+const SESSION_RE = new RegExp(`^curia-(\\d+|${CHAT_HANDLE_RE.source.replace(/^\^|\$$/g, '')})$`)
 
 // The cross-check reviewer's session name (#164, ADR-0010). Distinct from
 // `curia-<n>` by construction, and that is the point rather than a detail:
@@ -96,6 +104,36 @@ const MAP_LABEL = 'wayfinder:map'
 // #epochScan and for reconcile — so no READER can tell a respawn from a
 // re-dispatch. The writer can. It knows which one it is.
 const spawnKind = ({ reviewer = false, charting = false }) => (reviewer ? 'reviewer' : charting ? 'charting' : 'ticket')
+
+// How much of the operator's sentence becomes the session's name (#241).
+// It is a LABEL, not the map's title: the agent settles the real title with the
+// operator and writes it on the issue it creates. This one only has to say
+// which charting session this is, on the status line and in the thread name.
+const NEW_MAP_TITLE_MAX = 60
+
+// The issue record a new-map dispatch works from (#241). Nothing on GitHub
+// answers to it — the map does not exist — so it is synthesised from the
+// instruction, and every field is one #dispatch actually reads:
+//
+//   labels   routing. `wayfinder:map` is a row in the model table, and a new
+//            map must be charted by the same model an existing one is.
+//   title    the status line, the thread name, and the usage-limit guard.
+//   body     the usage-limit guard again: the operator's own sentence can
+//            carry the phrase that makes the watchdog cry cooling, so the
+//            text has to be visible to textCarriesLimitPhrase.
+//   number   the chat handle, which is what names the session.
+function newMapIssue(handle, instruction) {
+  const one = String(instruction).replace(/\s+/g, ' ').trim()
+  const short = one.length > NEW_MAP_TITLE_MAX ? `${one.slice(0, NEW_MAP_TITLE_MAX - 1).trimEnd()}…` : one
+  return {
+    number: handle,
+    title: `new map: ${short}`,
+    body: one,
+    labels: [{ name: MAP_LABEL }],
+    state: 'open',
+    assignees: [],
+  }
+}
 
 // The tracker doc every watched repo is meant to carry (#57 step 3). The
 // wayfinder skill reads it to learn how this repo expresses maps and tickets;
@@ -533,6 +571,17 @@ export class Dispatcher {
     const session = `curia-${n}`
     // The whole lock, in the same shape and the same order `start` uses.
     if (this.inFlight.has(session)) return `⚙️ \`${session}\` is already starting`
+    // #241: a chat agent that created this map takes its number as its own, so
+    // it holds this map's charting lock under a different session name. Without
+    // this the two would edit one body at once, which is the exact thing the
+    // session-name lock exists to stop.
+    const chat = this.#chatOnMap(n)
+    // Repo-scoped: two watched repos can both hold a #250, and refusing the
+    // other one's map because a chat is charting this one would be a lie about
+    // an issue nobody is touching.
+    if (chat && (!repo || repo === chat.repo)) {
+      return `▶️ \`${chat.session}\` is charting ${chat.repo ?? '?'}#${n} — it created that map and is still working on it. \`cancel ${chat.ticket}\` first, or \`attach ${chat.ticket}\``
+    }
     if (this.agents.has(session)) {
       const w = this.agents.get(session)
       return `▶️ \`${session}\` is already charting ${w.repo ?? '?'}#${w.ticket ?? n} (state **${w.state ?? '?'}**) — \`cancel ${n}\` first, or \`attach ${n}\``
@@ -554,6 +603,81 @@ export class Dispatcher {
     } finally {
       this.inFlight.delete(session)
     }
+  }
+
+  // ---- map with no issue (the new-map dispatch, #241) --------------------------
+
+  // `map [repo] -- <prose>`: a charting agent with NO map. It runs the wayfinder
+  // skill's CHART mode — name the destination, map the frontier breadth-first,
+  // then create the `wayfinder:map` issue and its first tickets. The operator's
+  // prose is the loose idea that mode starts from, which is why the parser makes
+  // it mandatory: there is no map body here to read the effort off instead.
+  //
+  // Three things are different from `chart`, and they all follow from the same
+  // fact — the issue does not exist yet:
+  //
+  //   1. **The identity is a CHAT HANDLE, not a number** (see attach.mjs). The
+  //      operator ruled these enumerated rather than singular: several new maps
+  //      may be charted at once, each in its own thread, and `chat-1` is what
+  //      `attach`, `cancel` and `resume` take. So there is no lock here — the
+  //      handle is picked free, and two of these never meet.
+  //   2. **The repo cannot be resolved from a number.** The caller supplies it —
+  //      the router fills in the only watched repo when there is one — so this
+  //      checks the watch list itself rather than asking #resolveRepo, which
+  //      answers "which repo owns #n" and no map owns anything yet.
+  //   3. **There is no issue to read.** The record #dispatch works from is
+  //      synthesised from the instruction, and it carries the map label so
+  //      routing picks the map model exactly as it does for `map <n>`.
+  //
+  // `handle` is passed only by resume, which is re-dispatching a chat that
+  // already has one — its thread, its worktree and its journal epoch all answer
+  // to that name, so picking a fresh index would strand all three.
+  async chartNew({ repo, model, instruction = null, by, reuse = false, threadId = null, handle = null } = {}) {
+    if (!String(instruction ?? '').trim()) {
+      return '❌ a new map needs a sentence to chart from — `map [repo] -- <what to chart>`'
+    }
+    if (!repo) return '❌ a new map needs a repo — nothing says where to create the issue'
+    if (!this.config.watch.some((w) => w.repo === repo)) return `❌ \`${repo}\` is not on the watch list`
+    // The index has to be free on the BOX, not merely in this process's memory:
+    // a restarted daemon holds no agents map, and handing a live pane's handle
+    // to a second agent would put two of them on one tmux session, one config
+    // dir and one thread. tmux is the authority the dispatch locks already ask.
+    let live = []
+    try {
+      live = await this.deps.listSessions()
+    } catch (e) {
+      return `❌ the tmux session list is indeterminate (${e.message}), so curia cannot pick a free chat handle — retry`
+    }
+    const chat = handle ?? nextChatHandle([...live, ...this.agents.keys(), ...this.inFlight])
+    const session = `curia-${chat}`
+    if (this.inFlight.has(session)) return `⚙️ \`${session}\` is already starting`
+    if (this.agents.has(session)) {
+      const w = this.agents.get(session)
+      return `▶️ \`${session}\` is already running (state **${w.state ?? '?'}**) — \`cancel ${chat}\` first, or \`attach ${chat}\``
+    }
+    this.inFlight.add(session)
+    try {
+      if (await this.deps.hasSession(session)) {
+        return `⚠️ tmux session \`${session}\` is already live but untracked — \`cancel ${chat}\` tears it down, then \`map -- …\` again`
+      }
+      const issue = newMapIssue(chat, instruction)
+      return (await this.#dispatch(repo, chat, issue, {
+        model, instruction, by, reuse, threadId, charting: true,
+      })) ?? this.#exhaustedReply()
+    } finally {
+      this.inFlight.delete(session)
+    }
+  }
+
+  // The live chat agent that has already created map #n (#241), if there is one.
+  // `chart` asks so that `map <n>` on a map still being charted is refused by
+  // the same lock every other charting dispatch obeys: the session name is the
+  // lock, and after the adoption a chat session speaks for that number too.
+  #chatOnMap(n) {
+    for (const w of this.agents.values()) {
+      if (w.mapNumber && String(w.mapNumber) === String(n)) return w
+    }
+    return null
   }
 
   // Resolve which watched repo a bare ticket number belongs to. A number
@@ -621,6 +745,12 @@ export class Dispatcher {
   // recreated from origin; absent one, resume degrades to an ordinary dispatch.
   async #dispatch(repo, n, issue, { model, instruction = null, by, reuse = false, threadId = null, charting = false }) {
     const session = `curia-${n}`
+    // #241: a new-map dispatch is charting with no map, so there is no number to
+    // name anywhere below. Everything downstream reads THIS rather than a falsy
+    // mapNumber, because a mapless TICKET is also falsy and means the opposite
+    // thing (the flat lane, where no map is involved at all). Declared out here
+    // because the failure path names it too.
+    const newMap = charting && isChatHandle(n)
     const labels = (issue.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name))
     // The type label, read once and used twice: it names the thread (#93) and
     // it reaches the agent prompt (#49 decision 2). One read, so the thread a
@@ -729,8 +859,8 @@ export class Dispatcher {
       // not asking #mapNumberFor for a parent) is what puts the `/wayfinder`
       // line on the prompt and arms #assertTracker: a charting agent without
       // the tracker doc is exactly the agent that would chart into `.scratch/`.
-      const mapNumber = charting ? Number(n) : await this.#mapNumberFor(repo, full)
-      this.#assertTracker(repo, n, session, wtPath, mapNumber)
+      const mapNumber = charting ? (newMap ? null : Number(n)) : await this.#mapNumberFor(repo, full)
+      this.#assertTracker(repo, n, session, wtPath, mapNumber, { charting })
       this.#assertNoPlantedConfig(wtPath, harnessName)
       this.#armAgent({ session, ticket: n, harness: harnessName, model: useModel, wtPath, cfgDir, view, sandbox })
       // #157: the prompt NAMES the published ports, so they are allocated before
@@ -742,7 +872,7 @@ export class Dispatcher {
       // that stops a dispatched `wayfinder:grilling` agent from standing in for
       // the human's side of its own ticket.
       const promptFile = this.deps.writePrompt(cfgDir, full, {
-        repo, wtPath: view.wt, mapNumber, type: typeLabel, charting, instruction, ports,
+        repo, wtPath: view.wt, mapNumber, type: typeLabel, charting, newMap, instruction, ports,
         // #173: the wayfinder invocation is spelled per harness, so the prompt
         // is no longer harness-blind.
         harness: harnessName,
@@ -763,6 +893,11 @@ export class Dispatcher {
       this.store.logEvent('agent_spawned', {
         repo, ticket: n, agent: session, instance, model: useModel, harness: harnessName,
         kind: spawnKind({ charting }), instruction: charting ? instruction : null,
+        // #241: which of the two charting shapes this is. A restarted daemon
+        // reads it back the same way it reads the kind — without it, a resumed
+        // new-map agent would be sent to `chart new`, and `chart` refuses a
+        // handle no issue answers to.
+        ...(newMap ? { newMap: true } : {}),
         // The journal is the state home for what a restart cannot re-derive
         // from tmux: which image this agent runs and which ports it published.
         ...(container ? { sandbox: 'docker', image: container.image, ports: container.ports } : {}),
@@ -787,6 +922,10 @@ export class Dispatcher {
         // asked for. Journalled beside it (agent_spawned above) so a daemon
         // restart re-derives both — see #epochCharting.
         charting, instruction: charting ? instruction : null,
+        // #241: a new-map agent, and the map number it has created so far. The
+        // number arrives on the side channel (see adoptMap) rather than at the
+        // spawn, because nothing knows it yet.
+        newMap, mapNumber: null,
         // this spawn's exit marker (#169) — the watchdog's fail-fast signal
         exitMarker,
         // this ticket's own text can forge the usage-limit signal ⇒ the
@@ -795,6 +934,9 @@ export class Dispatcher {
       }
       this.agents.set(session, agent)
       this.#watchdog(agent).catch((e) => this.log(`watchdog ${session} failed:`, e.message))
+      if (newMap) {
+        return `⚙️ charting agent for a NEW map in ${repo} → \`${session}\` on **${useModel}** — it settles the destination with you, then creates the \`${MAP_LABEL}\` issue. \`attach ${n}\` to watch, \`cancel ${n}\` to end it`
+      }
       if (charting) {
         return `⚙️ charting agent on map ${repo}#${n} → \`${session}\` on **${useModel}**${instruction ? '' : ' — no instruction rode this dispatch, so it will ask what should change'} — watching for readiness`
       }
@@ -830,9 +972,12 @@ export class Dispatcher {
       // The binding stays (#140): a failed dispatch is a claim release, not a
       // ticket-terminal state — the retry's traffic belongs in the same thread.
       const claimTail = charting
-        ? 'the map was never claimed, so nothing was released — `map ' + n + '` again when the cause is fixed'
+        ? `nothing was claimed, so nothing was released — \`${newMap ? 'map -- <what to chart>' : `map ${n}`}\` again when the cause is fixed`
         : released ? 'claim released' : 'claim release FAILED: the issue is still assigned to the bot; reconcile will retry'
-      return `⚠️ dispatch of ${repo}#${n} failed before the agent could run: ${e.message} — ${claimTail}`
+      // #241: a new-map dispatch has no issue to name, so it names what it was
+      // for. `${repo}#new` would read as an issue number that does not exist.
+      const what = newMap ? `a new map in ${repo}` : `${repo}#${n}`
+      return `⚠️ dispatch of ${what} failed before the agent could run: ${e.message} — ${claimTail}`
     }
   }
 
@@ -970,11 +1115,16 @@ export class Dispatcher {
   // and #10 watches ANY plain repo through the flat lane — refusing those for a
   // missing doc would take that lane away. It gets a journal line instead, so
   // the absence is on the record either way.
-  #assertTracker(repo, n, session, wtPath, mapNumber) {
+  #assertTracker(repo, n, session, wtPath, mapNumber, { charting = false } = {}) {
     if (fs.existsSync(path.join(wtPath, TRACKER_DOC))) return
-    if (mapNumber) {
-      const what = String(mapNumber) === String(n) ? `map #${n}` : `map child #${n}`
-      throw new Error(`${repo} has no ${TRACKER_DOC}, so an agent on ${what} would fall back to the local-markdown tracker and write .scratch/ files instead of resolving on GitHub — run \`/setup-matt-pocock-skills\` in ${repo} first`)
+    // #241: a NEW-map dispatch has no map number and still must not run without
+    // the doc — it is the agent that would create the whole map in `.scratch/`,
+    // which is the worst version of this fault rather than an exempt one.
+    if (mapNumber || charting) {
+      const what = mapNumber
+        ? `an agent on ${String(mapNumber) === String(n) ? `map #${n}` : `map child #${n}`}`
+        : 'an agent charting a new map'
+      throw new Error(`${repo} has no ${TRACKER_DOC}, so ${what} would fall back to the local-markdown tracker and write .scratch/ files instead of resolving on GitHub — run \`/setup-matt-pocock-skills\` in ${repo} first`)
     }
     this.store.logEvent('tracker_doc_missing', { repo, ticket: n, agent: session })
   }
@@ -2499,7 +2649,12 @@ export class Dispatcher {
       // #160: which of the two endings this agent is held to. `outstanding`
       // picks the checklist off it, so a charting agent is never nudged toward
       // a pull request, a review or a merge it is forbidden to reach.
+      // #241 adds the third: a NEW-map dispatch owes one step more than a map
+      // dispatch — the map has to exist, and curia has to be told its number,
+      // or the session ends with its summary nowhere and its thread on a handle.
       charting: this.#epochCharting(ticket, agentName).charting,
+      newMap: this.#epochCharting(ticket, agentName).newMap,
+      mapAdopted: Boolean(this.#chartedMap(agentName, ticket, w)),
     }
     // A charting agent has one daemon-visible step, and it is not in git or on
     // GitHub — so the reads below are skipped whole. The Stop hook fires at the
@@ -2688,11 +2843,17 @@ export class Dispatcher {
   // its life describing itself as a ticket dispatch.
   #epochCharting(ticket, agentName) {
     const w = this.agents.get(agentName)
-    if (w) return { charting: Boolean(w.charting), instruction: w.instruction ?? null }
-    let out = { charting: false, instruction: null }
+    if (w) {
+      return {
+        charting: Boolean(w.charting), instruction: w.instruction ?? null, newMap: Boolean(w.newMap),
+      }
+    }
+    let out = { charting: false, instruction: null, newMap: false }
     for (const ev of this.#readJournal()) {
       if (ev.type !== 'agent_spawned' || String(ev.ticket ?? '') !== String(ticket)) continue
-      out = { charting: ev.kind === 'charting', instruction: ev.instruction ?? null }
+      // #241: which SHAPE of charting, restated by every respawn for the same
+      // reason the kind is (#219) — the last line has to describe the agent whole.
+      out = { charting: ev.kind === 'charting', instruction: ev.instruction ?? null, newMap: Boolean(ev.newMap) }
     }
     return out
   }
@@ -2778,27 +2939,128 @@ export class Dispatcher {
     // until the session is positively gone — the #noteNonClean rule, same
     // reason (#34's snapshot bound).
     await this.#releaseClaim(record, 'charting agent reported in', { keepCredentials: true })
+    // #241: WHICH map this summary belongs on. For `map <n>` the ticket IS the
+    // map. For a new-map dispatch the ticket is a chat handle, and the map is
+    // whatever the agent created and adopted — so a session that never adopted
+    // one has nowhere to post, and that is said out loud rather than failing
+    // quietly against an issue called `chat-1`.
+    const map = this.#chartedMap(agentName, ticket, w)
     let noted = false
-    try {
-      await this.deps.commentIssue(repo, ticket, chartingComment({
-        agent: agentName, model: w?.model ?? null, instruction, result,
-      }))
-      noted = true
-    } catch (e) {
-      this.log(`could not post the charting summary on ${repo}#${ticket}: ${e.message}`)
+    if (map) {
+      try {
+        await this.deps.commentIssue(repo, map, chartingComment({
+          agent: agentName, model: w?.model ?? null, instruction, result,
+        }))
+        noted = true
+      } catch (e) {
+        this.log(`could not post the charting summary on ${repo}#${map}: ${e.message}`)
+      }
     }
     this.store.logEvent('charting_finished', {
-      repo, map: ticket, ticket, agent: agentName, status: result.status, commented: noted,
+      repo, map: map ?? null, ticket, agent: agentName, status: result.status, commented: noted,
     })
     const clean = result.status === 'resolved'
     const bits = [
-      noted ? 'summary posted on the map' : '⚠️ the summary comment could NOT be posted',
+      map
+        ? (noted ? 'summary posted on the map' : '⚠️ the summary comment could NOT be posted')
+        : '⚠️ this session created NO map, so there is nowhere to post its summary — read the thread',
       // #221: nothing to unassign — the dispatch never claimed the map.
       'the map was never claimed',
-      'the map stays open',
+      map ? 'the map stays open' : 'nothing on the tracker was touched by curia',
     ]
-    this.notify(ticket, `${clean ? '🗺️' : '↩️'} ${repo}#${ticket} charted (**${result.status}**) — ${bits.join('; ')}. Nobody reviewed these map edits: read them.`)
+    const what = map ? `${repo}#${map}` : `the new map in ${repo}`
+    this.notify(ticket, `${clean ? '🗺️' : '↩️'} ${what} charted (**${result.status}**) — ${bits.join('; ')}. Nobody reviewed these map edits: read them.`)
     return `charting recorded — ${bits.join('; ')}. Nothing was closed, resolved or pushed.`
+  }
+
+  // ---- adoption: the daemon learns the new map's number (#241) -----------------
+
+  // The `map_created` tool. A new-map charting agent calls it the moment it has
+  // created the `wayfinder:map` issue, and from that call on the session speaks
+  // for that number: the status line names it, `map <n>` is refused while this
+  // agent lives, the thread becomes the map's thread, and the charting summary
+  // has somewhere to land.
+  //
+  // curia VERIFIES the number rather than believing it. The whole reason the
+  // side channel exists is that a daemon record built from an agent's own
+  // account is not evidence (#40's rule, and the review gate's links follow it
+  // too) — so this reads the issue, and refuses a number that is not an open
+  // map in this session's own repo. A refusal is a sentence the agent can act
+  // on, never a silent no-op.
+  //
+  // Idempotent: the same number twice is a no-op, and a DIFFERENT number is
+  // refused. One charting session charts one map — a second one would leave the
+  // first with no summary, no thread and no lock.
+  async adoptMap(agentName, numberArg) {
+    const raw = String(numberArg ?? '').trim().replace(/^#/, '')
+    if (!/^\d+$/.test(raw)) {
+      return `❌ map_created takes the issue NUMBER of the map you created — \`${numberArg}\` is not one`
+    }
+    if (this.#isReviewer(agentName)) {
+      return '❌ a cross-check reviewer writes nothing — it does not create maps. Put what you found in your verdict.'
+    }
+    const w = this.agents.get(agentName)
+    if (!w) return `❌ curia holds no record of \`${agentName}\`, so it cannot take a map for it`
+    if (!w.newMap) {
+      return w.charting
+        ? `❌ \`${agentName}\` was dispatched on an existing map (${w.repo}#${w.ticket}) — there is no new map to take. Edit that one.`
+        : '❌ map_created belongs to a charting agent that was sent to create a map. This session is working a ticket.'
+    }
+    if (w.mapNumber && String(w.mapNumber) !== raw) {
+      return `❌ this session already created ${w.repo}#${w.mapNumber}. One charting session charts one map — put the rest on that map, or say so and stop.`
+    }
+    let issue
+    try {
+      issue = await this.deps.fetchIssue(w.repo, raw)
+    } catch (e) {
+      return `❌ curia could not read ${w.repo}#${raw} (${e.message}) — create the issue first, then call map_created again`
+    }
+    if (issue.state !== 'open') return `❌ ${w.repo}#${raw} is ${issue.state} — a map is charted open`
+    if (!hasLabel(issue, MAP_LABEL)) {
+      return `❌ ${w.repo}#${raw} carries no \`${MAP_LABEL}\` label, so nothing on the tracker reads it as a map — add the label, then call map_created again`
+    }
+    if (w.mapNumber) return `already taken — ${w.repo}#${raw} is this session's map`
+    w.mapNumber = raw
+    w.title = issue.title
+    this.store.logEvent('map_adopted', {
+      repo: w.repo, ticket: w.ticket, map: raw, agent: agentName, title: issue.title,
+    })
+    // The thread follows the map (#241). Never fatal: a rename that does not
+    // happen costs a stale thread name, and the binding is journalled either way.
+    try {
+      await this.threads.adoptMap?.(w.ticket, raw, { repo: w.repo, title: issue.title })
+    } catch (e) {
+      this.log(`thread adoption for ${agentName} → ${w.repo}#${raw} failed (${e.message}) — the binding stays on the handle`)
+    }
+    this.notify(w.ticket, `🗺️ \`${agentName}\` created ${w.repo}#${raw} **${issue.title}** — curia has taken it as this session's map`)
+    return `curia has taken ${w.repo}#${raw} **${issue.title}** as this session's map. \`map ${raw}\` is refused while you run, and your report_result summary lands there.`
+  }
+
+  // WHICH map a charting session is responsible for (#241). On `map <n>` the
+  // ticket IS the map. On a new-map dispatch the ticket is the handle, and the
+  // map is whatever the agent created and reported — null until it does, which
+  // is a real state and not a fault: a session cancelled before it created
+  // anything has no map, and saying so beats posting to an issue called `new`.
+  #chartedMap(agentName, ticket, w) {
+    if (!isChatHandle(ticket)) return String(ticket)
+    const live = (w ?? this.agents.get(agentName))?.mapNumber
+    if (live) return String(live)
+    return this.#epochAdoptedMap(agentName)
+  }
+
+  // The number this session reported through `map_created`, read off the
+  // journal for an agent record this process never held (a restart mid-session,
+  // or a reconcile-adopted agent). Reset at every spawn line for the session, so
+  // a resumed handle does not inherit the map of the dispatch before it — that
+  // map exists now, and `map <n>` is the verb for it.
+  #epochAdoptedMap(agentName) {
+    let out = null
+    for (const ev of this.#readJournal()) {
+      if (ev.agent !== agentName) continue
+      if (ev.type === 'agent_spawned') out = null
+      else if (ev.type === 'map_adopted' && ev.map) out = String(ev.map)
+    }
+    return out
   }
 
   // A non-clean result resolves NOTHING — and the ticket has to actually come
@@ -3322,6 +3584,10 @@ export class Dispatcher {
     // A cancelled MAP dispatch has no claim to release (#221) — the same guard
     // #releaseClaim carries, at the other teardown path.
     const charting = Boolean(w?.charting) || (!w && this.#epochCharting(ticket, session).charting)
+    // #241: what a cancelled CHAT leaves behind is its map, if it made one —
+    // and nothing at all if it did not. Both are worth saying: "the edits
+    // stand" on a session that created nothing is a lie about the tracker.
+    const chartedMap = charting && isChatHandle(ticket) ? this.#chartedMap(session, ticket, w) : null
     let released = false
     let failure = null
     if (w) {
@@ -3352,9 +3618,14 @@ export class Dispatcher {
     // status's recent-cancelled view reads this event; the unclaim events
     // above cannot carry it because an untracked cancel writes none.
     this.store.logEvent('agent_cancelled', { repo: w?.repo, ticket, agent: session, by: by ?? 'unknown', tracked: Boolean(w) })
+    const chartTail = isChatHandle(ticket)
+      ? (chartedMap
+        ? `, checkout removed — nothing was claimed, and the map it created (${w?.repo ? `${w.repo}#` : '#'}${chartedMap}) STANDS`
+        : ', checkout removed — nothing was claimed, and it had created no map yet, so the tracker is untouched')
+      : ', checkout removed — the map was never claimed, and whatever the agent already wrote to it STANDS'
     const tail = w
       ? (charting
-        ? ', checkout removed — the map was never claimed, and whatever the agent already wrote to it STANDS'
+        ? chartTail
         : released ? ', worktree removed, ticket re-frontiered' : ', worktree removed — but the claim release FAILED: the issue is still assigned; reconcile will retry')
       : ' (was untracked; GitHub claim untouched)'
     const msg = `⚰️ \`${session}\` cancelled — session killed${tail}${reviewerLine ? `\n${reviewerLine}` : ''}`
@@ -3423,8 +3694,25 @@ export class Dispatcher {
     // `chart`, and `chart` refuses an issue that has since lost the map label
     // rather than guessing: there is no map left to chart, and `start <n>` is
     // the verb for what the issue has become.
-    const { charting, instruction } = this.#epochCharting(ticket, session)
+    const { charting, instruction, newMap } = this.#epochCharting(ticket, session)
     const inherited = { repo, model: model ?? this.#inheritedModel(session), by, reuse: true, threadId }
+    // #241: `resume chat-1` is the one resume whose subject may have changed
+    // shape while it ran. Once the agent created its map, that map EXISTS — and
+    // resume names a session, not a subject, so it must not quietly re-dispatch
+    // a "create a map" agent onto a repo that now has one. It names the verb
+    // that carries on instead, which is the same refusal `start <map>` gives
+    // when the operator reached for the wrong one.
+    //
+    // The handle is carried over, not re-picked: the thread, the worktree and
+    // the journal epoch all answer to it.
+    if (newMap) {
+      const adopted = this.#epochAdoptedMap(session)
+      const theRepo = repo ?? this.#epochRepo(ticket)
+      if (adopted) {
+        return `❌ \`${session}\` already created ${theRepo ? `${theRepo}#${adopted}` : `#${adopted}`} — that map exists now, so it is charted by number: \`map ${adopted} -- <what is left to do>\``
+      }
+      return this.chartNew({ ...inherited, instruction, repo: theRepo, handle: ticket })
+    }
     if (charting) return this.chart(ticket, { ...inherited, instruction })
     return this.start(ticket, inherited)
   }
@@ -3838,7 +4126,17 @@ export class Dispatcher {
       // every spawn (#219), and that line is the positive evidence now: this
       // daemon (or its predecessor) spawned the session as charting. The map
       // being open still gates adoption below, exactly as it does a builder.
-      const { charting, instruction } = this.#epochCharting(n, session)
+      const { charting, instruction, newMap } = this.#epochCharting(n, session)
+      // #241: a CHAT session has no issue to prove itself by. `getIssue(repo,
+      // 'chat-1')` is a 404, which every test below reads as "positively
+      // absent" — so a live charting agent would be swept as an orphan on the
+      // first pass after a restart. Its positive evidence is the journal: this
+      // daemon, or its predecessor, spawned this handle as a new-map dispatch.
+      // The same evidence #228 gave a map dispatch, for the same reason.
+      if (isChatHandle(n)) {
+        await this.#reconcileChatSession(session, n, { journal, epochs, charting, instruction, newMap, getIssue, skipRepo, failedRepos })
+        continue
+      }
       const epoch = epochs.get(n)
       const reposToCheck = epoch?.repo ? [epoch.repo] : this.config.watch.map((w) => w.repo)
       let adopted = false
@@ -3940,6 +4238,98 @@ export class Dispatcher {
       this.deps.forgetAgentToken(this.dataDir, session)
       this.log(`reconcile: swept orphan ${session}`)
     }
+  }
+
+  // A live `curia-chat-<i>` session (#241): re-adopt it, or sweep it.
+  //
+  // The evidence is inverted here, and it has to be. Every other pass in this
+  // file asks GitHub "do we still own this?" — a claim, an open issue, an
+  // assignee. A chat session owns no issue by definition, so GitHub can say
+  // nothing about it, and the evidence rule forbids reading that silence as a
+  // disowning. What speaks positively is the journal: a spawn line naming this
+  // handle as a new-map dispatch says curia (or its predecessor) started it.
+  //
+  // So there are exactly two ways to sweep one, and both are positive:
+  //
+  //   1. NO spawn line for the handle at all. Nothing curia ever did explains
+  //      this pane, which is what "orphan" has always meant.
+  //   2. It adopted a map, and that map is now CLOSED. The subject of the work
+  //      is positively finished — the same test that retires a builder.
+  //
+  // A `map_adopted` epoch whose map is open, or a chat with no map yet, is
+  // adopted. Adoption is what keeps its ending: `report_result` needs a record
+  // to post the charting summary against.
+  async #reconcileChatSession(session, handle, { journal, epochs, charting, instruction, newMap, getIssue, skipRepo, failedRepos }) {
+    const epoch = epochs.get(handle)
+    const spawn = this.#epochSpawn(journal, session)
+    const repo = epoch?.repo ?? null
+    if (!charting || !repo) {
+      this.store.logEvent('orphan_swept', { agent: session, ticket: handle, reason: 'no curia dispatch explains this chat handle' })
+      await this.deps.killSession(session).catch(() => {})
+      try {
+        this.deps.removeConfigDir(cfgDirFor(this.root, session))
+      } catch (e) {
+        this.log(`reconcile: could not remove the config dir of swept orphan ${session} (${e.message}) — leftovers stay for the next pass`)
+      }
+      this.deps.forgetAgentToken(this.dataDir, session)
+      this.log(`reconcile: swept orphan ${session} — no charting dispatch in the journal`)
+      return
+    }
+    const mapNumber = this.#epochAdoptedMap(session)
+    let title = `new map in ${repo}`
+    if (mapNumber && !failedRepos.has(repo)) {
+      let issue
+      try {
+        issue = await getIssue(repo, mapNumber)
+      } catch (e) {
+        // indeterminate ⇒ neither adopt on a guess nor sweep on one: leave the
+        // pane alone and let the next pass read it
+        skipRepo(repo, e)
+        return
+      }
+      if (issue && issue.state !== 'open') {
+        this.store.logEvent('orphan_swept', { agent: session, ticket: handle, reason: `${repo}#${mapNumber} is ${issue.state}` })
+        await this.deps.killSession(session).catch(() => {})
+        await this.#sweepWorktree(repo, handle, session)
+        try {
+          this.deps.removeConfigDir(cfgDirFor(this.root, session))
+        } catch (e) {
+          this.log(`reconcile: could not remove the config dir of swept orphan ${session} (${e.message}) — leftovers stay for the next pass`)
+        }
+        this.deps.forgetAgentToken(this.dataDir, session)
+        return
+      }
+      if (issue) title = issue.title
+    }
+    const ports = this.config.sandbox
+      ? await this.deps.containerPorts(session).catch((e) => {
+        this.log(`reconcile: could not read the published ports of ${session} (${e.message}) — previews are refused for it`)
+        return []
+      })
+      : []
+    const instance = `${session}@adopted-${Date.now()}`
+    this.agents.set(session, {
+      repo, ticket: handle, title, session, instance,
+      wtPath: worktreePathFor(this.root, repo, handle),
+      cfgDir: cfgDirFor(this.root, session),
+      promptFile: path.join(cfgDirFor(this.root, session), 'prompt.md'),
+      model: spawn?.model ?? null, requestedModel: null,
+      harness: spawn?.harness ?? null,
+      provider: this.routing.models[spawn?.model]?.provider ?? null,
+      ports: ports.length ? ports : null,
+      sandbox: ports.length ? 'docker' : null,
+      spawnedAt: null, state: 'ready',
+      // A chat handle is a new-map dispatch and nothing else today. The journal
+      // is still read for it (newMap above) so that the day a second kind of
+      // chat exists, this line is the one that has to change.
+      charting: true, instruction, newMap: newMap !== false,
+      // the map it had already created, restated on the record so #chartedMap
+      // and the `map <n>` lock answer without re-reading the journal
+      mapNumber: mapNumber ?? null,
+      resultReceived: fs.existsSync(path.join(this.dataDir, 'results', `${session}.json`)),
+    })
+    this.log(`reconcile: re-adopted live chat agent ${session} (${repo}${mapNumber ? `#${mapNumber}` : ', no map yet'})`)
+    this.expireNotesFor(session, handle, 'was adopted after a daemon restart', instance)
   }
 
   // Live `curia-review-<n>` sessions (#164): re-adopt the ones the journal can

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -265,7 +265,10 @@ function settle(record, text, attachments = []) {
 // journalled channel a resumed agent drains on its first tool result — and
 // say in the thread where the answer went.
 function handOffAnswer(record) {
-  if (!/^curia-\d+$/.test(record.agent)) return // synthetic/lab callers have no resume
+  // #241: a chat handle is resumable too — `resume chat-1` re-dispatches it and
+  // it drains the queue on its first tool result, exactly as a numbered one
+  // does. Only synthetic and lab callers are excluded here.
+  if (!/^curia-(\d+|chat-\d+)$/.test(record.agent)) return
   store.queueRecordedAnswer(record)
   const live = dispatcher.agents.has(record.agent)
   notifyThread(record.ticket, live
@@ -460,6 +463,17 @@ const threads = {
   // next dispatch relabels the thread anyway.
   async cancelled(ticket) {
     if (bridge) return bridge.cancelTicket(ticket)
+  },
+  // #241: a new-map session's thread moves from the handle `new` onto the map
+  // number the moment the agent creates the map. With the bridge down the
+  // journal still has to move, so the binding is written either way — only the
+  // rename is display, and only the rename is lost.
+  async adoptMap(handle, mapNumber, opts) {
+    if (bridge) return bridge.adoptMapThread(handle, mapNumber, opts)
+    const threadId = store.threadForTicket(handle)
+    if (!threadId) return { ok: false, reason: 'unbound' }
+    store.releaseTicketThread(handle, 'the map this session created now names it')
+    return store.bindTicketThread(String(mapNumber), threadId)
   },
 }
 
@@ -909,6 +923,21 @@ function buildMcpServer(agent, ticket) {
       // button press rides the answer itself — the grace window's best case.
       return { content: [...refusalNote, { type: 'text', text }, ...inboundContent(attachments), ...drainNotes()] }
     },
+  )
+
+  // #241: the one thing a NEW-map charting agent knows that the daemon cannot
+  // find out for itself. GitHub has no query for "the map this pane just made",
+  // so the number arrives on the side channel — which is the rule already
+  // (CONTEXT.md: curia never parses the terminal to learn agent state), not a
+  // new one. The dispatcher VERIFIES the number before taking it, so this
+  // remains a report the daemon checks rather than an account it believes.
+  server.tool(
+    'map_created',
+    'Tell curia the issue number of the `wayfinder:map` you just created. Call it as soon as the issue exists, not at the end: until you do, curia does not know which map is yours, so your thread keeps a placeholder name, another charting agent could be dispatched onto the same map, and your final summary has nowhere to land. curia checks the number is really an open map in this repo and refuses one that is not. Only an agent sent to chart a NEW map has this tool.',
+    { number: z.string().describe('The issue number of the map you created — the bare number, e.g. "250".') },
+    async ({ number }) => ({
+      content: [{ type: 'text', text: await dispatcher.adoptMap(agent, number) }, ...drainNotes()],
+    }),
   )
 
   // #41: this call now also closes the TICKET, not just curia's dispatch

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -138,6 +138,46 @@ export const CHARTING_ENDING = [
   },
 ]
 
+// ---- the new-map ending (#241) ------------------------------------------------
+//
+// A third ending, and it is the charting one with a step in front of it. A map
+// dispatch is handed its map; a NEW-map dispatch has to bring one into being
+// first, and until it does, curia knows nothing to hang the session on: not
+// where the summary comment goes, not what the thread is called, not which map
+// `map <n>` must refuse while this agent lives.
+//
+// So the adoption is a STEP, not a courtesy. It is the one thing the daemon
+// cannot see for itself — GitHub has no query for "the map this pane just made"
+// — and the Stop hook holds the agent to it for exactly that reason. The tool
+// verifies the number before taking it (dispatch.mjs, adoptMap), so a step
+// reported is a step done.
+export const NEW_MAP_ENDING = [
+  {
+    key: 'chart',
+    prose: () => [
+      'Settle the destination and the scope WITH the operator, then create the `wayfinder:map` issue and',
+      'its first tickets yourself. Those tracker writes ARE the work. Nothing here is staged or merged.',
+    ],
+  },
+  {
+    key: 'adopt',
+    prose: () => [
+      'Call `map_created` with the number of the map you created, as soon as it exists — not at the end.',
+      'Until you do, curia does not know which map is yours: your thread keeps a handle for a name, a',
+      'second charting agent could be sent to the same map, and your summary has nowhere to land.',
+    ],
+    todo: (s) => (s.mapAdopted ? null : 'create the `wayfinder:map` issue, then call `map_created` with its number'),
+  },
+  {
+    key: 'report',
+    prose: () => [
+      'Call `report_result` exactly once, with `resolved` and a summary of what you charted.',
+      'curia posts that summary as a comment on the map you created. It never closes the map.',
+    ],
+    todo: (s) => (s.hasResult ? null : 'call `report_result` exactly once'),
+  },
+]
+
 // What a charting agent must NOT do — one bullet per entry, its own lines.
 // Prose only: the refusals themselves live in dispatch.mjs, and this is the
 // copy the model reads.
@@ -198,6 +238,7 @@ export const REVIEWER_NEVER = [
 
 const listFor = (state) => {
   if (state.reviewer) return REVIEW_ENDING
+  if (state.newMap) return NEW_MAP_ENDING
   return state.charting ? CHARTING_ENDING : ENDING
 }
 

--- a/daemon/src/overseer.mjs
+++ b/daemon/src/overseer.mjs
@@ -38,7 +38,13 @@ export function canonicalFor(verb, args = {}) {
     case 'start':
       return `start ${args.repo ? `${args.repo}#` : ''}${args.ticket}${args.model ? ` model=${args.model}` : ''}`
     case 'map': {
-      let text = `map ${args.repo ? `${args.repo}#` : ''}${args.ticket}`
+      // #241: with no map number this is the NEW-map shape, where the repo is a
+      // bare token rather than the `repo#n` qualifier — there is no `n` to
+      // qualify. The instruction is mandatory there, and a call that omits it
+      // composes a bare `map`, which the router refuses by naming both shapes.
+      let text = args.ticket
+        ? `map ${args.repo ? `${args.repo}#` : ''}${args.ticket}`
+        : `map${args.repo ? ` ${args.repo}` : ''}`
       if (args.model) text += ` model=${args.model}`
       // The instruction (#160, moved here by #221) rides LAST, after a bare
       // `--`, because it is the one argument that is a whole sentence.
@@ -88,10 +94,10 @@ export function buildVerbTools(command) {
       repo: repoArg,
       model: z.string().optional().describe('model override — the harness follows it, so there is no harness argument'),
     }, run('start')),
-    tool('map', 'Dispatch a charting agent that UPDATES a map: add tickets, graduate fog, change scope, fix what the map says. Takes the map\'s own number. It edits the map and its tickets and closes nothing.', {
-      ticket: ticketArg,
+    tool('map', 'Dispatch a charting agent. WITH a map number it UPDATES that map: add tickets, graduate fog, change scope, fix what the map says. WITHOUT one it charts a NEW map: the agent settles the destination and the scope with the operator, then creates the `wayfinder:map` issue itself — use that form when the operator asks for a map that does not exist yet ("make a map for the next feature"), and put their words in the instruction. It closes nothing either way.', {
+      ticket: ticketArg.optional(),
       repo: repoArg,
-      instruction: z.string().optional().describe('What the operator wants changed on the map, in their own words ("update the landing page map so that X"). The charting agent reads it as its first input. Leave it out and the agent asks the operator what should change.'),
+      instruction: z.string().optional().describe('What the operator wants, in their own words. On an existing map: what should change ("update the landing page map so that X") — leave it out and the agent asks. On a NEW map it is REQUIRED: it is the whole brief the agent chooses a destination from.'),
       model: z.string().optional().describe('model override — the harness follows it, so there is no harness argument'),
     }, run('map')),
     tool('cancel', 'Cancel the agent on a ticket, or "all" for every agent. Destructive, so the daemon posts ✅/❌ buttons and executes ONLY after the operator presses ✅. Call this directly when asked — never seek confirmation in conversation first, and never report the cancel as done: report that the confirm was posted.', {
@@ -119,7 +125,7 @@ export const DISALLOWED_TOOLS = [
   'Task', 'TodoWrite', 'NotebookEdit', 'AskUserQuestion', 'ToolSearch',
 ]
 
-const SYSTEM_PROMPT = `You are the curia overseer. Curia is a personal orchestration daemon: it watches GitHub trackers, dispatches AI agents on tickets, and keeps the operator in the loop from any device. You are the command brain over its Discord surface.
+export const SYSTEM_PROMPT = `You are the curia overseer. Curia is a personal orchestration daemon: it watches GitHub trackers, dispatches AI agents on tickets, and keeps the operator in the loop from any device. You are the command brain over its Discord surface.
 
 You speak with one operator, in one Discord thread, in short Discord markdown. You act only through the curia tools. The daemon executes every effect.
 
@@ -135,6 +141,8 @@ Vocabulary the operator uses:
 - Two verbs take a map's own number, and they mean different things. \`start\` WORKS the map: it dispatches the map's next takeable ticket. \`map\` UPDATES the map: a charting agent edits the map itself.
 - Use \`map\` when the operator asks to CHANGE a map ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words. Do not rewrite it and do not summarize it.
 - Use \`start\` when the operator asks to work the map ("continue with <map>", "start the landing page map"). Either the map's own number or the ticket number listed under its header does this.
+- Use \`map\` with NO ticket when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". There is no number to give, and asking them for one is wrong — the whole point is that the map does not exist. Put their words in \`instruction\`, unchanged: it is the whole brief the charting agent settles the destination from. Add \`repo\` only when more than one repo is watched.
+- The test between the two shapes is whether the map EXISTS. A map you can name from \`tickets\` output takes its number. A map the operator is asking you to bring into being takes no number.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run \`tickets\` or \`status\` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -1199,7 +1199,7 @@ export function writeConnectionSettings({
 // has to mean for an instruction that decides what the whole session does.
 // The text is never shell-substituted — the spawn template reads this file with
 // `$(cat …)` — so it needs no quoting rules of its own.
-export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, type = null, charting = false, instruction = null, ports = null, harness = 'claude' }) {
+export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, type = null, charting = false, newMap = false, instruction = null, ports = null, harness = 'claude' }) {
   const promptFile = path.join(cfgDir, 'prompt.md')
   // An unknown harness would take the claude spelling of the invocation in
   // silence, which is the failure #173 exists to end. harnessDef throws on a
@@ -1226,8 +1226,42 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   // claude slash command, `$wayfinder` is codex's own way of naming a skill.
   // Everything after the sigil is identical, so a human reading two prompts
   // side by side reads one document.
+  //
+  // A NEW-map dispatch (#241) names no map, because there is none: the bare
+  // sigil is the skill's OTHER invocation, "chart the map", which starts from a
+  // loose idea. The operator's sentence IS that idea, and it rides the params
+  // below rather than the invocation line — the line is one line, and this one
+  // is a paragraph the operator wrote.
   const sigil = harness === 'codex' ? '$wayfinder' : '/wayfinder'
-  const invocation = mapNumber ? [`${sigil} ${mapUrl}${charting ? '' : ` ticket #${n}`}`, ''] : []
+  const invocation = newMap
+    ? [sigil, '']
+    : mapNumber ? [`${sigil} ${mapUrl}${charting ? '' : ` ticket #${n}`}`, ''] : []
+
+  // The params of a NEW-map dispatch (#241). The difference from a map dispatch
+  // is one fact with consequences everywhere: the map does not exist. So this
+  // session runs the skill's CHART mode whole — name the destination, grill
+  // breadth-first, then create the map and the tickets it can already state —
+  // and it owes curia the number the moment it has one.
+  const newMapParams = [
+    '- **This is a NEW-MAP DISPATCH.** No map exists yet. Run the skill\'s "Chart the map" mode from the',
+    '  top: name the destination with the operator, map the frontier breadth-first, then create the',
+    `  \`wayfinder:map\` issue in ${repo} and the tickets you can already state. Its "work through the map"`,
+    '  mode does not apply — there is nothing to work through until you have built it.',
+    '- **The destination and the scope are the operator\'s to settle, not yours.** This is a HITL session:',
+    '  many `ask_human` calls, one question at a time, until the destination is sharp enough to write down.',
+    '  Never answer for them, and never chart around a question you could have asked.',
+    '- **The moment the map issue exists, call `map_created` with its number.** Not at the end — then.',
+    '  Until you do, curia does not know which map is yours: your thread has no name, another charting',
+    '  agent could be sent to the same map, and your summary at the end has nowhere to go.',
+    '- **If the grilling shows no map is needed** — the whole way is already clear, and one session could',
+    '  do it — say so and stop. The skill says this too. Report `blocked` with that finding, and create no',
+    '  map. An unnecessary map is worse than none.',
+    '- **What the operator asked for**, in their own words:',
+    '',
+    `  > ${instruction ?? '(nothing)'}`,
+    '',
+    '  This is the loose idea, not a specification. It is where the grilling starts.',
+  ]
 
   const chartingParams = [
     `- **This is a MAP DISPATCH.** ${repo}#${n} is the map itself, not a ticket under it. Your job is to`,
@@ -1252,7 +1286,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
       ]),
   ]
 
-  const params = charting ? chartingParams : [
+  const params = newMap ? newMapParams : charting ? chartingParams : [
     ...(mapNumber
       ? [`- The map is ${repo}#${mapNumber} — ${mapUrl}. curia has loaded it for you.`]
       : ['- This ticket belongs to no map, so there is no map to work through and no map line to append.']),
@@ -1288,7 +1322,15 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   const bounds = [
     '- **Read anything.** Zoom into any issue, map, sibling or closed ticket you need. Nothing here limits',
     '  reading.',
-    ...(charting
+    ...(newMap
+      ? [
+        `- **Write only:** the ONE \`wayfinder:map\` issue you create in ${repo}, and its child tickets.`,
+        '  Nothing else on the tracker — no existing issue is yours to edit, whatever you find while',
+        `  reading. And nothing on disk: ${wtPath} is a read-only checkout to you. A charting session`,
+        '  produces no code, no commit and no branch.',
+        "- Do not rewrite anyone else's text.",
+      ]
+      : charting
       ? [
         `- **Write only:** the map ${repo}#${n} and its child tickets. Nothing else on the tracker, and`,
         `  nothing on disk: ${wtPath} is a read-only checkout to you. A map dispatch produces no code, no`,
@@ -1366,6 +1408,12 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '- `ask_human` — a decision you cannot make alone. Blocks until a human answers, for as long as it',
     '  takes. This is how you reach the operator who dispatched you.',
     '- `notify` — a status line for the human. Returns at once.',
+    ...(newMap ? [
+      '- `map_created` — tell curia the number of the map you created, the moment it exists. curia checks',
+      '  the issue is really an open `wayfinder:map` in this repo, then takes it as this session\'s map:',
+      '  the thread is renamed to it, `map <n>` on it is refused while you run, and your final summary',
+      '  lands there. Call it once, and never before the issue exists.',
+    ] : []),
     '- `report_result` — exactly once, at the very end. Its summary becomes curia\'s comment on the map.',
     '- `open_pull_request`, `request_review` and `publish_preview` belong to a ticket dispatch. curia',
     '  refuses the first two on a map dispatch, and there is nothing here to preview.',
@@ -1432,7 +1480,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '',
     '## How this ends',
     '',
-    ...endingProse({ repo, ticket: n, branch, mapNumber, charting }),
+    ...endingProse({ repo, ticket: n, branch, mapNumber, charting, newMap }),
     '',
     ...(charting
       ? [

--- a/daemon/test/attach.test.mjs
+++ b/daemon/test/attach.test.mjs
@@ -11,7 +11,7 @@ import path from 'node:path'
 import {
   ttydArgv, ensureTtyd, verifiedHardenedArgv, canonicalArgv, WRAPPER_PATH, validSessionName,
   attachUrl, serveOff, DEFAULT_INDEX, CHROME_BASENAME, indexRefusal, readIndexStamp,
-  stampMeta, sha256, ttydVersion, TTYD_BIN,
+  stampMeta, sha256, ttydVersion, TTYD_BIN, isChatHandle, nextChatHandle,
 } from '../src/attach.mjs'
 
 const INDEX = '/opt/curia/attach-index.html'
@@ -254,5 +254,30 @@ describe('session-name gate', () => {
   test('attachUrl refuses an invalid session name', () => {
     assert.throws(() => attachUrl('host.ts.net', 8443, '42; x'))
     assert.equal(attachUrl('host.ts.net', 8443, '42'), 'https://host.ts.net:8443/?arg=curia-42')
+  })
+
+  // #241: an agent no issue answers for is named by a chat handle, and the
+  // wrapper whitelist has to take it as it stands — session names were never
+  // numeric-only, which is what makes this a widening of use, not of trust.
+  test('a chat handle is a valid session name and reaches attach', () => {
+    assert.ok(validSessionName('curia-chat-1'))
+    assert.ok(isChatHandle('chat-1'))
+    assert.ok(!isChatHandle('chat'))
+    assert.ok(!isChatHandle('chat-1; rm -rf /'))
+    assert.equal(attachUrl('host.ts.net', 8443, 'chat-2'), 'https://host.ts.net:8443/?arg=curia-chat-2')
+  })
+})
+
+describe('chat handles enumerate (#241)', () => {
+  test('the first free index wins, and gaps are reused', () => {
+    assert.equal(nextChatHandle([]), 'chat-1')
+    assert.equal(nextChatHandle(['curia-chat-1']), 'chat-2')
+    assert.equal(nextChatHandle(['curia-chat-1', 'curia-chat-2']), 'chat-3')
+    // chat-1 ended; its index comes back rather than counting up forever
+    assert.equal(nextChatHandle(['curia-chat-2', 'curia-chat-3']), 'chat-1')
+  })
+
+  test('numbered and reviewer sessions are not chat handles', () => {
+    assert.equal(nextChatHandle(['curia-147', 'curia-review-42', 'other-chat-1']), 'chat-1')
   })
 })

--- a/daemon/test/commands.test.mjs
+++ b/daemon/test/commands.test.mjs
@@ -263,6 +263,105 @@ describe('parseCommand', () => {
     assert.match(reply, /no watched repo matches/)
   })
 
+  // ---- `map` with no issue: chart a NEW map from prose (#241) ----------------
+  //
+  // The second shape of one verb. It carries no issue reference because the
+  // issue does not exist yet, so the sentence after `--` is the whole input —
+  // and that is why it is mandatory here where `map <n>` makes it optional.
+
+  test('map with no issue parses the prose as the instruction', () => {
+    const c = parseCommand('map -- create new map for next feature. Read direction.md first')
+    assert.equal(c.verb, 'map')
+    assert.equal(c.ticket, undefined)
+    assert.equal(c.instruction, 'create new map for next feature. Read direction.md first')
+  })
+
+  test('a new map takes an optional repo and an optional model, in that shape', () => {
+    const c = parseCommand('map alp82/curia model=opus -- chart the next feature')
+    assert.equal(c.repo, 'alp82/curia')
+    assert.equal(c.model, 'opus')
+    assert.equal(c.ticket, undefined)
+    assert.equal(c.instruction, 'chart the next feature')
+    // the fuzzy repo form the other shape takes, on this one too
+    assert.equal(parseCommand('map cur -- chart it').repoArg, 'cur')
+    assert.equal(parseCommand('map cur -- chart it').repo, undefined)
+  })
+
+  test('the instruction is MANDATORY with no issue — a bare map is refused', () => {
+    // On an existing map a missing sentence means "ask me what should change"
+    // (#160). With no map there is nothing to ask about, so this is a refusal.
+    assert.equal(parseCommand('map'), null)
+    assert.equal(parseCommand('map --'), null)
+    assert.equal(parseCommand('map alp82/curia'), null)
+    assert.equal(parseCommand('map model=opus'), null)
+  })
+
+  test('a number before the -- is the OTHER shape, never a repo called 147', () => {
+    // `map 147 -- x` must keep parsing as an update of map 147. A number that
+    // fell through to the new-map parser would chart into a repo named "147".
+    assert.equal(parseCommand('map 147 -- do X').ticket, '147')
+    assert.equal(parseCommand('map 12 34 -- do X'), null)
+  })
+
+  test('one repo token and one model, never two of either', () => {
+    assert.equal(parseCommand('map cur other -- do X'), null)
+    assert.equal(parseCommand('map model=opus model=gpt -- do X'), null)
+  })
+
+  test('the refusal for a broken map names BOTH shapes', async () => {
+    const router = new CommandRouter({
+      dispatcher: { routing: { harnesses: { claude: {} } }, config: { watch: [{ repo: 'alp82/curia' }] } },
+      attach: {},
+      log: () => {},
+    })
+    const reply = await router.handle('map', 'user-1')
+    assert.match(reply, /map <n>/)
+    assert.match(reply, /map \[repo\]/)
+  })
+
+  test('a new map with one watched repo needs no repo token', async () => {
+    const seen = []
+    const router = new CommandRouter({
+      dispatcher: {
+        routing: { harnesses: { claude: {} } },
+        config: { watch: [{ repo: 'alp82/curia' }] },
+        chartNew: async (opts) => { seen.push(opts); return 'ok' },
+      },
+      attach: {},
+      log: () => {},
+    })
+    await router.handle('map -- chart the next feature', 'user-1')
+    assert.equal(seen[0].repo, 'alp82/curia')
+    assert.equal(seen[0].instruction, 'chart the next feature')
+  })
+
+  test('a new map with two watched repos refuses rather than picking one', async () => {
+    const router = new CommandRouter({
+      dispatcher: {
+        routing: { harnesses: { claude: {} } },
+        config: { watch: [{ repo: 'alp82/curia' }, { repo: 'alp82/other' }] },
+        chartNew: async () => 'dispatched',
+      },
+      attach: {},
+      log: () => {},
+    })
+    const reply = await router.handle('map -- chart the next feature', 'user-1')
+    assert.match(reply, /needs one named/)
+    // and the named form it recommends resolves through the same fuzzy matcher
+    const seen = []
+    const router2 = new CommandRouter({
+      dispatcher: {
+        routing: { harnesses: { claude: {} } },
+        config: { watch: [{ repo: 'alp82/curia' }, { repo: 'alp82/other' }] },
+        chartNew: async (opts) => { seen.push(opts); return 'ok' },
+      },
+      attach: {},
+      log: () => {},
+    })
+    await router2.handle('map curia -- chart it', 'user-1')
+    assert.equal(seen[0].repo, 'alp82/curia')
+  })
+
   test('cancel', () => {
     const c = parseCommand('cancel 42')
     assert.equal(c.verb, 'cancel')

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -263,6 +263,77 @@ describe('the charting prompt', () => {
   })
 })
 
+describe('the new-map prompt (#241)', () => {
+  const NEW_MAP_ISSUE = {
+    number: 'chat-1', title: 'new map: chart the next feature', body: 'chart the next feature',
+    state: 'open', assignees: [], labels: [{ name: 'wayfinder:map' }],
+  }
+  const write = (opts = {}) => {
+    const file = writePrompt(tmp, NEW_MAP_ISSUE, {
+      repo: 'o/r', wtPath: '/w/chat-1', mapNumber: null, type: 'wayfinder:map',
+      charting: true, newMap: true, instruction: 'read direction.md and chart the next feature', ...opts,
+    })
+    return fs.readFileSync(file, 'utf8')
+  }
+
+  test('the /wayfinder line names NO map — it is the skill\'s chart mode', () => {
+    // "Chart the map" starts from a loose idea. A map URL here would invoke
+    // "work through the map" against an issue that does not exist.
+    assert.equal(write().split('\n')[0], '/wayfinder')
+  })
+
+  test('it says the map does not exist and orders the chart mode from the top', () => {
+    const p = write()
+    assert.match(p, /\*\*This is a NEW-MAP DISPATCH\.\*\*/)
+    assert.match(p, /No map exists yet/)
+    assert.match(p, /"Chart the map" mode/)
+    assert.ok(!p.includes('This is a MAP DISPATCH'), 'the map-dispatch wording must not reach a new-map agent')
+    assert.ok(!p.includes('already CLAIMED it in your name'))
+  })
+
+  test('the operator\'s prose rides verbatim, as the loose idea and not a specification', () => {
+    const p = write()
+    assert.match(p, /> read direction\.md and chart the next feature/)
+    assert.match(p, /loose idea, not a specification/)
+  })
+
+  test('the adoption is ordered in the params AND in the ending', () => {
+    const p = write()
+    assert.match(p, /call `map_created` with its number/)
+    const ending = p.slice(p.indexOf('## How this ends'))
+    assert.match(ending, /map_created/)
+    assert.match(ending, /report_result/)
+    assert.ok(!/Only after the approval: merge it/.test(ending))
+  })
+
+  test('map_created is listed as a tool, and only here', () => {
+    assert.match(write(), /- `map_created`/)
+    const onAMap = writePrompt(tmp, MAP_ISSUE, {
+      repo: 'o/r', wtPath: '/w/147', mapNumber: 147, type: 'wayfinder:map', charting: true, instruction: 'x',
+    })
+    assert.ok(!fs.readFileSync(onAMap, 'utf8').includes('map_created'))
+  })
+
+  test('the write bound is the ONE map it creates, and no existing issue', () => {
+    const p = write()
+    assert.match(p, /the ONE `wayfinder:map` issue you create in o\/r/)
+    assert.match(p, /no existing issue is yours to edit/)
+    assert.match(p, /read-only checkout/)
+  })
+
+  test('it is told to create NO map when the grilling shows none is needed', () => {
+    // The skill says this too, and it is the finding most easily overridden by
+    // the pull to produce the artifact the dispatch named.
+    assert.match(write(), /If the grilling shows no map is needed/)
+  })
+
+  test('the HITL rule is stated — the destination is the operator\'s to settle', () => {
+    const p = write()
+    assert.match(p, /many `ask_human` calls, one question at a time/)
+    assert.match(p, /Never answer for them/)
+  })
+})
+
 // ---- the ending (#149 point 3) ------------------------------------------------
 
 describe('the charting checklist', () => {
@@ -724,6 +795,366 @@ describe('cancel on a map dispatch (#221)', () => {
 
 // ---- the phone's command surface ----------------------------------------------
 
+// ---- map with no issue: chart a NEW map (#241) --------------------------------
+//
+// The second shape of the verb, and the first curia agent that no issue answers
+// for. What this section pins is the consequence of that, not the parse (which
+// commands.test.mjs holds): the identity is a chat handle, the daemon learns the
+// map number through `map_created` and CHECKS it, and the ending owes that step.
+
+describe('map with no issue — the new-map dispatch (#241)', () => {
+  test('it spawns on a chat handle, claims nothing, and names the handle in the reply', async () => {
+    const d = makeDispatcher()
+    const reply = await d.chartNew({ repo: 'o/r', instruction: 'chart the next feature', by: 'u' })
+    assert.match(reply, /NEW map in o\/r/)
+    assert.match(reply, /curia-chat-1/)
+    assert.match(reply, /cancel chat-1/)
+    assert.ok(d.agents.has('curia-chat-1'))
+    const w = d.agents.get('curia-chat-1')
+    assert.equal(w.ticket, 'chat-1')
+    assert.equal(w.repo, 'o/r')
+    assert.equal(w.charting, true)
+    assert.equal(w.newMap, true)
+    assert.equal(w.mapNumber, null)
+    // no claim: there is no issue to assign, and #221's rule holds anyway
+    assert.deepEqual(calls.filter((c) => c.startsWith('claim')), [])
+  })
+
+  test('the handles ENUMERATE — two new maps chart side by side', async () => {
+    const d = makeDispatcher()
+    await d.chartNew({ repo: 'o/r', instruction: 'one', by: 'u' })
+    await d.chartNew({ repo: 'o/r', instruction: 'two', by: 'u' })
+    assert.deepEqual([...d.agents.keys()].sort(), ['curia-chat-1', 'curia-chat-2'])
+  })
+
+  test('the free index is read off TMUX, not only off the agents map', async () => {
+    // A restarted daemon holds no agents map. Handing chat-1 to a second agent
+    // would put two of them on one pane, one config dir and one thread.
+    const d = makeDispatcher({ listSessions: async () => ['curia-chat-1', 'curia-9'] })
+    await d.chartNew({ repo: 'o/r', instruction: 'one', by: 'u' })
+    assert.ok(d.agents.has('curia-chat-2'))
+  })
+
+  test('an indeterminate tmux list refuses rather than guessing an index', async () => {
+    const d = makeDispatcher({ listSessions: async () => { throw new Error('no server') } })
+    const reply = await d.chartNew({ repo: 'o/r', instruction: 'one', by: 'u' })
+    assert.match(reply, /indeterminate/)
+    assert.equal(d.agents.size, 0)
+  })
+
+  test('an unwatched repo and an empty instruction are both refused', async () => {
+    const d = makeDispatcher()
+    assert.match(await d.chartNew({ repo: 'o/nope', instruction: 'x' }), /not on the watch list/)
+    assert.match(await d.chartNew({ repo: 'o/r', instruction: '  ' }), /needs a sentence/)
+    assert.equal(d.agents.size, 0)
+  })
+
+  test('the spawn is journalled as charting AND as a new map', async () => {
+    const d = makeDispatcher()
+    await d.chartNew({ repo: 'o/r', instruction: 'chart the next feature', by: 'u' })
+    const spawn = events.filter((e) => e.type === 'agent_spawned').at(-1)
+    assert.equal(spawn.kind, 'charting')
+    assert.equal(spawn.newMap, true)
+    assert.equal(spawn.ticket, 'chat-1')
+    assert.equal(spawn.instruction, 'chart the next feature')
+  })
+
+  test('the routing reads the map row — a new map runs the model an old one does', async () => {
+    const d = makeDispatcher()
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    assert.equal(d.agents.get('curia-chat-1').model, 'opus')
+  })
+
+  test('no tracker doc refuses the dispatch — a mapless charting agent is the worst case', async () => {
+    const d = makeDispatcher({
+      createWorktree: async (b, n) => {
+        const wt = path.join(path.dirname(b), 'wt', String(n))
+        fs.mkdirSync(wt, { recursive: true })
+        return wt
+      },
+    })
+    const reply = await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    assert.match(reply, /charting a new map/)
+    assert.match(reply, /issue-tracker\.md/)
+    assert.equal(d.agents.size, 0)
+  })
+})
+
+describe('map_created — the daemon learns the number (#241)', () => {
+  const MADE = {
+    number: 250, title: 'The next feature', state: 'open', assignees: [],
+    labels: [{ name: 'wayfinder:map' }],
+  }
+
+  test('curia takes the map, journals it, and moves the thread onto it', async () => {
+    const moved = []
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    d.threads = {
+      bind: async () => ({ ok: true }),
+      release: async () => {},
+      cancelled: async () => {},
+      adoptMap: async (handle, n, opts) => { moved.push({ handle, n, ...opts }) },
+    }
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    const text = await d.adoptMap('curia-chat-1', '250')
+    assert.match(text, /o\/r#250/)
+    assert.equal(d.agents.get('curia-chat-1').mapNumber, '250')
+    assert.deepEqual(moved, [{ handle: 'chat-1', n: '250', repo: 'o/r', title: 'The next feature' }])
+    const ev = events.find((e) => e.type === 'map_adopted')
+    assert.equal(ev.map, '250')
+    assert.equal(ev.ticket, 'chat-1')
+  })
+
+  test('the number is CHECKED, never believed', async () => {
+    // A record curia writes from an agent's own account is not evidence (#40).
+    const cases = [
+      [{ ...MADE, state: 'closed' }, /is closed/],
+      [{ ...MADE, labels: [{ name: 'wayfinder:task' }] }, /carries no `wayfinder:map` label/],
+    ]
+    for (const [issue, re] of cases) {
+      const d = makeDispatcher({ fetchIssue: async () => ({ ...issue }) })
+      await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+      assert.match(await d.adoptMap('curia-chat-1', '250'), re)
+      assert.equal(d.agents.get('curia-chat-1').mapNumber, null)
+    }
+  })
+
+  test('an unreadable issue refuses and says to call again — it never adopts on a failed read', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => { throw new Error('gh exploded') } })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    const text = await d.adoptMap('curia-chat-1', '250')
+    assert.match(text, /could not read/)
+    assert.match(text, /again/)
+    assert.equal(d.agents.get('curia-chat-1').mapNumber, null)
+  })
+
+  test('the same number twice is a no-op; a different one is refused', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    await d.adoptMap('curia-chat-1', '250')
+    assert.match(await d.adoptMap('curia-chat-1', '250'), /already taken/)
+    assert.match(await d.adoptMap('curia-chat-1', '251'), /already created o\/r#250/)
+    assert.equal(d.agents.get('curia-chat-1').mapNumber, '250')
+  })
+
+  test('a ticket agent and a map-dispatch agent are both refused', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MAP_ISSUE }) })
+    await d.chart('147', { repo: 'o/r', instruction: 'x', by: 'u' })
+    assert.match(await d.adoptMap('curia-147', '250'), /dispatched on an existing map/)
+    assert.match(await d.adoptMap('curia-999', '250'), /holds no record/)
+  })
+
+  test('a number that is not one is refused before any read', async () => {
+    let read = 0
+    const d = makeDispatcher({ fetchIssue: async () => { read += 1; return { ...MADE } } })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    assert.match(await d.adoptMap('curia-chat-1', 'the map'), /is not one/)
+    assert.equal(read, 0)
+  })
+
+  test('`#250` is taken — the agent writes the number the way GitHub prints it', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    await d.adoptMap('curia-chat-1', '#250')
+    assert.equal(d.agents.get('curia-chat-1').mapNumber, '250')
+  })
+
+  test('the adopted map is LOCKED — `map 250` is refused while the chat runs', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    await d.adoptMap('curia-chat-1', '250')
+    const reply = await d.chart('250', { repo: 'o/r', by: 'u' })
+    assert.match(reply, /curia-chat-1/)
+    assert.match(reply, /cancel chat-1/)
+    assert.ok(!d.agents.has('curia-250'))
+  })
+})
+
+describe('the new-map ending (#241)', () => {
+  test('the checklist owes the map BEFORE the result', () => {
+    const items = outstanding({ newMap: true, charting: true, hasResult: false, mapAdopted: false })
+    assert.equal(items.length, 2)
+    assert.match(items[0], /map_created/)
+    assert.match(items[1], /report_result/)
+  })
+
+  test('an adopted map clears its step and leaves only the result', () => {
+    const items = outstanding({ newMap: true, charting: true, hasResult: false, mapAdopted: true })
+    assert.deepEqual(items.map((i) => /map_created/.test(i)), [false])
+  })
+
+  test('a reported result ends it, whatever the status — the same rule as every ending', () => {
+    assert.deepEqual(outstanding({ newMap: true, charting: true, hasResult: true, mapAdopted: false }), [])
+  })
+
+  test('a map dispatch is untouched by any of it', () => {
+    const items = outstanding({ charting: true, hasResult: false, mapAdopted: false })
+    assert.deepEqual(items.map((i) => /map_created/.test(i)), [false])
+  })
+})
+
+describe('report_result on a new-map dispatch (#241)', () => {
+  const MADE = {
+    number: 250, title: 'The next feature', state: 'open', assignees: [],
+    labels: [{ name: 'wayfinder:map' }],
+  }
+
+  test('the summary lands on the map the agent created, not on the handle', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    await d.chartNew({ repo: 'o/r', instruction: 'chart it', by: 'u' })
+    await d.adoptMap('curia-chat-1', '250')
+    calls.length = 0
+    await d.onResult('curia-chat-1', { status: 'resolved', summary: 'charted the map' })
+    assert.ok(calls.includes('comment o/r#250'), `expected a comment on the map, got ${JSON.stringify(calls)}`)
+    assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')))
+    assert.ok(!calls.some((c) => String(c).startsWith('unclaim')))
+  })
+
+  test('a session that created NO map says so instead of posting nowhere', async () => {
+    const d = makeDispatcher()
+    await d.chartNew({ repo: 'o/r', instruction: 'chart it', by: 'u' })
+    calls.length = 0
+    const text = await d.onResult('curia-chat-1', { status: 'blocked', summary: 'the way was already clear' })
+    assert.match(text, /created NO map/)
+    assert.ok(!calls.some((c) => String(c).startsWith('comment')))
+    const ev = events.find((e) => e.type === 'charting_finished')
+    assert.equal(ev.map, null)
+    assert.equal(ev.commented, false)
+  })
+})
+
+describe('cancel and resume on a chat handle (#241)', () => {
+  const MADE = {
+    number: 250, title: 'The next feature', state: 'open', assignees: [],
+    labels: [{ name: 'wayfinder:map' }],
+  }
+
+  test('cancel claims nothing back and says whether a map was left behind', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    await d.adoptMap('curia-chat-1', '250')
+    const msg = await d.cancel('chat-1', { by: 'u' })
+    assert.match(msg, /o\/r#250\) STANDS/)
+    assert.ok(!calls.some((c) => String(c).startsWith('unclaim')))
+    assert.ok(!d.agents.has('curia-chat-1'))
+  })
+
+  test('cancel before any map says the tracker is untouched', async () => {
+    const d = makeDispatcher()
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    const msg = await d.cancel('chat-1', { by: 'u' })
+    assert.match(msg, /created no map yet/)
+  })
+
+  test('resume re-dispatches the SAME handle, with the instruction it rode', async () => {
+    const d = makeDispatcher()
+    await d.chartNew({ repo: 'o/r', instruction: 'read direction.md and chart it', by: 'u' })
+    d.agents.delete('curia-chat-1')
+    await d.resume('chat-1', { by: 'u' })
+    assert.ok(d.agents.has('curia-chat-1'), 'the handle must not be re-picked — its thread and worktree answer to it')
+    assert.equal(d.agents.get('curia-chat-1').instruction, 'read direction.md and chart it')
+  })
+
+  test('resume after the map exists names `map <n>` instead of charting a second one', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...MADE }) })
+    await d.chartNew({ repo: 'o/r', instruction: 'x', by: 'u' })
+    await d.adoptMap('curia-chat-1', '250')
+    d.agents.delete('curia-chat-1')
+    const reply = await d.resume('chat-1', { by: 'u' })
+    assert.match(reply, /already created o\/r#250/)
+    assert.match(reply, /map 250 --/)
+    assert.equal(d.agents.size, 0)
+  })
+})
+
+// A restarted daemon and a live chat pane. The fault this pins is the one #228
+// pinned for map dispatches: a session GitHub cannot speak for is swept as an
+// orphan, killing a charting agent mid-conversation. A chat handle is that case
+// permanently — `getIssue(repo, 'chat-1')` is a 404 forever.
+describe('reconcile and a live chat session (#241)', () => {
+  const MADE = {
+    number: 250, title: 'The next feature', state: 'open', assignees: [],
+    labels: [{ name: 'wayfinder:map' }],
+  }
+  const writeJournal = (lines) => {
+    fs.writeFileSync(path.join(tmp, 'data', 'events.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')
+  }
+
+  test('a spawn line in the journal is the positive evidence — it is adopted, not swept', async () => {
+    const killed = []
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', kind: 'charting', newMap: true, instruction: 'chart it', model: 'opus', harness: 'claude' },
+    ])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-chat-1'],
+      killSession: async (s) => { killed.push(s) },
+    })
+    await d.reconcile({ boot: false })
+    assert.deepEqual(killed, [])
+    const w = d.agents.get('curia-chat-1')
+    assert.ok(w, 'the live charting agent was swept instead of adopted')
+    assert.equal(w.charting, true)
+    assert.equal(w.newMap, true)
+    assert.equal(w.instruction, 'chart it')
+    assert.equal(w.model, 'opus')
+    assert.equal(w.repo, 'o/r')
+  })
+
+  test('the map it already created comes back on the record, so the lock holds', async () => {
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', kind: 'charting', newMap: true, model: 'opus', harness: 'claude' },
+      { type: 'map_adopted', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', map: '250' },
+    ])
+    const d = makeDispatcher({ listSessions: async () => ['curia-chat-1'], fetchIssue: async () => ({ ...MADE }) })
+    await d.reconcile({ boot: false })
+    assert.equal(d.agents.get('curia-chat-1').mapNumber, '250')
+    assert.match(await d.chart('250', { repo: 'o/r' }), /curia-chat-1/)
+  })
+
+  test('a chat pane no dispatch explains is swept', async () => {
+    const killed = []
+    writeJournal([{ type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', kind: 'ticket' }])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-chat-7'],
+      killSession: async (s) => { killed.push(s) },
+    })
+    await d.reconcile({ boot: false })
+    assert.deepEqual(killed, ['curia-chat-7'])
+    assert.ok(!d.agents.has('curia-chat-7'))
+  })
+
+  test('a CLOSED map sweeps it — the subject is positively finished', async () => {
+    const killed = []
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', kind: 'charting', newMap: true, model: 'opus', harness: 'claude' },
+      { type: 'map_adopted', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', map: '250' },
+    ])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-chat-1'],
+      fetchIssue: async () => ({ ...MADE, state: 'closed' }),
+      killSession: async (s) => { killed.push(s) },
+    })
+    await d.reconcile({ boot: false })
+    assert.deepEqual(killed, ['curia-chat-1'])
+  })
+
+  test('an UNREADABLE map neither adopts nor sweeps — a failed read is not evidence', async () => {
+    const killed = []
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', kind: 'charting', newMap: true, model: 'opus', harness: 'claude' },
+      { type: 'map_adopted', repo: 'o/r', ticket: 'chat-1', agent: 'curia-chat-1', map: '250' },
+    ])
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-chat-1'],
+      fetchIssue: async () => { throw new Error('gh exploded') },
+      killSession: async (s) => { killed.push(s) },
+    })
+    await d.reconcile({ boot: false })
+    assert.deepEqual(killed, [])
+    assert.ok(!d.agents.has('curia-chat-1'), 'an indeterminate read must not adopt either')
+  })
+})
+
 describe('the /map slash expansion', () => {
   const interaction = (commandName, options) => ({
     commandName,
@@ -746,8 +1177,37 @@ describe('the /map slash expansion', () => {
     assert.equal(expandCommand(interaction('map', { ticket: '147', instruction: '  ' })), 'map 147')
   })
 
-  test('a /map with no ticket is the missing-option error, not `map null`', () => {
-    assert.deepEqual(expandCommand(interaction('map', {})), { error: 'missing' })
+  // #241 changed what "no ticket" means on this verb: it is now the NEW-map
+  // shape, not a stale manifest. So the error is its own kind, and the reply
+  // teaches the two shapes instead of telling the operator to restart Discord.
+  test('a /map with neither ticket nor instruction is the shape error', () => {
+    assert.deepEqual(expandCommand(interaction('map', {})), { error: 'map-shape' })
+    assert.deepEqual(expandCommand(interaction('map', { model: 'opus' })), { error: 'map-shape' })
+  })
+
+  test('an instruction with NO ticket expands to the new-map shape', () => {
+    assert.equal(
+      expandCommand(interaction('map', { instruction: 'chart the next feature' })),
+      'map -- chart the next feature',
+    )
+    assert.equal(
+      expandCommand(interaction('map', { instruction: 'chart it', repo: 'cur', model: 'opus' })),
+      'map cur model=opus -- chart it',
+    )
+  })
+
+  test('what the phone sends for a NEW map, the router reads back', () => {
+    const text = expandCommand(interaction('map', { instruction: 'read direction.md\nand chart it', repo: 'cur' }))
+    assert.deepEqual(parseCommand(text), {
+      verb: 'map', repoArg: 'cur', instruction: 'read direction.md and chart it',
+    })
+  })
+
+  // The repo option only means anything on the new-map shape: with a number,
+  // the repo is resolved from the number itself. Dropping it there keeps one
+  // meaning per option rather than two that disagree.
+  test('repo is ignored when a map number is given', () => {
+    assert.equal(expandCommand(interaction('map', { ticket: '147', repo: 'cur' })), 'map 147')
   })
 
   test('what the phone sends, the router reads back', () => {

--- a/daemon/test/overseer.test.mjs
+++ b/daemon/test/overseer.test.mjs
@@ -11,7 +11,7 @@ import path from 'node:path'
 import { EscalationStore } from '../src/store.mjs'
 import { parseCommand } from '../src/commands.mjs'
 import {
-  OverseerHost, canonicalFor, buildVerbTools, ALLOWED_TOOLS, DISALLOWED_TOOLS,
+  OverseerHost, canonicalFor, buildVerbTools, ALLOWED_TOOLS, DISALLOWED_TOOLS, SYSTEM_PROMPT,
 } from '../src/overseer.mjs'
 
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'overseer-test-'))
@@ -127,6 +127,31 @@ describe('canonicalFor', () => {
   test('an empty instruction posts no -- at all', () => {
     assert.equal(canonicalFor('map', { ticket: '147', instruction: '' }), 'map 147')
     assert.equal(canonicalFor('map', { ticket: '147', instruction: '   ' }), 'map 147')
+  })
+
+  // #241: the operator says "chart a new map for X" in prose, and the overseer
+  // reaches `map` with an instruction and NO ticket. The repo is a bare token
+  // here, not the `repo#n` qualifier — there is no n to qualify.
+  test('a map with no ticket composes the new-map shape', () => {
+    assert.equal(
+      canonicalFor('map', { instruction: 'chart the next feature' }),
+      'map -- chart the next feature',
+    )
+    assert.equal(
+      canonicalFor('map', { repo: 'cur', model: 'opus', instruction: 'chart the next feature' }),
+      'map cur model=opus -- chart the next feature',
+    )
+  })
+
+  test('the overseer is told when to reach for the new-map shape', () => {
+    // The prose triggers the operator actually uses. A vocabulary the system
+    // prompt does not carry is a verb the overseer never picks.
+    for (const phrase of ['create a new map', 'chart a new map', 'add a map']) {
+      assert.ok(
+        SYSTEM_PROMPT.toLowerCase().includes(phrase),
+        `the system prompt does not teach the phrase "${phrase}"`,
+      )
+    }
   })
 
   // #221: `start` no longer charts, so it can no longer carry a sentence. A


### PR DESCRIPTION
Ticket: alp82/curia#241 — [`map` with no issue charts a new map from prose](https://github.com/alp82/curia/issues/241)

`map [repo] [model=x] -- <prose>` dispatches a charting agent that has no map. It runs the wayfinder chart mode, settles the destination with the operator, and creates the `wayfinder:map` issue itself.

**Parser.** The issue-reference shape parses first, so every command that worked still works. The new shape carries no number, and the instruction is mandatory there. A `map` that fails to parse names both shapes. The repo token is optional when one repo is watched.

**Identity.** An agent no issue answers for gets a chat handle: `chat-1`, `chat-2`, the lowest free index. The index is read off tmux, not only off daemon memory. `status`, `attach`, `cancel` and `resume` take the handle. Several new maps chart at once, each in its own thread.

**Adoption.** A new curia tool, `map_created`. The agent calls it the moment the map exists. curia reads the issue and refuses a number that is not an open `wayfinder:map` in that repo. After it, `map <n>` on that map is refused while the chat runs, and the charting summary lands there. The Stop hook holds the agent to the call.

**Thread.** The session opens its own thread on the handle. On adoption the binding moves onto the map number and the thread is renamed.

Reconcile adopts a live chat session off its journal spawn line, and sweeps it only on positive evidence.

Daemon suite: 1285 tests, green.

---

Dispatched by the curia daemon — session `curia-241`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `2e99b19` `map` with no issue charts a new map from prose (wayfinder #241)