### PR TITLE
A thread message queues or interrupts, and no verdict dies silently (alp82/curia#252)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -258,10 +258,11 @@ Text the operator types in an agent's thread while no escalation is open. It bel
 _Avoid_: message, comment.
 
 **Queued**:
-The default delivery mode. The note rides the agent's next tool result, and nothing owes a reply. The receipt carries the interrupt button, and no drain receipt follows.
+The default delivery mode. The note rides the agent's next tool result, and nothing owes a reply. The receipt carries the "Ask now" button, and no drain receipt follows.
 
-**Interrupt**:
-The other delivery mode, picked by the button under the receipt. The current tool call gets a grace of a few seconds, then the note goes into the pane as a user turn. The agent's own reply is the outcome.
+**Ask now**:
+The other delivery mode, and the button under the receipt that picks it. The current tool call gets a grace of a few seconds, then the note goes into the pane as a user turn. The agent's own reply is the outcome. [ADR-0013](docs/adr/0013-one-voice-per-fact.md) names the mechanics an interrupt, and so do the code and the journal.
+_Avoid_: interrupt on the operator's surfaces (it reads as an ending, and no button ends an agent).
 
 **Verdict carrier**:
 The whole verdict, posted into the thread when no agent is left to read it. It names the reviewer, its model, its findings and the pull request that holds the full text. A verdict is never mourned in one line.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -253,6 +253,19 @@ The rule that divides the thread's speakers. CuriaBot states mechanics, the agen
 A fire-and-forget line of agent prose into the ticket thread.
 _Avoid_: status line (that names the daemon's own line, below).
 
+**Operator note**:
+Text the operator types in an agent's thread while no escalation is open. It belongs to the instance it was typed at and dies with it. It has two delivery modes, and the operator picks.
+_Avoid_: message, comment.
+
+**Queued**:
+The default delivery mode. The note rides the agent's next tool result, and nothing owes a reply. The receipt carries the interrupt button, and no drain receipt follows.
+
+**Interrupt**:
+The other delivery mode, picked by the button under the receipt. The current tool call gets a grace of a few seconds, then the note goes into the pane as a user turn. The agent's own reply is the outcome.
+
+**Verdict carrier**:
+The whole verdict, posted into the thread when no agent is left to read it. It names the reviewer, its model, its findings and the pull request that holds the full text. A verdict is never mourned in one line.
+
 ### The ending
 
 **Ending**:

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -197,16 +197,22 @@ export function queuedNoteReply({ owner, q, text, channelId, now = Date.now() })
 // mode — an operator who wants a reply presses it, and the words go into the
 // pane as a user turn instead.
 //
+// The label is "Ask now", the operator's own pick. "Interrupt" was the first
+// wording and it was wrong on the surface that matters: it reads as "end this
+// agent", which is the one thing no button does any more (#200). The press asks
+// a question and gets an answer, so the label says that. ADR-0013 keeps the word
+// interrupt for the MECHANICS, and so do the code and the journal.
+//
 // The button rides the receipt rather than a message of its own, so one note
 // makes one message. No button on a dead agent's receipt: nothing queued, so
-// there is nothing to interrupt. No button on a note with no id either — every
-// note journalled before #252 has none, and Discord keeps an old button
-// pressable forever (#200's lesson).
+// there is nothing to ask. No button on a note with no id either — every note
+// journalled before #252 has none, and Discord keeps an old button pressable
+// forever (#200's lesson).
 export const noteInterruptId = (noteId) => `note|${noteId}|interrupt`
 
 export function interruptRow(noteId) {
   return [new ActionRowBuilder().addComponents(
-    new ButtonBuilder().setCustomId(noteInterruptId(noteId)).setLabel('⚙️ Interrupt').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId(noteInterruptId(noteId)).setLabel('⚙️ Ask now').setStyle(ButtonStyle.Secondary),
   )]
 }
 
@@ -228,7 +234,7 @@ export function noteReceipt({ owner, q, text, channelId, now = Date.now() }) {
 // in the agent's own voice.
 export function interruptedReceipt(content, { by, session, graceMs }) {
   const secs = Math.max(1, Math.round(graceMs / 1000))
-  return `${content}\n${smallPrint(`⚙️ interrupted by <@${by}> — \`${session}\` gets ${secs}s to finish its tool call, then these words go in as a user turn. Its reply is the answer.`)}`
+  return `${content}\n${smallPrint(`⚙️ <@${by}> asked for this now — \`${session}\` gets ${secs}s to finish its tool call, then these words go in as a user turn. Its reply is the answer.`)}`
 }
 
 // #81's grown catalogue — a static macro manifest; expansion only, never
@@ -1268,7 +1274,7 @@ export class DiscordBridge {
       const res = await this.handlers.interruptNote?.(noteId, i.user.id)
         ?? { ok: false, why: 'this daemon has no interrupt path' }
       if (!res.ok) {
-        await i.reply({ content: `⚠️ not interrupted — ${res.why}`, ephemeral: true }).catch(() => {})
+        await i.reply({ content: `⚠️ not asked — ${res.why}`, ephemeral: true }).catch(() => {})
         return
       }
       await i.deferUpdate().catch(() => {})

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -190,6 +190,47 @@ export function queuedNoteReply({ owner, q, text, channelId, now = Date.now() })
   return lines
 }
 
+// The two delivery modes, on the receipt (#252, ADR-0013). Queued is the
+// default and is fire-and-forget: the words ride the agent's next tool result,
+// and no drain receipt follows, because a second small-print line saying "it
+// read them" states nothing the operator can act on. The button IS the other
+// mode — an operator who wants a reply presses it, and the words go into the
+// pane as a user turn instead.
+//
+// The button rides the receipt rather than a message of its own, so one note
+// makes one message. No button on a dead agent's receipt: nothing queued, so
+// there is nothing to interrupt. No button on a note with no id either — every
+// note journalled before #252 has none, and Discord keeps an old button
+// pressable forever (#200's lesson).
+export const noteInterruptId = (noteId) => `note|${noteId}|interrupt`
+
+export function interruptRow(noteId) {
+  return [new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId(noteInterruptId(noteId)).setLabel('⚙️ Interrupt').setStyle(ButtonStyle.Secondary),
+  )]
+}
+
+// The whole receipt, text and button together — pure and exported for the
+// reason queuedNoteReply is: this one message is the operator's only surface
+// for the choice between the two modes, and the choice must be checkable
+// without a live gateway.
+export function noteReceipt({ owner, q, text, channelId, now = Date.now() }) {
+  return {
+    content: smallPrint(queuedNoteReply({ owner, q, text, channelId, now }).join('\n')),
+    components: q.reads === false || !q.id ? [] : interruptRow(q.id),
+  }
+}
+
+// What the receipt becomes once the button is pressed. The press is recorded on
+// the receipt itself, in place, and the button goes — the same rule the
+// escalation card lives under (ADR-0013: the card is the only record). No
+// CuriaBot line states the outcome, because the outcome is the agent's reply,
+// in the agent's own voice.
+export function interruptedReceipt(content, { by, session, graceMs }) {
+  const secs = Math.max(1, Math.round(graceMs / 1000))
+  return `${content}\n${smallPrint(`⚙️ interrupted by <@${by}> — \`${session}\` gets ${secs}s to finish its tool call, then these words go in as a user turn. Its reply is the answer.`)}`
+}
+
 // #81's grown catalogue — a static macro manifest; expansion only, never
 // interpretation. `tickets` renames `frontier` on the command surface.
 const SLASH_MANIFEST = [
@@ -1212,6 +1253,32 @@ export class DiscordBridge {
       return
     }
 
+    // The interrupt button under a queued-note receipt (#252, ADR-0013).
+    //
+    // A success is acknowledged SILENTLY and written onto the receipt in place:
+    // the receipt is the record of what happened to those words, and an
+    // interaction reply beside it would say the same fact twice. A refusal is
+    // the other case — nothing happened, so there is no record to show, and the
+    // presser is told EPHEMERALLY. That puts no second line in the thread and
+    // leaves the button pressable, which is what an operator who answers the
+    // escalation first and presses again needs.
+    if (i.isButton() && i.customId.startsWith('note|')) {
+      const [, noteId, action] = i.customId.split('|')
+      if (action !== 'interrupt') return
+      const res = await this.handlers.interruptNote?.(noteId, i.user.id)
+        ?? { ok: false, why: 'this daemon has no interrupt path' }
+      if (!res.ok) {
+        await i.reply({ content: `⚠️ not interrupted — ${res.why}`, ephemeral: true }).catch(() => {})
+        return
+      }
+      await i.deferUpdate().catch(() => {})
+      await i.message.edit({
+        content: interruptedReceipt(i.message.content, { by: i.user.id, session: res.session, graceMs: res.graceMs }),
+        components: [],
+      }).catch(() => {})
+      return
+    }
+
     if (i.isButton() && i.customId.startsWith('esc|')) {
       const [, id, action, value] = i.customId.split('|')
       // A message posted before #200 still carries the old cancel button, and
@@ -1301,8 +1368,10 @@ export class DiscordBridge {
           // A command still queues — the operator may mean the word for the
           // agent — but the reply names the way out, so `cancel 166` typed at
           // an agent never dies silently as a note (#108 item 23, #170).
-          const lines = queuedNoteReply({ owner, q, text: m.content, channelId: this.channel.id })
-          await m.channel.send(smallPrint(lines.join('\n'))).catch(() => {})
+          // The receipt carries the interrupt button, the operator's pick of
+          // the other delivery mode (#252). A dead agent queued nothing, so its
+          // receipt gets none.
+          await m.channel.send(noteReceipt({ owner, q, text: m.content, channelId: this.channel.id })).catch(() => {})
         } else {
           await m.react('⚠️').catch(() => {})
           await m.channel.send(smallPrint(

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -27,7 +27,7 @@ import {
   resolveModel, candidates, buildSpawnCmd, spawnModelId, parseUsageLimit, parseCreditGate,
   carriesLimitPhrase, resolveReviewer, Cooling, SAME_PROVIDER_STAMP,
 } from './routing.mjs'
-import { hasSession, listSessions, newSession, capturePane, killSession } from './tmux.mjs'
+import { hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey } from './tmux.mjs'
 import {
   createPrivateClone, removeWorkspace,
   removeConfigDir, removeCredentials, createReviewCheckout, reviewPathFor, writeReviewPrompt,
@@ -45,10 +45,10 @@ import {
 } from './sandbox.mjs'
 import {
   resolveAndLand, summariseOutcome, nonCleanComment, landBranch, prLinkComment, chartingComment,
-  verdictComment, judgementComment, verdictNote,
+  verdictComment, judgementComment, verdictNote, verdictCarrier,
 } from './resolve.mjs'
 import { outstanding, stopReason, reviewGateText, classifyReviewAnswer, REVIEW_KIND, dutyLines } from './lifecycle.mjs'
-import { CONFIRM_KIND, normalizeEvent } from './store.mjs'
+import { CONFIRM_KIND, VERDICT_LABEL, normalizeEvent } from './store.mjs'
 import {
   probeTtyd, assertServe, serveOff, CHAT_HANDLE_RE, isChatHandle, nextChatHandle,
 } from './attach.mjs'
@@ -154,9 +154,15 @@ const ISSUE_ABSENT_RE = /HTTP 404|Not Found/i
 // unref'd so a pending poll never holds the process open
 const sleep = (ms) => sleepFor(ms, undefined, { ref: false })
 
+// The interrupt's grace (#252, ADR-0013): "a few seconds for the current tool
+// call". Long enough that an ordinary read, edit or grep finishes on its own and
+// the Escape lands on a clear composer; short enough that the operator who
+// pressed the button reads it as an interrupt rather than a queue.
+const INTERRUPT_GRACE_MS = 5_000
+
 const DEFAULT_DEPS = {
   viewerLogin, repoMaps, mapFrontier, flatFrontier, fetchIssue, claim, unclaim, blockedByOf,
-  hasSession, listSessions, newSession, capturePane, killSession,
+  hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey,
   createPrivateClone, removeWorkspace, removeConfigDir, removeCredentials,
   createReviewCheckout, writeReviewPrompt,
   seedConfigDir, writeConnectionSettings, writePrompt,
@@ -332,6 +338,10 @@ export class Dispatcher {
     // agents map: `data/verdicts/<ticket>.json` is what survives a restart, and
     // verdictFor() reads it back. The return path (#165) takes it from here.
     this.verdicts = new Map()
+    // The interrupt's grace (#252): how long the CURRENT tool call gets before
+    // Escape lands on it. A field rather than a constant so a test can drive
+    // the path without waiting out a real one.
+    this.interruptGraceMs = INTERRUPT_GRACE_MS
     // Builders parked at the gate waiting for a verdict (#165), ticket ->
     // { agent, resolve }. Process-scoped on purpose: the thing waiting is a live
     // MCP call, and a daemon restart kills the call before it kills this map.
@@ -2154,7 +2164,7 @@ export class Dispatcher {
     if (unjudged) {
       this.store.logEvent('review_refused', { repo, ticket, agent: agentName, reason: 'unjudged cross-check verdict' })
       this.store.queueAgentNote?.(agentName, verdictNote(unjudged), {
-        instance: w?.instance ?? null, label: 'cross-check verdict',
+        instance: w?.instance ?? null, label: VERDICT_LABEL,
       })
       return {
         ok: false,
@@ -2427,20 +2437,45 @@ export class Dispatcher {
     this.store.logEvent('verdict_commented', {
       repo: verdict.repo, ticket, agent: verdict.agent, ok: posted.ok, why: posted.why ?? null,
     })
+    // The comment url rides on the held artifact, because the carrier below —
+    // and the one the expiry path posts later — link the full text, and this is
+    // the only moment curia learns where that text lives. It goes to disk too:
+    // the expiry can come after a restart, and a link only memory holds is a
+    // link the carrier would not have.
+    if (posted.ok && posted.url) {
+      verdict.pr_url = posted.url
+      this.verdicts.set(ticket, verdict)
+      try {
+        fs.writeFileSync(this.#verdictFile(ticket), JSON.stringify(verdict, null, 2))
+      } catch (e) {
+        this.log(`could not record the pull-request link on the verdict for #${ticket}: ${e.message}`)
+      }
+    }
     if (!posted.ok) {
       this.notify(ticket, `⚠️ the cross-check verdict could NOT be posted on the pull request — ${posted.why}. curia still holds it, and the builder still gets it.`)
     }
     const w = this.agents.get(builder)
     if (!w) {
+      // #252, ADR-0013: a verdict with no live reader is POSTED, not mourned.
+      // The old line said only that it had nowhere to go, which on #223 was the
+      // whole record of a four-finding fail verdict. The thread is the verdict's
+      // last reader, so the thread gets the verdict.
       this.store.logEvent('verdict_undelivered', { repo: verdict.repo, ticket, agent: builder, reason: 'no builder is running' })
-      this.notify(ticket, `📭 the verdict on #${ticket} has nowhere to go — \`${builder}\` is not running. It is on the pull request, and \`resume ${ticket}\` puts an agent back on the ticket.`)
+      this.notify(ticket, verdictCarrier({
+        agent: verdict.agent,
+        model: verdict.model,
+        verdict: verdict.verdict,
+        ticket,
+        url: posted.ok ? posted.url : null,
+        why: `\`${builder}\` is not running`,
+      }))
       return
     }
     // #208's rule, and the caller is what marks the note: these words are for
     // THIS builder. A successor must not read a verdict about a diff it did not
     // write.
     this.store.queueAgentNote?.(builder, verdictNote(verdict), {
-      instance: w.instance ?? null, label: 'cross-check verdict',
+      instance: w.instance ?? null, label: VERDICT_LABEL,
     })
     this.#settleReviewWait(ticket, { ok: true, verdict })
   }
