### PR TITLE
A failure line posts once and speaks prose, not stderr (alp82/curia#256)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -249,6 +249,10 @@ One Discord thread per ticket. It carries the ticket's escalations, notifies, an
 **Voice ownership**:
 The rule that divides the thread's speakers. CuriaBot states mechanics, the agent voice states meaning, and no fact is said twice in one thread. See [ADR-0013](docs/adr/0013-one-voice-per-fact.md).
 
+**Failure line**:
+The daemon's own message about a failure it hit. It is one sentence of prose, and the thread hears it once (#256). The raw error stays in the journal and in the reply the failing agent reads. A retry loop inside the repeat window adds nothing to the thread. A loop that outlasts the window says the line again with a count.
+_Avoid_: error message (that names the raw text, which never reaches the thread).
+
 **Speaker name**:
 The webhook username an agent speaks under: its session name, and nothing else. Discord caps the username at 80 characters, so a name that carries more can truncate, and a truncated identity is a mangled one (#254). The label says who speaks. The thread says which ticket.
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -52,6 +52,7 @@ import { CONFIRM_KIND, VERDICT_LABEL, normalizeEvent } from './store.mjs'
 import {
   probeTtyd, assertServe, serveOff, CHAT_HANDLE_RE, isChatHandle, nextChatHandle,
 } from './attach.mjs'
+import { failureProse, FailureLines } from './messaging.mjs'
 
 // A ticket session's name. Chat handles are in here since #241: an agent no
 // issue answers for — today, the one charting a map that does not exist yet —
@@ -311,6 +312,10 @@ export class Dispatcher {
     this.root = config.dispatch.workspace_root
     this.agents = new Map() // session -> agent record (disposable cache)
     this.inFlight = new Set() // admission guard: sessions mid-start, pre-spawn
+    // The repeat filter behind #failureNotify (#256). In-memory on purpose: a
+    // restart loses the counters, and a restart is exactly when a failure
+    // deserves to be said again.
+    this.failures = new FailureLines()
     // Teardowns this dispatcher ordered (#138). killSession is wrapped so
     // EVERY ordered kill — cancel, finish, limit respawn, orphan sweep —
     // registers before the tmux call, and the liveness sweep can tell an
@@ -1481,7 +1486,7 @@ export class Dispatcher {
       await this.#deliverVerdict(verdict)
     } catch (e) {
       this.store.logEvent('verdict_delivery_failed', { repo, ticket, agent: agentName, error: e.message })
-      this.notify(ticket, `⚠️ the verdict on #${ticket} is captured, but curia's return path failed — ${e.message}. The builder may still be waiting at the gate.`)
+      this.#failureNotify(ticket, 'verdict-return', `⚠️ the verdict on #${ticket} is captured, but curia's return path failed — ${failureProse(e.message)}. The builder may still be waiting at the gate.`)
     }
     return `verdict captured${held ? '' : ' in memory only — writing the artifact FAILED'}. curia has posted it on the pull request and handed it to the builder, which judges it and puts it to a human. You push nothing, resolve nothing and answer nothing further — your work here is done, so stop.`
   }
@@ -2038,11 +2043,32 @@ export class Dispatcher {
   // where that fact is known, rather than at the two call sites — the rule
   // #releaseTail above follows, for the same reason. Everything else is shared:
   // one shape, one verb swapped, so the two messages stay comparable.
+  //
+  // Prose, but NOT deduped (#256): one agent life ends once, so there is no
+  // repeat to swallow, and a re-dispatch that dies the same way is a second
+  // death the operator has to hear about. A REFUSAL is already prose — curia
+  // composed it, and #174's way out lives in that sentence — so only the failed
+  // arm, which carries whatever tmux or docker said, is translated.
   #noRespawnNotify(agent, next, cause, e, released) {
     const head = e.refusal
       ? `🚫 \`${agent.session}\` ${cause} and curia REFUSED to respawn it on **${next}**`
       : `⚠️ \`${agent.session}\` ${cause} and the respawn on **${next}** failed`
-    return `${head}: ${e.message} — ${this.#releaseTail(agent, released)}`
+    const why = e.refusal ? e.message : failureProse(e.message)
+    return `${head}: ${why} — ${this.#releaseTail(agent, released)}`
+  }
+
+  // Every daemon-side failure the thread hears goes through here (#256). The
+  // line is already prose — `failureProse` runs at the call site, where the raw
+  // error is — and this adds the other half: the thread hears one failure once.
+  //
+  // The key is the ticket, the failing act and the composed line together, so
+  // two different failures of one act both speak, and one failure retried says
+  // nothing new. Nothing is hidden by the silence: the failure event is
+  // journalled on every occurrence, so the count is in the record whether or
+  // not the thread carries it.
+  #failureNotify(ticket, kind, text) {
+    const line = this.failures.say(`${ticket} ${kind} ${text}`, text)
+    if (line) this.notify(ticket, line)
   }
 
   // ---- the merge-gated ending (#54) ---------------------------------------------
@@ -2100,7 +2126,7 @@ export class Dispatcher {
       })
     } catch (e) {
       this.store.logEvent('land_failed', { repo, ticket, agent: agentName, branch, error: e.message })
-      this.notify(ticket, `⚠️ \`${agentName}\`: opening the pull request FAILED — ${e.message}`)
+      this.#failureNotify(ticket, 'land', `⚠️ \`${agentName}\`: opening the pull request FAILED — ${failureProse(e.message)}`)
       return `❌ curia could not land \`${branch}\`: ${e.message}. Your commits are safe in the worktree; fix what you can and call this again.`
     }
     if (!out.ok) {
@@ -2452,7 +2478,7 @@ export class Dispatcher {
       }
     }
     if (!posted.ok) {
-      this.notify(ticket, `⚠️ the cross-check verdict could NOT be posted on the pull request — ${posted.why}. curia still holds it, and the builder still gets it.`)
+      this.#failureNotify(ticket, 'verdict-comment', `⚠️ the cross-check verdict could NOT be posted on the pull request — ${failureProse(posted.why)}. curia still holds it, and the builder still gets it.`)
     }
     const w = this.agents.get(builder)
     if (!w) {
@@ -2512,7 +2538,7 @@ export class Dispatcher {
       repo: verdict.repo, ticket, agent: agentName, ok: posted.ok, why: posted.why ?? null,
     })
     if (!posted.ok) {
-      this.notify(ticket, `⚠️ \`${agentName}\`'s judgement of the cross-check could NOT be posted on the pull request — ${posted.why}. The question itself is in this thread.`)
+      this.#failureNotify(ticket, 'judgement-comment', `⚠️ \`${agentName}\`'s judgement of the cross-check could NOT be posted on the pull request — ${failureProse(posted.why)}. The question itself is in this thread.`)
     }
     return posted.ok
   }
