### PR TITLE
A pending cross-check parks the builder's ending (alp82/curia#258)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -229,7 +229,10 @@ The reviewer's findings on one diff. It reaches the builder on its note queue, a
 The builder's reading of a verdict. It agrees or disagrees with each finding and recommends what to do. It reaches the operator as a plain question, and it lands as the second pull-request comment.
 
 **Parked**:
-A builder idle inside its own gate call while a cross-check reads. It holds its claim, its worktree and its slot, and it wakes when the verdict lands.
+A builder idle inside its own `request_review` or `report_result` call while a cross-check reads. It holds its claim, its worktree and its slot, and it wakes when the verdict lands.
+
+**Start notice**:
+The message curia queues at the builder the moment a reviewer spawns. It names the reviewer and holds the ending: no resolve, no merge and no `report_result` until the verdict lands. A cross-check pressed at the gate sends none, because the builder is already parked.
 
 **First-valid-wins**:
 The answer rule. The first valid answer closes the escalation atomically. Any device may answer. Later answers get a refusal.

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -49,7 +49,7 @@ import {
 } from './resolve.mjs'
 import { smallPrint } from './messaging.mjs'
 import { outstanding, stopReason, reviewGateText, classifyReviewAnswer, REVIEW_KIND, dutyLines } from './lifecycle.mjs'
-import { CONFIRM_KIND, VERDICT_LABEL, normalizeEvent } from './store.mjs'
+import { CONFIRM_KIND, CROSS_CHECK_LABEL, VERDICT_LABEL, normalizeEvent } from './store.mjs'
 import {
   probeTtyd, assertServe, serveOff, CHAT_HANDLE_RE, isChatHandle, nextChatHandle,
 } from './attach.mjs'
