### PR TITLE
The daemon serves its overview (alp82/curia#262)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,12 @@ The operator's sentence on a map dispatch, in their own words. It rides the `map
 **Frontier**:
 The takeable tickets of a watched repo, in map order.
 
+**Two-level frontier**:
+The frontier plus the tickets each of its members directly unblocks. One level, never a chain. It is what the dashboard draws as a tree, and it comes from the blocking edges the agent-only count already reads.
+
+**Frontier snapshot**:
+The two-level frontier as reconcile last computed it, under the instant it did. Reconcile computes it, because that pass already holds the GitHub credentials and the dashboard holds none. The stamp is what makes a served frontier honest: the page states the age of the reading.
+
 **Takeable**:
 Open, not a pull request, no open blockers, no assignee.
 
@@ -341,6 +347,9 @@ Open escalations shown on the timeline from the daemon's record, because a trans
 **Dialog guard**:
 The timeline's refusal to send text while a native terminal dialog holds the pane.
 
+**Overview**:
+The daemon's one loopback read of itself, `GET /overview`. It joins every section the dashboard draws. These are the live agents, the open escalations, the review gate, bridge health, the usage windows, the journal tail, and the frontier snapshot. The sidecar polls it, and holds no secret, no GitHub token and no journal handle. Each section is nullable on its own, so an unreadable one costs the page nothing else.
+
 **Status line**:
 One Discord message per agent, written by the daemon, that says what the agent is doing now. A state change reposts it at the thread bottom. Everything else edits it in place.
 
@@ -348,7 +357,7 @@ One Discord message per agent, written by the daemon, that says what the agent i
 A number the status line carries beside the state: the model name, its reasoning effort, the context percent, and the account usage bars. Each meter has its own source and drops alone when that source is silent. Meters drop from the tail when the line runs out of columns. The model is the exception: the escalation title is cut to keep it.
 
 **Account bars**:
-The 5-hour and 7-day usage windows. They are an account fact, not an agent fact, so every agent on a provider shows the same reading. The provider follows from the agent's harness, never from the routing label: a label is a spawn-time fact and a harness has on-disk evidence. A window whose reset has passed rolls over — the bar shows the fresh window at 0%, and that reading counts as stale at once, so the next probe measures it.
+The 5-hour and 7-day usage windows. They are an account fact, not an agent fact, so every agent on a provider shows the same reading. The provider follows from the agent's harness, never from the routing label: a label is a spawn-time fact and a harness has on-disk evidence. A window whose reset has passed rolls over — the bar shows the fresh window at 0%, and that reading counts as stale at once, so the next probe measures it. Every window also carries the instant it rolls. The status line has no room for a clock time and shows the pace instead. The overview carries the instant, and the dashboard prints it.
 
 **Pace**:
 Usage measured against the time already gone from its window. A bar shows the window's clock as `┃` and renders spending past it as overshoot. The square before the bar states the same fact at a glance: 🟩 behind the clock, 🟨 on it, 🟥 ahead.

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -53,6 +53,7 @@ Two of these routes are the AGENT's, and since #159 they are gated: `/mcp` and `
 
 - `POST /mcp?agent=<name>&ticket=<n>` — MCP tools `ask_human` (blocking), `notify`, `report_result`, `publish_preview` (#40, `path` since #68), `open_pull_request` and `request_review` (#54). Ticket binding rides the spawn URL (#11). `ask_human` and `notify` also take `images: [<path>]` (#34).
 - `GET /state` — open escalations + bridge status.
+- `GET /overview` — the dashboard's whole read of the daemon (#262, per [#249](https://github.com/alp82/curia/issues/249)). It carries the live agents, open escalations, the review gate with its pull request, bridge health, one usage reading per provider with its stated reset, the last 100 journal events, and the two-level frontier under the instant reconcile computed it. Each section is nullable on its own. An unreadable fleet says so, and costs the page nothing else. The journal file itself never crosses. Its tail does.
 - `POST /escalate` — synthetic escalation (testing / non-MCP emitters); `?wait=1` blocks until answered.
 - `POST /answer {id, answer, attachments?}` / `POST /cancel {id}` — same first-valid-wins gate as Discord.
 - `POST /agent_done?agent=` — Stop-hook webhook (#29); closes the dispatch lifecycle (result recorded ⇒ clean close; result-less ⇒ abnormal exit, session kept for post-mortem).

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -19,7 +19,7 @@ import crypto from 'node:crypto'
 import { setTimeout as sleepFor } from 'node:timers/promises'
 import {
   viewerLogin, repoMaps, mapFrontier, flatFrontier, fetchIssue, claim, unclaim, blockedByOf,
-  selectLane, frontierForRepo, filterTakeable, agentOnlyChainCount, commentIssue, closeIssue, setIssueBody, issueComments,
+  selectLane, frontierForRepo, filterTakeable, agentOnlyChainCount, directUnblocks, commentIssue, closeIssue, setIssueBody, issueComments,
   parentNumberOf, hasLabel, findPullRequest, createPullRequest, setPullRequestBody,
   deleteRemoteBranch,
 } from './github.mjs'
@@ -354,11 +354,39 @@ export class Dispatcher {
     this.reviewWaits = new Map()
     this.mapLocks = new Map() // "repo#map" -> tail of that map's write chain (#41)
     this.exhaustionNotified = false
+    // The dashboard's frontier and the instant reconcile computed it (#262).
+    // Null until the first pass lands, which is how `GET /overview` says "no
+    // frontier has been read yet" rather than "the frontier is empty".
+    this.frontierAt = null
     this.autoTimer = null
     this.wakeTimer = null
   }
 
   // ---- frontier --------------------------------------------------------------
+
+  // The frontier the dashboard draws (#262): the same two-level read as
+  // `frontier()`, computed during reconcile and stamped with the instant it was
+  // computed. Two reasons it lives on the reconcile pass rather than under the
+  // route. The pass already holds the `gh` credentials and already spends this
+  // repo's reads, so the frontier costs it nothing new — and the sidecar that
+  // asks for it holds no token at all (#249). The stamp is what makes a served
+  // snapshot honest: the page says how old the frontier is, instead of dressing
+  // a boot-time read as a live one. `POST /reconcile` recomputes it.
+  frontierSnapshot() {
+    return this.frontierAt ?? { computed_at: null, repos: [] }
+  }
+
+  // Never throws and never fails the pass: a frontier the dashboard cannot draw
+  // must not cost reconcile its sweeps. The previous snapshot stands, with its
+  // own older stamp saying so.
+  async #computeFrontier() {
+    try {
+      const repos = await this.frontier()
+      this.frontierAt = { computed_at: new Date().toISOString(), repos }
+    } catch (e) {
+      this.log(`reconcile: the dashboard frontier failed (${e.message}) — the last snapshot stands`)
+    }
+  }
 
   // Shallow per-repo frontier (numbers/titles/labels); gh errors are surfaced
   // per repo, never thrown across the whole read.
@@ -396,11 +424,18 @@ export class Dispatcher {
     }
     for (const item of flatItems) index.set(item.number, { item, map: null })
     const mapTitle = new Map(maps.map((m) => [m.number, m.title]))
+    // The blocked-by edges, read ONCE per repo and shared (#262). The agent-only
+    // count and level two of the frontier ask the same edges two questions, and
+    // this is one `gh` call per open blocked ticket — so reading them twice
+    // would double the cost of every tickets view for no new fact.
+    const pool = lane === 'map' ? Object.values(mapItems).flat() : flatItems
+    const edges = await this.#blockerEdges(entry.repo, lane, pool)
+    const unblocks = edges ? directUnblocks({ items: pool, edges }) : {}
     return {
       repo: entry.repo,
       lane,
       numbers,
-      agentOnly: await this.#agentOnlyCount(entry.repo, lane, mapItems, numbers),
+      agentOnly: this.#agentOnlyCount(lane, pool, edges, numbers),
       items: numbers.map((n) => {
         const e = index.get(n)
         return {
@@ -409,33 +444,53 @@ export class Dispatcher {
           labels: (e?.item?.labels ?? []).map((l) => l.name),
           map: e?.map ?? null,
           mapTitle: e?.map != null ? mapTitle.get(e.map) ?? '' : '',
+          // Level two (#262): the tickets this one directly unblocks, which is
+          // what makes the dashboard's frontier a tree rather than a list.
+          unblocks: (unblocks[n] ?? []).map((i) => ({
+            number: i.number,
+            title: i.title ?? '',
+            labels: (i.labels ?? []).map((l) => l.name),
+          })),
         }
       }),
     }
   }
 
-  // The HITL-free chain count for the tickets view (#81). Map lane: fetch the
-  // dependency edges of every open blocked child, then run the pure closure.
-  // Flat lane: every ready-for-agent ticket is by definition agent-ready, so
-  // the count is the takeable count. Fails soft to null — the tickets view
-  // must render even when an edge read does not.
-  async #agentOnlyCount(repo, lane, mapItems, numbers) {
-    if (lane === 'flat') return numbers.length
-    if (lane !== 'map') return 0
+  // The dependency edges of every open blocked ticket in the pool:
+  // { [number]: [{number, state}] }. Null when a read failed — an unreadable
+  // edge is not an open way, and both readers below treat null as "no answer"
+  // rather than "no edges".
+  //
+  // The MAP lane only. A flat-lane ticket is takeable because a human labelled
+  // it `ready-for-agent`, not because a chain opened, so neither reader has a
+  // question for its edges — and asking anyway would spend one `gh` call per
+  // blocked ticket on every tickets view that a flat repo has never paid.
+  async #blockerEdges(repo, lane, pool) {
+    if (lane !== 'map') return {}
     try {
-      const items = Object.values(mapItems).flat()
       const edges = {}
-      for (const i of items) {
+      for (const i of pool) {
         if (i.state !== 'open' || i.pull_request) continue
         if ((i.issue_dependencies_summary?.blocked_by ?? 0) === 0) continue
         edges[i.number] = (await this.deps.blockedByOf(repo, i.number))
           .map((b) => ({ number: b.number, state: b.state }))
       }
-      return agentOnlyChainCount({ items, edges })
+      return edges
     } catch (e) {
-      this.log(`agent-only count for ${repo} failed (${e.message}) — omitting it`)
+      this.log(`dependency edges for ${repo} failed (${e.message}) — omitting the agent-only count and the unblocks`)
       return null
     }
+  }
+
+  // The HITL-free chain count for the tickets view (#81), over the edges above.
+  // Flat lane: every ready-for-agent ticket is by definition agent-ready, so
+  // the count is the takeable count. Fails soft to null — the tickets view
+  // must render even when an edge read does not.
+  #agentOnlyCount(lane, pool, edges, numbers) {
+    if (lane === 'flat') return numbers.length
+    if (lane !== 'map') return 0
+    if (!edges) return null
+    return agentOnlyChainCount({ items: pool, edges })
   }
 
   // ---- next ------------------------------------------------------------------
@@ -4348,6 +4403,11 @@ export class Dispatcher {
     if (this.timeline) {
       await this.timeline.assert().catch((e) => this.log(`reconcile: timeline surface assertion failed (${e.message}) — the timeline may be unavailable`))
     }
+
+    // Last, because it reads GitHub and the sweeps above must not wait on it
+    // (#262). It is the only part of the pass whose failure costs a surface
+    // rather than a decision.
+    await this.#computeFrontier()
   }
 
   // Everything the passes share: the journal, the latest dispatch epoch per

--- a/daemon/src/github.mjs
+++ b/daemon/src/github.mjs
@@ -267,6 +267,27 @@ export function agentOnlyChainCount({ items = [], edges = {} } = {}) {
   return reachable.size
 }
 
+// Level two of the dashboard's frontier (#262): what each takeable ticket
+// DIRECTLY unblocks. `edges[number]` is the blocked-by list agentOnlyChainCount
+// already reads, walked the other way round — so this costs no extra read.
+//
+// Returns { [blockerNumber]: item[] }. Only OPEN, non-PR items are listed under
+// only OPEN blockers: a closed ticket unblocks nothing anyone can take, and a
+// closed dependent is already done. One level, never a transitive closure — the
+// tree the operator reads is the frontier and the row behind it (#248).
+export function directUnblocks({ items = [], edges = {} } = {}) {
+  const out = {}
+  for (const i of items) {
+    if (i.state !== 'open' || i.pull_request) continue
+    for (const b of edges[i.number] ?? []) {
+      if (b.state === 'closed') continue
+      out[b.number] ??= []
+      if (!out[b.number].some((x) => x.number === i.number)) out[b.number].push(i)
+    }
+  }
+  return out
+}
+
 // Composes selectLane + filterTakeable over pre-fetched data; returns the
 // deduped, sorted takeable issue numbers. Multi-map union counts a ticket once.
 export function frontierForRepo({ mode = 'auto', maps = [], mapItems = {}, flatItems = [] }) {

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -7,6 +7,7 @@
 // mints; the rest are the operator's own and never leave loopback.
 //
 //   GET  /state                          — open escalations
+//   GET  /overview                       — the dashboard's whole read (#262)
 //   POST /escalate                       — synthetic escalation (testing / non-MCP emitters)
 //   POST /answer {id, answer}            — REST answer (same first-valid-wins gate as Discord)
 //   POST /agent_done?agent=            — Stop-hook webhook (closes the dispatch lifecycle)
@@ -35,7 +36,7 @@ import { resolveOutboundImages, inboundContent } from './images.mjs'
 import { PreviewRegistry } from './preview.mjs'
 import { loadCuriaConfig, loadRoutingConfig } from './config.mjs'
 import { PROBE_MARK, PROBE_PATH, dockerGateway, probeSideChannel } from './sandbox.mjs'
-import { Cooling } from './routing.mjs'
+import { Cooling, providerOf } from './routing.mjs'
 import { Dispatcher } from './dispatch.mjs'
 import { REVIEW_KIND } from './lifecycle.mjs'
 import { CommandRouter } from './commands.mjs'
@@ -144,6 +145,30 @@ const accountUsage = new AccountUsage({
 // `account_bars`: that switch exists because the account probe spends quota,
 // and this lookup spends none.
 const modelWindows = new ModelWindows({ log })
+
+// Same harness resolution the timeline uses: the dispatcher's word on what it
+// spawned, on-disk evidence for re-adopted and lab sessions.
+const cfgDirFor = (session) => path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)
+const harnessFor = (session) => dispatcher?.agents.get(session)?.harness ?? detectHarness(cfgDirFor(session))
+
+// Everything the status line says about one agent beyond its state. Named
+// rather than inlined because `GET /overview` reads the same meters for the
+// dashboard's provider strip (#262), and one agent must not be measured two
+// ways on two surfaces.
+//
+// The routing label takes the same route (#187). The status line only learns
+// it from a spawn event, so a line first drawn after a restart carries none —
+// and the effort meter reads off the label's routing row. The dispatcher's
+// record answers instead, which reconcile now rebuilds from the journal.
+const metersFor = (session, model) => agentMeters({
+  harness: harnessFor(session),
+  cfgDir: cfgDirFor(session),
+  model: model ?? dispatcher?.agents.get(session)?.model ?? null,
+  routing: routingConfig,
+  account: accountUsage,
+  models: modelWindows,
+})
+
 const statusLine = new StatusLine({
   post: (ticket, text) => (bridge ? bridge.postStatus(ticket, text) : null),
   edit: (ids, text) => (bridge ? bridge.editStatus(ids, text) : false),
@@ -154,22 +179,7 @@ const statusLine = new StatusLine({
   flag: (ticket, state) => (bridge ? bridge.flagTicket(ticket, state) : null),
   get: (id) => store.get(id),
   log,
-  // Same harness resolution the timeline uses: the dispatcher's word on what it
-  // spawned, on-disk evidence for re-adopted and lab sessions.
-  //
-  // The routing label takes the same route (#187). The status line only learns
-  // it from a spawn event, so a line first drawn after a restart carries none —
-  // and the effort meter reads off the label's routing row. The dispatcher's
-  // record answers instead, which reconcile now rebuilds from the journal.
-  meters: (session, model) => agentMeters({
-    harness: dispatcher?.agents.get(session)?.harness
-      ?? detectHarness(path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)),
-    cfgDir: path.join(curiaConfig.dispatch.workspace_root, 'cfg', session),
-    model: model ?? dispatcher?.agents.get(session)?.model ?? null,
-    routing: routingConfig,
-    account: accountUsage,
-    models: modelWindows,
-  }),
+  meters: metersFor,
 })
 statusLine.start()
 store.onEvent = (ev) => statusLine.onEvent(ev)
@@ -1159,6 +1169,124 @@ async function assertSideChannel(image) {
   return bound.address
 }
 
+// ---- the dashboard's one read (#262) ----------------------------------------
+
+// A usage window on the wire. The meters speak camelCase because the status
+// line composes them in the same file that reads them; `/overview` is a
+// contract between two processes, so it speaks the snake_case every other
+// route on this port already does.
+const wireWindow = (w) => ({
+  label: w.label,
+  pct: w.pct,
+  elapsed_pct: w.elapsedPct ?? null,
+  resets_at: w.resetsAt ?? null,
+  fresh: Boolean(w.fresh),
+})
+
+// An open escalation on the wire. The record's own bookkeeping — the payload
+// hash, the successor chain, the action targets — is how the gate decides
+// things and says nothing a page can draw, so it stays here.
+const wireEscalation = (r) => ({
+  id: r.id,
+  agent: r.agent,
+  ticket: r.ticket,
+  kind: r.kind,
+  prompt: r.prompt,
+  options: r.options ?? null,
+  preview_url: r.preview_url ?? null,
+  opened_at: r.opened_at,
+  agent_died: Boolean(r.agent_died),
+  rendered: Boolean(r.discord),
+  thread_id: r.discord?.threadId ?? null,
+})
+
+// The provider strip (#248's home screen): one usage reading per provider, said
+// once above a fleet whose every agent repeats it.
+//
+// Anthropic answers from the account probe and needs no agent at all. Every
+// other provider states its windows only inside an agent's own transcript, so
+// the first live agent on it is the evidence, and the reading names where it
+// came from. A provider with no probe and no agent says NOTHING rather than
+// zero: an unmeasured window and an unspent one are not the same fact.
+function providerUsage() {
+  const out = new Map()
+  const account = accountUsage.windows()
+  if (account) out.set('anthropic', { provider: 'anthropic', from: 'account', session: null, windows: account })
+  for (const w of dispatcher?.agents.values() ?? []) {
+    const provider = routingConfig.models?.[w.model]?.provider ?? providerOf(routingConfig, harnessFor(w.session))
+    if (!provider || out.has(provider)) continue
+    const { windows } = metersFor(w.session, w.model)
+    if (!windows) continue
+    out.set(provider, { provider, from: 'transcript', session: w.session, windows })
+  }
+  return [...out.values()].map((p) => ({ ...p, windows: p.windows.map(wireWindow) }))
+}
+
+// Everything the console shell draws, in one read (#262, per the where-it-lives
+// decision #249). The sidecar holds no secret, no GitHub token and no journal
+// handle: it polls this and renders what comes back.
+//
+// The journal FILE stays daemon-private. What crosses is its last hundred
+// events, which is the feed and nothing more.
+//
+// The frontier is the only field this route does not compute. Reconcile does,
+// on the credentials that pass already holds, and the stamp beside it says how
+// old the reading is (see Dispatcher#frontierSnapshot).
+//
+// One cost worth stating rather than hiding: `dispatcher.status()` derives its
+// recent outcomes by reading the whole journal off disk, exactly as `/status`
+// in Discord does, and the review gate's pull-request lookup reads it again.
+// The journal grows without bound, so the poll interval the sidecar picks (the
+// #263 decision) is what decides how often that read happens.
+async function overview() {
+  // The fleet read asks tmux, and an indeterminate tmux is not "no agents" —
+  // the evidence rule holds on a page exactly as it holds in reconcile. It must
+  // not cost the rest of the page either: the feed, the escalations, the gate
+  // and the frontier are all still readable while tmux is wedged, and a
+  // dashboard that goes blank is worst precisely when the box is worst. So the
+  // section says it could not be read, and every other section answers.
+  let fleet = null
+  let fleetError = null
+  try {
+    fleet = await dispatcher.status()
+  } catch (e) {
+    fleetError = e.message
+    log(`overview: the fleet read failed (${e.message}) — serving every other section`)
+  }
+  const health = bridge ? bridge.status() : null
+  const open = store.openEscalations()
+  return {
+    at: new Date().toISOString(),
+    daemon: {
+      port: PORT,
+      uptime_s: Math.round(process.uptime()),
+      auto_dispatch: curiaConfig.dispatch.auto_dispatch,
+      max_concurrent: curiaConfig.dispatch.max_concurrent,
+    },
+    // Null, never empty, when the read above failed: an unreadable fleet and an
+    // idle box are opposite facts and must never render the same.
+    agents: fleet?.agents ?? null,
+    untracked: fleet?.untracked ?? null,
+    recent: fleet?.recent ?? null,
+    fleet_error: fleetError,
+    // The gate is its own list, not a kind to filter for. It is the one
+    // escalation the daemon opens about an agent's ENDING, it carries the pull
+    // request nothing else carries, and the page draws it as its own card.
+    escalations: open.filter((r) => r.kind !== REVIEW_KIND).map(wireEscalation),
+    review_gate: open.filter((r) => r.kind === REVIEW_KIND).map((r) => ({
+      ...wireEscalation(r),
+      pull_request: dispatcher.pullRequestUrlFor(r.agent),
+    })),
+    // `bridge` keeps the string shape /state gave it, and `bridge_health` the
+    // whole record — one name for one thing across both routes.
+    bridge: health?.state ?? 'down',
+    bridge_health: health ?? { state: 'down', since: null, unhealthy_for_s: 0, last_error: null },
+    usage: providerUsage(),
+    events: store.recentEvents(),
+    frontier: dispatcher.frontierSnapshot(),
+  }
+}
+
 async function handleRequest(req, res, { fromContainer = false } = {}) {
   const url = new URL(req.url, `http://127.0.0.1:${PORT}`)
   const json = (code, obj) => {
@@ -1252,6 +1380,12 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
       bridge_health: health ?? { state: 'down', since: null, unhealthy_for_s: 0, last_error: null },
       open_escalations: store.openEscalations(),
     })
+  }
+
+  // The dashboard's read (#262). Loopback only, and absent from AGENT_ROUTES,
+  // so the container-facing listener refuses it before it reaches here.
+  if (url.pathname === '/overview' && req.method === 'GET') {
+    return json(200, await overview())
   }
 
   if (url.pathname === '/escalate' && req.method === 'POST') {

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -21,6 +21,14 @@ import crypto from 'node:crypto'
 // LAPSING when the agent instance it is bound to exits.
 export const CONFIRM_KIND = 'confirm'
 
+// How much of the journal the feed keeps in memory (#262). The dashboard reads
+// the daemon's last events over `GET /overview`, and the journal FILE stays
+// daemon-private — so the tail is held here, filled by replay at boot and by
+// every append after it. A ring rather than a re-read: the file grows without
+// bound and the dashboard polls, so parsing it once per poll would make the
+// cost of watching curia rise with its history.
+export const RECENT_EVENTS = 100
+
 // The journal in the old spelling (#184).
 //
 // Until #184 the process curia spawns was a "worker" and the program it ran
@@ -106,6 +114,7 @@ export class EscalationStore {
     this.ticketRepos = new Map() // ticket -> repo of its last dispatch (#235)
     this.lastAgentEvents = new Map() // agent session -> last journal event about it (#236)
     this.notes = new Map() // note id -> every note ever queued, pending or not (#252)
+    this.recent = [] // the last RECENT_EVENTS journal lines, oldest first (#262)
     this.seq = 0
     this.noteSeq = 0
     this._replay()
@@ -132,6 +141,12 @@ export class EscalationStore {
   }
 
   _apply(ev, { replay }) {
+    // The feed's tail (#262). Every event passes here exactly once, on replay
+    // and on append alike, so the ring is right the instant the boot replay
+    // ends and stays right for the rest of the run.
+    this.recent.push(ev)
+    if (this.recent.length > RECENT_EVENTS) this.recent.shift()
+
     // The last thing the journal says about an agent (#236): the direct answer
     // under a question in its thread reads it as progress evidence. The
     // note-queue family is excluded, because the question itself queues a note
@@ -597,6 +612,13 @@ export class EscalationStore {
   // Generic operational events (notify, result, agent_done…) share the journal.
   logEvent(type, data) {
     return this._append({ type, ...data })
+  }
+
+  // The feed the dashboard draws (#262): the journal's last events, oldest
+  // first. A copy, because the caller serializes it while the daemon keeps
+  // appending.
+  recentEvents(limit = RECENT_EVENTS) {
+    return this.recent.slice(-limit)
   }
 
   // The journal's last word about an agent (#236): { type, ts } or null.

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -221,6 +221,23 @@ export function paceOf(resetsAt, windowMs, now = Date.now()) {
   return { elapsedPct: Math.max(0, Math.min(100, Math.round(((windowMs - remaining) / windowMs) * 100))) }
 }
 
+// When the window on the line rolls, as an ISO instant — the reset the
+// dashboard prints beside the bar (#262). The status line says the pace and
+// nothing more, because a bar has no room for a clock time; a page has.
+//
+// A LIVE window states its own reset, so that instant is the answer. A ROLLED
+// window's stated reset is in the past and belongs to a window that ended, so
+// the fresh window that replaced it answers instead: it started at that
+// instant, and it ends one window later. That is knowable exactly while the
+// fresh window's own clock is knowable, and `paceOf` decides that from the same
+// instant — hence the pace is passed in rather than re-derived.
+function statedReset(resetsAt, windowMs, pace) {
+  const at = resetMs(resetsAt)
+  if (!Number.isFinite(at)) return null
+  if (!pace.expired) return pace.elapsedPct === null ? null : new Date(at).toISOString()
+  return pace.elapsedPct === null ? null : new Date(at + windowMs).toISOString()
+}
+
 // 300 -> "5h", 10080 -> "7d". The label is derived, never assumed: codex calls
 // its windows primary/secondary and which one is the short one depends on the
 // plan (a plus account was measured with a WEEKLY primary and no secondary).
@@ -239,11 +256,12 @@ function barsOf(limits, now) {
   const found = []
   for (const l of limits ?? []) {
     const pace = paceOf(l.resetsAt, l.windowMs, now)
+    const resetsAt = statedReset(l.resetsAt, l.windowMs, pace)
     if (pace.expired) {
-      found.push({ label: l.label, pct: 0, elapsedPct: pace.elapsedPct, fresh: true })
+      found.push({ label: l.label, pct: 0, elapsedPct: pace.elapsedPct, resetsAt, fresh: true })
       continue
     }
-    found.push({ label: l.label, pct: Math.round(l.usedPct), elapsedPct: pace.elapsedPct })
+    found.push({ label: l.label, pct: Math.round(l.usedPct), elapsedPct: pace.elapsedPct, resetsAt })
   }
   return found.length ? found : null
 }
@@ -293,7 +311,7 @@ function codexTail(lines, now) {
 
 const TAILS = { claude: claudeTail, codex: codexTail }
 
-// { ctx: {tokens, window} | null, windows: [{label, pct, elapsedPct, fresh?}] | null,
+// { ctx: {tokens, window} | null, windows: [{label, pct, elapsedPct, resetsAt, fresh?}] | null,
 //   limits: [{label, usedPct, windowMs, resetsAt}] | null }
 export function readTranscriptMeters(harness, file, now = Date.now()) {
   const tail = TAILS[harness]
@@ -538,11 +556,12 @@ export function accountWindows(payload, now = Date.now()) {
     const v = payload?.[w.key]
     if (!Number.isFinite(v?.utilization)) continue
     const p = paceOf(v.resets_at, w.ms, now)
+    const resetsAt = statedReset(v.resets_at, w.ms, p)
     if (p.expired) {
-      out.push({ label: w.label, pct: 0, elapsedPct: p.elapsedPct, fresh: true })
+      out.push({ label: w.label, pct: 0, elapsedPct: p.elapsedPct, resetsAt, fresh: true })
       continue
     }
-    out.push({ label: w.label, pct: Math.round(v.utilization), elapsedPct: p.elapsedPct })
+    out.push({ label: w.label, pct: Math.round(v.utilization), elapsedPct: p.elapsedPct, resetsAt })
   }
   return out.length ? out : null
 }
@@ -590,8 +609,8 @@ export class AccountUsage {
     return best ?? null
   }
 
-  // [{label, pct}] | null — the read never blocks; a refresh it decides to run
-  // lands on a later call.
+  // [{label, pct, elapsedPct, resetsAt, fresh?}] | null — the read never
+  // blocks; a refresh it decides to run lands on a later call.
   windows() {
     const best = this.#best()
     if (this.enabled) this.#maybeFetch(best)

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -1,0 +1,452 @@
+// `GET /overview` (#262) — the dashboard's one read of the daemon.
+//
+// Two halves, and they are tested two different ways on purpose.
+//
+// The ROUTE is a wire contract between two processes: the daemon and the
+// sidecar of #263, which holds no secret, no GitHub token and no journal
+// handle. A field that quietly changes name or nesting breaks a page nothing in
+// this repo compiles against, so the shape is pinned against a REAL boot —
+// src/index.mjs on an ephemeral port, the shipped code path, exactly as the
+// CSRF suite does it.
+//
+// The FRONTIER STAMP is a dispatcher fact: reconcile computes the two-level
+// frontier with the credentials that pass already holds, and stamps the instant
+// it did. That is driven through the Dispatcher's injected `deps` seam — no gh,
+// no tmux, no live box.
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { AGENT_ROUTES } from '../src/agenttoken.mjs'
+import { Dispatcher } from '../src/dispatch.mjs'
+import { directUnblocks } from '../src/github.mjs'
+import { EscalationStore, RECENT_EVENTS } from '../src/store.mjs'
+import { REVIEW_KIND } from '../src/lifecycle.mjs'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
+import { sandboxYaml, TEST_PINS } from './fixtures/sandbox.mjs'
+
+const DIR = path.dirname(fileURLToPath(import.meta.url))
+const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
+
+function request(port, method, urlPath, { headers = {}, body = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method, path: urlPath, headers }, (res) => {
+      let data = ''
+      res.on('data', (c) => { data += c })
+      res.on('end', () => resolve({ status: res.statusCode, body: data }))
+    })
+    req.once('error', reject)
+    if (body !== null) req.write(body)
+    req.end()
+  })
+}
+
+describe('GET /overview (index.mjs, real boot)', () => {
+  let tmp
+  let child
+  let port
+  let watch
+  let tmuxShim
+
+  const setTmux = (body) => {
+    fs.writeFileSync(tmuxShim, `#!/bin/sh\n${body}\n`)
+    fs.chmodSync(tmuxShim, 0o755)
+  }
+
+  before(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-overview-test-'))
+    const cfgDir = path.join(tmp, 'config')
+    const dataDir = path.join(tmp, 'data')
+    const shim = path.join(tmp, 'shim')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    fs.mkdirSync(shim, { recursive: true })
+    // Inert failing stubs: boot reconcile's gh read comes back indeterminate,
+    // which is a failed pass by design — and a failed pass is exactly the state
+    // that must still serve an honest overview.
+    for (const bin of ['gh', 'tailscale']) {
+      const p = path.join(shim, bin)
+      fs.writeFileSync(p, '#!/bin/sh\nexit 1\n')
+      fs.chmodSync(p, 0o755)
+    }
+    // tmux answers as a box with no server, which is POSITIVE evidence of no
+    // sessions rather than an unreadable fleet — see tmux.mjs's NO_SERVER_RE.
+    // One test below rewrites this file to make the read indeterminate instead.
+    tmuxShim = path.join(shim, 'tmux')
+    setTmux('echo "no server running on /tmp/tmux-0/default" >&2\nexit 1')
+    const [daemonPort, ttydPort, servePort, proxyPort] = [await freePort(), await freePort(), await freePort(), await freePort()]
+    port = daemonPort
+    fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
+      'watch:',
+      '  - repo: example/fixture',
+      '    mode: ready-for-agent',
+      'dispatch:',
+      '  auto_dispatch: false',
+      '  max_concurrent: 3',
+      '  poll_interval_s: 60',
+      `  workspace_root: ${path.join(tmp, 'work')}`,
+      '  ready_timeout_s: 5',
+      '  confirm_ttl_h: 1',
+      'attach:',
+      `  ttyd_port: ${ttydPort}`,
+      `  serve_port: ${servePort}`,
+      'identity:',
+      '  allow: [tester@example.com]',
+      `  proxy_port: ${proxyPort}`,
+      ...skillsYaml(seedSkillsRoot(tmp)),
+      ...sandboxYaml(),
+      '',
+    ].join('\n'))
+    fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
+      'defaults:',
+      '  untyped: sonnet',
+      'models:',
+      '  sonnet: { provider: anthropic, harness: claude }',
+      'harnesses:',
+      '  claude:',
+      '    template: claude --model {model} "$(cat {prompt_file})"',
+      "    ready: '⏵⏵|bypass permissions'",
+      '    tool_channel_grace_s: 15',
+      '',
+    ].join('\n'))
+
+    child = spawn(process.execPath, [DAEMON], {
+      env: {
+        ...process.env,
+        PORT: String(daemonPort),
+        CURIA_CONFIG_DIR: cfgDir,
+        CURIA_DATA_DIR: dataDir,
+        PATH: `${shim}:${process.env.PATH}`,
+        DISCORD_BOT_TOKEN: '', // REST-only: the overview must never depend on the bridge
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    watch = watchDaemon(child)
+    await waitForBoot(watch, async () => {
+      try {
+        return (await request(port, 'GET', '/state')).status === 200
+      } catch { return false }
+    }, 'the /state route')
+    // Listening is not settled. Boot reconcile runs AFTER the bind, and the
+    // frontier is the last thing it does — so wait for the stamp, and every
+    // test below reads a daemon that has finished booting rather than racing it.
+    await waitForBoot(watch, async () => {
+      try {
+        return JSON.parse((await request(port, 'GET', '/overview')).body).frontier.computed_at !== null
+      } catch { return false }
+    }, 'a frontier stamped by boot reconcile')
+  })
+
+  after(() => {
+    if (child && child.exitCode === null) child.kill('SIGKILL')
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const overview = async () => {
+    const res = await request(port, 'GET', '/overview')
+    assert.equal(res.status, 200)
+    return JSON.parse(res.body)
+  }
+
+  test('the route answers every section the console shell draws', async () => {
+    const o = await overview()
+    assert.match(o.at, /^\d{4}-\d{2}-\d{2}T/, 'the payload dates itself')
+    assert.deepEqual(o.daemon, {
+      port, uptime_s: o.daemon.uptime_s, auto_dispatch: false, max_concurrent: 3,
+    })
+    assert.ok(Number.isFinite(o.daemon.uptime_s))
+    for (const key of ['agents', 'untracked', 'recent', 'escalations', 'review_gate', 'usage', 'events']) {
+      assert.ok(Array.isArray(o[key]), `${key} is a list`)
+    }
+    assert.equal(o.fleet_error, null, 'tmux answered, so the fleet is a reading rather than a refusal')
+    // A bridgeless daemon says down in both spellings — the string /state
+    // already gave this reader, and the whole record beside it.
+    assert.equal(o.bridge, 'down')
+    assert.deepEqual(o.bridge_health, { state: 'down', since: null, unhealthy_for_s: 0, last_error: null })
+  })
+
+  test('an unreadable fleet is null and says why, and every other section still answers', async () => {
+    // The evidence rule on a page (tmux.mjs): a wedged tmux is not "no agents".
+    // Serving `[]` here would draw an idle box over a live one, and 500-ing the
+    // route would blank the feed, the escalations and the frontier as well —
+    // exactly when the operator most needs to see them.
+    setTmux('echo "connect failed: no such file or directory" >&2\nexit 1')
+    try {
+      const o = await overview()
+      assert.equal(o.agents, null)
+      assert.equal(o.untracked, null)
+      assert.equal(o.recent, null)
+      assert.match(o.fleet_error, /indeterminate/)
+      assert.ok(Array.isArray(o.events) && o.events.length > 0, 'the feed still answers')
+      assert.ok(Array.isArray(o.escalations), 'and so do the escalations')
+      assert.ok(o.frontier, 'and so does the frontier')
+    } finally {
+      setTmux('echo "no server running on /tmp/tmux-0/default" >&2\nexit 1')
+    }
+  })
+
+  test('boot reconcile computes the frontier, and a repo it could not read says so', async () => {
+    // The frontier is the one section the route does not compute: reconcile
+    // does, on the credentials that pass already holds, and stamps it. This
+    // boot's `gh` stub fails, so the repo carries its error — which is a
+    // different fact from an empty frontier, and renders differently.
+    const o = await overview()
+    assert.ok(Number.isFinite(Date.parse(o.frontier.computed_at)), 'boot reconcile stamped it')
+    assert.deepEqual(o.frontier.repos.map((r) => r.repo), ['example/fixture'])
+    assert.match(o.frontier.repos[0].error, /gh api/)
+  })
+
+  test('the feed carries the daemon journal, and never the journal file', async () => {
+    const o = await overview()
+    assert.ok(o.events.length > 0, 'a booted daemon has journalled something')
+    assert.ok(o.events.length <= 100, 'the feed is the tail, not the file')
+    for (const ev of o.events) assert.ok(ev.type && ev.ts, 'every event names itself and dates itself')
+    assert.equal(JSON.stringify(o).includes('events.jsonl'), false, 'the journal file stays daemon-private')
+  })
+
+  test('open escalations and the review gate are two lists, and the gate carries its pull request', async () => {
+    const open = async (kind, prompt) => {
+      const res = await request(port, 'POST', '/escalate', {
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent: 'curia-1', ticket: '1', kind, prompt }),
+      })
+      assert.equal(res.status, 200)
+      return JSON.parse(res.body).id
+    }
+    const askId = await open('free-text', 'which way round?')
+    const gateId = await open(REVIEW_KIND, 'is this done?')
+
+    const o = await overview()
+    const ask = o.escalations.find((r) => r.id === askId)
+    assert.ok(ask, 'the question is an open escalation')
+    assert.equal(ask.kind, 'free-text')
+    assert.equal(ask.prompt, 'which way round?')
+    assert.equal(ask.agent, 'curia-1')
+    assert.equal(ask.rendered, false, 'no bridge rendered it')
+    assert.equal(ask.payload_hash, undefined, 'the gate\'s own bookkeeping stays off the wire')
+
+    assert.equal(o.escalations.some((r) => r.id === gateId), false, 'the gate is not in the escalation list')
+    const gate = o.review_gate.find((r) => r.id === gateId)
+    assert.ok(gate, 'the gate is its own list')
+    assert.equal(gate.kind, REVIEW_KIND)
+    assert.ok('pull_request' in gate, 'the gate card carries the pull request nothing else carries')
+
+    // And an answered escalation leaves both lists at once.
+    const answered = await request(port, 'POST', '/answer', {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: askId, answer: 'this way' }),
+    })
+    assert.equal(answered.status, 200)
+    const after = await overview()
+    assert.equal(after.escalations.some((r) => r.id === askId), false)
+  })
+
+  test('the route is loopback tooling only — a browser and a container are both refused', async () => {
+    const cross = await request(port, 'GET', '/overview', { headers: { origin: 'http://evil.com' } })
+    assert.equal(cross.status, 403, 'the CSRF gate covers the whole surface, this route included')
+    assert.equal(AGENT_ROUTES.has('/overview'), false, 'an agent container cannot reach the operator\'s own read')
+  })
+})
+
+describe('the journal tail the feed reads (#262)', () => {
+  let dir
+  const store = () => new EscalationStore(dir)
+
+  before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-overview-store-')) })
+  after(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('the ring holds the last events, oldest first, and survives a restart as the file does', () => {
+    const a = store()
+    for (let i = 1; i <= RECENT_EVENTS + 20; i += 1) a.logEvent('notify', { n: i })
+    const tail = a.recentEvents()
+    assert.equal(tail.length, RECENT_EVENTS)
+    assert.equal(tail[0].n, 21, 'oldest first, and the head has fallen off')
+    assert.equal(tail.at(-1).n, RECENT_EVENTS + 20)
+    assert.deepEqual(a.recentEvents(3).map((e) => e.n), [118, 119, 120], 'a smaller ask takes the newest')
+
+    // A second store over the same journal replays the file, so the tail is
+    // right the instant the boot replay ends — no first-append warm-up.
+    assert.deepEqual(store().recentEvents().map((e) => e.n), tail.map((e) => e.n))
+  })
+})
+
+describe('the two-level frontier, and reconcile\'s stamp (#262)', () => {
+  let tmp
+  const dispatchers = []
+
+  before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-overview-frontier-')) })
+  after(() => {
+    for (const d of dispatchers) d.agents.clear()
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  // A map child, in the gh payload shape the frontier reads: labels and
+  // assignees are arrays of OBJECTS.
+  const child = (number, title, { blockedBy = 0, labels = [], assignees = [], state = 'open' } = {}) => ({
+    number,
+    title,
+    state,
+    assignees,
+    labels: labels.map((name) => ({ name })),
+    issue_dependencies_summary: { blocked_by: blockedBy, blocking: 0, total_blocked_by: blockedBy, total_blocking: 0 },
+  })
+
+  // #262's fixture map: two takeable tickets, and three behind them.
+  //   11 (takeable) unblocks 21 and 22
+  //   12 (takeable) unblocks 22 as well — one dependent, two blockers
+  //   13 is claimed, so it is off the frontier and unblocks nothing anyone sees
+  //   23 is blocked by 13 alone
+  const ITEMS = [
+    child(11, 'the first takeable one', { labels: ['wayfinder:task'] }),
+    child(12, 'the second takeable one', { labels: ['wayfinder:grilling'] }),
+    child(13, 'somebody is on this one', { assignees: [{ login: 'someone' }] }),
+    child(21, 'waits on the first', { blockedBy: 1 }),
+    child(22, 'waits on both', { blockedBy: 2 }),
+    child(23, 'waits on the claimed one', { blockedBy: 1 }),
+  ]
+  const EDGES = {
+    21: [{ number: 11, state: 'open' }],
+    22: [{ number: 11, state: 'open' }, { number: 12, state: 'open' }],
+    23: [{ number: 13, state: 'open' }],
+  }
+
+  function makeDispatcher(deps = {}) {
+    const config = {
+      watch: [{ repo: 'o/r', mode: 'map' }],
+      dispatch: {
+        auto_dispatch: false, max_concurrent: 1, poll_interval_s: 60,
+        workspace_root: path.join(tmp, 'work'), ready_timeout_s: 5, stop_nudge_budget: 3,
+      },
+      attach: { ttyd_port: 7681, serve_port: 8443 },
+      identity: { allow: ['tester@example.com'], proxy_port: 7682 },
+      skills: null,
+      sandbox: TEST_PINS,
+    }
+    const d = new Dispatcher({
+      config,
+      routing: { defaults: { untyped: 'sonnet' }, models: { sonnet: { provider: 'anthropic', harness: 'claude' } }, fallbacks: {}, harnesses: {} },
+      store: { logEvent: () => {}, openEscalations: () => [], boundTickets: () => [] },
+      notify: () => {},
+      log: () => {},
+      dataDir: path.join(tmp, 'data'),
+      deps: {
+        viewerLogin: async () => null, // reconcile skips its sweeps; the frontier is not one of them
+        listSessions: async () => [],
+        hasSession: async () => false,
+        repoMaps: async () => [{ number: 9, title: 'the map', state: 'open', labels: [] }],
+        mapFrontier: async () => ITEMS,
+        flatFrontier: async () => [],
+        blockedByOf: async (repo, n) => EDGES[n] ?? [],
+        probeTtyd: async () => ({ verified: true }),
+        assertServe: async () => {},
+        serveOff: async () => {},
+        ...deps,
+      },
+    })
+    dispatchers.push(d)
+    return d
+  }
+
+  test('level two is what each takeable ticket directly unblocks', async () => {
+    const [repo] = await makeDispatcher().frontier()
+    assert.deepEqual(repo.numbers, [11, 12], 'level one is the takeable set, unchanged')
+    const byNumber = Object.fromEntries(repo.items.map((i) => [i.number, i]))
+    assert.deepEqual(byNumber[11].unblocks, [
+      { number: 21, title: 'waits on the first', labels: [] },
+      { number: 22, title: 'waits on both', labels: [] },
+    ])
+    // 22 sits behind two blockers, so it appears under each of them. It is one
+    // level, never a closure: 23 is behind a CLAIMED ticket, which is on no
+    // level of a frontier nobody can take.
+    assert.deepEqual(byNumber[12].unblocks.map((i) => i.number), [22])
+    assert.equal(repo.items.some((i) => i.unblocks.some((u) => u.number === 23)), false)
+  })
+
+  test('reconcile computes the frontier and stamps when it did', async () => {
+    const d = makeDispatcher()
+    assert.deepEqual(d.frontierSnapshot(), { computed_at: null, repos: [] }, 'nothing is stamped before a pass runs')
+
+    const before = Date.now()
+    await d.reconcile({ boot: true })
+    const snap = d.frontierSnapshot()
+    const at = Date.parse(snap.computed_at)
+    assert.ok(Number.isFinite(at), 'the snapshot dates itself')
+    assert.ok(at >= before && at <= Date.now(), 'and dates itself to this pass')
+    assert.deepEqual(snap.repos.map((r) => r.repo), ['o/r'])
+    assert.deepEqual(snap.repos[0].items.map((i) => i.number), [11, 12])
+    assert.deepEqual(snap.repos[0].items[0].unblocks.map((i) => i.number), [21, 22])
+
+    // A later pass re-stamps it: the page shows the age of the reading, so a
+    // stamp that never moved would age a frontier that had just been re-read.
+    await new Promise((r) => setTimeout(r, 5))
+    await d.reconcile({ boot: false })
+    assert.ok(Date.parse(d.frontierSnapshot().computed_at) > at)
+  })
+
+  test('a frontier that cannot be read costs the snapshot, never the pass', async () => {
+    const d = makeDispatcher()
+    await d.reconcile({ boot: true })
+    const good = d.frontierSnapshot()
+
+    // Every gh read for this repo now throws. `frontier()` catches per repo, so
+    // the pass completes and the snapshot re-stamps with the error in place of
+    // the items — the page says "this repo could not be read", not "nothing is
+    // takeable here".
+    d.deps.repoMaps = async () => { throw new Error('gh is down') }
+    await d.reconcile({ boot: false })
+    const after = d.frontierSnapshot()
+    assert.notEqual(after.computed_at, good.computed_at)
+    assert.equal(after.repos[0].error, 'gh is down')
+    assert.equal(after.repos[0].items, undefined)
+  })
+
+  test('an unreadable dependency edge drops the unblocks and the count, never the frontier', async () => {
+    const d = makeDispatcher({ blockedByOf: async () => { throw new Error('no dependency read') } })
+    const [repo] = await d.frontier()
+    assert.deepEqual(repo.numbers, [11, 12], 'level one still stands')
+    assert.equal(repo.agentOnly, null, 'the agent-only count says it does not know')
+    assert.deepEqual(repo.items[0].unblocks, [], 'and level two is empty rather than invented')
+  })
+})
+
+describe('directUnblocks', () => {
+  const item = (number, state = 'open', extra = {}) => ({ number, state, ...extra })
+
+  test('walks the blocked-by edges the other way round', () => {
+    const out = directUnblocks({
+      items: [item(21), item(22)],
+      edges: { 21: [{ number: 11, state: 'open' }], 22: [{ number: 11, state: 'open' }] },
+    })
+    assert.deepEqual(out[11].map((i) => i.number), [21, 22])
+  })
+
+  test('a closed blocker and a closed dependent both drop out', () => {
+    const out = directUnblocks({
+      items: [item(21), item(22, 'closed')],
+      edges: {
+        21: [{ number: 11, state: 'closed' }, { number: 12, state: 'open' }],
+        22: [{ number: 12, state: 'open' }],
+      },
+    })
+    assert.equal(out[11], undefined, 'a closed ticket unblocks nothing anyone can take')
+    assert.deepEqual(out[12].map((i) => i.number), [21], 'and a closed dependent is already done')
+  })
+
+  test('a pull request sharing the issue number space is never a dependent', () => {
+    const out = directUnblocks({
+      items: [item(21, 'open', { pull_request: {} })],
+      edges: { 21: [{ number: 11, state: 'open' }] },
+    })
+    assert.deepEqual(out, {})
+  })
+
+  test('no edges at all is an empty answer, not a throw', () => {
+    assert.deepEqual(directUnblocks(), {})
+    assert.deepEqual(directUnblocks({ items: [item(21)] }), {})
+  })
+})

--- a/daemon/test/usage.test.mjs
+++ b/daemon/test/usage.test.mjs
@@ -129,7 +129,9 @@ describe('transcript meters', () => {
     ])
     const { ctx, windows } = readTranscriptMeters('codex', file, NOW)
     assert.deepEqual(ctx, { tokens: 47481, window: 258400 })
-    assert.deepEqual(windows, [{ label: '7d', pct: 1, elapsedPct: 60 }])
+    // The stated reset rides along (#262): the status line has no room for a
+    // clock time and prints the pace, the dashboard has room and prints both.
+    assert.deepEqual(windows, [{ label: '7d', pct: 1, elapsedPct: 60, resetsAt: resetsInIso(10080 * 0.4) }])
   })
 
   test('the codex window label is derived, never assumed from the slot name', () => {
@@ -149,8 +151,8 @@ describe('transcript meters', () => {
       }),
     ])
     assert.deepEqual(readTranscriptMeters('codex', file, NOW).windows, [
-      { label: '5h', pct: 62, elapsedPct: 30 },
-      { label: '7d', pct: 41, elapsedPct: 50 },
+      { label: '5h', pct: 62, elapsedPct: 30, resetsAt: resetsInIso(210) },
+      { label: '7d', pct: 41, elapsedPct: 50, resetsAt: resetsInIso(10080 * 0.5) },
     ])
   })
 
@@ -167,9 +169,12 @@ describe('transcript meters', () => {
         secondary: { used_percent: 41, window_minutes: 10080, resets_at: resetsInSec(1000) },
       }),
     ])