@@ -3457,14 +3492,147 @@ export class Dispatcher {
   // `liveInstance` is null at every death. Adoption after a restart passes
   // the FRESH instance instead, which expires the pre-restart words on the
   // same rule that lapses a pre-restart confirm.
+  //
+  // #252 leaves this as the caller that knows WHY, and nothing else. The
+  // announcing moved into the store, which every expiry passes through, so a
+  // path that forgets to call this one still cannot lose a note in silence.
   expireNotesFor(session, ticket, why, liveInstance = null) {
-    const n = this.store.expireAgentNotes(session, liveInstance)
-    if (!n) return
-    this.log(`${n} operator note(s) for ${session} expired — ${why}`)
-    const again = liveInstance
-      ? 'Say them again in this thread.'
-      : `Say them again after \`resume ${ticket}\`.`
-    this.notify(ticket, `📭 \`${session}\` ${why} with ${n} operator note${n === 1 ? '' : 's'} it never read. A note dies with the agent it was typed at, so nothing carries these words to a successor. ${again}`)
+    this.store.expireAgentNotes(session, liveInstance, why)
+  }
+
+  // Expiry always announces (#252, ADR-0013). Wired to the store's expiry hook,
+  // so it runs once per expiry whichever path caused it — an ordered teardown,
+  // an adoption after a restart, or the drain's belt-and-braces sweep.
+  //
+  // Two shapes, because two kinds of words die here:
+  //
+  //   an operator note — one CuriaBot line with the count. The journal keeps
+  //     the text and the operator can say it again, so repeating it back is
+  //     noise (#108 item 14's contract, unchanged).
+  //   a cross-check verdict — its whole content, with attribution. It is the
+  //     output of a whole reviewer session and nobody can say it again: the
+  //     reviewer is gone and never reads the same diff twice. On #223 one
+  //     expired unread and the thread showed nothing, and that loss class is
+  //     what this branch makes impossible.
+  announceExpiredNotes({ agent, notes, liveInstance, why }) {
+    const ticket = this.agents.get(agent)?.ticket ?? String(agent).match(SESSION_RE)?.[1] ?? String(agent)
+    const verdicts = notes.filter((n) => n.label === VERDICT_LABEL)
+    const plain = notes.length - verdicts.length
+    this.log(`${notes.length} note(s) for ${agent} expired — ${why}`)
+    if (plain) {
+      const again = liveInstance
+        ? 'Say them again in this thread.'
+        : `Say them again after \`resume ${ticket}\`.`
+      this.notify(ticket, `📭 \`${agent}\` ${why} with ${plain} operator note${plain === 1 ? '' : 's'} it never read. A note dies with the agent it was typed at, so nothing carries these words to a successor. ${again}`)
+    }
+    const held = verdicts.length ? this.verdictFor(ticket) : null
+    for (const note of verdicts) {
+      this.store.logEvent('verdict_carried', { ticket, agent, reason: why })
+      this.notify(ticket, verdictCarrier({
+        agent: held?.agent ?? null,
+        model: held?.model ?? null,
+        // The held artifact is the fuller copy; the note text is the fallback
+        // for a verdict whose artifact this daemon no longer has.
+        verdict: held?.verdict ?? note.text,
+        ticket,
+        url: held?.pr_url ?? null,
+        why: `\`${agent}\` ${why}`,
+      }))
+    }
+  }
+
+  // ---- the interrupt, the second delivery mode (#252, ADR-0013) ---------------
+  //
+  // Queued is the default and is fire-and-forget: the words ride the agent's
+  // next tool result and nothing owes a reply. Interrupt is the other mode, and
+  // the operator picks it by pressing the button under the receipt — which is
+  // why it takes a NOTE id rather than a session: the button names the words it
+  // sits under.
+  //
+  // What it does: gives the current tool call a grace of a few seconds, then
+  // sends Escape and types the words into the pane as a user turn. The agent
+  // answers them the way it answers any user message, and that reply is the
+  // outcome — in the thread, in the agent's voice. No CuriaBot line states it,
+  // because the agent's own words are the fact.
+  //
+  // Three refusals, and each one is a case where the keystrokes would do harm
+  // rather than nothing:
+  //
+  //   the agent is gone — words typed at an agent die with it (#208), and
+  //     Escape into a dead session names no pane at all.
+  //   the note belongs to an earlier instance — the same rule, one layer in.
+  //   an escalation is open — the agent is BLOCKED inside `ask_human`, and
+  //     Escape would abort the very tool call that is asking the question. The
+  //     answer surface is the card, and the refusal says so.
+  //
+  // A native terminal dialog (#75) needs no refusal here, unlike the timeline's
+  // /send: the Escape goes first, and Escape is the key #75 itself rules safe
+  // through a dialog — it dismisses rather than answers. The composer is back
+  // by the time the text lands.
+  //
+  // The press RETURNS as soon as the guards pass; the grace and the keystrokes
+  // run after it. The button surface must not sit on a Discord interaction for
+  // seconds, and the injection reports its own failure on the thread.
+  async interruptNote(id, { by = null } = {}) {
+    const note = this.store.noteById(id)
+    if (!note) return { ok: false, why: 'curia has no record of that note, so there is nothing to interrupt' }
+    const session = note.agent
+    const ticket = this.agents.get(session)?.ticket ?? String(session).match(SESSION_RE)?.[1] ?? String(session)
+    const w = this.agents.get(session)
+    if (!w) {
+      return { ok: false, session, ticket, why: `\`${session}\` is NOT running, so there is nothing to interrupt — \`resume ${ticket}\` puts an agent back on the ticket, then say the words again` }
+    }
+    if (note.instance && w.instance && note.instance !== w.instance) {
+      return { ok: false, session, ticket, why: `those words were typed at an earlier \`${session}\`, and a note dies with the agent it was typed at — say them again in this thread` }
+    }
+    const open = this.#openEscalationsFor(session)
+    if (open.length) {
+      const ids = open.map((r) => `**${r.id}**`).join(', ')
+      return { ok: false, session, ticket, why: `\`${session}\` is waiting on ${ids} — answer that question instead. An interrupt here would abort the call that is asking it.` }
+    }
+    const wasPending = note.pending
+    // Out of the queue first: a note the interrupt carries must never also ride
+    // a tool result. One fact, one delivery, whichever mode carries it.
+    this.store.interruptAgentNote(id, { by })
+    this.store.logEvent('note_interrupt', {
+      id, agent: session, ticket, by, grace_ms: this.interruptGraceMs, was_queued: wasPending,
+    })
+    this.#injectNote(session, ticket, note).catch((e) => this.log(`note interrupt for ${session} failed: ${e.message}`))
+    return { ok: true, session, ticket, graceMs: this.interruptGraceMs, was_queued: wasPending }
+  }
+
+  // The words, in the pane, as a user turn. The wrapper is short and it says
+  // the two things the agent cannot know from the text alone: a human typed
+  // this in the thread, and the reply has to go back through `notify` — the
+  // pane is not a surface the operator reads.
+  //
+  // ONE line, and the operator's own whitespace is collapsed into it for the
+  // same reason the map instruction's is (see expandCommand): a composer reads
+  // a newline as a submit, so a two-line send is a half-sent message and a turn
+  // that starts on the first half.
+  async #injectNote(session, ticket, note) {
+    await sleep(this.interruptGraceMs)
+    const w = this.agents.get(session)
+    if (!w) {
+      this.store.logEvent('note_interrupt_failed', { agent: session, ticket, reason: 'the agent exited during the grace' })
+      this.notify(ticket, `📭 \`${session}\` exited during the interrupt grace, so these words reached nobody: ${note.text}`)
+      return
+    }
+    const said = String(note.text ?? '').replace(/\s+/g, ' ').trim()
+    const text = `[the operator, interrupting from the thread] ${said}`
+      + ' — answer this now with the `notify` tool: your terminal output does not reach them. Then carry on.'
+    try {
+      // Escape aborts whatever tool call the grace did not let finish. It is a
+      // separate write from the text on purpose: tmux paces and queues per pane
+      // (#223), so the two land in order with the composer clear between them.
+      await this.deps.sendKey(session, 'Escape')
+      await this.deps.sendText(session, text)
+    } catch (e) {
+      this.store.logEvent('note_interrupt_failed', { agent: session, ticket, reason: e.message })
+      this.notify(ticket, `⚠️ curia could not interrupt \`${session}\` — ${e.message}. The words are NOT with the agent: say them again.`)
+      return
+    }
+    this.store.logEvent('note_interrupt_delivered', { agent: session, ticket })
   }
 
   // The teardown a confirmed cancel runs — shared verbatim by cancel and

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -3575,12 +3575,12 @@ export class Dispatcher {
   // seconds, and the injection reports its own failure on the thread.
   async interruptNote(id, { by = null } = {}) {
     const note = this.store.noteById(id)
-    if (!note) return { ok: false, why: 'curia has no record of that note, so there is nothing to interrupt' }
+    if (!note) return { ok: false, why: 'curia has no record of that note, so there is nothing to ask' }
     const session = note.agent
     const ticket = this.agents.get(session)?.ticket ?? String(session).match(SESSION_RE)?.[1] ?? String(session)
     const w = this.agents.get(session)
     if (!w) {
-      return { ok: false, session, ticket, why: `\`${session}\` is NOT running, so there is nothing to interrupt — \`resume ${ticket}\` puts an agent back on the ticket, then say the words again` }
+      return { ok: false, session, ticket, why: `\`${session}\` is NOT running, so there is nobody to ask — \`resume ${ticket}\` puts an agent back on the ticket, then say the words again` }
     }
     if (note.instance && w.instance && note.instance !== w.instance) {
       return { ok: false, session, ticket, why: `those words were typed at an earlier \`${session}\`, and a note dies with the agent it was typed at — say them again in this thread` }
@@ -3615,7 +3615,7 @@ export class Dispatcher {
     const w = this.agents.get(session)
     if (!w) {
       this.store.logEvent('note_interrupt_failed', { agent: session, ticket, reason: 'the agent exited during the grace' })
-      this.notify(ticket, `📭 \`${session}\` exited during the interrupt grace, so these words reached nobody: ${note.text}`)
+      this.notify(ticket, `📭 \`${session}\` exited during the grace, so these words reached nobody: ${note.text}`)
       return
     }
     const said = String(note.text ?? '').replace(/\s+/g, ' ').trim()
@@ -3629,7 +3629,7 @@ export class Dispatcher {
       await this.deps.sendText(session, text)
     } catch (e) {
       this.store.logEvent('note_interrupt_failed', { agent: session, ticket, reason: e.message })
-      this.notify(ticket, `⚠️ curia could not interrupt \`${session}\` — ${e.message}. The words are NOT with the agent: say them again.`)
+      this.notify(ticket, `⚠️ curia could not put those words to \`${session}\` — ${e.message}. The words are NOT with the agent: say them again.`)
       return
     }
     this.store.logEvent('note_interrupt_delivered', { agent: session, ticket })

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -377,7 +377,7 @@ const gate = {
       store.logEvent('agent_note_refused', { agent, ticket, by, reason: 'agent not running' })
       return { agent, after: null, reads, ticket }
     }
-    const { after } = store.queueAgentNote(agent, text.trim(), { by, instance })
+    const { id, after } = store.queueAgentNote(agent, text.trim(), { by, instance })
     log(`agent note queued for ${agent}${after ? ` (after ${after})` : ''}`)
     // #236: the facts a status question needs, gathered from records the
     // daemon already holds — the status line's state machine, the dispatch
@@ -395,8 +395,14 @@ const gate = {
       esc: sl?.detail?.esc ?? null,
       last: store.lastAgentEvent(agent),
     } : null
-    return { agent, after, reads, ticket, status }
+    // `id` is what the interrupt button under this receipt points at (#252):
+    // queued is the default mode, and the button is how the operator picks the
+    // other one for these exact words.
+    return { agent, id, after, reads, ticket, status }
   },
+  // #252, ADR-0013: the second delivery mode. The bridge presses this from the
+  // button under a receipt; the dispatcher owns the grace and the keystrokes.
+  interruptNote: (id, by) => dispatcher.interruptNote(id, { by }),
 }
 
 // ---- dispatch loop (#33) ----------------------------------------------------
@@ -522,6 +528,12 @@ const dispatcher = new Dispatcher({
     assertSideChannel,
   },
 })
+
+// Expiry always announces (#252, ADR-0013). The hook is set HERE, once, on the
+// one call every expiry path runs through — an exit, an adoption, the drain's
+// own sweep — so no future path can lose a note in silence the way #223 lost a
+// whole cross-check verdict.
+store.onNotesExpired = (ev) => dispatcher.announceExpiredNotes(ev)
 
 // ---- the identity check (#151) ----------------------------------------------
 //

--- a/daemon/src/resolve.mjs
+++ b/daemon/src/resolve.mjs
@@ -226,6 +226,35 @@ export function verdictNote({ agent, model, verdict }) {
   ].join('\n')
 }
 
