### PR TITLE
One live thread per ticket, and the final name matches the ending (alp82/curia#257)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -244,7 +244,10 @@ The half-hour re-post of an open escalation into its thread.
 The Discord module. It renders and captures. It never interprets.
 
 **Thread-per-ticket**:
-One Discord thread per ticket. It carries the ticket's escalations, notifies, and answers. The binding outlives the agent: it releases only when the ticket itself closes, so a resumed agent lands back in the same thread. The name carries the state at a glance: 🎫 bound, ✅ finished, ⚰️ cancelled.
+One Discord thread per ticket. It carries the ticket's escalations, notifies, and answers. The binding outlives the agent: it releases only when the ticket itself closes, so a resumed agent lands back in the same thread. Every path that resolves a thread goes back to the ticket's last thread first, and one ticket resolves one thread at a time, so a re-dispatch adds no second thread (#257). The name carries the state at a glance: 🎫 bound, ✅ finished, ⚰️ cancelled.
+
+**Settling a thread name**:
+Putting the terminal glyph on a thread whose ticket has ended (#257). A rename rides a budget of 2 per thread per 10 minutes, so a ✅ can wait, and the gate that holds it dies with the daemon. Two passes catch what is dropped. A release settles the ticket's last thread even when the binding is already gone. Every bridge start settles each active thread curia once labeled that is bound to nothing and still wears a live glyph.
 
 **Voice ownership**:
 The rule that divides the thread's speakers. CuriaBot states mechanics, the agent voice states meaning, and no fact is said twice in one thread. See [ADR-0013](docs/adr/0013-one-voice-per-fact.md).

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -399,6 +399,7 @@ export class DiscordBridge {
     this.log = log
     this.onHealth = onHealth
     this.threadByName = new Map() // ephemeral cache for UNBOUND threads ('all'), rebuilt on demand
+    this.threadWork = new Map() // ticket -> the in-flight thread resolution for it (#257)
     // Bridge health (#56). Ephemeral like every other cache here: the journal
     // holds the transitions, this holds only what is true right now.
     this.health = { state: 'down', since: Date.now(), last_error: null }
@@ -595,14 +596,39 @@ export class DiscordBridge {
     await this.renamer.set(t.id, name, { reserve: glyph !== '🎫' })
   }
 
+  // One thread per ticket needs ONE thread-resolving path per ticket at a time
+  // (#257). Every path here reads the binding, then awaits a Discord round
+  // trip, then creates — so two callers that both read "unbound" both created,
+  // and each one's bind refused the other's. That is the three "🎫 173" threads
+  // born within 600 ms on 2026-08-05: a notify and two escalations racing the
+  // same lazy open. This chain makes read-then-create atomic per ticket, and a
+  // busy ticket never holds up a different one.
+  //
+  // The chain never rejects, and it deletes itself once it is the tail, so a
+  // long-lived bridge does not accumulate one entry per ticket it ever saw.
+  #perTicket(ticket, fn) {
+    const key = String(ticket)
+    const prev = this.threadWork.get(key) ?? Promise.resolve()
+    const run = prev.then(fn, fn)
+    const tail = run.then(() => {}, () => {}).then(() => {
+      if (this.threadWork.get(key) === tail) this.threadWork.delete(key)
+    })
+    this.threadWork.set(key, tail)
+    return run
+  }
+
   // The thread a ticket's traffic lands in (#93): the journalled binding first.
   // An unbound ticket gets a fresh thread, bound on creation — that is the
   // "autonomous dispatch opens and binds a fresh thread" leg of #89, reached
   // lazily by whichever notify or escalation speaks first. Pseudo-tickets with
   // no binding seam ('all', tests without `bindings`) keep the old name-based
   // lookup so bulk confirms still share one thread.
-  async ensureThread(ticket) {
+  ensureThread(ticket) {
     if (!this.bindings || !/^\d+$/.test(String(ticket))) return this.#namedThread(`ticket-${ticket}`)
+    return this.#perTicket(ticket, () => this.#ensureThread(ticket))
+  }
+
+  async #ensureThread(ticket) {
     const bound = this.bindings.get(ticket)
     if (bound) {
       const t = await this.client.channels.fetch(bound).catch(() => null)
@@ -614,6 +640,16 @@ export class DiscordBridge {
       // deleted thread can carry no traffic — release and fall through.
       this.bindings.release(ticket, 'thread-gone')
     }
+    // The dispatch backstop (#140), now on the lazy path too (#257). The two
+    // paths disagreed: a dispatch went back to the ticket's last thread, a
+    // notify or escalation opened a second one. So every ticket worked twice
+    // ended with a thread per run — #147 collected four that way.
+    //
+    // The name is left as it is. This path knows no ticket type, so relabeling
+    // would drop the type field, and a late line after an ending must never put
+    // a live glyph back on a finished thread.
+    const revived = await this.#reviveLastThread(ticket, '', '', { relabel: false })
+    if (revived) return revived
     const thread = await this.channel.threads.create({
       name: DiscordBridge.labelName(ticket, '', this.#repoOf(ticket)), autoArchiveDuration: 10080,
     })
@@ -621,7 +657,13 @@ export class DiscordBridge {
     if (!r.ok && r.threadId) {
       // lost a race: another path bound this ticket between the read and here
       const winner = await this.client.channels.fetch(r.threadId).catch(() => null)
-      if (winner) return winner
+      // The thread just opened carries nothing and would stand in the list as a
+      // twin of the winner. Delete it (#257) — leaving it is how the duplicates
+      // in the history got there.
+      if (winner) {
+        await thread.delete().catch(() => {})
+        return winner
+      }
     }
     return thread
   }
@@ -674,8 +716,14 @@ export class DiscordBridge {
   // breadcrumbs link both ways — the origin learns where the work went, the
   // new thread names who sent it. Composition from ids the daemon holds at
   // bind time; no new state.
-  async bindTicket(ticket, { threadId = null, type = '', repo = '' } = {}) {
-    if (!this.bindings) return { ok: false, reason: 'no-bindings' }
+  bindTicket(ticket, opts = {}) {
+    if (!this.bindings) return Promise.resolve({ ok: false, reason: 'no-bindings' })
+    // the same one-at-a-time chain ensureThread runs on (#257): a dispatch and
+    // a lazy open for one ticket must not each create a thread
+    return this.#perTicket(ticket, () => this.#bindTicket(ticket, opts))
+  }
+
+  async #bindTicket(ticket, { threadId = null, type = '', repo = '' } = {}) {
     // The dispatch hands the repo over (#235); a caller without one falls back
     // to the journal's record, and a ticket with neither keeps the short label.
     repo = repo || this.#repoOf(ticket)
@@ -712,8 +760,12 @@ export class DiscordBridge {
   // sentence the operator typed once. A bind that refuses puts the handle back
   // — an unbound thread would send the running agent's next notify into a
   // fresh thread, which is worse than a stale name.
-  async adoptMapThread(handle, mapNumber, { repo = '' } = {}) {
-    if (!this.bindings) return { ok: false, reason: 'no-bindings' }
+  adoptMapThread(handle, mapNumber, opts = {}) {
+    if (!this.bindings) return Promise.resolve({ ok: false, reason: 'no-bindings' })
+    return this.#perTicket(mapNumber, () => this.#adoptMapThread(handle, mapNumber, opts))
+  }
+
+  async #adoptMapThread(handle, mapNumber, { repo = '' } = {}) {
     const threadId = this.bindings.get(handle)
     if (!threadId) return { ok: false, reason: 'unbound' }
     this.bindings.release(handle, 'the map this session created now names it')
@@ -741,6 +793,15 @@ export class DiscordBridge {
         name: DiscordBridge.labelName(ticket, type, repo), autoArchiveDuration: 10080,
       })
       r = this.bindings.bind(ticket, thread.id)
+      // the same lost-race cleanup ensureThread does (#257): an empty twin of
+      // the thread that won is a duplicate, so it goes
+      if (!r.ok && r.threadId) {
+        const winner = await this.client.channels.fetch(r.threadId).catch(() => null)
+        if (winner) {
+          await thread.delete().catch(() => {})
+          return { ok: true, threadId: winner.id }
+        }
+      }
     }
     if (r.ok && originThreadId) {
       const origin = await this.client.channels.fetch(originThreadId).catch(() => null)
@@ -792,7 +853,12 @@ export class DiscordBridge {
   // The journal's last thread for a ticket, when it still exists on Discord
   // and is still free to take back (#140). Rebinds it — unarchived, relabeled
   // — or returns null so the caller opens a fresh thread instead.
-  async #reviveLastThread(ticket, type, repo) {
+  //
+  // `relabel: false` takes the thread back and leaves its name alone (#257).
+  // The lazy path uses it: a notify knows no ticket type, so the label it would
+  // write is shorter than the one already there, and a line arriving after an
+  // ending must not put 🎫 back on a ✅ thread.
+  async #reviveLastThread(ticket, type, repo, { relabel = true } = {}) {
     const last = this.bindings.last?.(ticket)
     if (!last) return null
     const t = await this.client.channels.fetch(last).catch(() => null)
@@ -801,6 +867,7 @@ export class DiscordBridge {
     // the meantime — it is not this ticket's to take back
     if (!this.bindings.bind(ticket, t.id).ok) return null
     if (t.archived) await t.setArchived(false).catch(() => {})
+    if (!relabel) return t
     // the label goes back on: a ✅ from an earlier release, or a ⚰️ from a
     // cancel (#200), goes back to 🎫 because a ticket is being worked again
     const name = DiscordBridge.labelName(ticket, type, repo)
@@ -818,12 +885,65 @@ export class DiscordBridge {
     if (!this.bindings) return
     const bound = this.bindings.get(ticket)
     this.bindings.release(ticket, reason)
-    if (!bound) return
-    const t = await this.client.channels.fetch(bound).catch(() => null)
+    // An ending whose binding is already gone still owes the thread its final
+    // name (#257). Two releases land for one ending often enough — reconcile
+    // drops the binding of a ticket whose issue is closed, and the agent's own
+    // `finished` release arrives after it — and the first one takes the binding
+    // off whether or not its rename got through. A thread fetch that failed, or
+    // a rename the budget deferred and the process then lost, left the thread
+    // wearing the glyph it had. The second release used to return right here,
+    // before the rename, so nothing ever corrected it: #81 stayed 🔎 and reads
+    // as "in review" forever.
+    const target = bound ?? this.#endedThread(ticket)
+    if (!target) return
+    const t = await this.client.channels.fetch(target).catch(() => null)
     if (!t) return
     const base = this.renamer.desired(t.id) ?? t.name
     if (!LIVE_GLYPH_RE.test(base)) return
     await this.renamer.set(t.id, DiscordBridge.doneName(base))
+  }
+
+  // The thread an unbound ticket last lived on, when it is still that ticket's
+  // to speak for (#257). A thread another ticket has taken over since answers
+  // null: its name is that ticket's business now.
+  #endedThread(ticket) {
+    const last = this.bindings.last?.(ticket)
+    if (!last) return null
+    const holder = this.bindings.ticketOf?.(last)
+    return holder && String(holder) !== String(ticket) ? null : last
+  }
+
+  // The ending's name outlives the process that owed it (#257).
+  //
+  // A rename rides a budget of 2 per thread per 10 minutes (threadname.mjs),
+  // so a ✅ can be deferred for minutes, and the gate's ledger dies with the
+  // daemon. A deploy or a crash inside that window dropped the rename with it,
+  // and nothing ever came back for it: the release had already taken the
+  // binding off, so reconcile's bound-ticket sweep could not see the thread.
+  // The name then lied for good.
+  //
+  // This runs at every bridge start and settles what the last process left: an
+  // ACTIVE thread the journal once bound, bound to nothing now, still wearing a
+  // live glyph. A thread curia never labeled is never touched, and an archived
+  // one is left alone — waking a thread to correct its name is louder than the
+  // wrong name.
+  async settleEndedThreads() {
+    if (!this.bindings?.lastTicketOf || !this.channel?.threads?.fetchActive) return 0
+    const active = await this.channel.threads.fetchActive().catch((e) => {
+      this.log(`[bridge] could not read the active threads to settle names: ${e.message}`)
+      return null
+    })
+    if (!active) return 0
+    let settled = 0
+    for (const t of active.threads.values()) {
+      if (!LIVE_GLYPH_RE.test(t.name)) continue
+      if (!this.bindings.lastTicketOf(t.id)) continue
+      if (this.bindings.ticketOf?.(t.id)) continue // still bound: live, or cancelled and kept (#140)
+      await this.renamer.set(t.id, DiscordBridge.doneName(t.name))
+      settled++
+    }
+    if (settled) this.log(`[bridge] settled ${settled} thread name(s) the last process left mid-rename`)
+    return settled
   }
 
   // The cancel counterpart (#200), and the one difference is the binding: a

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1460,6 +1460,12 @@ if (process.env.DISCORD_BOT_TOKEN) {
           release: (ticket, reason) => store.releaseTicketThread(ticket, reason),
           // the dispatch backstop (#140): the last binding, released or not
           last: (ticket) => store.lastThreadForTicket(ticket),
+          // the same two, thread first (#257): who holds this thread now, and
+          // who held it last. The boot pass that settles an ending's name asks
+          // both — the second says the thread is curia's, the first says it is
+          // free to settle.
+          ticketOf: (threadId) => store.ticketForThread(threadId),
+          lastTicketOf: (threadId) => store.lastTicketForThread(threadId),
           // the label's repo field (#235), read lazily off the journal
           repoOf: (ticket) => store.repoForTicket(ticket),
         },
@@ -1475,6 +1481,8 @@ if (process.env.DISCORD_BOT_TOKEN) {
           if (!r.discord) renderEscalation(r)
         }
         announceStart(b)
+        // #257: a ✅ the last process owed but never sent. Never fails a start.
+        b.settleEndedThreads().catch((e) => log(`settling ended thread names failed: ${e.message}`))
       }).catch((e) => {
         if (!bridgeDownSince) bridgeDownSince = Date.now()
         const delay = Math.min(60_000, 5_000 * attempt)

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -97,6 +97,7 @@ export class EscalationStore {
     this.ticketThreads = new Map() // ticket -> Discord thread id (#93)
     this.threadTickets = new Map() // Discord thread id -> ticket (#93)
     this.lastTicketThreads = new Map() // ticket -> last thread ever bound, releases notwithstanding (#140)
+    this.lastThreadTickets = new Map() // thread id -> last ticket ever bound to it, the same way round (#257)
     this.ticketRepos = new Map() // ticket -> repo of its last dispatch (#235)
     this.lastAgentEvents = new Map() // agent session -> last journal event about it (#236)
     this.notes = new Map() // note id -> every note ever queued, pending or not (#252)
@@ -192,6 +193,7 @@ export class EscalationStore {
         this.ticketThreads.set(String(ev.ticket), ev.thread_id)
         this.threadTickets.set(ev.thread_id, String(ev.ticket))
         this.lastTicketThreads.set(String(ev.ticket), ev.thread_id)
+        this.lastThreadTickets.set(ev.thread_id, String(ev.ticket))
         break
       }
       case 'thread_released': {
@@ -569,6 +571,15 @@ export class EscalationStore {
   // its predecessor's history, breadcrumbs and recorded answers live in.
   lastThreadForTicket(ticket) {
     return this.lastTicketThreads.get(String(ticket))
+  }
+
+  // The same pointer the other way round (#257): the last ticket this thread
+  // ever carried, released or not. `ticketForThread` answers only for a LIVE
+  // binding, and the boot pass that settles a thread name left mid-rename asks
+  // about threads whose binding is exactly what is gone. It is also the guard
+  // that keeps that pass off a thread curia never labeled.
+  lastTicketForThread(threadId) {
+    return this.lastThreadTickets.get(threadId)
   }
 
   // The repo of a ticket's last dispatch (#235), off the journal's

--- a/daemon/test/threads.test.mjs
+++ b/daemon/test/threads.test.mjs
@@ -91,6 +91,19 @@ describe('EscalationStore ticket-thread bindings', () => {
     assert.equal(store.lastThreadForTicket('85'), 't-9')
   })
 
+  test('lastTicketForThread answers the same way round, released or not (#257)', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    store.bindTicketThread('147', 't-1')
+    assert.equal(store.lastTicketForThread('t-1'), '147')
+    store.releaseTicketThread('147', 'finished')
+    assert.equal(store.ticketForThread('t-1'), undefined, 'the live binding is gone')
+    assert.equal(store.lastTicketForThread('t-1'), '147', 'the thread is still curia\'s to settle')
+    const reborn = new EscalationStore(dir)
+    assert.equal(reborn.lastTicketForThread('t-1'), '147')
+    assert.equal(reborn.lastTicketForThread('t-never'), undefined, 'a thread curia never labeled')
+  })
+
   // #197. #140 keeps a binding through a cancel so a `resume` lands back in the
   // ticket's own history. A fresh dispatch typed in ANOTHER thread is not a
   // resume, and before this it was refused silently — the agent went on
@@ -214,13 +227,17 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     id, name, sent: [],
     send: async (text) => { sentTo.push({ id, text }) },
     setName: async () => {},
+    delete: async () => { deleted.push(id); threads.delete(id) },
   })
+
+  let threads, deleted
 
   beforeEach(() => {
     store = new EscalationStore(tmp())
     created = []
     sentTo = []
-    const threads = new Map()
+    deleted = []
+    threads = new Map()
     bridge = new DiscordBridge({
       token: 'x', allowedUsers: [], dataDir: tmp(),
       handlers: {}, log: () => {},
@@ -229,6 +246,8 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
         bind: (t, id) => store.bindTicketThread(t, id),
         release: (t, r) => store.releaseTicketThread(t, r),
         last: (t) => store.lastThreadForTicket(t),
+        ticketOf: (id) => store.ticketForThread(id),
+        lastTicketOf: (id) => store.lastTicketForThread(id),
       },
     })
     bridge.guild = { id: 'G' }
@@ -241,6 +260,7 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
           threads.set(t.id, t)
           return t
         },
+        fetchActive: async () => ({ threads: new Map(threads) }),
       },
     }
     bridge.client = { channels: { fetch: async (id) => threads.get(id) ?? null } }
@@ -520,6 +540,147 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     await bridge.releaseTicket('133', 'finished')
     assert.equal(bridge.renamer.desired('t-conv'), '✅ 133 · task',
       'the swap read the pending label, not the unlabeled shown name')
+  })
+
+  // ---- one live thread per ticket (#257) --------------------------------------
+  // Seven tickets in the history own more than one thread. Two causes: the lazy
+  // path opened a thread where the dispatch path would have gone back to the
+  // ticket's own, and two callers for one unbound ticket each opened one.
+
+  test('the lazy path goes back to the ticket\'s last thread instead of opening a second', async () => {
+    const old = makeThread('t-147', '✅ 147 · curia · task')
+    bridge.registerThread(old)
+    store.bindTicketThread('147', 't-147')
+    store.releaseTicketThread('147', 'finished')
+
+    const t = await bridge.ensureThread('147')
+    assert.equal(t.id, 't-147', 'the ticket speaks where its history is')
+    assert.equal(created.length, 0, 'no second thread')
+    assert.equal(store.threadForTicket('147'), 't-147', 'and it is bound again')
+  })
+
+  test('the lazy revive leaves the name alone — a late line adds no glyph back', async () => {
+    const old = makeThread('t-148', '✅ 148 · curia · grilling')
+    const renames = []
+    old.setName = async (n) => { renames.push(n) }
+    bridge.registerThread(old)
+    store.bindTicketThread('148', 't-148')
+    store.releaseTicketThread('148', 'finished')
+
+    await bridge.ensureThread('148')
+    assert.deepEqual(renames, [], 'the ending stands, and the type field is not dropped')
+  })
+
+  test('a dispatch after a lazy revive still relabels — reopened work reads as open', async () => {
+    const old = makeThread('t-149', '✅ 149 · task')
+    const renames = []
+    old.setName = async (n) => { renames.push(n) }
+    bridge.registerThread(old)
+    store.bindTicketThread('149', 't-149')
+    store.releaseTicketThread('149', 'finished')
+
+    await bridge.ensureThread('149')
+    const r = await bridge.bindTicket('149', { type: 'task' })
+    assert.equal(r.threadId, 't-149')
+    assert.deepEqual(renames, ['🎫 149 · task'])
+  })
+
+  test('three callers racing one unbound ticket open ONE thread (the 600 ms triple)', async () => {
+    const [a, b, c] = await Promise.all([
+      bridge.ensureThread('173'), bridge.ensureThread('173'), bridge.ensureThread('173'),
+    ])
+    assert.equal(created.length, 1, 'one create, not three')
+    assert.equal(a.id, b.id)
+    assert.equal(b.id, c.id)
+    assert.equal(store.threadForTicket('173'), a.id)
+  })
+
+  test('a dispatch and a lazy open racing one ticket share the thread too', async () => {
+    const [t, r] = await Promise.all([bridge.ensureThread('174'), bridge.bindTicket('174', { type: 'task' })])
+    assert.equal(created.length, 1)
+    assert.equal(r.ok, true)
+    assert.equal(r.threadId, t.id)
+  })
+
+  test('a create that loses the bind race deletes its twin rather than leaving it in the list', async () => {
+    const winner = makeThread('t-winner', '🎫 175')
+    bridge.registerThread(winner)
+    // a bind that lands between this path's read and its own bind — the shape a
+    // second daemon process or the REST seam can still produce
+    let first = true
+    const realBind = bridge.bindings.bind
+    bridge.bindings.bind = (ticket, id) => {
+      if (first) { first = false; store.bindTicketThread('175', 't-winner') }
+      return realBind(ticket, id)
+    }
+    const t = await bridge.ensureThread('175')
+    assert.equal(t.id, 't-winner', 'the winner carries the traffic')
+    assert.deepEqual(deleted, [created[0].id], 'the empty twin is gone')
+  })
+
+  // ---- the ending always leaves the name in its final state (#257) -------------
+
+  test('a second release settles the name the first one dropped', async () => {
+    const t = makeThread('t-81', '🔎 81 · curia · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('81', 't-81')
+    // the first release drops the binding without renaming — a thread fetch
+    // that failed, or a rename the budget deferred and the process then lost
+    const realFetch = bridge.client.channels.fetch
+    bridge.client.channels.fetch = async () => null
+    await bridge.releaseTicket('81', 'reconcile')
+    bridge.client.channels.fetch = realFetch
+    assert.deepEqual(renames, [], 'nothing landed, and the binding is gone')
+
+    await bridge.releaseTicket('81', 'finished')
+    assert.deepEqual(renames, ['✅ 81 · curia · task'], 'the ending gets its name after all')
+  })
+
+  test('a release never renames a thread another ticket has taken over', async () => {
+    const t = makeThread('t-shared', '🎫 300 · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n) }
+    bridge.registerThread(t)
+    store.bindTicketThread('299', 't-shared')
+    store.releaseTicketThread('299', 'finished')
+    store.bindTicketThread('300', 't-shared') // the thread moved on
+
+    await bridge.releaseTicket('299', 'finished')
+    assert.deepEqual(renames, [], 'the name is 300\'s business now')
+  })
+
+  test('the boot pass settles a ✅ the last process owed but never sent', async () => {
+    const stuck = makeThread('t-stuck', '🔎 81 · curia · task')
+    const live = makeThread('t-live', '⏳ 82 · task')
+    const stranger = makeThread('t-stranger', '🎫 not a curia thread')
+    const done = makeThread('t-done3', '✅ 83 · task')
+    for (const t of [stuck, live, stranger, done]) {
+      bridge.registerThread(t)
+      t.setName = async (n) => { t.renamed = n }
+    }
+    store.bindTicketThread('81', 't-stuck')
+    store.releaseTicketThread('81', 'finished') // ended, rename lost with the process
+    store.bindTicketThread('82', 't-live') // still running
+    store.bindTicketThread('83', 't-done3')
+    store.releaseTicketThread('83', 'finished')
+
+    assert.equal(await bridge.settleEndedThreads(), 1)
+    assert.equal(stuck.renamed, '✅ 81 · curia · task', 'the ending finally reads as one')
+    assert.equal(live.renamed, undefined, 'a live ticket keeps its glyph')
+    assert.equal(stranger.renamed, undefined, 'a thread curia never labeled is not curia\'s to rename')
+    assert.equal(done.renamed, undefined, 'nothing to do')
+  })
+
+  test('the boot pass leaves a cancelled thread alone — #140 keeps its binding', async () => {
+    const cancelled = makeThread('t-dead', '⚰️ 84 · task')
+    bridge.registerThread(cancelled)
+    cancelled.setName = async (n) => { cancelled.renamed = n }
+    store.bindTicketThread('84', 't-dead')
+
+    assert.equal(await bridge.settleEndedThreads(), 0)
+    assert.equal(cancelled.renamed, undefined)
   })
 })
 


### PR DESCRIPTION
Ticket: alp82/curia#257 — [One live thread per ticket, and the final name matches the ending](https://github.com/alp82/curia/issues/257)

Resolves wayfinder #257. Four causes of the duplicate threads and the lying names, all in the bridge.

**The lazy path never went back.** A dispatch returns to the ticket's last thread (#140). A notify or an escalation opened a fresh one. So every ticket worked twice ended with a thread per run, and #147 collected four. `ensureThread` runs the same backstop now. It leaves the name alone: that path knows no ticket type, so relabeling would drop the type field, and a late line after an ending must not put a live glyph back on a finished thread. A dispatch that follows still relabels.

**Two callers raced one ticket.** Every path reads the binding, awaits a Discord round trip, then creates. Two callers that both read "unbound" both created. That is the three "🎫 173" threads born within 600 ms on 2026-08-05. One chain per ticket makes read-then-create atomic, and a busy ticket never holds up a different one. A create that still loses the bind race deletes its twin instead of leaving it in the thread list.

**A release dropped the binding whether or not its rename got through.** A thread fetch that failed, or a rename the budget deferred and the process then lost, left the thread wearing its live glyph. The second release for that ending returned before the rename, so nothing corrected it. It settles the ticket's last thread now, and never one that another ticket has taken over.

**A deferred ending died with the process.** The rename gate holds a budget of 2 per thread per 10 minutes, and its ledger does not survive a restart. A deploy inside that window dropped the ✅ with it. Nothing came back for it: the release had already taken the binding off, so reconcile's bound-ticket sweep could not see the thread. Every bridge start now settles what the last process left: an active thread curia once labeled, bound to nothing, still wearing a live glyph. A live ticket, a cancelled one (#140 keeps its binding), an archived thread, and a thread curia never labeled are all left alone.

The store grows the reverse pointer this needs: the last ticket a thread ever carried, released or not.

Tests: 11 new cases in `daemon/test/threads.test.mjs`. Full suite 1377 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-257`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `c7f9a46` One live thread per ticket, and the final name matches the ending (wayfinder #257)