+    // The rolled window states the FRESH window's reset (#262): the one the
+    // transcript carries is in the past and belongs to the window that ended,
+    // and the window that replaced it ends five hours after that instant.
     assert.deepEqual(readTranscriptMeters('codex', file, NOW).windows, [
-      { label: '5h', pct: 0, elapsedPct: 10, fresh: true },
-      { label: '7d', pct: 41, elapsedPct: 90 },
+      { label: '5h', pct: 0, elapsedPct: 10, resetsAt: resetsInIso(270), fresh: true },
+      { label: '7d', pct: 41, elapsedPct: 90, resetsAt: resetsInIso(1000) },
     ])
   })
 
@@ -184,8 +189,10 @@ describe('transcript meters', () => {
         primary: { used_percent: 88, window_minutes: 300, resets_at: resetsInSec(-360) },
       }),
     ])
+    // No clock and no reset, for the same reason: which window we are in is a
+    // guess, so when it ends is a guess too (#262).
     assert.deepEqual(readTranscriptMeters('codex', file, NOW).windows, [
-      { label: '5h', pct: 0, elapsedPct: null, fresh: true },
+      { label: '5h', pct: 0, elapsedPct: null, resetsAt: null, fresh: true },
     ])
   })
 
@@ -198,7 +205,7 @@ describe('transcript meters', () => {
     ])
     const { ctx, windows } = readTranscriptMeters('codex', file, NOW)
     assert.equal(ctx.tokens, 900)
