### PR TITLE
The nudge dies; the render-retry stands alone (alp82/curia#261)

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -22,7 +22,7 @@ The daemon expects these on the box before the first boot:
 - `DISCORD_BOT_TOKEN` — CuriaBot token. Omit to run REST-only (escalations stay answerable via `POST /answer`).
 - `DISCORD_ALLOWED_USERS` — comma-separated Discord user ids; the auth gate. The bridge refuses to start if empty.
 - `CURIA_AGENT_GH_TOKEN_<OWNER>` — the scoped GitHub token an agent gets as `GH_TOKEN` (#155). One key per resource owner, uppercased, hyphens folded to underscores: `alp82/curia` reads `CURIA_AGENT_GH_TOKEN_ALP82`. See [the agent's GitHub authority](#the-agents-github-authority-155) below.
-- `CURIA_GUILD_ID` (optional — defaults to the bot's first guild), `CURIA_CHANNEL` (default `curia`), `PORT` (default 4271), `NUDGE_MS` (default 30 min).
+- `CURIA_GUILD_ID` (optional — defaults to the bot's first guild), `CURIA_CHANNEL` (default `curia`), `PORT` (default 4271).
 - `OVERSEER_MODEL` (default `claude-haiku-4-5`) and `OVERSEER_FALLBACK_MODEL` (default `claude-sonnet-5`) — the overseer session models (#92).
 
 Config (validated on load; a bad shape refuses the boot): `../config/curia.yaml` (watch list, dispatch settings — `auto_dispatch` ships `false` — attach ports, preview range, agent skill set) and `../config/routing.yaml` (label-only model routing, fallback chains, harness command templates). Override the directory with `CURIA_CONFIG_DIR`.

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -51,6 +51,7 @@ import { IdentityProxy, identityRefusal, serveHosts, tailnetSelf } from './ident
 import { detectHarness } from './transcript.mjs'
 import { promptTitle, elapsedLabel, speakerName } from './messaging.mjs'
 import { StatusLine } from './statusline.mjs'
+import { remainingRenderRetries } from './renderretry.mjs'
 import { AccountUsage, ModelWindows, agentMeters } from './usage.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
@@ -66,7 +67,6 @@ if (fs.existsSync(envFile)) {
 }
 
 const PORT = Number(process.env.PORT ?? 4271)
-const NUDGE_MS = Number(process.env.NUDGE_MS ?? 30 * 60 * 1000) // ~30-min re-nudge (#11)
 // CURIA_DATA_DIR mirrors CURIA_CONFIG_DIR: the boot test points both at a
 // fixture dir so a test run never writes into the real journal.
 const DATA = process.env.CURIA_DATA_DIR ?? path.join(ROOT, 'data')
@@ -174,7 +174,7 @@ const statusLine = new StatusLine({
 statusLine.start()
 store.onEvent = (ev) => statusLine.onEvent(ev)
 const pending = new Map() // escalation id -> resolve(answerText) — ephemeral, dies with the process
-const nudgeTimers = new Map() // escalation id -> interval handle — ephemeral, rebuilt on boot
+const renderRetries = new Map() // escalation id -> timeout handles — ephemeral, rebuilt on boot
 
 let bridge = null
 
@@ -198,28 +198,33 @@ installCrashGuard({
 
 // ---- escalation lifecycle -------------------------------------------------
 
-function scheduleNudge(record) {
-  // #94: a confirm has no nudge and no expiry — it waits silently and lapses
-  // with its agent.
-  if (record.kind === CONFIRM_KIND) return
-  if (nudgeTimers.has(record.id)) return
-  const t = setInterval(() => {
-    const r = store.get(record.id)
-    if (!r || r.status !== 'open') return clearNudge(record.id)
-    // esc_nudge refreshes the status line's elapsed time in place (#108 items
-    // 8/13) — the separate still-waiting reminder message is gone.
-    store.nudge(r.id)
-    // a record that never rendered (bridge was down, #22) gets re-rendered here
-    if (bridge && !r.discord) renderEscalation(r).catch((e) => log('nudge render failed', e.message))
-  }, NUDGE_MS)
-  t.unref()
-  nudgeTimers.set(record.id, t)
+// #261: every open escalation arms its own bounded render retry — 1m, 5m and
+// 15m after it opened, then never again. A retry that finds the record rendered
+// (the usual case), closed, or gone does nothing, so the schedule costs an
+// escalation whose first render worked exactly three no-ops.
+function armRenderRetries(record) {
+  if (renderRetries.has(record.id)) return
+  const delays = remainingRenderRetries(record.opened_at, Date.now())
+  if (!delays.length) return
+  const timers = new Set()
+  renderRetries.set(record.id, timers)
+  for (const ms of delays) {
+    const t = setTimeout(() => {
+      timers.delete(t)
+      if (!timers.size) renderRetries.delete(record.id)
+      const r = store.get(record.id)
+      // rendered, answered or superseded in the meantime — nothing to retry
+      if (!r || r.status !== 'open' || r.discord) return clearRenderRetries(record.id)
+      renderEscalation(r)
+    }, ms)
+    t.unref()
+    timers.add(t)
+  }
 }
 
-function clearNudge(id) {
-  const t = nudgeTimers.get(id)
-  if (t) clearInterval(t)
-  nudgeTimers.delete(id)
+function clearRenderRetries(id) {
+  for (const t of renderRetries.get(id) ?? []) clearTimeout(t)
+  renderRetries.delete(id)
 }
 
 async function renderEscalation(record, files = []) {
@@ -227,8 +232,9 @@ async function renderEscalation(record, files = []) {
   try {
     const discord = await bridge.renderEscalation(record, { files })
     store.attachRender(record.id, discord)
+    clearRenderRetries(record.id)
   } catch (e) {
-    // record stays open + REST-answerable; next nudge tick retries the render
+    // record stays open + REST-answerable; the armed retries try again (#261)
     store.logEvent('bridge_render_failed', { id: record.id, error: e.message })
     log(`render failed for ${record.id}: ${e.message}`)
   }
@@ -241,10 +247,10 @@ function openEscalation({ agent, ticket, kind, prompt, options, preview_url, fil
   log(`escalation ${record.id} open (${kind}) agent=${agent} ticket=${ticket}${superseded ? ` supersedes ${superseded.id}` : ''}`)
   if (superseded) {
     pending.delete(superseded.id) // the agent aborted that call; nobody is waiting on it
-    clearNudge(superseded.id)
+    clearRenderRetries(superseded.id)
     if (bridge) bridge.markSuperseded(store.get(superseded.id)).catch(() => {})
   }
-  scheduleNudge(record)
+  armRenderRetries(record)
   renderEscalation(record, files)
   const answered = new Promise((resolve) => pending.set(record.id, resolve))
   return { record, answered }
@@ -255,7 +261,7 @@ function openEscalation({ agent, ticket, kind, prompt, options, preview_url, fil
 // actually waiting: false means the blocked call died with a previous daemon
 // process, and the answer needs the #139 hand-off instead.
 function settle(record, text, attachments = []) {
-  clearNudge(record.id)
+  clearRenderRetries(record.id)
   const resolve = pending.get(record.id)
   pending.delete(record.id)
   if (resolve) resolve({ text, attachments })
@@ -416,7 +422,7 @@ function notifyThread(ticket, message, opts = {}) {
 // Button confirms (#94, per #89): the interpreted cancel path opens a
 // `confirm` escalation — rendered with ✅/❌ through the same machinery as
 // every other escalation, journalled, answerable after a bridge outage — and
-// NOTHING waits on it: no resolver, no nudge, no TTL. The executing path is
+// NOTHING waits on it: no resolver, no reminder, no TTL. The executing path is
 // button → gate.answer → dispatcher.onConfirmAnswered, and the record lapses
 // the moment its agent exits.
 function openConfirm({ ticket, prompt, action, originThreadId }) {
@@ -425,6 +431,10 @@ function openConfirm({ ticket, prompt, action, originThreadId }) {
   })
   log(`confirm ${record.id} open (${action.verb}) ticket=${ticket}${superseded ? ` supersedes ${superseded.id}` : ''}`)
   if (superseded && bridge) bridge.markSuperseded(store.get(superseded.id)).catch(() => {})
+  // A confirm has no reminder and no expiry, but it still has to be SEEN: a
+  // confirm that never rendered carries buttons nobody can press, so it takes
+  // the same bounded render retry every other escalation takes (#261).
+  armRenderRetries(record)
   renderEscalation(record)
   return record
 }
@@ -432,6 +442,7 @@ function openConfirm({ ticket, prompt, action, originThreadId }) {
 function lapseEscalation(id, reason) {
   const r = store.lapse(id, reason)
   if (r.ok) {
+    clearRenderRetries(id)
     log(`confirm ${id} lapsed (${reason})`)
     if (bridge) bridge.markLapsed(store.get(id)).catch(() => {})
   }
@@ -439,7 +450,7 @@ function lapseEscalation(id, reason) {
 }
 
 // The review gate (#54 item 2). The same escalation machinery every ask_human
-// uses — so first-valid-wins, the ~30-min re-nudge, Discord buttons, thread-reply
+// uses — so first-valid-wins, the bounded render retry, Discord buttons, thread-reply
 // capture and restart survival all come free — under its own kind, which is what
 // makes an approval a fact the daemon can check (`/status`, the Stop hook) rather
 // than a string in a prompt. Unlike overseerConfirm there is NO ttl: #11's
@@ -738,9 +749,10 @@ function outboundImages(agent, images) {
 // The block itself is sound — the daemon holds the response for as long as it
 // takes. What killed real agents was the CLIENT: Claude Code aborts an MCP
 // tool call after 300s of server silence (CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT),
-// so an escalation was dead ~25 minutes before the #11 re-nudge could ever
-// fire. The fix belongs here rather than in a client env var: every harness
-// curia has evaluated (Claude Code, Codex, Cline, pi via ACP shims) speaks MCP,
+// so an escalation was dead ~25 minutes before the ~30-minute re-nudge of the
+// day (#11, removed in #261) could ever fire. The fix belongs here rather than
+// in a client env var: every harness curia has evaluated (Claude Code, Codex,
+// Cline, pi via ACP shims) speaks MCP,
 // and periodic traffic on the stream is the protocol's own answer to a long
 // call. Progress notifications when the client offered a token, logging
 // notifications otherwise — either way, bytes flow and no idle timer fires.
@@ -1374,11 +1386,12 @@ httpServer.listen(PORT, '127.0.0.1', () => {
     .catch((e) => log(`boot reconcile failed: ${e.message} — POST /reconcile to retry`))
 })
 
-// restart recovery: every open escalation in the journal gets its nudge timer
-// back; records that never rendered retry on the first tick
+// restart recovery: an open escalation that never rendered re-arms the retries
+// it has not used yet — measured from esc_open, so a restart re-arms the rest
+// of the window rather than starting a fresh one (#261)
 for (const r of store.openEscalations()) {
   log(`recovered open escalation ${r.id} (${r.kind}) agent=${r.agent} ticket=${r.ticket}`)
-  scheduleNudge(r)
+  if (!r.discord) armRenderRetries(r)
 }
 
 // #270: if this boot is the far side of a self-deploy, wait for the sibling's

--- a/daemon/src/renderretry.mjs
+++ b/daemon/src/renderretry.mjs
@@ -1,0 +1,26 @@
+// The escalation's own render retry (#261).
+//
+// Until #261 a per-escalation 30-minute interval carried three jobs, and two of
+// them were dead: an elapsed-time refresh the status line's own meter tick
+// already does (#146), and a journal counter nothing read. The third one is
+// real — an escalation whose Discord render failed (the bridge was down, #22)
+// has to try again — so it survives here, alone and BOUNDED.
+//
+// The offsets are measured from `esc_open`, not from the failure, because the
+// escalation owns the schedule: the record knows when it opened, so a daemon
+// restart re-arms exactly the retries that have not passed yet instead of
+// starting a fresh unbounded clock.
+//
+// After the last one the daemon stops trying. Nothing is lost: the record stays
+// open and REST-answerable, and the dashboard reads the store rather than
+// Discord, so it shows the question either way.
+export const RENDER_RETRY_MS = [60_000, 5 * 60_000, 15 * 60_000]
+
+// Delays from `now` for the retries still ahead of an escalation opened at
+// `openedAt`. Empty means the window is over and this record never renders
+// again — including a record whose `opened_at` cannot be read.
+export function remainingRenderRetries(openedAt, now) {
+  const opened = Date.parse(openedAt ?? '')
+  if (Number.isNaN(opened)) return []
+  return RENDER_RETRY_MS.map((ms) => opened + ms - now).filter((ms) => ms > 0)
+}

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -143,12 +143,13 @@ export class StatusLine {
     await Promise.all([...[...this.agents.values()].map((w) => w.chain), ...this.retiring])
   }
 
-  // The meter tick (#146). The elapsed time only refreshes while an escalation
-  // nudges, so context % and the usage bars would otherwise stand still through
-  // a whole working turn — a percentage that stops moving is a lie on a surface
-  // built to be trusted. Same message, edited in place, and #apply drops the
-  // edit when the composed text did not actually change, so a quiet agent
-  // costs no Discord call at all.
+  // The meter tick (#146). Nothing else moves a parked line: context %, the
+  // usage bars and the elapsed label would all stand still through a whole
+  // working turn — a percentage that stops moving is a lie on a surface built
+  // to be trusted. Since #261 removed the 30-minute nudge this tick is the
+  // ONLY refresh a waiting line gets. Same message, edited in place, and
+  // #apply drops the edit when the composed text did not actually change, so a
+  // quiet agent costs no Discord call at all.
   start() {
     if (this.timer) return
     this.timer = setInterval(() => this.refresh(), this.refreshMs)
@@ -194,16 +195,6 @@ export class StatusLine {
         return this.#set(ev.agent, ev.ticket, state, {
           esc: { id: ev.id, title: promptTitle(ev.prompt), opened_at: ev.ts },
         })
-      }
-      case 'esc_nudge': {
-        // The elapsed time is the only thing that changed — refresh the line
-        // in place. This replaces the separate still-waiting reminder message
-        // (#108 item 13): never fake-new content, never a re-posted body.
-        const r = this.get(ev.id)
-        if (!r || r.kind === CONFIRM_KIND) return
-        const w = this.agents.get(r.agent)
-        if (w && w.detail.esc?.id === r.id) return this.#set(r.agent, r.ticket, w.state, w.detail)
-        return
       }
       case 'esc_answer': {
         const r = this.get(ev.id)
@@ -257,7 +248,7 @@ export class StatusLine {
       case 'agent_blocked_on_human': {
         // The turn ended parked (#47) — the line keeps naming whom it waits on.
         // Live, this repeats what esc_open already drew; after a restart it is
-        // the only event that redraws a parked line before the next nudge.
+        // the only event that redraws a parked line before the next meter tick.
         // The redraw carries no entry point of its own, so it keeps the one the
         // park drew (#258) rather than guessing the gate.
         if (ev.cross_check) return this.#set(ev.agent, ev.ticket, 'cross-checking', { at: ev.ts, on: this.agents.get(ev.agent)?.detail?.on })

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -10,14 +10,13 @@
 //   - supersede (#29): a re-issued ask_human (same agent + same payload while an
 //     older escalation is open) marks the old record superseded; answers posted
 //     to a dead id are routed along the successor chain to the live call
-//   - nudge bookkeeping for the ~30-min re-nudge (#11)
 
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
 
 // The button-confirm kind (#94, per #89's messaging discipline). Its own kind
-// because a confirm behaves unlike every other escalation: no nudge timer, no
+// because a confirm behaves unlike every other escalation: no reminder, no
 // pending resolver — the executing path is button → daemon — and it closes by
 // LAPSING when the agent instance it is bound to exits.
 export const CONFIRM_KIND = 'confirm'
@@ -150,7 +149,7 @@ export class EscalationStore {
           prompt: ev.prompt, options: ev.options, preview_url: ev.preview_url,
           payload_hash: ev.payload_hash, status: 'open', opened_at: ev.ts,
           action: ev.action ?? null, origin_thread_id: ev.origin_thread_id ?? null,
-          discord: null, successor: null, nudges: 0, agent_died: false,
+          discord: null, successor: null, agent_died: false,
         })
         break
       }
@@ -190,11 +189,11 @@ export class EscalationStore {
         if (r) { r.status = 'superseded'; r.successor = ev.successor; r.closed_at = ev.ts }
         break
       }
-      case 'esc_nudge': {
-        const r = this.escalations.get(ev.id)
-        if (r) r.nudges++
+      case 'esc_nudge':
+        // The 30-minute tick died with #261, and nothing ever read its counter.
+        // The case stays because the journal is append-only: 243 of these sit
+        // in the real file, and an unknown type must not break the replay.
         break
-      }
       case 'thread_bound': {
         this.ticketThreads.set(String(ev.ticket), ev.thread_id)
         this.threadTickets.set(ev.thread_id, String(ev.ticket))
@@ -365,10 +364,6 @@ export class EscalationStore {
     if (r.status !== 'open') return { ok: false, reason: r.status, record: r }
     this._append({ type: 'esc_lapse', id, reason })
     return { ok: true, record: r }
-  }
-
-  nudge(id) {
-    this._append({ type: 'esc_nudge', id })
   }
 
   openEscalations() {

--- a/daemon/test/journal.test.mjs
+++ b/daemon/test/journal.test.mjs
@@ -83,4 +83,24 @@ describe('the pre-#184 journal reads as one vocabulary', () => {
     assert.equal(open.agent, 'curia-6')
     assert.equal(open.agent_died, true)
   })
+
+  // #261 deleted the 30-minute tick, but 243 `esc_nudge` lines sit in the real
+  // journal and the file is never rewritten. The replay has to walk straight
+  // past them and rebuild the record whole.
+  test('an escalation carrying the dead nudge events still replays', () => {
+    const dir = tmpdir()
+    fs.writeFileSync(path.join(dir, 'events.jsonl'), [
+      JSON.stringify({
+        ts: '2026-08-01T10:00:00Z', type: 'esc_open', id: 'esc-1', agent: 'curia-7',
+        ticket: '7', kind: 'free-text', prompt: 'which one?',
+      }),
+      JSON.stringify({ ts: '2026-08-01T10:30:00Z', type: 'esc_nudge', id: 'esc-1' }),
+      JSON.stringify({ ts: '2026-08-01T11:00:00Z', type: 'esc_nudge', id: 'esc-1' }),
+      '',
+    ].join('\n'))
+    const [open] = new EscalationStore(dir).openEscalations()
+    assert.equal(open.prompt, 'which one?')
+    assert.equal(open.status, 'open')
+    assert.equal('nudges' in open, false, 'the counter nothing read is gone from the record')
+  })
 })

--- a/daemon/test/renderretry.test.mjs
+++ b/daemon/test/renderretry.test.mjs
@@ -1,0 +1,38 @@
+// The bounded render retry (#261). The schedule lives in its own module for one
+// reason: the timers that drive it sit in index.mjs, where nothing can wait 15
+// minutes for them, so the ARITHMETIC is what gets pinned here — the offsets,
+// the restart math, and the point at which the daemon stops trying.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { RENDER_RETRY_MS, remainingRenderRetries } from '../src/renderretry.mjs'
+
+const OPENED = '2026-08-10T12:00:00Z'
+const at = (min) => Date.parse(OPENED) + min * 60_000
+
+describe('the render retry the escalation owns', () => {
+  test('the schedule is 1m, 5m, 15m — three tries, then never again', () => {
+    assert.deepEqual(RENDER_RETRY_MS, [60_000, 300_000, 900_000])
+  })
+
+  test('a fresh escalation arms all three, measured from esc_open', () => {
+    assert.deepEqual(remainingRenderRetries(OPENED, at(0)), [60_000, 300_000, 900_000])
+  })
+
+  test('a restart re-arms the rest of the window, not a fresh one', () => {
+    // Six minutes of downtime cost the 1m and 5m tries. The 15m one is still
+    // ahead, and it stays 15 minutes after esc_open — a daemon that restarts
+    // every minute must not retry forever.
+    assert.deepEqual(remainingRenderRetries(OPENED, at(6)), [9 * 60_000])
+  })
+
+  test('past the last offset the window is over and nothing is armed', () => {
+    assert.deepEqual(remainingRenderRetries(OPENED, at(15)), [])
+    assert.deepEqual(remainingRenderRetries(OPENED, at(600)), [])
+  })
+
+  test('a record with no readable open time arms nothing', () => {
+    assert.deepEqual(remainingRenderRetries(undefined, at(0)), [])
+    assert.deepEqual(remainingRenderRetries('not a date', at(0)), [])
+  })
+})

--- a/daemon/test/statusline.test.mjs
+++ b/daemon/test/statusline.test.mjs
@@ -98,11 +98,11 @@ describe('StatusLine', () => {
     }
   })
 
-  test('a nudge refreshes the waiting line in place — no reminder message (#108 item 13)', async () => {
-    // A nudge fires every ~30 min, so the elapsed label has always moved by the
-    // time it lands. The clock is injected rather than real: the refresh is only
-    // worth an edit when a number actually changed (#146), and asserting that
-    // needs time to pass on purpose.
+  test('the tick refreshes the waiting line in place — no reminder message (#108 item 13)', async () => {
+    // Since #261 the meter tick is the only thing that moves a parked line. The
+    // clock is injected rather than real: the refresh is only worth an edit when
+    // a number actually changed (#146), and asserting that needs time to pass on
+    // purpose.
     let clock = Date.parse('2026-08-03T12:00:00Z')
     const l = new StatusLine({
       post: async (ticket, text) => { posts.push({ ticket, text }); return { threadId: 't', messageId: 'm1' } },
@@ -115,10 +115,10 @@ describe('StatusLine', () => {
     records.set('esc-3', { id: 'esc-3', agent: 'curia-4', ticket: '4', kind: 'free-text', status: 'open' })
     l.onEvent({ type: 'esc_open', id: 'esc-3', agent: 'curia-4', ticket: '4', kind: 'free-text', prompt: 'A question', ts: opened })
     clock += 30 * 60_000
-    l.onEvent({ type: 'esc_nudge', id: 'esc-3' })
+    l.refresh()
     await l.settle()
     assert.equal(posts.length, 1)
-    assert.equal(edits.length, 1, 'the nudge edits, never posts')
+    assert.equal(edits.length, 1, 'the tick edits, never posts')
     assert.match(edits[0].text, /\[esc-3\].*1 h 15 min/)
   })
 
@@ -135,7 +135,7 @@ describe('StatusLine', () => {
     l.onEvent({ type: 'agent_ready', agent: 'curia-9', ticket: '9', model: 'opus', ts: 'T' })
     records.set('e1', { id: 'e1', agent: 'curia-9', ticket: '9', kind: 'choice', status: 'open' })
     l.onEvent({ type: 'esc_open', id: 'e1', agent: 'curia-9', ticket: '9', kind: 'choice', prompt: 'q?', ts: new Date().toISOString() })
-    l.onEvent({ type: 'esc_nudge', id: 'e1' }) // same state — no re-flag
+    l.refresh() // same state — no re-flag
     l.onEvent({ type: 'esc_answer', id: 'e1', answer: 'yes' })
     records.set('e2', { id: 'e2', agent: 'curia-9', ticket: '9', kind: REVIEW_KIND, status: 'open' })
     l.onEvent({ type: 'esc_open', id: 'e2', agent: 'curia-9', ticket: '9', kind: REVIEW_KIND, prompt: 'done?', ts: new Date().toISOString() })
@@ -144,7 +144,7 @@ describe('StatusLine', () => {
     await l.settle()
     assert.deepEqual(flags.map((f) => f.state), [
       'working', 'waiting', 'working', 'awaiting-review',
-    ], 'ready, nudge, and done fire no flag — and the approve→executing tail keeps 🔎, saving the rename slot the ✅ needs')
+    ], 'ready, tick, and done fire no flag — and the approve→executing tail keeps 🔎, saving the rename slot the ✅ needs')
     assert.ok(flags.every((f) => f.ticket === '9'))
   })
 

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -461,7 +461,7 @@ describe('TimelineSurface', () => {
   })
 
   test('open escalations overlay from the daemon record — the claude harness writes nothing while blocked (#74 item 5)', async () => {
-    escalations = [{ id: 'esc-7', kind: 'free-text', prompt: 'which shade?', options: null, preview_url: null, opened_at: 'T', nudges: 1 }]
+    escalations = [{ id: 'esc-7', kind: 'free-text', prompt: 'which shade?', options: null, preview_url: null, opened_at: 'T' }]
     try {
       const { events } = await sse(port, 'session=curia-9')
       const esc = events.filter((e) => e.event === 'escalations').at(-1)
@@ -478,7 +478,7 @@ describe('TimelineSurface', () => {
       prompt: 'a long question body\nwith a second line the transcript brief drops',
       options: ['red', 'blue'], opened_at: 'T1', closed_at: 'T2',
       status: 'answered', answer: 'blue, because contrast', answered_by: 'alp',
-      answered_via: 'button', nudges: 0,
+      answered_via: 'button',
     }]
     try {
       const { events } = await sse(port, 'session=curia-9')

--- a/docs/adr/0005-escalation-contract.md
+++ b/docs/adr/0005-escalation-contract.md
@@ -1,7 +1,7 @@
 # ADR-0005: The escalation contract
 
 **Status**: accepted (2026-07)
-**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200), [A cancel confirm lands in the ticket thread, not where the operator typed it (#218)](https://github.com/alp82/curia/issues/218)
+**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200), [A cancel confirm lands in the ticket thread, not where the operator typed it (#218)](https://github.com/alp82/curia/issues/218), [The nudge dies; the render-retry stands alone (#261)](https://github.com/alp82/curia/issues/261)
 
 ## Context
 
@@ -15,7 +15,7 @@ Agents need human answers from any device, with waits measured in hours, and the
 - One Discord thread per ticket carries the ticket's escalations, notifies, and answers. Buttons capture closed shapes, thread replies capture open ones. Images ride the contract in both directions.
 - A record renders where the person it is addressed to stands (#218). An agent escalation is addressed to the ticket conversation and renders in the ticket thread. A confirm is addressed to the operator, about a command typed one second ago, so it renders in the thread the command was typed in. A command typed in no thread puts its confirm in the command channel. The ticket thread gets a pointer to the buttons.
 - The first valid answer wins and closes the escalation atomically. Any device may answer. A later answer gets a clear refusal.
-- The escalation is a durable record in the journal. It survives restarts and bridge post-failures. The half-hour nudge re-posts an open escalation and re-renders any the bridge failed to post.
+- The escalation is a durable record in the journal. It survives restarts and bridge post-failures. A record the bridge failed to render retries at 1, 5 and 15 minutes after it opened, then stops (#261). Nothing re-posts an open escalation on a timer: the status line's own minute tick keeps the waiting line current, and the record stays open and answerable by REST whether or not Discord ever shows it.
 - A re-asked question supersedes the old record, and late answers route along the chain to the live call.
 - A keepalive on the MCP stream defeats the client's 300-second silence abort, so a block can outlast any human pause.
 - An open escalation is a liveness signal. A Stop hook fired while this agent has an open escalation means blocked, not crashed. Nothing terminal happens: no preview withdrawal, no failure mark, no session kill.

--- a/docs/index.html
+++ b/docs/index.html
@@ -439,7 +439,7 @@ TTYD_BIN=/home/&lt;you&gt;/.local/bin/ttyd</code></pre>
         agents at your repos. <code>TTYD_BIN</code> defaults to
         <code>/home/alp/.local/bin/ttyd</code>: leave it and attach is dead. Optional:
         <code>CURIA_GUILD_ID</code>, <code>CURIA_CHANNEL</code>, <code>PORT</code>,
-        <code>NUDGE_MS</code>, <code>OVERSEER_MODEL</code>. Run one daemon per bot token.</p>
+        <code>OVERSEER_MODEL</code>. Run one daemon per bot token.</p>
       </div>
 
       <div class="step">


### PR DESCRIPTION
Ticket: alp82/curia#261 — [The nudge dies; the render-retry stands alone](https://github.com/alp82/curia/issues/261)

Removes the nudge as a concept (#250) and leaves the render retry alone, bounded.

**Deleted**
- The per-escalation 30-minute timer: `scheduleNudge`, `clearNudge`, `nudgeTimers`.
- The `esc_nudge` emission, `store.nudge()`, and the `nudges` counter on the record.
- `NUDGE_MS` and its env override, plus its two doc mentions.
- The `esc_nudge` case in `statusline.mjs`. The meter tick (#146) already refreshes the elapsed label.

**Added**
- `daemon/src/renderretry.mjs`: the retry schedule, 1m / 5m / 15m after `esc_open`, then stop. Measured from the open time, so a restart re-arms only the retries still ahead instead of starting a fresh clock.
- `armRenderRetries` / `clearRenderRetries` in `index.mjs`. Every open escalation arms the schedule. A retry that finds the record rendered, closed or gone does nothing. Boot recovery arms it for open records that never rendered.
- A confirm takes the same retry. It has no reminder and no expiry, but a confirm that never rendered carries buttons nobody can press.

**Kept**
- A no-op `case 'esc_nudge'` in the store reducer, so old journals replay.

The record stays open and REST-answerable when the last retry fails. The dashboard reads the store, not Discord.

ADR-0005 carries the new contract line.

Tests: 1394 pass, 0 fail. New: `test/renderretry.test.mjs` (the schedule and the restart math) and a journal-replay test for the dead `esc_nudge` lines.

---

Dispatched by the curia daemon — session `curia-261`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `be7ad7b` The nudge dies; the render-retry stands alone (wayfinder #261)