@@ -2757,7 +2783,7 @@ export class Dispatcher {
         : await this.#noteNonClean(agentName, repo, ticket, result, w)
     } catch (e) {
       this.store.logEvent('resolve_failed', { repo, ticket, agent: agentName, status: result.status, error: e.message })
-      this.notify(ticket, `⚠️ ${repo}#${ticket}: the result was recorded but curia's resolve step failed — ${e.message}`)
+      this.#failureNotify(ticket, 'resolve', `⚠️ ${repo}#${ticket}: the result was recorded but curia's resolve step failed — ${failureProse(e.message)}`)
       return `result recorded — but curia's resolve step failed: ${e.message}`
     }
   }
@@ -3629,7 +3655,10 @@ export class Dispatcher {
       await this.deps.sendText(session, text)
     } catch (e) {
       this.store.logEvent('note_interrupt_failed', { agent: session, ticket, reason: e.message })
-      this.notify(ticket, `⚠️ curia could not put those words to \`${session}\` — ${e.message}. The words are NOT with the agent: say them again.`)
+      // Prose, but NOT deduped: this line answers words the operator just
+      // typed, and an answer to an act is owed once per act. Silence here would
+      // read as delivery (#256).
+      this.notify(ticket, `⚠️ curia could not put those words to \`${session}\` — ${failureProse(e.message)}. The words are NOT with the agent: say them again.`)
       return
     }
     this.store.logEvent('note_interrupt_delivered', { agent: session, ticket })

