### PR TITLE
The speaker name never truncates (alp82/curia#254)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -249,6 +249,9 @@ One Discord thread per ticket. It carries the ticket's escalations, notifies, an
 **Voice ownership**:
 The rule that divides the thread's speakers. CuriaBot states mechanics, the agent voice states meaning, and no fact is said twice in one thread. See [ADR-0013](docs/adr/0013-one-voice-per-fact.md).
 
+**Speaker name**:
+The webhook username an agent speaks under: its session name, and nothing else. Discord caps the username at 80 characters, so a name that carries more can truncate, and a truncated identity is a mangled one (#254). The label says who speaks. The thread says which ticket.
+
 **Notify**:
 A fire-and-forget line of agent prose into the ticket thread.
 _Avoid_: status line (that names the daemon's own line, below).

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -940,7 +940,7 @@ export class DiscordBridge {
   }
 
   // Speaker identities (#108 item 15): agent prose posts under a webhook
-  // identity ("curia-9 · <ticket title>", own identicon avatar), overseer
+  // identity ("curia-9", its session name and own identicon avatar), overseer
   // prose as "curia" with the bot's avatar — one thread, one voice, and "the
   // agent" moves from the prose into the speaker label. One channel webhook
   // serves every identity (username set per send). CONSTRAINT, verified
@@ -1012,9 +1012,13 @@ export class DiscordBridge {
   // default avatar (#143). Gravatar generates one from any hash, `f=y` forces
   // the generated face even when the hash happens to be a real account, and
   // curia still hosts no asset. md5 is Gravatar's key, not a security choice.
+  //
+  // The whole name is the seed. It used to be the first space-separated word,
+  // to hold the face still while the ticket title on the label changed. #254
+  // took the title off the label, so the name is already the session name.
   #avatarFor(as) {
     if (as === 'curia') return this.client.user?.displayAvatarURL?.() ?? undefined
-    const seed = createHash('md5').update(as.split(' ')[0]).digest('hex')
+    const seed = createHash('md5').update(String(as)).digest('hex')
     return `https://www.gravatar.com/avatar/${seed}?d=identicon&f=y&s=128`
   }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -775,9 +775,11 @@ function startKeepAlive(extra, id, label = null) {
 function buildMcpServer(agent, ticket) {
   const server = new McpServer({ name: 'curia-daemon', version: '0.1.0' }, { capabilities: { logging: {} } })
 
-  // The agent's speaker identity (#108 item 15): its own words post under
-  // "curia-<n> · <ticket title>", so the prose no longer says "the agent".
-  const speaker = () => speakerName(agent, dispatcher.agents.get(agent)?.title ?? '')
+  // The agent's speaker identity (#108 item 15, narrowed by #254): its own
+  // words post under its session name, so the prose no longer says "the
+  // agent". The name alone — the ticket title used to ride here and truncate.
+  // It is a constant now, where it used to read the live title per send.
+  const speaker = speakerName(agent)
 
   // Queued operator notes ride the agent's NEXT tool result (#108 item 14):
   // every tool below appends the drain, so a note is never older than one
@@ -804,7 +806,7 @@ function buildMcpServer(agent, ticket) {
     async ({ message, images }) => {
       const { files, refusals } = outboundImages(agent, images)
       store.logEvent('notify', { agent, ticket, message, images: files.map((f) => f.attachment), refusals })
-      if (bridge) bridge.notify(ticket, `⚙️ ${message}`, { files, as: speaker() }).catch(() => {})
+      if (bridge) bridge.notify(ticket, `⚙️ ${message}`, { files, as: speaker }).catch(() => {})
       return { content: [{ type: 'text', text: refusals.length ? `ok (${refusals.length} image(s) refused)\n${refusals.join('\n')}` : 'ok' }, ...drainNotes()] }
     },
   )
@@ -998,7 +1000,7 @@ function buildMcpServer(agent, ticket) {
       // Route by that same bound ticket: an agent-supplied id may be
       // repo-qualified or a URL, which ensureThread would send to a stray named
       // thread instead of the ticket's bound thread (#103).
-      if (bridge) bridge.notify(bound, `✅ reports **${result.status}**: ${result.summary}`, { as: speaker() }).catch(() => {})
+      if (bridge) bridge.notify(bound, `✅ reports **${result.status}**: ${result.summary}`, { as: speaker }).catch(() => {})
       const stopKeepAlive = startKeepAlive(extra, `${agent}/result`)
       try {
         return { content: [{ type: 'text', text: await dispatcher.onResult(agent, result) }, ...drainNotes()] }

--- a/daemon/src/messaging.mjs
+++ b/daemon/src/messaging.mjs
@@ -91,12 +91,22 @@ export function promptTitle(prompt, max = 80) {
   return `${(cut.includes(' ') ? cut.slice(0, cut.lastIndexOf(' ')) : cut).trimEnd()}…`
 }
 
-// Webhook speaker name (#108 item 15): `curia-9 · <ticket title>` — the
-// multi-agent shape moves from the prose into the speaker label. Discord caps
-// webhook usernames at 80 chars, so the title cuts at a word boundary.
-export function speakerName(agent, title = '') {
-  if (!title) return agent
-  return `${agent} · ${promptTitle(title, 80 - agent.length - 3)}`
+// Webhook speaker name: the session name, alone (#254). #108 item 15 moved
+// the multi-agent shape out of the prose and into the speaker label, and hung
+// the ticket title off it: `curia-9 · <ticket title>`. Discord caps a webhook
+// username at SPEAKER_NAME_LIMIT, so a long title was cut and given an
+// ellipsis, and nine agents in the #245 cold read spoke under a mangled
+// identity. The budget was also one char short of its own cap — a name of 81
+// chars, which Discord REFUSES, so the longest identities collapsed into the
+// bot voice instead of speaking at all.
+//
+// A session name is `curia-<n>` or `curia-review-<n>`. It always fits, one
+// agent wears one name for its whole life, and a reviewer adopted after a
+// restart wears the same name as before it. The title is not lost: the thread
+// is bound to the ticket, and the agent's own prose says what it did.
+export const SPEAKER_NAME_LIMIT = 80
+export function speakerName(agent) {
+  return String(agent)
 }
 
 // "how long has this been waiting" for reminders and keepalives (#118).

--- a/daemon/test/messaging.test.mjs
+++ b/daemon/test/messaging.test.mjs
@@ -4,7 +4,7 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { SIGNALS, smallPrint, link, clampList, lintReply, chunkMessage, promptTitle, elapsedLabel, speakerName, CHUNK_LIMIT } from '../src/messaging.mjs'
+import { SIGNALS, smallPrint, link, clampList, lintReply, chunkMessage, promptTitle, elapsedLabel, speakerName, CHUNK_LIMIT, SPEAKER_NAME_LIMIT } from '../src/messaging.mjs'
 
 describe('smallPrint', () => {
   test('prefixes every line with the -# marker', () => {
@@ -109,22 +109,26 @@ describe('promptTitle', () => {
   })
 })
 
-describe('speakerName (#108 item 15)', () => {
-  test('agent plus ticket title, middot-joined', () => {
-    assert.equal(speakerName('curia-9', 'Pin the landing page pitch'), 'curia-9 · Pin the landing page pitch')
-  })
-
-  test('no title means the bare session name', () => {
+describe('speakerName (#108 item 15, narrowed by #254)', () => {
+  test('the session name, alone — builder and reviewer alike', () => {
     assert.equal(speakerName('curia-9'), 'curia-9')
-    assert.equal(speakerName('curia-9', ''), 'curia-9')
+    assert.equal(speakerName('curia-review-9'), 'curia-review-9')
   })
 
-  test('the whole name stays under Discord\'s 80-char username cap, cut at a word boundary', () => {
+  test('a ticket title never reaches the label, however long', () => {
     const long = 'A very long ticket title that goes on and on about the landing page charting effort and more'
-    const name = speakerName('curia-121', long)
-    assert.ok(name.length <= 80, `${name.length} chars`)
-    assert.match(name, /^curia-121 · A very long/)
-    assert.ok(!/\w…\w/.test(name), 'never cut mid-word')
+    assert.equal(speakerName('curia-121', long), 'curia-121')
+  })
+
+  test('no name ever truncates: every session name fits Discord\'s cap with room to spare', () => {
+    // Four digits outlives this tracker, and the reviewer prefix is the longest
+    // one curia mints. The old shape spent the whole budget on the title and
+    // overspent it by one, so the longest names were REFUSED by Discord.
+    for (const agent of ['curia-1', 'curia-9999', 'curia-review-1', 'curia-review-9999']) {
+      const name = speakerName(agent)
+      assert.ok(name.length <= SPEAKER_NAME_LIMIT, `${name} is ${name.length} chars`)
+      assert.ok(!name.includes('…'), `${name} carries an ellipsis`)
+    }
   })
 })
 

--- a/daemon/test/speakers.test.mjs
+++ b/daemon/test/speakers.test.mjs
@@ -60,8 +60,8 @@ describe('speaker-identity degradation (#143)', () => {
     assert.equal(bridge.status().speakers.reason, 'Missing Permissions')
 
     // every later send falls back in silence — one notice, not one per send
-    await bridge.notify('85', 'first', { as: 'curia-85 · a ticket' })
-    await bridge.notify('85', 'second', { as: 'curia-85 · a ticket' })
+    await bridge.notify('85', 'first', { as: 'curia-85' })
+    await bridge.notify('85', 'second', { as: 'curia-85' })
     assert.deepEqual(asBot, ['first', 'second'], 'the words always land')
     assert.equal(asHook.length, 0)
     assert.equal(announced.length, 1, 'the notice does not repeat')
@@ -72,27 +72,28 @@ describe('speaker-identity degradation (#143)', () => {
     assert.deepEqual(announced, [])
     assert.equal(bridge.status().speakers.ok, true)
 
-    await bridge.notify('85', 'hello', { as: 'curia-85 · a ticket' })
+    await bridge.notify('85', 'hello', { as: 'curia-85' })
     assert.equal(asBot.length, 0)
     assert.equal(asHook.length, 1)
-    assert.equal(asHook[0].username, 'curia-85 · a ticket')
+    assert.equal(asHook[0].username, 'curia-85')
     assert.equal(asHook[0].threadId, 't-1')
   })
 
   test('the speaker avatar is a URL that exists, and one per agent (#143)', async () => {
     await bridge.probeSpeakers()
-    await bridge.notify('85', 'a', { as: 'curia-85 · a ticket' })
-    await bridge.notify('85', 'b', { as: 'curia-143 · another ticket' })
+    await bridge.notify('85', 'a', { as: 'curia-85' })
+    await bridge.notify('85', 'b', { as: 'curia-review-85' })
 
     // github.com/identicons/<name>.png answers for real accounts only, so the
     // old scheme 404ed for every agent and Discord drew the default face.
     for (const send of asHook) assert.doesNotMatch(send.avatarURL, /github\.com\/identicons/)
     for (const send of asHook) assert.match(send.avatarURL, /^https:\/\/www\.gravatar\.com\/avatar\/[0-9a-f]{32}\?d=identicon&f=y/)
-    assert.notEqual(asHook[0].avatarURL, asHook[1].avatarURL, 'two agents, two faces')
+    assert.notEqual(asHook[0].avatarURL, asHook[1].avatarURL, 'the builder and its reviewer, two faces')
 
-    // the ticket title moves, the agent does not — the face must not follow it
-    await bridge.notify('85', 'c', { as: 'curia-85 · a renamed ticket' })
-    assert.equal(asHook[2].avatarURL, asHook[0].avatarURL, 'the agent name alone seeds the face')
+    // One agent wears one face for its whole life. The name is the session
+    // name and nothing else (#254), so nothing on the label can move it.
+    await bridge.notify('85', 'c', { as: 'curia-85' })
+    assert.equal(asHook[2].avatarURL, asHook[0].avatarURL, 'the session name seeds the face')
   })
 
   test('a grant withdrawn while the daemon runs is caught at the send', async () => {
@@ -101,7 +102,7 @@ describe('speaker-identity degradation (#143)', () => {
 
     bridge.hook = null // the warmed hook is gone with the permission
     webhookFault = missingPermissions()
-    await bridge.notify('85', 'after the loss', { as: 'curia-85 · a ticket' })
+    await bridge.notify('85', 'after the loss', { as: 'curia-85' })
 
     assert.deepEqual(asBot, ['after the loss'])
     assert.equal(announced.length, 1)
@@ -114,7 +115,7 @@ describe('speaker-identity degradation (#143)', () => {
     assert.equal(announced.length, 1)
 
     webhookFault = null // the operator granted the permission
-    await bridge.notify('85', 'under my own name', { as: 'curia-85 · a ticket' })
+    await bridge.notify('85', 'under my own name', { as: 'curia-85' })
 
     assert.equal(asHook.length, 1, 'the send path is never disabled, so it simply works')
     assert.equal(announced.length, 2)
@@ -124,7 +125,7 @@ describe('speaker-identity degradation (#143)', () => {
     // and a second loss is announced again — the latch cleared with the recovery
     bridge.hook = null
     webhookFault = missingPermissions()
-    await bridge.notify('85', 'lost again', { as: 'curia-85 · a ticket' })
+    await bridge.notify('85', 'lost again', { as: 'curia-85' })
     assert.equal(announced.length, 3)
     assert.match(announced[2], /Speaker identities are off/)
   })


### PR DESCRIPTION
Ticket: alp82/curia#254 — [The speaker name never truncates](https://github.com/alp82/curia/issues/254)

Closes #254, on map #244.

An agent spoke under `curia-<n> · <ticket title>`. Discord caps a webhook username at 80 characters, so a long title was cut and given an ellipsis: nine agents in the #245 cold read wore a mangled identity. The budget was also one char short of its own cap, so the longest names came to 81 characters, which Discord refuses. Those agents fell back to the bot voice and never spoke under their own name.

The speaker name is the session name now, and nothing else — `curia-208`, `curia-review-208`. The operator picked this shape over a fitted title budget.

- `speakerName(agent)` returns the session name. `SPEAKER_NAME_LIMIT` names Discord's cap, and a test proves every session-name shape fits it with room to spare.
- The builder and the reviewer voice share the one call site in `index.mjs`, so both move together.
- An adopted reviewer used to lose its title on a daemon restart and change name mid-thread (`dispatch.mjs`, `title: ''`). That wobble is gone by construction.
- The avatar seed drops its space split. It held the face still while the title changed, and no title reaches the label now.
- `CONTEXT.md` gains the term **Speaker name**.

The daemon suite is green: 1323 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-254`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `752d650` The speaker name never truncates (#254)