-    assert.deepEqual(windows, [{ label: '5h', pct: 5, elapsedPct: 30 }])
+    assert.deepEqual(windows, [{ label: '5h', pct: 5, elapsedPct: 30, resetsAt: resetsInIso(210) }])
   })
 
   test('a missing, empty or unreadable transcript reads as no meters, never as a throw', () => {
@@ -227,8 +234,8 @@ describe('transcript meters', () => {
     // reading keeps what the transcript states, which is what tells the cooling
     // path that this window has already rolled and states no cap to wait for.
     assert.deepEqual(windows, [
-      { label: '5h', pct: 0, elapsedPct: 10, fresh: true },
-      { label: '7d', pct: 41, elapsedPct: 90 },
+      { label: '5h', pct: 0, elapsedPct: 10, resetsAt: resetsInIso(270), fresh: true },
+      { label: '7d', pct: 41, elapsedPct: 90, resetsAt: resetsInIso(1000) },
     ])
     assert.deepEqual(limits, [
       { label: '5h', usedPct: 99.4, windowMs: 300 * MIN, resetsAt: resetsInSec(-30) },
@@ -516,7 +523,7 @@ describe('agentMeters', () => {
     assert.equal(m.ctxPct, 50)
     assert.equal(m.model, 'gpt-5.6-sol')
     assert.equal(m.effort, 'high')
-    assert.deepEqual(m.windows, [{ label: '5h', pct: 3, elapsedPct: 50 }])
+    assert.deepEqual(m.windows, [{ label: '5h', pct: 3, elapsedPct: 50, resetsAt: resetsInIso(150) }])
   })
 
   test('the account bars survive an agent whose routing label is gone (#187)', () => {
@@ -674,8 +681,8 @@ describe('AccountUsage', () => {
   test('the five-hour and seven-day window lengths are known, so both carry pace', () => {
     // 150 minutes left of 300 -> 50% elapsed. 60% of a week left -> 40%.
     assert.deepEqual(accountWindows(payload(18, 57), NOW), [
-      { label: '5h', pct: 18, elapsedPct: 50 },
-      { label: '7d', pct: 57, elapsedPct: 60 },
+      { label: '5h', pct: 18, elapsedPct: 50, resetsAt: resetsInIso(150) },
+      { label: '7d', pct: 57, elapsedPct: 60, resetsAt: resetsInIso(10080 * 0.4) },
     ])
   })
 
@@ -712,8 +719,8 @@ describe('AccountUsage', () => {
     // long as the next probe took. Five minutes past the reset the window is
     // five minutes old and empty, which is 2% of its clock and 0% spent.
     assert.deepEqual(accountWindows(payload(18, 57, { fiveIn: -5 }), NOW), [
-      { label: '5h', pct: 0, elapsedPct: 2, fresh: true },
-      { label: '7d', pct: 57, elapsedPct: 60 },
+      { label: '5h', pct: 0, elapsedPct: 2, resetsAt: resetsInIso(295), fresh: true },
+      { label: '7d', pct: 57, elapsedPct: 60, resetsAt: resetsInIso(10080 * 0.4) },
     ])
   })
 


### PR DESCRIPTION
Ticket: alp82/curia#262 — [The daemon serves its overview](https://github.com/alp82/curia/issues/262)

One loopback route, `GET /overview`, per the where-it-lives decision (#249). It joins the live agents, the open escalations, the review gate with its pull request, bridge health, one usage reading per provider with its stated reset, the last 100 journal events, and the two-level frontier.

The frontier is the one section the route does not compute. Reconcile computes it, on the credentials that pass already holds, and stamps the instant it did. Level two is what each takeable ticket directly unblocks, read off the same blocked-by edges the agent-only count already spends. Those edges are now read once per repo and shared by both readers, so the tickets view costs no more `gh` calls than before.

Every section is nullable on its own. An unreadable fleet says so and costs the page nothing else, because a dashboard that goes blank is worst exactly when the box is worst. The journal file stays daemon-private: the store holds a 100-event ring, filled by the boot replay and by every append after it.

Every usage window now carries the instant it rolls. A rolled window states the fresh window's reset, which is knowable exactly while its clock is.

Tests: a real-boot suite pins the route shape, the two lists, the fleet refusal and the browser and container refusals. A dispatcher suite pins the two-level frontier and the reconcile stamp. `npm test` is green at 1409.

---

Dispatched by the curia daemon — session `curia-262`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `407814f` The daemon serves its overview (wayfinder #262)