--- a/daemon/src/messaging.mjs
+++ b/daemon/src/messaging.mjs
@@ -119,6 +119,101 @@ export function elapsedLabel(sinceIso, now = Date.now()) {
   return `${Math.floor(min / 60)} h ${String(min % 60).padStart(2, '0')} min`
 }
 
+// ---- failure lines (#256) ----------------------------------------------------
+//
+// A daemon-side failure says one sentence in the thread, once.
+//
+// #81 is the exhibit the #245 cold read caught: `open_pull_request` failed three
+// times, and every retry pasted the same two lines of git stderr — a
+// `git -C /home/alp/…` command echo and a `fatal:` line — into the thread. Two
+// faults ride one line. The daemon speaks its own internals in a surface built
+// for prose, and it speaks them once per retry.
+//
+// Nothing is lost by not saying the raw error here. Every failure path journals
+// it (`land_failed`, `resolve_failed`, `verdict_delivery_failed`, and the claim
+// release reason), and the tool return hands it back verbatim to the agent that
+// has to act on it. The thread is the operator's surface, so it gets the
+// operator's sentence.
+
+// The stderr shapes the daemon's own git, gh and tmux calls produce. Each maps
+// to one sentence, so one cause reads the same way wherever it is raised.
+const FAILURE_CAUSES = [
+  [/authentication failed|could not read username|bad credentials|invalid username or password|permission to .* denied|http 40[13]|gh auth login/i,
+    'GitHub refused the daemon login'],
+  [/rate limit/i, 'GitHub rate-limited the daemon'],
+  [/cannot change to|no such file or directory|not a git repository/i,
+    'the checkout on the box is gone'],
+  [/non-fast-forward|updates were rejected|fetch first|\[rejected\]/i,
+    'the branch on GitHub has moved on, so the push was refused'],
+  [/could not resolve host|connection timed out|network is unreachable|etimedout|econnreset|econnrefused|eai_again|enotfound/i,
+    'the box could not reach GitHub'],
+  [/no server running|session not found|can't find pane|no current session/i,
+    'the tmux session for this agent is gone'],
+]
+
+// The sentence is bounded because it is a thread line, not the record. This is
+// not the #119 rule breaking: decision-bearing text still never truncates, and
+// the raw error is decision-bearing text — which is why it goes to the journal
+// and to the agent whole, and why only its restatement is cut here.
+export const FAILURE_PROSE_LIMIT = 140
+
+export function failureProse(raw) {
+  const lines = String(raw ?? '').split('\n').map((l) => l.trim()).filter(Boolean)
+  // Node names the whole command in `Command failed: …`. That line is the
+  // daemon's own path and flags, and an operator can act on none of it.
+  const body = lines.filter((l) => !/^(Command failed:|\+ )/.test(l) && !/^(git|gh|docker|tmux|node) /.test(l))
+  // git says the reason on a `fatal:` line and the context on `remote:` or
+  // `error:` above it, so the strongest prefix wins rather than the first line.
+  const pick = (re) => body.find((l) => re.test(l))
+  const reason = pick(/^fatal:/i) ?? pick(/^error:/i) ?? pick(/^remote:/i) ?? body[0] ?? lines[0] ?? ''
+  for (const [re, sentence] of FAILURE_CAUSES) if (re.test(reason)) return sentence
+  // Unrecognized: say what the daemon was told, in one sentence. git quotes a
+  // path it could not use, and that path is always a daemon path.
+  const plain = reason
+    .replace(/^(fatal|error|remote|warning):\s*/i, '')
+    .replace(/'\/[^']*'/g, 'a path on the box')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[.\s]+$/, '')
+  if (!plain) return 'the daemon reported no reason'
+  const first = plain.includes('. ') ? plain.slice(0, plain.indexOf('. ')) : plain
+  if (first.length <= FAILURE_PROSE_LIMIT) return first
+  const cut = first.slice(0, FAILURE_PROSE_LIMIT)
+  return `${(cut.includes(' ') ? cut.slice(0, cut.lastIndexOf(' ')) : cut).trimEnd()}…`
+}
+
+// How long one failure stays said. A retry loop inside this window is one line.
+export const FAILURE_REPEAT_WINDOW_MS = 10 * 60_000
+
+// The repeat filter. `say` returns the line to post, or null when the thread has
+// already heard it.
+//
+// Silence is bounded on both sides. A loop that outlasts the window says the
+// line again with a count, so a stuck agent never reads as an idle one. A
+// failure that returns after the window is a fresh burst, not a repeat, and it
+// says the full line again.
+export class FailureLines {
+  constructor({ window = FAILURE_REPEAT_WINDOW_MS } = {}) {
+    this.window = window
+    this.seen = new Map()
+  }
+
+  say(key, text, now = Date.now()) {
+    for (const [k, v] of this.seen) if (now - v.last > this.window * 2) this.seen.delete(k)
+    const s = this.seen.get(key)
+    if (!s || now - s.last > this.window) {
+      this.seen.set(key, { first: now, last: now, posted: now, count: 1 })
+      return text
+    }
+    s.count += 1
+    s.last = now
+    if (now - s.posted < this.window) return null
+    s.posted = now
+    const span = elapsedLabel(new Date(s.first).toISOString(), now)
+    return `${text} (the same failure, ${s.count} times${span ? ` in ${span}` : ''})`
+  }
+}
+
 // Variation selectors differ between source literals and runtime strings, so
 // membership compares with them stripped.
 const bare = (s) => s.replace(/️/g, '')

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -2483,6 +2483,51 @@ describe('open_pull_request (#54 item 1)', () => {
     assert.match(reply, /commits are safe in the worktree/)
     assert.ok(typesOf().includes('land_failed'))
   })
