### PR TITLE
The rename line: what the thread list costs (alp82/curia#277)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -253,7 +253,10 @@ The half-hour re-post of an open escalation into its thread.
 The Discord module. It renders and captures. It never interprets.
 
 **Thread-per-ticket**:
-One Discord thread per ticket. It carries the ticket's escalations, notifies, and answers. The binding outlives the agent: it releases only when the ticket itself closes, so a resumed agent lands back in the same thread. Every path that resolves a thread goes back to the ticket's last thread first, and one ticket resolves one thread at a time, so a re-dispatch adds no second thread (#257). The name carries the state at a glance: 🎫 bound, ✅ finished, ⚰️ cancelled.
+One Discord thread per ticket. It carries the ticket's escalations, notifies, and answers. The binding outlives the agent: it releases only when the ticket itself closes, so a resumed agent lands back in the same thread. Every path that resolves a thread goes back to the ticket's last thread first, and one ticket resolves one thread at a time, so a re-dispatch adds no second thread (#257). The name carries the state at a glance: 🎫 bound, ⏳ waiting on the operator, 🔎 holding a review gate, ✅ finished, ⚰️ cancelled.
+
+**Held clear**:
+The wait before a thread name goes back to 🎫 (#277). Discord answers every rename with a system line, and no flag suppresses it. Putting ⏳ or 🔎 on the name is worth that line, because the reader is away. Taking it off is not, because the reader just answered. So a clear waits two minutes, and any newer state cancels it. A ticket that asks another question inside the window spends no rename at all. The wait dies with the daemon.
 
 **Settling a thread name**:
 Putting the terminal glyph on a thread whose ticket has ended (#257). A rename rides a budget of 2 per thread per 10 minutes, so a ✅ can wait, and the gate that holds it dies with the daemon. Two passes catch what is dropped. A release settles the ticket's last thread even when the binding is already gone. Every bridge start settles each active thread curia once labeled that is bound to nothing and still wears a live glyph.

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -40,6 +40,33 @@ const MAX_BUTTON_OPTIONS = 23 // 25 buttons max, minus cancel; keep rows tidy
 const STATE_GLYPHS = { waiting: '⏳', 'awaiting-review': '🔎' }
 const LIVE_GLYPH_RE = /^(?:🎫|⏳|🔎)/u
 
+// How long a cleared glyph is held before the rename goes out (#277).
+//
+// Discord answers every rename with a system line in the thread, and no flag
+// suppresses it — 179 of them across the #245 cold read, each repeating a state
+// change the status line had already made in the same thread. Renaming less is
+// the only lever, and the two directions are not worth the same:
+//
+//  - ⏳/🔎 ON is written for a reader who is AWAY. It is the whole reason the
+//    glyph exists, so it lands at once.
+//  - 🎫 OFF lands a moment after the operator answered, so its only reader is
+//    the person who just left the thread. It says a thing they already know,
+//    and its system line BUMPS that thread to the top of the list — pushing the
+//    threads that do need them further down.
+//
+// So the clear waits, and a fresh question inside the window cancels it: the
+// glyph never moves and BOTH renames are saved. A grilling ticket asks many
+// questions in one sitting, and every pair that collapses is two system lines
+// and two budget slots that the ending rename gets to keep instead — the same
+// budget whose exhaustion is why the ✅ used to arrive ten minutes late (#199).
+//
+// The cost is a false positive, bounded by this window: a thread can read ⏳
+// for up to two minutes after it was answered. The operator set the number.
+// The wait is ephemeral like every other cache here, so a daemon restart inside
+// the window loses the clear and the thread keeps ⏳ until the agent's next
+// question or its ending — the ending always settles it.
+export const CLEAR_DELAY_MS = 120_000
+
 // #108 item 23, widened by #170: a message that is nothing but a command,
 // typed at an agent thread — the shape that reads as "cancel the agent" but
 // queues as prose. Trailing punctuation forgiven; any surrounding words mean
@@ -388,7 +415,13 @@ export class DiscordBridge {
   // bindings: { get(ticket), bind(ticket, threadId), release(ticket, reason) }
   // — the store's journalled ticket↔thread map (#93). Absent (tests), threads
   // fall back to the name-based lookup only.
-  constructor({ token, allowedUsers, guildId, channelName = 'curia', dataDir, handlers, bindings = null, log = console.log, onHealth = () => {} }) {
+  // `clearDelayMs` / `timers` are the seam for #277's held clear — production
+  // never overrides them, and 0 means clear in the same call.
+  constructor({
+    token, allowedUsers, guildId, channelName = 'curia', dataDir, handlers, bindings = null,
+    log = console.log, onHealth = () => {},
+    clearDelayMs = CLEAR_DELAY_MS, timers = { set: setTimeout, clear: clearTimeout },
+  }) {
     this.token = token
     this.allowedUsers = allowedUsers // array of user-id strings; the auth gate
     this.guildId = guildId
@@ -400,6 +433,9 @@ export class DiscordBridge {
     this.onHealth = onHealth
     this.threadByName = new Map() // ephemeral cache for UNBOUND threads ('all'), rebuilt on demand
     this.threadWork = new Map() // ticket -> the in-flight thread resolution for it (#257)
+    this.clearDelayMs = clearDelayMs
+    this.timers = timers
+    this.flagClears = new Map() // ticket -> the held 🎫 clear (#277), ephemeral
     // Bridge health (#56). Ephemeral like every other cache here: the journal
     // holds the transitions, this holds only what is true right now.
     this.health = { state: 'down', since: Date.now(), last_error: null }
@@ -455,6 +491,8 @@ export class DiscordBridge {
 
   async stop() {
     this.#setHealth('down', { reason: 'stopped' })
+    for (const t of this.flagClears.values()) this.timers.clear(t)
+    this.flagClears.clear()
     this.renamer.stop()
     await this.client.destroy()
   }
@@ -574,7 +612,49 @@ export class DiscordBridge {
   // glyph and touches nothing else, so a released ✅, a ⚰️, or a hand-edited
   // name is left alone. The blocked glyphs ride the renamer's reserve rule —
   // they spend a slot only while a second stays free for the clear.
+  //
+  // #277 splits the two directions in time. Putting a glyph ON happens here and
+  // now; taking it OFF is HELD for CLEAR_DELAY_MS, and any flag arriving inside
+  // that window replaces the held one. A question that lands before the wait
+  // runs out therefore finds the name it wants already on the thread, so the
+  // whole pair costs nothing. See CLEAR_DELAY_MS for why the asymmetry points
+  // this way.
   async flagTicket(ticket, state) {
+    if (!this.bindings) return
+    // Whatever was held is stale now: a newer flag has an opinion. Dropped for
+    // an ON as well as an OFF, so an answered-then-asked-again ticket never
+    // wakes a timer that would clear the glyph it just put back.
+    const held = this.flagClears.get(String(ticket))
+    if (held) { this.timers.clear(held); this.flagClears.delete(String(ticket)) }
+    if (STATE_GLYPHS[state] || !this.clearDelayMs) return this.#applyFlag(ticket, state)
+    // The held clear re-enters through the front door, so every guard below is
+    // re-read against the state at the moment it lands, not the moment it was
+    // asked for. A ticket released, cancelled or re-flagged meanwhile dissolves
+    // it — the same way a stale flag already dissolves on a terminal name.
+    //
+    // The callback RETURNS its promise. setTimeout drops the value, but a test
+    // clock can await it, which is the only way a held rename is assertable.
+    const timer = this.timers.set(() => {
+      this.flagClears.delete(String(ticket))
+      return Promise.resolve(this.#applyFlag(ticket, state)).catch((e) => {
+        this.log(`held thread flag for ${ticket} failed: ${e.message}`)
+      })
+    }, this.clearDelayMs)
+    timer?.unref?.()
+    this.flagClears.set(String(ticket), timer)
+  }
+
+  // Drop a held clear outright: the ticket has reached a name no clear may
+  // touch. The guards in #applyFlag already make a late clear a no-op, so this
+  // is about not holding a timer for a thread that is done.
+  #dropHeldFlag(ticket) {
+    const held = this.flagClears.get(String(ticket))
+    if (!held) return
+    this.timers.clear(held)
+    this.flagClears.delete(String(ticket))
+  }
+
+  async #applyFlag(ticket, state) {
     if (!this.bindings) return
     const bound = this.bindings.get(ticket)
     if (!bound) return
@@ -883,6 +963,7 @@ export class DiscordBridge {
   // finish and keep 🎫 forever once the label landed.
   async releaseTicket(ticket, reason) {
     if (!this.bindings) return
+    this.#dropHeldFlag(ticket) // #277: the ✅ is this thread's last name
     const bound = this.bindings.get(ticket)
     this.bindings.release(ticket, reason)
     // An ending whose binding is already gone still owes the thread its final
@@ -952,6 +1033,10 @@ export class DiscordBridge {
   // every other rename here — the journal's `agent_cancelled` is the truth.
   async cancelTicket(ticket) {
     if (!this.bindings) return
+    // The binding SURVIVES a cancel (#140), so unlike a release this held clear
+    // would still find its ticket bound. ⚰️ is not a live glyph, so it would
+    // dissolve anyway — dropping it just saves the wake-up.
+    this.#dropHeldFlag(ticket)
     const bound = this.bindings.get(ticket)
     if (!bound) return
     const t = await this.client.channels.fetch(bound).catch(() => null)

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -105,6 +105,10 @@ const CROSS_CHECK_RE = /^cross[- ]?check$/i
 // the rename slot the ✅ needs (#199's budget of 2 per 10 min) — which is how
 // the checkmark used to arrive ten minutes late. An approve that sends the
 // builder back to real work still clears: the next `working` transition fires.
+//
+// #277's held clear now covers that same tail from the other side — a tail of a
+// minute or two never outlives the hold. This omission stays as the belt: it
+// keeps the funnel free of the rename whatever the hold is set to.
 const NAME_FLAG = {
   waiting: 'waiting',
   'awaiting-review': 'awaiting-review',
@@ -400,10 +404,12 @@ export class StatusLine {
     // which reconcile rebuilds from the journal — see index.mjs.
     if (detail.model) w.model = detail.model
     // The thread name follows the state (#199) — told to the bridge, which
-    // holds no state of its own (#93). Only a real projection CHANGE fires,
-    // so the meter tick and same-state refreshes cost no rename budget; the
-    // comment on `post` applies here too — a failure is the bridge's to log,
-    // and the next transition retries.
+    // decides WHEN the rename is worth its system line (#277: a clear is held
+    // for two minutes, so a question that lands inside the window costs no
+    // rename at all). This line owns WHAT the state is and nothing more. Only a
+    // real projection CHANGE fires, so the meter tick and same-state refreshes
+    // reach the bridge not at all; the comment on `post` applies here too — a
+    // failure is the bridge's to log, and the next transition retries.
     const f = NAME_FLAG[state]
     if (f && f !== w.flag) {
       w.flag = f

--- a/daemon/test/threads.test.mjs
+++ b/daemon/test/threads.test.mjs
@@ -230,7 +230,16 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     delete: async () => { deleted.push(id); threads.delete(id) },
   })
 
-  let threads, deleted
+  let threads, deleted, held
+
+  // The #277 clock. The bridge holds a 🎫 clear rather than sending it, so the
+  // tests own when that window runs out — `fireHeld` is "two minutes passed".
+  // It awaits the callback's promise, which is why flagTicket returns one.
+  const fireHeld = async () => {
+    const due = held.filter((h) => h.live)
+    held = []
+    for (const h of due) await h.fn()
+  }
 
   beforeEach(() => {
     store = new EscalationStore(tmp())
@@ -238,9 +247,14 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     sentTo = []
     deleted = []
     threads = new Map()
+    held = []
     bridge = new DiscordBridge({
       token: 'x', allowedUsers: [], dataDir: tmp(),
       handlers: {}, log: () => {},
+      timers: {
+        set: (fn) => { const h = { fn, live: true }; held.push(h); return h },
+        clear: (h) => { if (h) h.live = false },
+      },
       bindings: {
         get: (t) => store.threadForTicket(t),
         bind: (t, id) => store.bindTicketThread(t, id),
@@ -466,8 +480,10 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     store.bindTicketThread('121', 't-flag')
 
     await bridge.flagTicket('121', 'waiting')
+    assert.deepEqual(renames, ['⏳ 121 · task'], 'the ON direction never waits')
     await bridge.flagTicket('121', 'working')
     await bridge.flagTicket('121', 'working') // repeat: nothing to send
+    await fireHeld()
     assert.deepEqual(renames, ['⏳ 121 · task', '🎫 121 · task'])
   })
 
@@ -498,6 +514,106 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     assert.deepEqual(renames, [])
   })
 
+  // ---- the held clear (#277) -------------------------------------------------
+  //
+  // Discord answers every rename with a system line, and the clear back to 🎫
+  // is the half nobody reads: it lands a moment after the operator answered,
+  // so its only reader is the person who just left the thread. Holding it lets
+  // the next question cancel it, and a grilling asks many questions.
+
+  test('a question inside the window cancels the held clear — the pair costs one rename, not three (#277)', async () => {
+    const t = makeThread('t-grill', '🎫 140 · grilling')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('140', 't-grill')
+
+    await bridge.flagTicket('140', 'waiting') // question 1
+    await bridge.flagTicket('140', 'working') // answered — held, not sent
+    await bridge.flagTicket('140', 'waiting') // question 2, inside the window
+    await bridge.flagTicket('140', 'working')
+    await bridge.flagTicket('140', 'waiting') // question 3
+    await fireHeld() // nothing is due: every hold was replaced by a later flag
+
+    assert.deepEqual(renames, ['⏳ 140 · grilling'], 'the glyph never moved off ⏳')
+    assert.equal(t.name, '⏳ 140 · grilling')
+  })
+
+  test('a held clear lands once the window runs out, and only once', async () => {
+    const t = makeThread('t-hold', '🎫 141 · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('141', 't-hold')
+
+    await bridge.flagTicket('141', 'waiting')
+    await bridge.flagTicket('141', 'working')
+    assert.deepEqual(renames, ['⏳ 141 · task'], 'the clear is not out yet')
+    await fireHeld()
+    assert.deepEqual(renames, ['⏳ 141 · task', '🎫 141 · task'])
+    await fireHeld()
+    assert.deepEqual(renames, ['⏳ 141 · task', '🎫 141 · task'], 'the hold fires once')
+  })
+
+  test('a review gate holds its clear the same way — 🔎 survives a rejection that asks again', async () => {
+    const t = makeThread('t-gate', '🎫 142 · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('142', 't-gate')
+
+    await bridge.flagTicket('142', 'awaiting-review')
+    await bridge.flagTicket('142', 'working') // rejected, back to work — held
+    await bridge.flagTicket('142', 'awaiting-review') // second gate round
+    await fireHeld()
+    assert.deepEqual(renames, ['🔎 142 · task'])
+  })
+
+  test('a release drops the held clear — the thread ends ✅ and no 🎫 follows it', async () => {
+    const t = makeThread('t-end', '🎫 143 · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('143', 't-end')
+
+    await bridge.flagTicket('143', 'waiting')
+    await bridge.flagTicket('143', 'working') // held
+    await bridge.releaseTicket('143', 'finished')
+    await fireHeld()
+    assert.deepEqual(renames, ['⏳ 143 · task', '✅ 143 · task'])
+  })
+
+  test('a cancel drops the held clear too — the binding survives, the ⚰️ stands', async () => {
+    const t = makeThread('t-dead', '🎫 144 · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('144', 't-dead')
+
+    await bridge.flagTicket('144', 'waiting')
+    await bridge.flagTicket('144', 'working') // held
+    await bridge.cancelTicket('144')
+    await fireHeld()
+    assert.deepEqual(renames, ['⏳ 144 · task', '⚰️ 144 · task'])
+    assert.equal(store.threadForTicket('144'), 't-dead', 'a cancel keeps the binding (#140)')
+  })
+
+  test('stop() drops every held clear', async () => {
+    const t = makeThread('t-stop', '🎫 145 · task')
+    const renames = []
+    t.setName = async (n) => { renames.push(n); t.name = n }
+    bridge.registerThread(t)
+    store.bindTicketThread('145', 't-stop')
+    bridge.client.destroy = async () => {}
+
+    await bridge.flagTicket('145', 'waiting')
+    await bridge.flagTicket('145', 'working')
+    await bridge.stop()
+    assert.equal(bridge.flagClears.size, 0)
+    await fireHeld()
+    assert.deepEqual(renames, ['⏳ 145 · task'])
+  })
+
   // ---- the rename race on a finishing ticket ---------------------------------
   // A status flag and the release both swap the signal glyph, and each used to
   // base its swap on the name Discord SHOWS — a name that lags whenever a
@@ -512,7 +628,8 @@ describe('DiscordBridge cross-thread breadcrumbs', () => {
     bridge.registerThread(t)
     store.bindTicketThread('132', 't-late')
     await bridge.flagTicket('132', 'waiting') // spend 1 — reserve keeps the second slot
-    await bridge.flagTicket('132', 'working') // spend 2 — the budget is out
+    await bridge.flagTicket('132', 'working')
+    await fireHeld() // spend 2 — the budget is out
     assert.deepEqual(renames, ['⏳ 132 · task', '🎫 132 · task'])
     // park a flag past its binding guard, inside the fetch, while release runs
     let resume

--- a/docs/adr/0013-one-voice-per-fact.md
+++ b/docs/adr/0013-one-voice-per-fact.md
@@ -22,6 +22,7 @@ CuriaBot states mechanics. The agent voice states meaning. A fact belongs to exa
 - **Ending**: two messages, fixed order. First the agent's report. The report holds the pull-request link, and it is the only place the link appears. Then one CuriaBot small-print receipt that merges the old resolved, done, and finished lines. The mechanics line carries no bare links, so nothing re-unfurls.
 - **Spawn**: CuriaBot's composer-ready line is the only announcement. The overseer never narrates a dispatch it triggered. When the overseer chose the ticket, the choice is meaning: it may state the choice and the reason, never "is running".
 - **Button answer**: the card is the only record. The bridge acknowledges the interaction silently and edits the card in place. No interaction reply exists.
+- **Thread rename**: Discord posts one system line per rename, and no flag suppresses it. This is the one voice curia does not own, so the rule is enforced by renaming less. The thread name answers one question the status line cannot reach: does this thread need the operator. Putting the ⏳ or 🔎 glyph ON is worth its line, because its reader is away. Taking it OFF is not, because its reader just answered. So a clear is held for two minutes and any newer state cancels it ([#277](https://github.com/alp82/curia/issues/277)).
 
 ### The note loop
 
@@ -39,6 +40,7 @@ A thread message has two delivery modes, and the operator picks.
 ## Consequences
 
 - The ending trio, the spawn duo, and the answer echo collapse. A thread reads as one narrator per fact.
+- A held clear buys a false positive, bounded by the window: a thread can read ⏳ for two minutes after it was answered. The hold is ephemeral, so a daemon restart inside the window loses it and the thread keeps the glyph until the agent's next question or its ending. The ending always settles the name.
 - The interrupt mode needs daemon plumbing: abort a running tool call after grace and inject a user turn. Queued keeps the shipped path.
 - The cross-check gate closes the #223 race by construction. The carrier rule stays as the net for a cross-check started after the builder is gone.
 - The overseer loses its spawn narration. Its remaining surface is conversation and choice rationale.


### PR DESCRIPTION
Ticket: alp82/curia#277 — [The rename line: what the thread list costs](https://github.com/alp82/curia/issues/277)

Resolves #277. Discord answers every rename with a system line, and no flag suppresses it. The #245 cold read counted 179. Renaming less is the only lever.

The glyph stays: the operator scans the thread list for it. What goes is half the traffic that carries it.

The two directions are not worth the same. Putting ⏳ or 🔎 ON is written for a reader who is away. Taking it OFF lands a moment after the operator answered, so its only reader is the person who just left the thread. That line also bumps the thread to the top of the list, which pushes the threads that do need the operator further down.

So the bridge HOLDS a clear for two minutes (`CLEAR_DELAY_MS`), and any newer state cancels it. A grilling that asks another question inside the window spends no rename at all, because the glyph never moved. Every collapsed pair also returns two slots to the 2-per-10-minutes budget, which is why the ✅ used to arrive late.

- `flagTicket` splits into the hold policy and `#applyFlag`. A held clear re-enters through the front door, so every guard is re-read at the moment it lands.
- A release and a cancel drop the held clear. `stop()` drops all of them.
- `clearDelayMs` and `timers` are the test seam. Production never overrides them.
- ADR-0013 gains the rename rule and its cost. CONTEXT.md gains the term.

Six new tests. The suite is green: 1415 pass, 0 fail.

Known limit, stated not hidden: the wait is ephemeral. A daemon restart inside the window loses the clear, and the thread keeps ⏳ until the agent's next question or its ending. The ending always settles the name.

---

Dispatched by the curia daemon — session `curia-277`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `16813bd` The clear waits, the glyph stays (wayfinder #277)