+// The verdict as the THREAD reads it when no agent is left to read it (#252,
+// ADR-0013). A whole reviewer session's output is not a thing to mourn in one
+// line: on #223 a four-finding `fail` verdict expired nine seconds after it was
+// written and the thread showed nothing, so the loss was total and silent.
+//
+// Attribution first, because the thread is now the verdict's only reader and it
+// must not read as curia's own opinion: who wrote it, what model, what it found,
+// and where the full text lives. The pull-request comment is that full text and
+// it is posted first on every path, so the link here always resolves — when
+// curia has one. It is wrapped in <> so Discord renders no embed (#89): the
+// findings above it are what a reader came for.
+//
+// This one is a MESSAGE, unlike its two neighbours, and it lives beside them
+// anyway: verdictComment, verdictNote and this are the three renderings of one
+// verdict, and one thing is easier to keep true in one place.
+export function verdictCarrier({ agent, model, verdict, ticket, url, why }) {
+  return [
+    `📭 the cross-check verdict on #${ticket} has no live reader — ${why}. It is posted here in full rather than lost.`,
+    '',
+    `\`${agent ?? '?'}\` on \`${model ?? '?'}\` read the diff and returned this:`,
+    '',
+    String(verdict ?? '').trim() || '(the reviewer said nothing)',
+    '',
+    url
+      ? `The full text is on the pull request: <${url}>. \`resume ${ticket}\` puts an agent back on the ticket to act on it.`
+      : `curia could NOT put this on a pull request, so this message is the only copy. \`resume ${ticket}\` puts an agent back on the ticket to act on it.`,
+  ].join('\n')
+}
+
 export function prLinkComment({ branch, commits, url, state }) {
   return machine([
     `🔗 curia pushed \`${branch}\` (${commits} commit${commits === 1 ? '' : 's'}) and ${state === 'updated' ? 'updated' : 'opened'} ${url}`,

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -76,7 +76,14 @@ export function noteDisposition(agent) {
 }
 
 // The events lastAgentEvent must not count (#236) — see _apply.
-const NOTE_EVENTS = new Set(['agent_note', 'agent_notes_drained', 'agent_notes_expired', 'agent_note_refused'])
+const NOTE_EVENTS = new Set([
+  'agent_note', 'agent_notes_drained', 'agent_notes_expired', 'agent_note_refused', 'agent_note_interrupted',
+])
+
+// The label a cross-check verdict rides under on the note queue (#165). It is
+// the one label the expiry path treats differently: an ordinary note that dies
+// gets a line, a verdict that dies gets its whole content (#252, ADR-0013).
+export const VERDICT_LABEL = 'cross-check verdict'
 
 export class EscalationStore {
   constructor(dataDir) {
@@ -92,7 +99,9 @@ export class EscalationStore {
     this.lastTicketThreads = new Map() // ticket -> last thread ever bound, releases notwithstanding (#140)
     this.ticketRepos = new Map() // ticket -> repo of its last dispatch (#235)
     this.lastAgentEvents = new Map() // agent session -> last journal event about it (#236)
+    this.notes = new Map() // note id -> every note ever queued, pending or not (#252)
     this.seq = 0
+    this.noteSeq = 0
     this._replay()
   }
 
@@ -203,19 +212,47 @@ export class EscalationStore {
         // `label` is what the note calls itself on the agent's tool result
         // (#165). Absent means the operator typed it, which is every note
         // journalled before the cross-check had a way back.
-        arr.push({ text: ev.text, after: ev.after ?? null, instance: ev.instance ?? null, label: ev.label ?? null })
+        // `id` names ONE note (#252), so the interrupt button under a receipt
+        // can point at the words that receipt was about. Absent on every note
+        // journalled before the two delivery modes existed, and a receipt with
+        // no id carries no button.
+        const note = {
+          id: ev.id ?? null, agent: ev.agent, text: ev.text, after: ev.after ?? null,
+          instance: ev.instance ?? null, label: ev.label ?? null, pending: true, at: ev.ts ?? null,
+        }
+        if (note.id) {
+          const n = Number(String(note.id).split('-')[1])
+          if (Number.isFinite(n) && n >= this.noteSeq) this.noteSeq = n
+          this.notes.set(note.id, note)
+        }
+        arr.push(note)
         this.agentNotes.set(ev.agent, arr)
         break
       }
       case 'agent_notes_drained': {
         const arr = this.agentNotes.get(ev.agent) ?? []
-        arr.splice(0, ev.count)
+        for (const n of arr.splice(0, ev.count)) n.pending = false
         break
       }
       case 'agent_notes_expired': {
         const live = ev.live_instance ?? null
         const arr = this.agentNotes.get(ev.agent) ?? []
-        this.agentNotes.set(ev.agent, arr.filter((n) => !n.instance || n.instance === live))
+        const kept = []
+        for (const n of arr) {
+          if (!n.instance || n.instance === live) kept.push(n)
+          else n.pending = false
+        }
+        this.agentNotes.set(ev.agent, kept)
+        break
+      }
+      // #252: the interrupt took these words out of the queue and put them in
+      // the pane as a user turn. The note is no longer pending, so it can never
+      // also ride a tool result — one fact, one delivery.
+      case 'agent_note_interrupted': {
+        const arr = this.agentNotes.get(ev.agent) ?? []
+        const note = this.notes.get(ev.id)
+        if (note) note.pending = false
+        this.agentNotes.set(ev.agent, arr.filter((n) => n.id !== ev.id))
         break
       }
       case 'overseer_notes_drained': {
@@ -393,8 +430,30 @@ export class EscalationStore {
       .at(-1)
     const closedMs = recent ? now - Date.parse(recent.closed_at) : Infinity
     const after = Number.isFinite(closedMs) && closedMs <= graceMs ? recent.id : null
-    this._append({ type: 'agent_note', agent, text, after, by, instance, label })
-    return { after }
+    const id = `note-${++this.noteSeq}`
+    this._append({ type: 'agent_note', id, agent, text, after, by, instance, label })
+    return { id, after }
+  }
+
+  // One note by its id, pending or not (#252). The interrupt button reads this:
+  // the words it names may still be queued, or the agent may have read them
+  // already and said nothing back, and the operator presses the same button in
+  // both cases.
+  noteById(id) {
+    return this.notes.get(id) ?? null
+  }
+
+  // The interrupt's half of the queue (#252, ADR-0013). The words leave the
+  // queue here and go into the pane as a user turn, so a note is delivered once
+  // whichever mode carries it. A note the agent has ALREADY read leaves nothing
+  // to take out, and it journals nothing: the operator presses this button
+  // precisely because no reply came, and by then the drain has usually run.
+  // Returns the note, or null when the id names none.
+  interruptAgentNote(id, { by = null } = {}) {
+    const note = this.notes.get(id)
+    if (!note) return null
+    if (note.pending) this._append({ type: 'agent_note_interrupted', id, agent: note.agent, by })
+    return note
   }
 
   // The hand-off half of #139: an answer that settled an escalation nothing
@@ -421,15 +480,26 @@ export class EscalationStore {
   // Two callers, one rule. The exit paths call it so the operator is told at
   // the moment the words die. The drain calls it so a successor can never
   // read them even if some exit path was missed.
-  expireAgentNotes(agent, liveInstance = null) {
+  //
+  // #252 moves the ANNOUNCEMENT here, to the one place every expiry passes
+  // through. Before it, the exit paths announced and the drain did not, so a
+  // note that died on a path nobody had wired stayed silent — the #223 loss
+  // class. `onNotesExpired` fires once per expiry with the notes themselves,
+  // because a dead verdict is posted in full and a count cannot carry it.
+  // Returns those notes: an empty array means nothing died.
+  expireAgentNotes(agent, liveInstance = null, why = 'is gone') {
     const arr = this.agentNotes.get(agent) ?? []
-    const stale = arr.filter((n) => n.instance && n.instance !== liveInstance).length
-    if (stale) this._append({ type: 'agent_notes_expired', agent, live_instance: liveInstance, count: stale })
+    const stale = arr.filter((n) => n.instance && n.instance !== liveInstance)
+    if (!stale.length) return []
+    this._append({ type: 'agent_notes_expired', agent, live_instance: liveInstance, count: stale.length })
+    // An observer failure never poisons the record, for the reason onEvent does
+    // not: the journal write already happened and it is the truth.
+    try { this.onNotesExpired?.({ agent, notes: stale, liveInstance, why }) } catch { /* announced or not, the note is gone */ }
     return stale
   }
 
   takeAgentNotes(agent, instance = null) {
-    this.expireAgentNotes(agent, instance)
+    this.expireAgentNotes(agent, instance, 'is running as a fresh instance')
     const notes = [...(this.agentNotes.get(agent) ?? [])]
     if (notes.length) this._append({ type: 'agent_notes_drained', agent, count: notes.length })
     return notes

--- a/daemon/test/agentnotes.test.mjs
+++ b/daemon/test/agentnotes.test.mjs
@@ -237,7 +237,9 @@ describe('agent-note queue', () => {
       store.queueAgentNote('curia-166', 'cancel 166', { instance: 'curia-166@1' })
       store.queueRecordedAnswer({ id: 'esc-3', agent: 'curia-166', prompt: 'ship it?', answer: 'yes' })
 
-      assert.equal(store.expireAgentNotes('curia-166', null), 1, 'one stamped note died')
+      // #252: expiry hands back the notes themselves, not a count — a dead
+      // verdict is posted in full and a number cannot carry it.
+      assert.deepEqual(store.expireAgentNotes('curia-166', null).map((n) => n.text), ['cancel 166'])
       const [survivor, ...rest] = store.takeAgentNotes('curia-166')
       assert.deepEqual(rest, [], 'exactly one note survived')
       assert.match(survivor.text, /a human answered esc-3/)
@@ -262,7 +264,7 @@ describe('agent-note queue', () => {
 
     test('expiring nothing writes nothing — an empty sweep is not an event', () => {
       store.queueAgentNote('curia-166', 'a note for whoever resumes', {})
-      assert.equal(store.expireAgentNotes('curia-166', null), 0)
+      assert.deepEqual(store.expireAgentNotes('curia-166', null), [])
       assert.deepEqual(store.takeAgentNotes('curia-166').map((n) => n.text), ['a note for whoever resumes'])
     })
 

--- a/daemon/test/crosscheck.test.mjs
+++ b/daemon/test/crosscheck.test.mjs
@@ -421,6 +421,26 @@ describe('the verdict\'s way back (#165)', () => {
     assert.ok(typesOf().includes('verdict_undelivered'))
     assert.match(notifies.map((n) => n.message).join('\n'), /resume 42/)
   })
+
+  // #252, ADR-0013: a verdict with no live reader is POSTED, not mourned. The
+  // old line said only that it had nowhere to go, and on #223 that one line was
+  // the entire surviving record of a four-finding `fail` verdict.
+  test('a verdict with no live reader is posted in FULL, with attribution', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+    await d.crossCheck('42')
+    d.agents.delete('curia-42')
+
+    await d.onResult('curia-review-42', {
+      ticket: '42', status: 'resolved', summary: 'VERDICT: fail\n1. the drain path races the exit',
+    })
+
+    const carried = notifies.map((n) => n.message).find((m) => /has no live reader/.test(m))
+    assert.ok(carried, 'the thread is the verdict\'s last reader, so the thread gets the verdict')
+    assert.match(carried, /the drain path races the exit/, 'the findings themselves, not a count')
+    assert.match(carried, /curia-review-42/, 'who wrote it')
+    assert.match(carried, /https:\/\/github\.com\/o\/r\/pull\/7/, 'where the full text lives')
+  })
 })
 
 describe('a cross-check that produces no verdict releases the builder (#165)', () => {

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -119,11 +119,22 @@ function makeDispatcher(deps = {}, {
     // #208, the real EscalationStore predicate: a note stamped with an
     // instance dies when that instance is no longer the live one. An
     // unstamped note is session-keyed and stays (the #139 hand-off).
-    expireAgentNotes: (agent, live = null) => {
+    // #252 moved the ANNOUNCEMENT behind the hook the real store fires here,
+    // so the double fires it too — the count in the thread comes from it now.
+    expireAgentNotes: (agent, live = null, why = 'is gone') => {
       const arr = agentNotes.get(agent) ?? []
       const keep = arr.filter((n) => !n.instance || n.instance === live)
+      const stale = arr.filter((n) => n.instance && n.instance !== live)
       agentNotes.set(agent, keep)
-      return arr.length - keep.length
+      if (stale.length) store.onNotesExpired?.({ agent, notes: stale, liveInstance: live, why })
+      return stale
+    },
+    // #252: the note-by-id half the interrupt button reads.
+    noteById: (id) => [...agentNotes.values()].flat().find((n) => n.id === id) ?? null,
+    interruptAgentNote: (id) => {
+      const note = [...agentNotes.values()].flat().find((n) => n.id === id) ?? null
+      if (note) agentNotes.set(note.agent, (agentNotes.get(note.agent) ?? []).filter((n) => n.id !== id))
+      return note
     },
   }
   const base = {
@@ -199,6 +210,9 @@ function makeDispatcher(deps = {}, {
   // the timeline. Reconcile refuses to publish the terminal surface while the
   // proxy is down, so the default here is up — the down case gets its own test.
   d.identityProxy = identityProxy
+  // #252: index.mjs wires the store's expiry hook to the dispatcher's one
+  // announcer, so every expiry — exit, adoption, drain — says so exactly once.
+  store.onNotesExpired = (ev) => d.announceExpiredNotes(ev)
   dispatchers.push(d)
   return d
 }
@@ -1379,6 +1393,210 @@ describe('operator notes die with the instance they were typed at (#208)', () =>
     const line = notifies.find((n) => /operator note/.test(n.message))
     // this agent IS running, so the way out is the thread, not a resume
     assert.match(line.message, /Say them again in this thread/)
+  })
+})
+
+// #252, ADR-0013: the second delivery mode. Queued is the default and owes no
+// reply; the operator picks interrupt by pressing the button under the receipt,
+// and the words then go into the pane as a user turn. The agent's own reply is
+// the outcome, so nothing here composes one.
+describe('a note interrupts instead of queueing (#252)', () => {
+  const liveAgent = (instance = 'curia-42@1') => ({
+    repo: 'o/r', ticket: '42', session: 'curia-42', instance,
+    wtPath: '/w/42', cfgDir: '/c/curia-42', state: 'ready',
+  })
+  const queued = (id, instance = 'curia-42@1') => ({
+    id, agent: 'curia-42', text: 'whats taking so long', instance, label: null, pending: true,
+  })
+
+  // The keystrokes the pane would see, in order.
+  const keyed = () => {
+    const typed = []
+    const d = makeDispatcher({
+      sendKey: async (session, key) => typed.push({ session, key }),
+      sendText: async (session, text) => typed.push({ session, text }),
+    })
+    d.interruptGraceMs = 0
+    return { d, typed }
+  }
+
+  test('Escape first, then the words as a user turn', async () => {
+    const { d, typed } = keyed()
+    d.agents.set('curia-42', liveAgent())
+    agentNotes.set('curia-42', [queued('note-1')])
+
+    const res = await d.interruptNote('note-1', { by: 'u1' })
+    await new Promise((r) => setTimeout(r, 5))
+
+    assert.equal(res.ok, true)
+    assert.equal(typed[0].key, 'Escape', 'the grace is over, so the current tool call is aborted')
+    assert.match(typed[1].text, /whats taking so long/)
+    assert.match(typed[1].text, /interrupting from the thread/, 'the agent must know a human typed this')
+    assert.match(typed[1].text, /`notify` tool/, 'the pane is not a surface the operator reads')
+    assert.ok(typesOf().includes('note_interrupt_delivered'))
+  })
+
+  // A composer reads a newline as a submit, so a two-line send starts a turn on
+  // the first half and leaves the rest in the box.
+  test('the pane gets ONE line, whatever the operator typed', async () => {
+    const { d, typed } = keyed()
+    d.agents.set('curia-42', liveAgent())
+    agentNotes.set('curia-42', [{ ...queued('note-1'), text: 'stop\n\nand check #118 first' }])
+
+    await d.interruptNote('note-1', { by: 'u1' })
+    await new Promise((r) => setTimeout(r, 5))
+
+    assert.ok(!typed[1].text.includes('\n'), 'a newline mid-send is a half-sent message')
+    assert.match(typed[1].text, /stop and check #118 first/)
+  })
+
+  test('the words leave the queue, so no tool result carries them too', async () => {
+    const { d } = keyed()
+    d.agents.set('curia-42', liveAgent())
+    agentNotes.set('curia-42', [queued('note-1'), queued('note-2')])
+
+    await d.interruptNote('note-1', { by: 'u1' })
+
+    assert.deepEqual(agentNotes.get('curia-42').map((n) => n.id), ['note-2'])
+  })
+
+  test('a dead agent refuses, and nothing is typed anywhere', async () => {
+    const { d, typed } = keyed()
+    agentNotes.set('curia-42', [queued('note-1')])
+
+    const res = await d.interruptNote('note-1', { by: 'u1' })
+    await new Promise((r) => setTimeout(r, 5))
+
+    assert.equal(res.ok, false)
+    assert.match(res.why, /NOT running/)
+    assert.match(res.why, /resume 42/)
+    assert.deepEqual(typed, [])
+  })
+
+  test('words typed at an earlier instance refuse — a note dies with its agent (#208)', async () => {
+    const { d, typed } = keyed()
+    d.agents.set('curia-42', liveAgent('curia-42@2'))
+    agentNotes.set('curia-42', [queued('note-1', 'curia-42@1')])
+
+    const res = await d.interruptNote('note-1', { by: 'u1' })
+
+    assert.equal(res.ok, false)
+    assert.match(res.why, /earlier/)
+    assert.deepEqual(typed, [])
+  })
+
+  // The refusal that matters most: the agent is blocked INSIDE ask_human, so
+  // the Escape would abort the very tool call that is asking the question.
+  test('an open escalation refuses, and names the question to answer instead', async () => {
+    const { d, typed } = keyed()
+    d.agents.set('curia-42', liveAgent())
+    agentNotes.set('curia-42', [queued('note-1')])
+    escalations.push({ id: 'esc-3', agent: 'curia-42', ticket: '42', status: 'open', kind: 'free-text' })
+
+    const res = await d.interruptNote('note-1', { by: 'u1' })
+    await new Promise((r) => setTimeout(r, 5))
+
+    assert.equal(res.ok, false)
+    assert.match(res.why, /esc-3/)
+    assert.deepEqual(typed, [], 'an interrupt here would abort the call that is asking')
+  })
+
+  test('an id that names nothing refuses rather than guessing at a note', async () => {
+    const { d } = keyed()
+    assert.equal((await d.interruptNote('note-404', { by: 'u1' })).ok, false)
+  })
+
+  test('an agent that exits during the grace loses the words, and the thread is told', async () => {
+    const typed = []
+    const d = makeDispatcher({
+      sendKey: async () => typed.push('key'),
+      sendText: async () => typed.push('text'),
+    })
+    d.interruptGraceMs = 5
+    d.agents.set('curia-42', liveAgent())
+    agentNotes.set('curia-42', [queued('note-1')])
+
+    await d.interruptNote('note-1', { by: 'u1' })
+    d.agents.delete('curia-42')
+    await new Promise((r) => setTimeout(r, 25))
+
+    assert.deepEqual(typed, [], 'a dead session names no pane')
+    assert.match(notifies.at(-1).message, /reached nobody/)
+    assert.match(notifies.at(-1).message, /whats taking so long/, 'the words are quoted back — nobody else holds them')
+  })
+
+  test('a send that fails says so, rather than leaving the operator to assume delivery', async () => {
+    const d = makeDispatcher({
+      sendKey: async () => {},
+      sendText: async () => { throw new Error('no server running') },
+    })
+    d.interruptGraceMs = 0
+    d.agents.set('curia-42', liveAgent())
+    agentNotes.set('curia-42', [queued('note-1')])
+
+    await d.interruptNote('note-1', { by: 'u1' })
+    await new Promise((r) => setTimeout(r, 10))
+
+    assert.match(notifies.at(-1).message, /could not interrupt/)
+    assert.ok(typesOf().includes('note_interrupt_failed'))
+  })
+})
+
+// #252, ADR-0013: an ordinary note that dies gets one line with the count. A
+// cross-check verdict that dies gets its whole content — it is the output of a
+// whole reviewer session, and nobody can say it again.
+describe('an expiring verdict is posted in full, never mourned (#252)', () => {
+  const agentAt = (instance) => ({
+    repo: 'o/r', ticket: '42', session: 'curia-42', instance,
+    wtPath: '/w/42', cfgDir: '/c/curia-42', state: 'ready', resultReceived: false,
+  })
+
+  test('the verdict content reaches the thread when the builder dies unread', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+    d.verdicts.set('42', {
+      ticket: '42', agent: 'curia-review-42', model: 'gpt-5',
+      verdict: 'VERDICT: fail\n1. the drain path races the exit', pr_url: 'https://github.com/o/r/pull/7',
+    })
+    agentNotes.set('curia-42', [{
+      agent: 'curia-42', text: 'a verdict note', instance: 'curia-42@1', label: 'cross-check verdict',
+    }])
+
+    await d.onAgentDone('curia-42')
+
+    const carried = notifies.map((n) => n.message).find((m) => /has no live reader/.test(m))
+    assert.ok(carried, 'a whole reviewer session\'s output must not die as a count')
+    assert.match(carried, /the drain path races the exit/)
+    assert.match(carried, /curia-review-42/)
+    assert.match(carried, /pull\/7/)
+    assert.ok(typesOf().includes('verdict_carried'))
+  })
+
+  test('an ordinary note beside it still gets the count, and only the count', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+    agentNotes.set('curia-42', [
+      { agent: 'curia-42', text: 'cancel 42', instance: 'curia-42@1', label: null },
+      { agent: 'curia-42', text: 'a verdict note', instance: 'curia-42@1', label: 'cross-check verdict' },
+    ])
+
+    await d.onAgentDone('curia-42')
+
+    const line = notifies.map((n) => n.message).find((m) => /operator note/.test(m))
+    assert.match(line, /1 operator note it never read/, 'the verdict is not counted as one of them')
+    assert.ok(!line.includes('cancel 42'), 'the count, never the words')
+  })
+
+  test('with no artifact left, the note text itself is what gets carried', async () => {
+    const d = makeDispatcher({ hasSession: async () => false })
+    d.agents.set('curia-42', agentAt('curia-42@1'))
+    agentNotes.set('curia-42', [{
+      agent: 'curia-42', text: 'VERDICT: fail — the only copy left', instance: 'curia-42@1', label: 'cross-check verdict',
+    }])
+
+    await d.onAgentDone('curia-42')
+
+    assert.match(notifies.map((n) => n.message).join('\n'), /the only copy left/)
   })
 })
 

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -1537,7 +1537,7 @@ describe('a note interrupts instead of queueing (#252)', () => {
     await d.interruptNote('note-1', { by: 'u1' })
     await new Promise((r) => setTimeout(r, 10))
 
-    assert.match(notifies.at(-1).message, /could not interrupt/)
+    assert.match(notifies.at(-1).message, /could not put those words/)
     assert.ok(typesOf().includes('note_interrupt_failed'))
   })
 })

--- a/daemon/test/notemodes.test.mjs
+++ b/daemon/test/notemodes.test.mjs
@@ -1,0 +1,289 @@
+// The two delivery modes, and the notes that must never die in silence (#252,
+// ADR-0013 "One voice per fact").
+//
+// Queued is the default: today's fire-and-forget path, and the receipt under it
+// now carries an interrupt button. Interrupt is the other mode: a grace for the
+// current tool call, then the words go into the pane as a user turn and the
+// agent's own reply is the outcome.
+//
+// The other half is loss. Every expiry announces, on every path, and a
+// cross-check verdict that expires is posted in FULL rather than mourned in one
+// line — the #223 shape, where a four-finding `fail` verdict expired nine
+// seconds after a whole reviewer session produced it and the thread showed
+// nothing at all.
+
+import { test, describe, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { EscalationStore, VERDICT_LABEL } from '../src/store.mjs'
+import { DiscordBridge, noteReceipt, noteInterruptId, interruptedReceipt } from '../src/bridge.mjs'
+import { verdictCarrier } from '../src/resolve.mjs'
+
+const dirs = []
+const tmpDir = () => {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-notemodes-'))
+  dirs.push(d)
+  return d
+}
+after(() => { for (const d of dirs) fs.rmSync(d, { recursive: true, force: true }) })
+
+// ---------------------------------------------------------------------------
+// the queue: one note, one identity, one delivery
+// ---------------------------------------------------------------------------
+
+describe('a note has an identity, so a button can name it (#252)', () => {
+  let dir, store
+
+  beforeEach(() => {
+    dir = tmpDir()
+    store = new EscalationStore(dir)
+  })
+
+  test('queueing returns the id, and the id finds the note back', () => {
+    const { id } = store.queueAgentNote('curia-9', 'look at the logs', { instance: 'curia-9@1' })
+    assert.match(id, /^note-\d+$/)
+    assert.equal(store.noteById(id).text, 'look at the logs')
+    assert.equal(store.noteById(id).pending, true)
+  })
+
+  test('ids do not repeat, and a restart does not hand out one twice', () => {
+    const a = store.queueAgentNote('curia-9', 'first', {}).id
+    const b = store.queueAgentNote('curia-9', 'second', {}).id
+    assert.notEqual(a, b)
+    const reborn = new EscalationStore(dir)
+    assert.notEqual(reborn.queueAgentNote('curia-9', 'third', {}).id, b)
+  })
+
+  test('an interrupt takes the words OUT of the queue — one fact, one delivery', () => {
+    const { id } = store.queueAgentNote('curia-9', 'answer me', { instance: 'curia-9@1' })
+    store.queueAgentNote('curia-9', 'and this one stays queued', { instance: 'curia-9@1' })
+
+    assert.equal(store.interruptAgentNote(id).text, 'answer me')
+
+    assert.deepEqual(store.takeAgentNotes('curia-9', 'curia-9@1').map((n) => n.text),
+      ['and this one stays queued'], 'the interrupted words must never also ride a tool result')
+  })
+
+  test('the removal is journalled, so a restart does not resurrect the words', () => {
+    const { id } = store.queueAgentNote('curia-9', 'answer me', { instance: 'curia-9@1' })
+    store.interruptAgentNote(id, { by: 'alp' })
+    assert.deepEqual(new EscalationStore(dir).takeAgentNotes('curia-9', 'curia-9@1'), [])
+  })
+
+  // The ADR's own case: no drain receipt exists, so an operator who wants a
+  // reply presses interrupt — and by then the agent has usually read the words
+  // already and said nothing. The button must still work.
+  test('a note the agent already read is still interruptable, and nothing is journalled twice', () => {
+    const { id } = store.queueAgentNote('curia-9', 'whats taking so long', { instance: 'curia-9@1' })
+    store.takeAgentNotes('curia-9', 'curia-9@1')
+    assert.equal(store.noteById(id).pending, false)
+
+    assert.equal(store.interruptAgentNote(id).text, 'whats taking so long')
+
+    const journal = fs.readFileSync(path.join(dir, 'events.jsonl'), 'utf8').trim().split('\n').map((l) => JSON.parse(l))
+    assert.equal(journal.filter((e) => e.type === 'agent_note_interrupted').length, 0,
+      'nothing left the queue, so nothing is recorded as leaving it')
+  })
+
+  test('an id that names nothing is null, never a guess', () => {
+    assert.equal(store.noteById('note-404'), null)
+    assert.equal(store.interruptAgentNote('note-404'), null)
+  })
+})
+
+describe('expiry always announces, on every path (#252)', () => {
+  let dir, store, fired
+
+  beforeEach(() => {
+    dir = tmpDir()
+    store = new EscalationStore(dir)
+    fired = []
+    store.onNotesExpired = (ev) => fired.push(ev)
+  })
+
+  test('the hook carries the notes themselves, not a count', () => {
+    store.queueAgentNote('curia-9', 'cancel 9', { instance: 'curia-9@1' })
+    store.queueAgentNote('curia-9', 'and check the logs', { instance: 'curia-9@1' })
+
+    const gone = store.expireAgentNotes('curia-9', null, 'finished')
+
+    assert.deepEqual(gone.map((n) => n.text), ['cancel 9', 'and check the logs'])
+    assert.equal(fired.length, 1, 'one expiry, one announcement')
+    assert.deepEqual(fired[0].notes.map((n) => n.text), ['cancel 9', 'and check the logs'])
+    assert.equal(fired[0].why, 'finished')
+  })
+
+  // The path that was silent before this ticket: an exit that nothing swept,
+  // caught by the drain's own belt-and-braces sweep. It expired the words and
+  // said nothing, which is exactly how the #223 verdict vanished.
+  test('the drain sweep announces too — the path that used to be silent', () => {
+    store.queueAgentNote('curia-9', 'typed at the predecessor', { instance: 'curia-9@15:13' })
+
+    store.takeAgentNotes('curia-9', 'curia-9@16:36')
+
+    assert.equal(fired.length, 1)
+    assert.deepEqual(fired[0].notes.map((n) => n.text), ['typed at the predecessor'])
+  })
+
+  test('expiring nothing announces nothing — an empty sweep is not an event', () => {
+    store.queueAgentNote('curia-9', 'a note for whoever resumes', {})
+    assert.deepEqual(store.expireAgentNotes('curia-9', null), [])
+    assert.deepEqual(fired, [])
+  })
+
+  test('an observer that throws never poisons the record', () => {
+    store.onNotesExpired = () => { throw new Error('boom') }
+    store.queueAgentNote('curia-9', 'cancel 9', { instance: 'curia-9@1' })
+    assert.equal(store.expireAgentNotes('curia-9', null).length, 1)
+    assert.deepEqual(new EscalationStore(dir).takeAgentNotes('curia-9'), [], 'the journal write already happened')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// the receipt and its button
+// ---------------------------------------------------------------------------
+
+const idsOf = (rows) => rows.flatMap((r) => r.toJSON().components.map((c) => c.custom_id))
+
+describe('the receipt carries the interrupt button (#252)', () => {
+  test('a live agent gets the button, pointing at the note the receipt is about', () => {
+    const r = noteReceipt({
+      owner: 'curia-9', q: { reads: true, ticket: '9', id: 'note-7' }, text: 'look at the logs', channelId: 'C1',
+    })
+    assert.match(r.content, /queued for `curia-9`/)
+    assert.deepEqual(idsOf(r.components), ['note|note-7|interrupt'])
+    assert.equal(noteInterruptId('note-7'), 'note|note-7|interrupt')
+  })
+
+  test('a dead agent gets no button — nothing queued, so nothing to interrupt', () => {
+    const r = noteReceipt({
+      owner: 'curia-166', q: { reads: false, ticket: '166' }, text: 'look at the logs', channelId: 'C1',
+    })
+    assert.match(r.content, /NOT running/)
+    assert.deepEqual(r.components, [])
+  })
+
+  test('a note journalled before this ticket has no id, so its receipt has no button', () => {
+    const r = noteReceipt({ owner: 'curia-9', q: { reads: true, ticket: '9' }, text: 'hi', channelId: 'C1' })
+    assert.deepEqual(r.components, [])
+  })
+
+  test('the pressed receipt records the press in place and says what happens next', () => {
+    const out = interruptedReceipt('-# queued for `curia-9`', { by: 'u1', session: 'curia-9', graceMs: 5000 })
+    assert.match(out, /^-# queued for `curia-9`\n/, 'the receipt itself is kept — this is one message, edited')
+    assert.match(out, /interrupted by <@u1>/)
+    assert.match(out, /5s/)
+    assert.match(out, /Its reply is the answer/)
+  })
+})
+
+describe('a press on the interrupt button (#252)', () => {
+  let bridge, replies, edits, calls, result
+
+  beforeEach(() => {
+    replies = []
+    edits = []
+    calls = []
+    result = { ok: true, session: 'curia-9', ticket: '9', graceMs: 5000 }
+    bridge = new DiscordBridge({
+      token: 'x',
+      allowedUsers: ['u1'],
+      dataDir: tmpDir(),
+      handlers: {
+        interruptNote: async (id, by) => { calls.push({ id, by }); return result },
+      },
+      log: () => {},
+    })
+    bridge.channel = { id: 'C' }
+  })
+
+  const press = async (customId, userId = 'u1') => {
+    let deferred = false
+    await bridge.handleInteraction({
+      customId,
+      user: { id: userId },
+      isButton: () => true,
+      isChatInputCommand: () => false,
+      isRepliable: () => true,
+      message: {
+        content: '-# queued for `curia-9` — it reads this with its next tool result',
+        edit: async (payload) => { edits.push(payload) },
+      },
+      deferUpdate: async () => { deferred = true },
+      reply: async (payload) => { replies.push(payload) },
+    })
+    return deferred
+  }
+
+  test('it reaches the daemon with the note id and the presser', async () => {
+    await press('note|note-7|interrupt')
+    assert.deepEqual(calls, [{ id: 'note-7', by: 'u1' }])
+  })
+
+  // ADR-0013's button rule: the card is the only record. The receipt IS the
+  // record of what happened to those words, so the press is written onto it and
+  // no interaction reply exists beside it.
+  test('a success is silent and edits the receipt in place, button gone', async () => {
+    const deferred = await press('note|note-7|interrupt')
+    assert.equal(deferred, true)
+    assert.deepEqual(replies, [], 'an interaction reply here would say the same fact twice')
+    assert.equal(edits.length, 1)
+    assert.match(edits[0].content, /queued for `curia-9`/)
+    assert.match(edits[0].content, /interrupted by <@u1>/)
+    assert.deepEqual(edits[0].components, [], 'pressed once, and there is nothing left to press')
+  })
+
+  // A refusal is the other case: nothing happened, so there is no record to
+  // show. The presser is told privately and the button stays pressable.
+  test('a refusal replies ephemerally and leaves the receipt alone', async () => {
+    result = { ok: false, why: '`curia-9` is waiting on **esc-3** — answer that question instead' }
+    await press('note|note-7|interrupt')
+    assert.deepEqual(edits, [], 'nothing happened, so the thread gains no line')
+    assert.equal(replies.length, 1)
+    assert.equal(replies[0].ephemeral, true)
+    assert.match(replies[0].content, /not interrupted/)
+    assert.match(replies[0].content, /esc-3/)
+  })
+
+  test('an unauthorized press does nothing at all', async () => {
+    await press('note|note-7|interrupt', 'someone-else')
+    assert.deepEqual(calls, [])
+    assert.deepEqual(edits, [])
+  })
+
+  test('an unknown note action is ignored rather than guessed at', async () => {
+    await press('note|note-7|something-else')
+    assert.deepEqual(calls, [])
+    assert.deepEqual(replies, [])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// the carrier text
+// ---------------------------------------------------------------------------
+
+describe('the verdict carrier (#252)', () => {
+  test('it names the reviewer, the model, the findings and where the full text lives', () => {
+    const out = verdictCarrier({
+      agent: 'curia-review-223',
+      model: 'gpt-5',
+      verdict: 'VERDICT: fail\n1. a real race in the drain path',
+      ticket: '223',
+      url: 'https://github.com/o/r/pull/9',
+      why: '`curia-223` is not running',
+    })
+    assert.match(out, /curia-review-223/, 'who wrote it')
+    assert.match(out, /gpt-5/, 'what it ran on')
+    assert.match(out, /a real race in the drain path/, 'what it found, in full')
+    assert.match(out, /pull\/9/, 'where the full text lives')
+    assert.match(out, /resume 223/, 'the way to act on it')
+    assert.ok(!/^expired/im.test(out), 'never just "expired" — that is the #223 loss')
+  })
+
+  test('with no pull request it says this message is the only copy', () => {
+    const out = verdictCarrier({ agent: 'r', model: 'm', verdict: 'fail', ticket: '5', url: null, why: 'it died' })
+    assert.match(out, /only copy/)
+  })
+})

--- a/daemon/test/notemodes.test.mjs
+++ b/daemon/test/notemodes.test.mjs
@@ -146,8 +146,9 @@ describe('expiry always announces, on every path (#252)', () => {
 // ---------------------------------------------------------------------------
 
 const idsOf = (rows) => rows.flatMap((r) => r.toJSON().components.map((c) => c.custom_id))
+const labelsOf = (rows) => rows.flatMap((r) => r.toJSON().components.map((c) => c.label))
 
-describe('the receipt carries the interrupt button (#252)', () => {
+describe('the receipt carries the "Ask now" button (#252)', () => {
   test('a live agent gets the button, pointing at the note the receipt is about', () => {
     const r = noteReceipt({
       owner: 'curia-9', q: { reads: true, ticket: '9', id: 'note-7' }, text: 'look at the logs', channelId: 'C1',
@@ -157,7 +158,17 @@ describe('the receipt carries the interrupt button (#252)', () => {
     assert.equal(noteInterruptId('note-7'), 'note|note-7|interrupt')
   })
 
-  test('a dead agent gets no button — nothing queued, so nothing to interrupt', () => {
+  // The operator's own wording. "Interrupt" was the first label and it read as
+  // "end this agent" — the one thing no button does any more (#200). The press
+  // asks a question and gets an answer, so the label says that.
+  test('the label asks, and never reads as an ending', () => {
+    const r = noteReceipt({
+      owner: 'curia-9', q: { reads: true, ticket: '9', id: 'note-7' }, text: 'hi', channelId: 'C1',
+    })
+    assert.deepEqual(labelsOf(r.components), ['⚙️ Ask now'])
+  })
+
+  test('a dead agent gets no button — nothing queued, so nothing to ask', () => {
     const r = noteReceipt({
       owner: 'curia-166', q: { reads: false, ticket: '166' }, text: 'look at the logs', channelId: 'C1',
     })
@@ -173,7 +184,7 @@ describe('the receipt carries the interrupt button (#252)', () => {
   test('the pressed receipt records the press in place and says what happens next', () => {
     const out = interruptedReceipt('-# queued for `curia-9`', { by: 'u1', session: 'curia-9', graceMs: 5000 })
     assert.match(out, /^-# queued for `curia-9`\n/, 'the receipt itself is kept — this is one message, edited')
-    assert.match(out, /interrupted by <@u1>/)
+    assert.match(out, /<@u1> asked for this now/)
     assert.match(out, /5s/)
     assert.match(out, /Its reply is the answer/)
   })
@@ -231,7 +242,7 @@ describe('a press on the interrupt button (#252)', () => {
     assert.deepEqual(replies, [], 'an interaction reply here would say the same fact twice')
     assert.equal(edits.length, 1)
     assert.match(edits[0].content, /queued for `curia-9`/)
-    assert.match(edits[0].content, /interrupted by <@u1>/)
+    assert.match(edits[0].content, /<@u1> asked for this now/)
     assert.deepEqual(edits[0].components, [], 'pressed once, and there is nothing left to press')
   })
 
@@ -243,7 +254,7 @@ describe('a press on the interrupt button (#252)', () => {
     assert.deepEqual(edits, [], 'nothing happened, so the thread gains no line')
     assert.equal(replies.length, 1)
     assert.equal(replies[0].ephemeral, true)
-    assert.match(replies[0].content, /not interrupted/)
+    assert.match(replies[0].content, /not asked/)
     assert.match(replies[0].content, /esc-3/)
   })
 


### PR DESCRIPTION
Ticket: alp82/curia#252 — [A thread message queues or interrupts, and no verdict dies silently](https://github.com/alp82/curia/issues/252)

Two delivery modes for an operator note, per ADR-0013, plus the two loss classes the note queue still had.

**Queued** stays the default and stays fire-and-forget. Its receipt now carries an **⚙️ Ask now** button, and no drain receipt follows.

**Ask now** is the other mode. The current tool call gets a grace of five seconds, then curia sends Escape and types the words into the pane as a user turn. The agent's own reply is the outcome, in the thread, in the agent's voice. The press refuses on a dead agent, on words typed at an earlier instance, and while an escalation is open — an Escape there would abort the call that is asking the question.

The label is the operator's own pick. "Interrupt" was the first wording and it read as "end this agent", which is the one thing no button does any more (#200). ADR-0013 keeps the word interrupt for the mechanics, and so do the code and the journal.

**Expiry always announces.** The announcement moved into the store, to the one call every expiry passes through, so the drain's own sweep can no longer drop a note in silence.

**A verdict with no live reader is posted in full.** It names the reviewer, its model, its findings and the pull request that holds the full text. The #223 loss class — a four-finding fail verdict expired unread, and the thread showed nothing — is now impossible.

CONTEXT.md gains four terms: operator note, queued, ask now, verdict carrier.

The daemon suite is green: 1307 tests, 0 failures.

---

Dispatched by the curia daemon — session `curia-252`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `8115b29` The note button says "Ask now", not "Interrupt" (wayfinder #252)
- `f4133ca` A thread message queues or interrupts, and no verdict dies silently (wayfinder #252)