@@ -1208,7 +1208,12 @@ export class Dispatcher {
   // still alive: a cross-check adds a second agent, it does not replace the
   // first. Both count against `max_concurrent`, which is the cost ADR-0010
   // names.
-  async crossCheck(n, { repo, model, by } = {}) {
+  // `tellBuilder` is #258: a cross-check the operator starts from the command
+  // seam lands on a builder that is WORKING, and nothing in its context says a
+  // second model is reading. The notice is what says it. The gate press passes
+  // `false`, because the builder there is about to park inside the very call
+  // that would carry the notice — one fact, one voice (ADR-0013).
+  async crossCheck(n, { repo, model, by, tellBuilder = true } = {}) {
     const ticket = String(n)
     const session = reviewSessionFor(ticket)
     const builderSession = `curia-${ticket}`
@@ -1273,7 +1278,7 @@ export class Dispatcher {
       }
       return await this.#spawnReviewer({
         session, ticket, repo: theRepo, issue, model: useModel, builderModel,
-        harnessName, sameProvider, by,
+        harnessName, sameProvider, by, tellBuilder,
       })
     } finally {
       this.inFlight.delete(session)
@@ -1300,7 +1305,7 @@ export class Dispatcher {
   // inside one try — a failure here removes the checkout and the config dir it
   // made and leaves the builder untouched, because the cross-check owns nothing
   // the ticket depends on.
-  async #spawnReviewer({ session, ticket, repo, issue, model, builderModel, harnessName, sameProvider, by }) {
+  async #spawnReviewer({ session, ticket, repo, issue, model, builderModel, harnessName, sameProvider, by, tellBuilder = true }) {
     const cfgDir = cfgDirFor(this.root, session)
     let checkout = null
     try {
@@ -1357,6 +1362,7 @@ export class Dispatcher {
       }
       this.agents.set(session, agent)
       this.#watchdog(agent).catch((e) => this.log(`watchdog ${session} failed:`, e.message))
+      if (tellBuilder) this.#tellBuilderOfCrossCheck(ticket, session)
       const named = spawnModelId(this.routing, model)
       const note = sameProvider ? ` — **${SAME_PROVIDER_STAMP}**, so this is the weaker check` : ''
       return `🔎 cross-checking ${repo}#${ticket} → \`${session}\` on **${named}**${note} — it reads \`${checkout.sha.slice(0, 12)}\` and writes nothing`
@@ -1368,6 +1374,42 @@ export class Dispatcher {
       this.store.logEvent('reviewer_spawn_failed', { repo, ticket, agent: session, error: e.message })
       return `⚠️ the cross-check of ${repo}#${ticket} could not start: ${e.message} — the builder is untouched`
     }
+  }
+
+  // The notice the builder gets the moment a reviewer starts on its diff (#258).
+  //
+  // #223 died of a builder that never knew: the operator started the cross-check
+  // from the command seam, the builder was working, and it merged, resolved and
+  // reported while the reviewer was still reading. The park closes the race for
+  // every call curia holds the wire on; this closes the half curia does not hold.
+  // `gh pr merge` and `gh issue close` run in the agent's own shell, and the only
+  // way into a running agent is its next tool result.
+  //
+  // Queued, never injected. #252 gives the interrupt to the OPERATOR, behind a
+  // button, because Escape aborts whatever the agent is doing — and the thing it
+  // would abort here is often the merge this notice exists to stop half-way
+  // through. A queued note is what the ticket asks for: the verdict arrives as a
+  // message, and so does its warning.
+  #tellBuilderOfCrossCheck(ticket, reviewer) {
+    const builder = `curia-${ticket}`
+    const w = this.agents.get(builder)
+    // No builder, no reader. The verdict's own carrier (#252) is the net for
+    // that case, and it states the whole verdict rather than a warning about one.
+    if (!w) {
+      this.store.logEvent('cross_check_unannounced', { ticket, agent: builder, reason: 'no builder is running' })
+      return false
+    }
+    this.store.queueAgentNote?.(builder, [
+      `\`${reviewer}\` is reading your diff on #${ticket} right now. The operator started a cross-check.`,
+      'Its verdict comes to you as a message on a later tool result, and judging it is your duty.',
+      '',
+      'Until it lands: do not resolve the ticket, do not merge the pull request, and do not call',
+      '`report_result`. `report_result` and `request_review` park until the verdict arrives, so neither',
+      'call is a way past this. The resolve and the merge are `gh` commands in your own shell, and you',
+      'are the only one who can hold those.',
+    ].join('\n'), { instance: w.instance ?? null, label: CROSS_CHECK_LABEL })
+    this.store.logEvent('cross_check_announced', { ticket, agent: builder, reviewer })
+    return true
   }
 
   // Is this agent the cross-check reviewer? The NAME is the authority, not the
@@ -2279,7 +2321,10 @@ export class Dispatcher {
     // the builder untouched. What decides here is the RECORD, not that line: a
     // reviewer in the agents map is the thing that can produce a verdict, and
     // parking on anything less would park on a sentence.
-    const spawned = await this.crossCheck(ticket, { repo, by: 'review gate' })
+    // #258: no start notice on this path. The builder is inside the call that
+    // would carry it, and the park text below says the same thing at the moment
+    // the call returns — a queued notice would only ride out beside the verdict.
+    const spawned = await this.crossCheck(ticket, { repo, by: 'review gate', tellBuilder: false })
     if (!this.agents.has(reviewSessionFor(ticket))) {
       if (w) w.state = 'ready'
       this.store.logEvent('cross_check_returned', { repo, ticket, agent: agentName, ok: false, why: 'not spawned' })
@@ -2342,14 +2387,17 @@ export class Dispatcher {
     }
   }
 
-  // Park the builder until this ticket's verdict lands. One waiter per ticket:
-  // a second press cannot exist while the first is parked, because the builder
-  // that would press is the one inside this call.
-  #awaitVerdict(ticket, agentName) {
+  // Park the builder until this ticket's verdict lands. ONE waiter per ticket,
+  // and the newest call owns it: `#endReviewWait` settles exactly one waiter, so
+  // a second one left in the map would be a builder parked forever on a reviewer
+  // that is already gone. #258 gives `report_result` the same park, which is
+  // what makes a replacement possible at all — a gate park the client aborted
+  // leaves a promise nobody reads, and the ending call takes the wait from it.
+  #awaitVerdict(ticket, agentName, on = 'gate') {
     const key = String(ticket)
-    this.#endReviewWait(key, 'a newer cross-check replaced it')
+    this.#endReviewWait(key, 'the builder is now waiting on a newer call')
     return new Promise((resolve) => {
-      this.reviewWaits.set(key, { agent: agentName, resolve })
+      this.reviewWaits.set(key, { agent: agentName, on, resolve })
     })
   }
 
@@ -2414,6 +2462,51 @@ export class Dispatcher {
     return spawned >= 0 && resolved > spawned
   }
 
+  // The PARK a builder's `report_result` earns while its cross-check is still
+  // reading (#258). It runs at the wire, ahead of everything `resultRefusal`
+  // guards, and it is the same control `request_review` has had since #165.
+  //
+  // #237 made this a refusal, and a refusal is a sentence the model reads and
+  // then decides about. The park is not: the call stays open, the builder holds
+  // its claim, its worktree and its context for nearly nothing (ADR-0005), and
+  // the verdict lands ON this call. So the agent that tried to end the ticket is
+  // the one that judges the verdict, which is what ADR-0010 asks for and what
+  // #223 never got.
+  //
+  // Returns the text to hand back, or null to let the ending run on. Null is the
+  // honest answer when the cross-check produced NO verdict: the reviewer died,
+  // there is nothing to judge, and holding the builder any longer would punish
+  // it for the operator's press.
+  async endingHold(agentName) {
+    if (this.#isReviewer(agentName)) return null
+    const ticket = String(this.agents.get(agentName)?.ticket ?? String(agentName).match(SESSION_RE)?.[1] ?? '')
+    if (!ticket) return null
+    if (this.#epochCharting(ticket, agentName).charting) return null
+    if (!this.#crossCheckInFlight(ticket)) return null
+
+    const w = this.agents.get(agentName)
+    const wasState = w?.state ?? null
+    if (w) w.state = 'cross-checking'
+    this.store.logEvent('result_parked', { repo: w?.repo, ticket, agent: agentName, reason: 'cross-check in flight' })
+    this.notify(ticket, `⏸️ \`${agentName}\` tried to end #${ticket} while \`${reviewSessionFor(ticket)}\` is still reading its diff — parked until the verdict lands, and nothing was recorded`)
+    const out = await this.#awaitVerdict(ticket, agentName, 'ending')
+    if (w) w.state = wasState ?? 'ready'
+    this.store.logEvent('cross_check_returned', {
+      repo: w?.repo, ticket, agent: agentName, ok: out.ok, why: out.why ?? null, on: 'report_result',
+    })
+    if (!out.ok) return null
+    // The verdict is not in this text. It is on the note queue, and the drain
+    // appends it to this very tool result — the same shape the gate's park
+    // returns, for the same reason: duty and findings in one turn.
+    return [
+      `HELD — \`${out.verdict.agent}\` read your diff on **${spawnModelId(this.routing, out.verdict.model ?? '')}**`,
+      'while this call waited, so nothing was recorded and nothing was resolved. Its verdict rides in',
+      'this same tool result as a note. Read it, then:',
+      '',
+      ...dutyLines(),
+    ].join('\n')
+  }
+
   // The refusal a builder's `report_result` earns while its cross-check is
   // unfinished (#237). The operator ruled the shape: after a verdict is
   // captured, the builder's next act toward the operator is its judgement, and
@@ -2421,6 +2514,11 @@ export class Dispatcher {
   // the wire, BEFORE the result is journalled or written to disk — a results
   // file on disk reads as `hasResult` everywhere, and a refused result must
   // not leave that trace.
+  //
+  // #258 puts `endingHold` in front of it, so on the wire the in-flight case
+  // parks rather than refuses. This stays the BELT: every caller that reaches
+  // `onResult` directly passes here, and a refusal is the only answer a
+  // synchronous belt can give.
   resultRefusal(agentName) {
     if (this.#isReviewer(agentName)) return null
     const ticket = String(this.agents.get(agentName)?.ticket ?? String(agentName).match(SESSION_RE)?.[1] ?? '')
@@ -2430,8 +2528,9 @@ export class Dispatcher {
       this.store.logEvent('result_refused', { ticket, agent: agentName, reason: 'cross-check in flight' })
       return [
         `❌ report_result refused — \`${reviewSessionFor(ticket)}\` is still reading your diff, and a ticket`,
-        'cannot end around its own cross-check. Call `request_review`: it parks you until the verdict',
-        'lands, and hands you the findings to judge. Nothing was recorded and nothing was resolved.',
+        'cannot end around its own cross-check. Call `report_result` again, or `request_review`: both park',
+        'you until the verdict lands and hand you the findings to judge. Nothing was recorded and nothing',
+        'was resolved.',
       ].join('\n')
     }
     if (this.#liveUnjudgedVerdict(ticket)) {
@@ -3629,7 +3728,11 @@ export class Dispatcher {
   announceExpiredNotes({ agent, notes, liveInstance, why }) {
     const ticket = this.agents.get(agent)?.ticket ?? String(agent).match(SESSION_RE)?.[1] ?? String(agent)
     const verdicts = notes.filter((n) => n.label === VERDICT_LABEL)
-    const plain = notes.length - verdicts.length
+    // #258: a cross-check START notice that dies gets no line of its own. It
+    // says one thing — do not end while the reviewer reads — and an agent it
+    // failed to reach has already ended. The fact the operator needs then is the
+    // VERDICT's, and the carrier below states that one in full.
+    const plain = notes.filter((n) => n.label !== VERDICT_LABEL && n.label !== CROSS_CHECK_LABEL).length
     this.log(`${notes.length} note(s) for ${agent} expired — ${why}`)
     if (plain) {
       const again = liveInstance

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -976,10 +976,21 @@ function buildMcpServer(agent, ticket) {
       details: z.record(z.string(), z.any()).optional(),
     },
     async (result, extra) => {
-      // #237: a cross-check that has not been judged shuts this tool, and the
-      // refusal runs BEFORE anything persists — the `result` journal line, the
+      // #258: a cross-check still reading PARKS this call, exactly as it parks
+      // the gate. The keepalive starts first, because the park lasts as long as
+      // a reviewer takes and the client aborts an MCP call after 300s of silence
+      // (#34). #237: a captured verdict nobody judged shuts the tool instead.
+      // Both run BEFORE anything persists — the `result` journal line, the
       // results file and the ✅ thread post all read as "the ticket ended", and
-      // a refused result must leave none of the three.
+      // a held or refused result must leave none of the three.
+      const stopHoldKeepAlive = startKeepAlive(extra, `${agent}/result`)
+      let heldText
+      try {
+        heldText = await dispatcher.endingHold(agent)
+      } finally {
+        stopHoldKeepAlive()
+      }
+      if (heldText) return { content: [{ type: 'text', text: heldText }, ...drainNotes()] }
       const refusedText = dispatcher.resultRefusal(agent)
       if (refusedText) return { content: [{ type: 'text', text: refusedText }, ...drainNotes()] }
       // The BOUND ticket is this event's ticket, not `result.ticket` (#202).

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -268,7 +268,9 @@ export function outstanding(state) {
   if (state.unjudgedVerdict) {
     items.unshift('judge the cross-check verdict finding by finding, then put one summary with a recommendation to the operator with `ask_human` — the verdict is on the pull request if you no longer hold it')
   } else if (state.crossCheckInFlight) {
-    items.unshift('a cross-check is still reading your diff — call `request_review`, which parks you until the verdict lands')
+    // #258: `report_result` parks now too, and a builder that has already
+    // merged and resolved must not be sent back to a gate it has passed.
+    items.unshift('a cross-check is still reading your diff — call `request_review`, or `report_result` if you are at the end. Both park you until the verdict lands.')
   }
   return items
 }

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -220,7 +220,13 @@ export class StatusLine {
       // #165: the builder's own line while a second agent reads its diff. The
       // reviewer draws its own line beside it, off its `agent_spawned`.
       case 'cross_check_requested':
-        return this.#set(ev.agent, ev.ticket, 'cross-checking', { at: ev.ts })
+        return this.#set(ev.agent, ev.ticket, 'cross-checking', { at: ev.ts, on: 'gate' })
+      // #258: the same idle, entered from the other end — the builder tried to
+      // report a result and parked on the verdict instead. Where it parked is
+      // where it wakes, so the line says which. `cross_check_returned` takes both
+      // back to working.
+      case 'result_parked':
+        return this.#set(ev.agent, ev.ticket, 'cross-checking', { at: ev.ts, on: 'ending' })
       case 'cross_check_returned':
         return this.#set(ev.agent, ev.ticket, 'working', {})
       case 'esc_cancel':
@@ -252,7 +258,9 @@ export class StatusLine {
         // The turn ended parked (#47) — the line keeps naming whom it waits on.
         // Live, this repeats what esc_open already drew; after a restart it is
         // the only event that redraws a parked line before the next nudge.
-        if (ev.cross_check) return this.#set(ev.agent, ev.ticket, 'cross-checking', { at: ev.ts })
+        // The redraw carries no entry point of its own, so it keeps the one the
+        // park drew (#258) rather than guessing the gate.
+        if (ev.cross_check) return this.#set(ev.agent, ev.ticket, 'cross-checking', { at: ev.ts, on: this.agents.get(ev.agent)?.detail?.on })
         const recs = (ev.escalations ?? []).map((id) => this.get(id)).filter(Boolean)
         const r = recs.find((x) => x.kind === REVIEW_KIND) ?? recs[0]
         if (!r) return
@@ -314,7 +322,7 @@ export class StatusLine {
       }
       case 'cross-checking': {
         const waited = elapsedLabel(detail.at, this.now())
-        return `⏸️ \`${session}\`${GROUP_SEP}idle at the gate — a cross-check is reading its diff${waited ? ` — ${waited}` : ''}`
+        return `⏸️ \`${session}\`${GROUP_SEP}idle at ${detail.on === 'ending' ? 'its ending' : 'the gate'} — a cross-check is reading its diff${waited ? ` — ${waited}` : ''}`
       }
       case 'executing':
         return `🚀 \`${session}\`${GROUP_SEP}executing approved writes`

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -85,6 +85,12 @@ const NOTE_EVENTS = new Set([
 // gets a line, a verdict that dies gets its whole content (#252, ADR-0013).
 export const VERDICT_LABEL = 'cross-check verdict'
 
+// The label the cross-check START notice rides under (#258). A second label
+// rather than the operator default, for the reason the verdict has its own: the
+// words are curia's own mechanics, and a builder that read them as an operator
+// note would answer them instead of obeying them (ADR-0013).
+export const CROSS_CHECK_LABEL = 'cross-check started'
+
 export class EscalationStore {
   constructor(dataDir) {
     this.dir = dataDir

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -1390,6 +1390,13 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '',
     ...dutyLines(),
     '',
+    'The operator can also start a cross-check from the thread, at any moment. Then the news reaches you',
+    'as a message on a tool result: a reviewer is reading your diff, and the verdict follows the same way.',
+    'Until it lands, do not resolve the ticket, do not merge the pull request, and do not call',
+    '`report_result`. `report_result` and `request_review` park until the verdict arrives, so neither call',
+    'is a way past this. The resolve and the merge are `gh` commands in your own shell, and you are the',
+    'only one who can hold those. Judge the verdict first, then end.',
+    '',
     'The reviewer never gets a reply and never reads the same diff twice. curia posts the verdict and your',
     'question on the pull request by itself, so you post neither.',
   ]

--- a/daemon/test/crosscheck.test.mjs
+++ b/daemon/test/crosscheck.test.mjs
@@ -417,7 +417,9 @@ describe('the verdict\'s way back (#165)', () => {
     await d.onResult('curia-review-42', { ticket: '42', status: 'resolved', summary: 'VERDICT: pass' })
 
     assert.equal(comments.filter((c) => /Cross-check verdict/.test(c.body)).length, 1)
-    assert.deepEqual(notes, [], 'nothing is queued for an agent that is not there')
+    // The start notice (#258) reached the builder while it was still there; the
+    // VERDICT is what must not queue at an agent that has since gone.
+    assert.deepEqual(notes.filter((n) => n.label === 'cross-check verdict'), [], 'nothing is queued for an agent that is not there')
     assert.ok(typesOf().includes('verdict_undelivered'))
     assert.match(notifies.map((n) => n.message).join('\n'), /resume 42/)
   })
@@ -633,6 +635,14 @@ describe('the builder\'s duty, in its standing orders (#165)', () => {
     assert.match(p, /approve-or-reject about the final code/)
     assert.match(p, /Never open a fault/)
     assert.match(p, /curia posts the verdict and your/)
+  })
+
+  test('it says the ending waits for a cross-check the operator starts from the thread (#258)', () => {
+    const p = write({ mapNumber: 1 })
+    assert.match(p, /start a cross-check from the thread/)
+    assert.match(p, /do not resolve the ticket, do not merge the pull request/)
+    assert.match(p, /park until the verdict arrives/)
+    assert.match(p, /`gh` commands in your own shell/, 'the two acts curia holds no wire on')
   })
 
   test('a charting agent is told none of it — it has no gate to press a button on', () => {
@@ -887,5 +897,149 @@ describe('a verdict that lost the race says so (#237)', () => {
 
     assert.match(notifies.map((n) => n.message).join('\n'), /curia is holding it/)
     assert.ok(!typesOf().includes('verdict_late'))
+  })
+})
+
+// ---- 6. the race the park closes (#258) --------------------------------------
+//
+// #237 made the builder lose loudly; it did not stop it from losing. A
+// cross-check started from the command seam lands on a builder that is WORKING,
+// and #223 is what that costs: merge, resolve and report all ran while the
+// reviewer read. Two halves close it — the start speaks, and the ending parks.
+
+describe('the start of a cross-check speaks to the builder (#258)', () => {
+  test('a press from the command seam queues the notice at the builder', async () => {
+    const d = makeDispatcher()
+    const w = withBuilder(d)
+
+    const reply = await d.crossCheck('42', { by: 'test' })
+
+    assert.match(reply, /cross-checking o\/r#42/)
+    const said = notes.at(-1)
+    assert.equal(said.agent, 'curia-42')
+    assert.equal(said.label, 'cross-check started')
+    assert.equal(said.instance, w.instance, 'the words are for THIS builder (#208)')
+    assert.match(said.text, /`curia-review-42` is reading your diff/)
+    assert.match(said.text, /do not resolve the ticket, do not merge the pull request/)
+    assert.match(said.text, /park until the verdict arrives/)
+    assert.match(said.text, /`gh` commands in your own shell/, 'the two acts curia holds no wire on')
+    assert.equal(events.find((e) => e.type === 'cross_check_announced').reviewer, 'curia-review-42')
+  })
+
+  test('the gate press queues nothing — the park says it on the call itself', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+
+    const { gate } = await pressAndPark(d)
+
+    assert.equal(notes.length, 0, 'a notice here would ride out beside the verdict')
+    assert.ok(!typesOf().includes('cross_check_announced'))
+    await d.onResult('curia-review-42', { ticket: '42', status: 'resolved', summary: 'VERDICT: pass' })
+    const r = await gate
+    assert.match(r.text, /rides in this same tool result as a note/)
+    assert.equal(notes.length, 1, 'the verdict is the one thing that reached it')
+  })
+
+  test('no builder to reach, so nothing queues and the journal says why', async () => {
+    const d = makeDispatcher()
+    d.store.logEvent('agent_spawned', { repo: 'o/r', ticket: '42', agent: 'curia-42', model: 'opus', kind: 'ticket' })
+
+    await d.crossCheck('42', { repo: 'o/r' })
+
+    assert.equal(notes.length, 0)
+    assert.equal(events.find((e) => e.type === 'cross_check_unannounced').reason, 'no builder is running')
+  })
+
+  test('a start notice that dies gets no operator-note line of its own', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+
+    d.announceExpiredNotes({
+      agent: 'curia-42',
+      notes: [{ label: 'cross-check started', text: 'a reviewer is reading' }],
+      liveInstance: null,
+      why: 'is gone',
+    })
+
+    assert.equal(notifies.length, 0, 'the verdict carrier is the fact worth a line, not its warning')
+  })
+})
+
+describe('a pending cross-check parks the ending (#258)', () => {
+  test('report_result parks, and the verdict lands on that call', async () => {
+    const d = makeDispatcher()
+    const w = withBuilder(d)
+    withAdoptedReviewer(d)
+
+    const held = d.endingHold('curia-42')
+    await waitFor(() => d.reviewWaits.has('42'))
+    assert.equal(w.state, 'cross-checking')
+    assert.match(notifies.map((n) => n.message).join('\n'), /parked until the verdict lands/)
+
+    await d.onResult('curia-review-42', { ticket: '42', status: 'resolved', summary: 'VERDICT: fail\n- b.mjs:2 wrong' })
+    const text = await held
+
+    assert.match(text, /^HELD/)
+    assert.match(text, /rides in\nthis same tool result as a note/)
+    assert.match(text, /Judge every finding/)
+    assert.equal(notes.at(-1).agent, 'curia-42', 'the verdict reached the builder that tried to end')
+    assert.equal(notes.at(-1).label, 'cross-check verdict')
+    assert.equal(events.find((e) => e.type === 'result_parked').reason, 'cross-check in flight')
+    assert.equal(events.findLast((e) => e.type === 'cross_check_returned').on, 'report_result')
+    assert.ok(!w.resultReceived, 'a held result must not read as hasResult')
+    assert.ok(!typesOf().includes('ticket_resolved'), 'nothing on the tracker moved')
+  })
+
+  test('a cross-check that ends with no verdict releases the ending', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+    withAdoptedReviewer(d)
+
+    const held = d.endingHold('curia-42')
+    await waitFor(() => d.reviewWaits.has('42'))
+    await d.onAgentDone('curia-review-42')
+
+    assert.equal(await held, null, 'there is nothing to judge, so the builder is not punished for the press')
+    assert.equal(events.findLast((e) => e.type === 'cross_check_returned').ok, false)
+  })
+
+  test('no cross-check, no hold — the ordinary ending is untouched', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+
+    assert.equal(await d.endingHold('curia-42'), null)
+    assert.equal(notifies.length, 0)
+  })
+
+  test('an unjudged verdict still refuses rather than parking — nothing is coming', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+    plantVerdict()
+
+    assert.equal(await d.endingHold('curia-42'), null, 'the hold waits for a reviewer, and none is reading')
+    assert.match(d.resultRefusal('curia-42'), /UNJUDGED/)
+  })
+
+  test('the reviewer\'s own ending is never held', async () => {
+    const d = makeDispatcher()
+    withBuilder(d)
+    withAdoptedReviewer(d)
+
+    assert.equal(await d.endingHold('curia-review-42'), null)
+  })
+
+  test('a parked ending reads as idle at the turn end, never as gone', async () => {
+    const d = makeDispatcher({ hasSession: async () => true })
+    withBuilder(d)
+    withAdoptedReviewer(d)
+
+    const held = d.endingHold('curia-42')
+    await waitFor(() => d.reviewWaits.has('42'))
+    await d.onAgentDone('curia-42')
+
+    assert.ok(events.some((e) => e.type === 'agent_blocked_on_human' && e.cross_check === true))
+    assert.ok(!typesOf().includes('agent_finished'), 'a parked builder is not a finished one')
+    await d.onResult('curia-review-42', { ticket: '42', status: 'resolved', summary: 'VERDICT: pass' })
+    await held
   })
 })

--- a/docs/adr/0010-the-cross-check.md
+++ b/docs/adr/0010-the-cross-check.md
@@ -44,3 +44,12 @@ The park is process-scoped and dies with the daemon. The reviewer record does no
 - A verdict that lands after the ticket resolved says TOO LATE in the thread instead of the neutral holding line. The pull-request comment still lands, and reopening is the operator's call.
 
 A verdict binds only the dispatch that earned it: one captured before the ticket's last claim does not shut a later agent's gate. A resume is not a cut, so the duty survives it.
+
+## Amendment: a pending cross-check parks the ending ([#258](https://github.com/alp82/curia/issues/258), 2026-08)
+
+#237 made the builder lose loudly. It did not stop it from losing. The operator can start a cross-check from the thread, and that press lands on a builder that is working. Nothing in that builder's context says a second model is reading. So the builder merges, it resolves, and curia refuses its `report_result` after the fact. Two more rules close the race, per [ADR-0013](0013-one-voice-per-fact.md):
+
+- **The start speaks.** The moment a reviewer spawns, curia queues a note at the builder. The note names the reviewer, says the verdict arrives as a message, and holds the ending until it lands. The gate press queues nothing. The builder there is already inside the call that carries the same words back.
+- **The ending parks.** `report_result` with a reviewer in flight parks exactly as `request_review` parks. The verdict lands on the parked call, the builder wakes, judges it, and then ends. The refusal stays as the belt for a caller that reaches `onResult` directly. The unjudged-verdict refusal does not change: nothing is left to wait for there, only a duty to do.
+
+The park is the control, and the note is the reach. `gh pr merge` and `gh issue close` run in the agent's own shell, where curia holds no wire. The note is the only thing that can hold those two, so it says that in plain words rather than promise a park it cannot give. The carrier rule on [#252](https://github.com/alp82/curia/issues/252) stays as the net for a cross-check started after the builder is gone.


### PR DESCRIPTION
Ticket: alp82/curia#258 — [A pending cross-check parks the builder's ending](https://github.com/alp82/curia/issues/258)

Closes the #223 race per ADR-0013: a pending cross-check parks the builder's ending.

Two rules.

**The start speaks.** When a reviewer spawns, curia queues a note at the builder: this reviewer is reading your diff, the verdict arrives as a message, and the ending waits for it. Queued, never injected — the interrupt belongs to the operator (#252), and its Escape would cut the merge the notice exists to stop. The gate press queues nothing: the builder there is already inside the call that carries the same words back.

**The ending parks.** `report_result` with a reviewer in flight now parks exactly as `request_review` parks (ADR-0005 makes a parked agent nearly free). The verdict lands on the parked call, the builder wakes, judges it, and then ends. A cross-check that produces no verdict releases the call and the ending runs on. The #237 refusal stays as the belt for a caller that reaches `onResult` directly, and the unjudged-verdict refusal does not change.

The park is the control, and the note is the reach: `gh pr merge` and `gh issue close` run in the agent's own shell, where curia holds no wire, so the note and the standing orders say that in plain words rather than promise a park they cannot give. The carrier rule on #252 stays as the net for a cross-check started after the builder is gone.

The status line names where the builder parked, because that is where it wakes: idle at the gate, or idle at its ending.

ADR-0010 gains an amendment. CONTEXT.md gains the start notice and a widened "Parked". 11 new tests; the daemon suite is green at 1388.

---

Dispatched by the curia daemon — session `curia-258`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `eb69788` A pending cross-check parks the builder's ending (wayfinder #258)