### PR TITLE
The status line shows only the text that reached the router (alp82/curia#275)

### DIFF
--- a/daemon/src/overseer.mjs
+++ b/daemon/src/overseer.mjs
@@ -79,6 +79,9 @@ const asText = (text) => ({ content: [{ type: 'text', text }] })
 // the daemon it is gate.command, so every overseer effect is journalled and
 // routed exactly like a slash verb.
 export function buildVerbTools(command) {
+  // A handler runs only after the MCP layer has validated the arguments, so
+  // this call is the proof that the text reached the router. #275 hangs the
+  // status line off the injected `command` for exactly that reason.
   const run = (verb) => async (args) => asText(await command(canonicalFor(verb, args)))
   // #255: the regex is enforced, but the JSON schema the model reads drops it —
   // the SDK publishes `{"type":"string"}` and the description is the only place
@@ -211,11 +214,16 @@ export class OverseerHost {
   // server is a plain object over the same seven handlers. `interpreted`
   // marks the text as model-produced (#94): the router routes interpreted
   // destructive verbs through the button confirm instead of executing.
-  #mcpFor(threadId) {
+  // `narrate` runs on the way in, so the status line states the text this
+  // seam carried and nothing else (#275).
+  #mcpFor(threadId, narrate) {
     return createSdkMcpServer({
       name: 'curia',
       version: '0.1.0',
-      tools: buildVerbTools((text) => this.command(text, { threadId, interpreted: true })),
+      tools: buildVerbTools(async (text) => {
+        await narrate(text)
+        return this.command(text, { threadId, interpreted: true })
+      }),
     })
   }
 
@@ -273,6 +281,23 @@ export class OverseerHost {
     let result = null
     let toolCalls = 0
     let thrown = null
+    // #275: a streamed tool_use block is a REQUEST, not an event. The MCP
+    // layer validates the model's arguments after that block is written, and a
+    // call that dies there — prose packed into `ticket` — reaches no handler
+    // and no router. So each block is held here until its result comes back,
+    // the canonical text is narrated from the seam itself (see #mcpFor), and a
+    // result for a call that never reached the seam says so. The operator
+    // reads one true line per call: the text the router got, or the refusal.
+    const calls = new Map() // tool_use id -> verb
+    const crossed = new Map() // verb -> seam crossings no result has claimed yet
+    const narrate = (text) => {
+      // Count first, then await the edit: the tally is what the result reads,
+      // and a status edit that fails must not read back as a refusal. The verb
+      // is the first word of the canonical text, by construction.
+      const verb = text.split(' ')[0]
+      crossed.set(verb, (crossed.get(verb) ?? 0) + 1)
+      return step(`\`${text}\``)
+    }
     try {
       const q = this.queryFn({
         prompt,
@@ -282,7 +307,7 @@ export class OverseerHost {
           model,
           resume,
           systemPrompt: SYSTEM_PROMPT,
-          mcpServers: { curia: this.#mcpFor(threadId) },
+          mcpServers: { curia: this.#mcpFor(threadId, narrate) },
           allowedTools: ALLOWED_TOOLS,
           disallowedTools: DISALLOWED_TOOLS,
           maxTurns: this.maxTurns,
@@ -298,13 +323,23 @@ export class OverseerHost {
           for (const block of msg.message?.content ?? []) {
             if (block.type === 'tool_use') {
               toolCalls += 1
-              // The status line shows the canonical verb text — the same
-              // string the router receives — as inline code (#89).
-              const verb = block.name.replace('mcp__curia__', '')
-              let text
-              try { text = canonicalFor(verb, block.input ?? {}) } catch { text = verb }
-              await step(`\`${text}\``)
+              calls.set(block.id, block.name.replace('mcp__curia__', ''))
             }
+          }
+        }
+        if (msg.type === 'user') {
+          const content = msg.message?.content
+          for (const block of Array.isArray(content) ? content : []) {
+            if (block.type !== 'tool_result') continue
+            const verb = calls.get(block.tool_use_id)
+            if (verb === undefined) continue
+            calls.delete(block.tool_use_id)
+            // A result exists only after its handler returned, so the tally is
+            // already settled here. Nothing to claim means the MCP layer
+            // refused the call: name the verb, not a command line nothing ran.
+            const crossings = crossed.get(verb) ?? 0
+            if (crossings > 0) crossed.set(verb, crossings - 1)
+            else await step(`${SIGNALS.warn} \`${verb}\` refused before the router`)
           }
         }
         if (msg.type === 'result') result = msg

--- a/daemon/test/overseer.test.mjs
+++ b/daemon/test/overseer.test.mjs
@@ -8,6 +8,8 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { EscalationStore } from '../src/store.mjs'
 import { parseCommand } from '../src/commands.mjs'
 import {
@@ -19,12 +21,43 @@ const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'overseer-test-'))
 // ---- scripted stand-in for the SDK's query() --------------------------------
 
 const init = (id) => ({ type: 'system', subtype: 'init', session_id: id })
-const toolUse = (name, input = {}) => ({ type: 'assistant', message: { content: [{ type: 'tool_use', name, input }] } })
+const toolUse = (name, input = {}, id = 'tu-x') => ({ type: 'assistant', message: { content: [{ type: 'tool_use', id, name, input }] } })
 const success = (text) => ({ type: 'result', subtype: 'success', result: text, num_turns: 2, total_cost_usd: 0.01 })
 const failure = (subtype) => ({ type: 'result', subtype })
 
-// Each call to the fake consumes the next script (an array of messages, or an
-// Error to throw mid-stream) and records {prompt, options}.
+// One MCP client per turn server, over the in-memory transport. This is what
+// makes #275 testable: the arguments meet the REAL schema, so a refusal in a
+// test is the same refusal the live SDK produces, not a stub of one.
+const clients = new WeakMap()
+async function mcpCall(server, name, args) {
+  let client = clients.get(server)
+  if (!client) {
+    const [ours, theirs] = InMemoryTransport.createLinkedPair()
+    client = new Client({ name: 'overseer-test', version: '1' })
+    await Promise.all([server.instance.connect(theirs), client.connect(ours)])
+    clients.set(server, client)
+  }
+  return client.callTool({ name, arguments: args })
+}
+
+// A real tool call, scripted: the assistant block the model writes, the round
+// trip through this turn's own MCP server, and the tool_result that comes
+// back. A call the schema refuses reaches no handler, exactly as it does live.
+let nextToolUseId = 0
+const call = (verb, input = {}) => ({
+  async * expand(options) {
+    const id = `tu-${++nextToolUseId}`
+    yield toolUse(`mcp__curia__${verb}`, input, id)
+    const res = await mcpCall(options.mcpServers.curia, verb, input)
+    yield {
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: id, is_error: !!res.isError, content: res.content }] },
+    }
+  },
+})
+
+// Each call to the fake consumes the next script (an array of messages, an
+// Error to throw mid-stream, or a call() to run) and records {prompt, options}.
 function scriptedQuery(...scripts) {
   const fn = ({ prompt, options }) => {
     fn.calls.push({ prompt, options })
@@ -32,6 +65,7 @@ function scriptedQuery(...scripts) {
     return (async function* () {
       for (const m of script) {
         if (m instanceof Error) throw m
+        if (typeof m?.expand === 'function') { yield* m.expand(options); continue }
         yield m
       }
     })()
@@ -206,7 +240,7 @@ describe('OverseerHost turns', () => {
   test('a fresh turn journals the session, narrates tool calls in status, says the answer', async () => {
     const queryFn = scriptedQuery([
       init('sess-1'),
-      toolUse('mcp__curia__status'),
+      call('status'),
       success('all quiet'),
     ])
     const { host, store } = makeHost({ queryFn })
@@ -221,18 +255,73 @@ describe('OverseerHost turns', () => {
   test('the status line accumulates canonical verb text across tool calls (#95)', async () => {
     const queryFn = scriptedQuery([
       init('sess-1'),
-      toolUse('mcp__curia__tickets'),
-      toolUse('mcp__curia__start', { ticket: '85', repo: 'alp82/curia' }),
+      call('tickets'),
+      call('start', { ticket: '85', repo: 'alp82/curia' }),
       success('started'),
     ])
-    const { host } = makeHost({ queryFn })
+    const seen = []
+    const { host } = makeHost({ queryFn, command: async (text) => { seen.push(text); return 'ok' } })
     const { posts, statuses, io } = collector()
     await host.runTurn('thread-1', 'start 85', io)
     assert.deepEqual(statuses, [
       '-# ⚙️ `tickets`',
       '-# ⚙️ `tickets` · `start alp82/curia#85`',
     ])
+    // #275: the line and the seam carry the same two strings, in the same order
+    assert.deepEqual(seen, ['tickets', 'start alp82/curia#85'])
     assert.deepEqual(posts, ['started'])
+  })
+
+  // #275, the 2026-08-06 incident: the overseer packed the operator's sentence
+  // into `ticket`, the MCP schema refused it, and no router ever saw the call —
+  // but the status line had already printed `map <sentence>` as if it ran.
+  test('a call the schema refuses shows the refusal, never a command that never ran', async () => {
+    const prose = 'new ticket to make the map commands ticket param optional'
+    const queryFn = scriptedQuery([
+      init('sess-1'),
+      call('map', { ticket: prose }),
+      success('I could not read that as a map number.'),
+    ])
+    const seen = []
+    const { host } = makeHost({ queryFn, command: async (text) => { seen.push(text); return 'ok' } })
+    const { statuses, io } = collector()
+    await host.runTurn('thread-1', 'add a ticket to the map', io)
+    assert.deepEqual(seen, [], 'the router must receive nothing')
+    assert.deepEqual(statuses, ['-# ⚙️ ⚠️ `map` refused before the router'])
+    assert.ok(!statuses.some((s) => s.includes(prose)), 'the sentence must never appear as a command')
+  })
+
+  test('a refusal keeps its place beside the calls that did run (#275)', async () => {
+    const queryFn = scriptedQuery([
+      init('sess-1'),
+      call('tickets'),
+      call('start', { ticket: 'the landing page one' }),
+      call('start', { ticket: '85' }),
+      success('done'),
+    ])
+    const seen = []
+    const { host } = makeHost({ queryFn, command: async (text) => { seen.push(text); return 'ok' } })
+    const { statuses, io } = collector()
+    await host.runTurn('thread-1', 'start the landing page one', io)
+    assert.deepEqual(seen, ['tickets', 'start 85'])
+    assert.equal(
+      statuses.at(-1),
+      '-# ⚙️ `tickets` · ⚠️ `start` refused before the router · `start 85`',
+    )
+  })
+
+  test('a map instruction reaches the status line only as the router got it (#275)', async () => {
+    const queryFn = scriptedQuery([
+      init('sess-1'),
+      call('map', { ticket: '147', instruction: 'add a ticket\nthen wire it' }),
+      success('on it'),
+    ])
+    const seen = []
+    const { host } = makeHost({ queryFn, command: async (text) => { seen.push(text); return 'ok' } })
+    const { statuses, io } = collector()
+    await host.runTurn('thread-1', 'add a ticket then wire it', io)
+    assert.deepEqual(seen, ['map 147 add a ticket then wire it'])
+    assert.deepEqual(statuses, ['-# ⚙️ `map 147 add a ticket then wire it`'])
   })
 
   test('the next turn in the same thread resumes the journalled session', async () => {
@@ -393,11 +482,13 @@ describe('OverseerHost turns', () => {
       [init('never'), success('must not run')],
     )
     const { host } = makeHost({ queryFn })
-    const { posts, io } = collector()
+    const { posts, statuses, io } = collector()
     const r = await host.runTurn('t', 'start 85', io)
     assert.equal(r.ok, false)
     assert.equal(queryFn.calls.length, 1)
     assert.ok(posts.at(-1).includes('session ended without an answer'))
+    // #275: the block was written, the tool never ran — so the line says nothing
+    assert.deepEqual(statuses, [])
   })
 
   test('a failed fallback reports the failure instead of looping', async () => {


### PR DESCRIPTION
Ticket: alp82/curia#275 — [The status line shows only the text that reached the router](https://github.com/alp82/curia/issues/275)

The overseer status line now states only what happened.

Before: the line was built from the model's raw tool arguments on each streamed `tool_use` block, ahead of MCP validation. A call that died on the schema — prose packed into `ticket` — still showed the operator a command the router never saw. That is the 2026-08-06 thread in #255.

Now:
- The narration hangs off the command seam. A verb handler runs only after validation passes, so the text on the line is the text the router received.
- The turn holds each `tool_use` block until its result comes back. A result for a call that never crossed the seam prints `⚠️ \`map\` refused before the router` and names the verb only.
- A block whose tool never ran at all (the turn died first) prints nothing.

Tests drive the real MCP server over an in-memory transport, so a refusal in a test is the refusal the live SDK produces. `npm test` in `daemon/`: 1412 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-275`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `5461383` The status line shows only the text that reached the router (wayfinder #275)