+
+  // #256, the #81 case: the agent retried three times, and each retry pasted the
+  // same two lines of git stderr into the thread. The thread hears the failure
+  // once, in prose. The raw error is not lost — it is journalled every time, and
+  // the reply hands it whole to the agent that has to act on it.
+  test('a retried failure posts one prose line, and the raw error stays in the journal (#256)', async () => {
+    const raw = "Command failed: git -C /home/alp/work/wt/42 push https://github.com/o/r.git abc:refs/heads/curia/42\n"
+      + "fatal: cannot change to '/home/alp/work/wt/42': No such file or directory"
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'a', subject: 's' }],
+      pushBranch: async () => { throw new Error(raw) },
+    })
+    liveAgent(d)
+
+    const replies = []
+    for (let i = 0; i < 3; i++) replies.push(await d.openPullRequest('curia-42', { summary: 's' }))
+
+    const failures = notifies.filter((n) => /opening the pull request FAILED/.test(n.message))
+    assert.equal(failures.length, 1, 'the thread heard the same failure more than once')
+    assert.match(failures[0].message, /opening the pull request FAILED — the checkout on the box is gone$/)
+    assert.ok(!/fatal:|\/home\/alp/.test(failures[0].message), 'stderr reached the thread')
+
+    const journalled = events.filter((e) => e.type === 'land_failed')
+    assert.equal(journalled.length, 3, 'every occurrence is in the record')
+    for (const e of journalled) assert.equal(e.error, raw)
+    for (const r of replies) assert.match(r, /fatal: cannot change to/, 'the agent needs the raw error to fix it')
+  })
+
+  test('a second, different failure on the same act still speaks (#256)', async () => {
+    let boom = 'fatal: Authentication failed'
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'a', subject: 's' }],
+      pushBranch: async () => { throw new Error(boom) },
+    })
+    liveAgent(d)
+
+    await d.openPullRequest('curia-42', { summary: 's' })
+    boom = 'fatal: Could not resolve host: github.com'
+    await d.openPullRequest('curia-42', { summary: 's' })
+
+    const said = notifies.filter((n) => /opening the pull request FAILED/.test(n.message)).map((n) => n.message)
+    assert.equal(said.length, 2)
+    assert.match(said[0], /GitHub refused the daemon login/)
+    assert.match(said[1], /the box could not reach GitHub/)
+  })
 })
 
 describe('request_review: the one gate (#54 item 2)', () => {

--- a/daemon/test/messaging.test.mjs
+++ b/daemon/test/messaging.test.mjs
@@ -4,7 +4,11 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { SIGNALS, smallPrint, link, clampList, lintReply, chunkMessage, promptTitle, elapsedLabel, speakerName, CHUNK_LIMIT, SPEAKER_NAME_LIMIT } from '../src/messaging.mjs'
+import {
+  SIGNALS, smallPrint, link, clampList, lintReply, chunkMessage, promptTitle, elapsedLabel,
+  speakerName, failureProse, FailureLines, CHUNK_LIMIT, SPEAKER_NAME_LIMIT,
+  FAILURE_PROSE_LIMIT, FAILURE_REPEAT_WINDOW_MS,
+} from '../src/messaging.mjs'
 
 describe('smallPrint', () => {
   test('prefixes every line with the -# marker', () => {
@@ -142,5 +146,103 @@ describe('elapsedLabel', () => {
 
   test('garbage input yields null, not NaN text', () => {
     assert.equal(elapsedLabel('not a date'), null)
+  })
+})
+
+// The #81 stderr, as Node hands it over: the command echo curia built, then
+// what git said about it. The whole of it went into the thread three times.
+const PUSH_STDERR = [
+  "Command failed: git -C /home/alp/curia/work/repos/alp82__curia/wt/81 -c credential.helper=!gh auth git-credential push https://github.com/alp82/curia.git abc1234:refs/heads/curia/81",
+  "fatal: cannot change to '/home/alp/curia/work/repos/alp82__curia/wt/81': No such file or directory",
+].join('\n')
+
+describe('failureProse (#256)', () => {
+  test('the #81 stderr becomes one sentence, and the daemon path is not in it', () => {
+    const prose = failureProse(PUSH_STDERR)
+    assert.equal(prose, 'the checkout on the box is gone')
+    assert.ok(!/\/home\/alp/.test(prose), 'a daemon path reached the thread')
+    assert.ok(!prose.includes('\n'), 'more than one line reached the thread')
+  })
+
+  test('one cause reads one way, whichever wording git chose', () => {
+    assert.equal(failureProse('fatal: Authentication failed for \'https://github.com/o/r.git\''), 'GitHub refused the daemon login')
+    assert.equal(failureProse('remote: Invalid username or password.'), 'GitHub refused the daemon login')
+    assert.equal(failureProse('fatal: Updates were rejected because the remote contains work'), 'the branch on GitHub has moved on, so the push was refused')
+    assert.equal(failureProse('fatal: unable to access: Could not resolve host: github.com'), 'the box could not reach GitHub')
+    assert.equal(failureProse("can't find pane: curia-42"), 'the tmux session for this agent is gone')
+  })
+
+  test('the fatal line wins over the context lines above it', () => {
+    const raw = 'remote: Support for password authentication was removed.\nfatal: Authentication failed'
+    assert.equal(failureProse(raw), 'GitHub refused the daemon login')
+  })
+
+  test('an unrecognized failure still says what happened, in one bounded sentence', () => {
+    const prose = failureProse('Command failed: gh pr create\nerror: something nobody has seen before')
+    assert.equal(prose, 'something nobody has seen before')
+    const long = failureProse(`error: ${'a reason '.repeat(40)}`)
+    assert.ok(long.length <= FAILURE_PROSE_LIMIT + 1, `${long.length} chars reached the thread`)
+    assert.ok(long.endsWith('…'))
+  })
+
+  test('a quoted daemon path in an unrecognized failure is named, not pasted', () => {
+    assert.equal(
+      failureProse("error: unable to write '/home/alp/curia/work/cfg/curia-42/settings.json'"),
+      'unable to write a path on the box',
+    )
+  })
+
+  test('nothing to translate says so rather than composing an empty line', () => {
+    assert.equal(failureProse(''), 'the daemon reported no reason')
+    assert.equal(failureProse(undefined), 'the daemon reported no reason')
+  })
+
+  test('the composed sentence passes the reply lint', () => {
+    for (const raw of [PUSH_STDERR, 'fatal: Authentication failed', 'error: unheard of']) {
+      assert.deepEqual(lintReply(failureProse(raw)), [])
+    }
+  })
+})
+
+describe('FailureLines (#256)', () => {
+  const WINDOW = FAILURE_REPEAT_WINDOW_MS
+
+  test('a retry loop inside the window says the failure once', () => {
+    const f = new FailureLines()
+    const t = Date.now()
+    assert.equal(f.say('k', 'it failed', t), 'it failed')
+    assert.equal(f.say('k', 'it failed', t + 30_000), null)
+    assert.equal(f.say('k', 'it failed', t + 90_000), null)
+  })
+
+  test('a loop that outlasts the window says it again, with the count', () => {
+    const f = new FailureLines()
+    const t = Date.now()
+    f.say('k', 'it failed', t)
+    f.say('k', 'it failed', t + 4 * 60_000)
+    const again = f.say('k', 'it failed', t + WINDOW + 60_000)
+    assert.match(again, /^it failed \(the same failure, 3 times in 11 min\)$/)
+  })
+
+  test('a failure that returns after the window is a fresh burst, said in full', () => {
+    const f = new FailureLines()
+    const t = Date.now()
+    f.say('k', 'it failed', t)
+    assert.equal(f.say('k', 'it failed', t + WINDOW + 1000), 'it failed')
+  })
+
+  test('two different failures both speak', () => {
+    const f = new FailureLines()
+    const t = Date.now()
+    assert.equal(f.say('k', 'the login was refused', t), 'the login was refused')
+    assert.equal(f.say('k2', 'the checkout is gone', t + 1000), 'the checkout is gone')
+  })
+
+  test('a key nobody has raised in a long time is forgotten, not held forever', () => {
+    const f = new FailureLines()
+    const t = Date.now()
+    f.say('old', 'it failed', t)
+    f.say('new', 'it failed', t + WINDOW * 3)
+    assert.deepEqual([...f.seen.keys()], ['new'])
   })
 })


### PR DESCRIPTION
Ticket: alp82/curia#256 — [A failure line posts once and speaks prose, not stderr](https://github.com/alp82/curia/issues/256)

A daemon-side failure now says one sentence of prose in the thread, once.

`failureProse` (messaging.mjs) turns a raw error into one sentence. A small table maps the stderr shapes the daemon's own git, gh and tmux calls produce, so one cause reads one way wherever it is raised. An unrecognized failure still says what happened: the command echo is dropped, a quoted daemon path is named, and the sentence is bounded.

`FailureLines` is the repeat filter. The first occurrence posts in full. A retry loop inside the ten-minute window posts nothing. A loop that outlasts the window posts the line again with a count. A failure that returns after the window is a fresh burst, said in full.

The raw error is not lost. Every failure path already journals it, and the tool return hands it back whole to the agent that has to act on it.

Two lines keep the prose and skip the dedupe, for stated reasons. The note-interrupt failure answers words the operator just typed. The no-respawn line ends one agent life. A refusal is already curia's own prose, so it is not translated.

Tests: 14 new (7 for the translator, 5 for the filter, 2 end to end on the #81 retry case). The daemon suite is green: 1337 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-256`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `e187aea` A failure line posts once and speaks prose, not stderr (wayfinder #256)