### PR TITLE
The read screens land: home, agents, frontier, feed (alp82/curia#264)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -351,10 +351,13 @@ Open escalations shown on the timeline from the daemon's record, because a trans
 The timeline's refusal to send text while a native terminal dialog holds the pane.
 
 **Overview**:
-The daemon's one loopback read of itself, `GET /overview`. It joins every section the dashboard draws. These are the live agents, the open escalations, the review gate, bridge health, the usage windows, the journal tail, and the frontier snapshot. The sidecar polls it, and holds no secret, no GitHub token and no journal handle. Each section is nullable on its own, so an unreadable one costs the page nothing else.
+The daemon's one loopback read of itself, `GET /overview`. It joins every section the dashboard draws. These are the live agents with their context meters, the open escalations, the review gate, bridge health, the usage windows, the journal tail, and the frontier snapshot. The sidecar polls it, and holds no secret, no GitHub token and no journal handle. Each section is nullable on its own, so an unreadable one costs the page nothing else.
 
 **Dashboard**:
 The browser console for the box, on loopback `4273` and Serve `8445`. It draws the overview behind the same identity check every other surface uses.
+
+**Read screen**:
+A dashboard screen that only draws the overview: home, agents, frontier, feed. Two rules hold across all four. Color marks attention and nothing else, so a state, a ticket type and a repo are told in words. Null is not empty, so an unreadable fleet never renders as an idle box and an uncomputed frontier never renders as an empty one.
 
 **Sidecar**:
 The process that serves the dashboard. It runs beside the daemon and never inside it, so it stays up while the daemon restarts. It holds no secret: its container mounts the code and the config directory, and neither the journal nor the `.env`.

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
-<!-- The console shell (#263), on the look settled by the prototype (#248):
-     dark-first tokens, system mono for data, one accent.
+<!-- The console (#263 the shell, #264 the read screens), on the look settled by
+     the prototype (#248): dark-first tokens, system mono for data, one accent.
 
      THE STAMP BELOW IS LOAD-BEARING. This page and daemon/src/dashboard.mjs are
      two halves of one protocol, and there is no build step — the file on disk IS
@@ -10,9 +10,19 @@
      speaks and the server refuses anything else (#70's rule, as timeline.html
      carries it).
 
-     The read screens land in #264, the settings in #265, the verbs in #266 and
-     the chat in #267. What this page owes is the shell, the poll, and the
-     restarting marker. -->
+     The four read screens draw one payload: `GET /api/overview`, which is the
+     sidecar's held snapshot of the daemon's own `GET /overview` (#262). They
+     write nothing. The operator verbs land in #266, the settings in #265 and the
+     chat in #267.
+
+     TWO RULES RUN THROUGH EVERY SCREEN HERE.
+
+     1. Color marks attention, and nothing else. Warn and bad are spent on an
+        open question, the review gate and a spent usage window. A state, a
+        ticket type and a repo are told in words.
+     2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
+        nobody has computed is not an empty frontier. Every section that can fail
+        on its own says which of the two it is. -->
 <meta name="curia-dashboard" content="proto=1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>curia</title>
@@ -42,10 +52,12 @@
     font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
   }
   .mono, code { font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace; }
+  .num { font-variant-numeric: tabular-nums; }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   button { font: inherit; cursor: pointer; }
   h1, h2, h3 { margin: 0; text-wrap: balance; }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
   /* ---------- shell ---------- */
   .shell { display: grid; grid-template-columns: 172px 1fr; min-height: 100vh; }
@@ -86,19 +98,125 @@
   .readbar.down .why { color: var(--warn); opacity: .85; }
   .readbar .spacer { flex: 1; }
 
-  .tiles { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); margin-bottom: 16px; }
+  /* ---------- shared atoms (#248) ---------- */
+  .eyebrow { font-size: 11px; letter-spacing: .09em; text-transform: uppercase; color: var(--ink-faint); font-weight: 700; }
+  .dim-note { font-size: 12px; color: var(--ink-faint); }
+  .empty { font-size: 13px; color: var(--ink-dim); padding: 6px 0; }
+  /* An unreadable section. It is a fact about the READ, so it is marked. */
+  .unread {
+    border-left: 3px solid var(--warn); background: var(--chip-warn-bg); color: var(--warn);
+    border-radius: 0 8px 8px 0; padding: 8px 12px; font-size: 13px; margin-bottom: 10px;
+  }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--idle); flex: none; display: inline-block; }
+  .dot.attn { background: var(--warn); }
+  .dot.off { background: var(--ink-faint); }
+
+  .bar { position: relative; height: 7px; border-radius: 4px; background: var(--bg-inset); overflow: hidden; min-width: 60px; display: inline-block; }
+  .bar .fill { position: absolute; inset: 0 auto 0 0; border-radius: 4px; background: var(--ink-dim); }
+  .bar .fill.warn { background: var(--warn); } .bar .fill.bad { background: var(--bad); }
+  .bar .clock { position: absolute; top: -2px; bottom: -2px; width: 2px; background: var(--ink-faint); }
+  .meter-row { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; color: var(--ink-dim); }
+  .meter-row .lbl { width: 2.2em; flex: none; font-family: ui-monospace, Menlo, monospace; }
+  .meter-row .pct { width: 3.4em; flex: none; text-align: right; font-variant-numeric: tabular-nums; }
+
+  /* ---------- home ---------- */
+  .stat-tiles { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
   .tile { border: 1px solid var(--line); border-radius: 10px; background: var(--bg-raise); padding: 12px 14px; box-shadow: var(--shadow); }
   .tile .v { font-size: 22px; font-weight: 700; font-family: ui-monospace, Menlo, monospace; }
   .tile .l { font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--ink-faint); margin-top: 2px; }
   .tile.warn { border-color: var(--warn); } .tile.warn .v { color: var(--warn); }
   .tile .v.none { color: var(--ink-faint); }
 
-  .facts { border: 1px solid var(--line); border-radius: 10px; background: var(--bg-raise); padding: 12px 14px; }
-  .facts h3 { font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--ink-faint); margin-bottom: 8px; }
-  .facts dl { display: grid; grid-template-columns: max-content 1fr; gap: 5px 16px; margin: 0; font-size: 13px; }
-  .facts dt { color: var(--ink-dim); }
-  .facts dd { margin: 0; font-family: ui-monospace, Menlo, monospace; }
+  .split-cols { display: grid; grid-template-columns: 5fr 7fr; gap: 22px; align-items: start; margin-top: 16px; }
+  .split-cols > div { min-width: 0; }
+  @media (max-width: 900px) { .split-cols { grid-template-columns: 1fr; } }
+  .h-sect { margin: 16px 0; }
+  .h-sect:first-child { margin-top: 0; }
+  .h-sect > h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: var(--ink-faint); margin-bottom: 6px; font-weight: 700; }
+  .h-sect > h3 .hot { color: var(--warn); }
+  .h-sect .more { display: block; margin-top: 8px; font-size: 12.5px; }
 
+  .att-item { border-left: 3px solid var(--warn); background: var(--chip-warn-bg); border-radius: 0 8px 8px 0; padding: 9px 12px; font-size: 13px; margin-bottom: 8px; }
+  .att-item .who { font-family: ui-monospace, Menlo, monospace; font-weight: 700; margin-right: 8px; }
+  .att-item .dim { color: var(--ink-dim); font-size: 12px; }
+  .att-item .opts { margin-top: 5px; font-size: 12.5px; color: var(--ink-dim); }
+  .att-item.gate { border-left-color: var(--accent); background: var(--chip-ok-bg); }
+  .att-item.limit { border-left-color: var(--bad); background: var(--chip-bad-bg); }
+
+  .prov-strip { display: flex; gap: 26px; flex-wrap: wrap; align-items: center; margin-top: 14px; font-size: 12px; color: var(--ink-dim); }
+  .prov { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .prov > b { font-family: ui-monospace, Menlo, monospace; color: var(--ink); font-size: 12.5px; }
+  .prov .meter-row .bar { flex: none; width: 76px; }
+  .prov .pnote { color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
+  .prov .pnote.hot { color: var(--bad); }
+
+  /* ---------- tables ---------- */
+  .tbl-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 9px; }
+  table.agents { width: 100%; border-collapse: collapse; font-size: 13px; background: var(--bg-raise); }
+  table.agents.wide { min-width: 760px; }
+  table.agents.narrow { min-width: 520px; }
+  table.agents th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--ink-faint); padding: 8px 12px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+  table.agents td { padding: 9px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  table.agents tr:last-child td { border-bottom: 0; }
+  table.agents .sess { font-family: ui-monospace, Menlo, monospace; font-weight: 700; white-space: nowrap; }
+  table.agents .t { font-family: ui-monospace, Menlo, monospace; color: var(--ink-dim); margin-right: 6px; }
+  table.agents .state { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+  table.agents .over { color: var(--warn); }
+  .esc-row td { background: var(--chip-warn-bg); }
+  .statusbar { display: flex; gap: 18px; font-size: 12.5px; color: var(--ink-dim); margin-bottom: 14px; font-family: ui-monospace, Menlo, monospace; flex-wrap: wrap; }
+
+  /* ---------- feed ---------- */
+  .feed-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+  .feed-list li { display: grid; grid-template-columns: 3.9em 1fr; gap: 10px; padding: 7px 0; border-bottom: 1px solid var(--line); font-size: 13px; }
+  .feed-list li:last-child { border-bottom: 0; }
+  .feed-list time { color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; font-size: 12px; padding-top: 1px; }
+  .feed-list .ev b { font-weight: 600; }
+  .feed-list .tag { font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--ink-dim); }
+  .feed-list li.warn .tag { color: var(--warn); }
+  .feed-list li.bad .tag { color: var(--bad); }
+
+  /* ---------- frontier ---------- */
+  .seg { display: inline-flex; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; background: var(--bg-raise); }
+  .seg button { border: 0; background: none; color: var(--ink-dim); padding: 5px 12px; font-size: 12.5px; }
+  .seg button.on { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
+  .frx-filter { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+  .frx-filter .fchip { border: 1px solid var(--line); border-radius: 999px; background: var(--bg-raise); color: var(--ink-dim); padding: 3px 12px; font-size: 12.5px; }
+  .frx-filter .fchip.on { border-color: var(--accent); color: var(--accent); background: var(--chip-ok-bg); font-weight: 600; }
+  .frx-filter select { padding: 3px 8px; }
+  .frx-filter .sep { color: var(--ink-faint); }
+  select {
+    background: var(--bg-inset); color: var(--ink); border: 1px solid var(--line);
+    border-radius: 6px; padding: 4px 8px; font: 12.5px ui-monospace, Menlo, monospace; max-width: 100%;
+  }
+  .frx-sect { margin: 4px 0 18px; }
+  .frx-sect > .eyebrow { display: block; margin-bottom: 8px; }
+  .frx-big { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+  .frx-card {
+    border: 1px solid var(--line); border-top: 3px solid var(--accent); border-radius: 10px;
+    background: var(--bg-raise); padding: 12px 14px; box-shadow: var(--shadow);
+    display: flex; flex-direction: column; gap: 6px;
+  }
+  .frx-card .head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+  .frx-card .t { font-family: ui-monospace, Menlo, monospace; font-weight: 700; color: var(--accent); }
+  .frx-card .typ { font-size: 11px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
+  .frx-card .title { font-size: 13.5px; font-weight: 600; }
+  .frx-card .foot { display: flex; justify-content: space-between; gap: 8px; font-size: 11.5px; color: var(--ink-dim); font-family: ui-monospace, Menlo, monospace; flex-wrap: wrap; }
+  .frx-dim { display: grid; gap: 8px; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); }
+  .frx-dimcard { border: 1px solid var(--line); border-radius: 8px; background: var(--bg-inset); padding: 8px 11px; font-size: 12.5px; color: var(--ink-dim); }
+  .frx-dimcard .t { font-family: ui-monospace, Menlo, monospace; margin-right: 5px; }
+  .frx-dimcard .from { display: block; margin-top: 4px; font-size: 11px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
+  .fr-repo { margin-bottom: 14px; }
+  .fr-repo > .eyebrow { margin-bottom: 6px; display: block; }
+  .fr-group { margin-bottom: 10px; }
+  .fr-node { border: 1px solid var(--line); border-left: 3px solid var(--accent); background: var(--bg-raise); border-radius: 7px; padding: 7px 10px; font-size: 13px; }
+  .fr-node .t { font-family: ui-monospace, Menlo, monospace; color: var(--ink-dim); margin-right: 6px; }
+  .fr-node .typ { float: right; font-size: 11px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; margin-left: 8px; }
+  .fr-kids { margin: 0 0 10px 14px; padding-left: 14px; border-left: 1px dashed var(--line); }
+  .fr-kid { position: relative; margin-top: 6px; font-size: 12.5px; color: var(--ink-dim); }
+  .fr-kid::before { content: "└─"; position: absolute; left: -16px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
+  .fr-kid .t { font-family: ui-monospace, Menlo, monospace; margin-right: 6px; }
+
+  /* ---------- the screens that land later ---------- */
   .later {
     border: 1px dashed var(--line); border-radius: 9px; padding: 12px 14px;
     color: var(--ink-dim); font-size: 13px; background: var(--bg-inset);
@@ -109,23 +227,40 @@
 <div id="app"></div>
 
 <script>
-/* The shell (#263). The screens it names land on their own tickets; what runs
-   here is the nav, the poll and the marker. */
+/* The console's own code. One classic script, no build step and no module
+   boundary: the file on disk is the reviewed source and the served page at once.
+   Its test drives these same functions in a vm, which is why the screens take
+   the payload as an ARGUMENT and the page state sits on one plain object —
+   nothing here reads a global the test cannot set. */
+
+/* Every screen this shell carries. The four read screens are #264; the two
+   named tickets below draw their own. */
 const SCREENS = {
   home:     ["Home",     screenHome],
-  agents:   ["Agents",   () => later("The agents screen", "#264")],
-  frontier: ["Frontier", () => later("The frontier tree", "#264")],
-  feed:     ["Feed",     () => later("The event feed", "#264")],
-  chat:     ["Chat",     () => later("The chat", "#267")],
-  settings: ["Settings", () => later("The settings screens", "#265")],
+  agents:   ["Agents",   screenAgents],
+  frontier: ["Frontier", screenFrontier],
+  feed:     ["Feed",     screenFeed],
+  chat:     ["Chat",     (p) => later(p, "The chat", "#267")],
+  settings: ["Settings", (p) => later(p, "The settings screens", "#265")],
 };
 const NAMES = Object.keys(SCREENS);
 
-let screen = NAMES.includes(location.hash.slice(1)) ? location.hash.slice(1) : "home";
-let payload = null;   /* the sidecar's last answer */
-let reachable = true; /* is the SIDECAR itself answering — a different fact from daemon_up */
+/* A usage window is spent at the same number the daemon calls spent
+   (usage.mjs SPENT_PCT). One name for one thing: the page must not invent a
+   second threshold for the same fact. */
+const SPENT_PCT = 95;
+/* The gate is its own escalation kind (lifecycle.mjs REVIEW_KIND). */
+const REVIEW_KIND = "review-gate";
+
+/* The page's whole mutable state. `var` on purpose — the test reaches it. */
+var UI = { screen: "home", fr: { view: "cards", repo: "all", type: "all" } };
+var payload = null;   /* the sidecar's last answer */
+var reachable = true; /* is the SIDECAR itself answering — a different fact from daemon_up */
+
+/* ---- words ---------------------------------------------------------------- */
 
 const esc = (s) => String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const snip = (s, n) => { const t = String(s ?? "").replace(/\s+/g, " ").trim(); return t.length > n ? t.slice(0, n - 1) + "…" : t; };
 
 function ago(iso) {
   if (!iso) return "never";
@@ -141,22 +276,35 @@ function dur(s) {
   if (s < 86400) return (s / 3600).toFixed(1) + "h";
   return (s / 86400).toFixed(1) + "d";
 }
+function clock(iso) {
+  const d = iso ? new Date(iso) : null;
+  if (!d || Number.isNaN(d.getTime())) return "—";
+  return String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0");
+}
+/* A ticket as the tracker names it: `owner/repo#12`, or `#12` when the event
+   carries no repo. */
+function ticketName(repo, ticket) {
+  if (ticket == null || ticket === "") return "";
+  return (repo ? repo + "#" : "#") + ticket;
+}
 
-/* How many things want the operator. The nav badge and the tile read one
-   function, so they can never disagree. */
-function needsYou() {
-  const o = payload?.overview;
+/* How many things want the operator. The nav badge, the tab title and the tile
+   read one function, so they can never disagree. Usage limits are NOT counted:
+   a spent window is on the attention list because it explains a slow box, but
+   nobody can answer it. */
+function needsYou(o) {
   return (o?.escalations?.length ?? 0) + (o?.review_gate?.length ?? 0);
 }
 
-/* The marker. Three states, and they are three different facts:
-   the sidecar is unreachable, the daemon is not answering it, or all is well. */
-function readbar() {
+/* ---- the reading's own age ------------------------------------------------- */
+
+/* Three states, and they are three different facts: the sidecar is
+   unreachable, the daemon is not answering it, or all is well. */
+function readbar(p) {
   if (!reachable) {
     return `<div class="readbar down"><span class="dot"></span><b>the console is offline</b>
       <span class="why">this page cannot reach the sidecar that serves it</span></div>`;
   }
-  const p = payload;
   if (!p) return `<div class="readbar"><span class="dot"></span>reading…</div>`;
   if (!p.daemon_up) {
     /* The sidecar is up and holding the last good reading — which is exactly
@@ -171,62 +319,415 @@ function readbar() {
     <span class="why">refreshing every ${esc(p.poll_interval_s)}s while this tab is visible</span></div>`;
 }
 
+/* Every screen opens the same way, and no screen draws before the first read
+   lands. */
+function head(p, title, right) {
+  return `<div class="screen-head"><h2>${esc(title)}</h2>${right ?? ""}</div>${readbar(p)}`;
+}
+function noSnapshot(p, title) {
+  return `${head(p, title)}<div class="later">No snapshot yet. The sidecar is up and has not read the daemon successfully even once.</div>`;
+}
+function later(p, what, ticket) {
+  return `${head(p, SCREENS[UI.screen][0])}
+    <div class="later"><b>${esc(what)}</b> lands on ${esc(ticket)}. It draws the same snapshot the bar above reads.</div>`;
+}
+
+/* ---- the fleet ------------------------------------------------------------- */
+
+/* The state in the vocabulary the status line already uses (statusline.mjs):
+   `ready` and `working` are one state, and an agent with an open question is
+   waiting whatever its record says. */
+function stateWord(a) {
+  if (a.state === "awaiting-review") return "awaiting review";
+  if (waitingOn(a).length) return "waiting";
+  return { ready: "working", spawning: "dispatched", failed: "failed", "cross-checking": "cross-checking" }[a.state] ?? String(a.state ?? "unknown");
+}
+/* The questions bound to this agent, minus the gate — the gate is its own list
+   and its own card, never a row's footnote. */
+const waitingOn = (a) => (a.waiting_on ?? []).filter((w) => w.kind !== REVIEW_KIND);
+/* Attention is one test, used by the dot, the row tint and nothing else. */
+const wantsYou = (a) => waitingOn(a).length > 0;
+
+function agentDot(a) {
+  return `<span class="dot ${wantsYou(a) ? "attn" : a.state === "failed" ? "off" : ""}"></span>`;
+}
+
+/* The context meter (#264, usage.mjs ctxOnWire). No reading is "—", never 0%.
+   A figure above 100% is the daemon's own complaint about the denominator, not
+   a reading about the agent, so it is marked rather than drawn flat. */
+function ctxCell(a) {
+  if (a.ctx_pct == null) return `<span class="dim-note">—</span>`;
+  return `${esc(a.ctx_pct)}%${a.ctx_over ? ` <span class="over">⚠</span>` : ""}`;
+}
+
+/* The fleet, narrow: the home's right column. `agents: null` is an unreadable
+   tmux, which is the opposite fact from an idle box, so it renders as neither a
+   table nor an empty line. */
+function fleetTable(o) {
+  if (o.agents == null) {
+    return `<div class="unread">the fleet could not be read${o.fleet_error ? ` — ${esc(o.fleet_error)}` : ""}. Every other section below is still a live reading.</div>`;
+  }
+  if (!o.agents.length) return `<div class="empty">No agent is running.</div>`;
+  const rows = [...o.agents].sort((a, b) => (wantsYou(b) ? 1 : 0) - (wantsYou(a) ? 1 : 0));
+  return `<div class="tbl-wrap"><table class="agents narrow">
+    <tr><th>session</th><th>state</th><th>ticket</th><th>ctx</th><th>up</th></tr>
+    ${rows.map((a) => `<tr class="${wantsYou(a) ? "esc-row" : ""}">
+      <td class="sess">${esc(a.session)}</td>
+      <td><span class="state">${agentDot(a)} ${esc(stateWord(a))}</span></td>
+      <td><span class="t">${esc(ticketName(a.repo, a.ticket))}</span>${esc(a.title ?? "")}</td>
+      <td class="num">${ctxCell(a)}</td>
+      <td class="num">${esc(dur(a.uptime_s))}</td></tr>`).join("")}
+  </table></div>`;
+}
+
+/* ---- the provider strip ---------------------------------------------------- */
+
+/* One reading per provider, said once (#248). It is an account fact, not an
+   agent fact, so no agent row repeats it (CONTEXT.md, usage windows).
+
+   The bar is neutral until the window is worth attention: a fill that ran ahead
+   of its own clock, and bad once the window is spent. The thin mark is where
+   the clock stands, so "62% of the window at 48% of the time" is one glance. */
+function meterBar(label, w) {
+  const pct = Number(w.pct ?? 0);
+  const elapsed = w.elapsed_pct == null ? null : Number(w.elapsed_pct);
+  const cls = pct >= SPENT_PCT ? "bad" : elapsed != null && pct > elapsed ? "warn" : "";
+  return `<span class="meter-row"><span class="lbl">${esc(label)}</span>
+    <span class="bar"><span class="fill ${cls}" style="width:${Math.min(100, Math.max(0, pct))}%"></span>
+      ${elapsed == null ? "" : `<span class="clock" style="left:${Math.min(100, Math.max(0, elapsed))}%"></span>`}</span>
+    <span class="pct num">${esc(pct)}%</span></span>`;
+}
+function provStrip(o) {
+  const usage = o.usage ?? [];
+  /* A provider with no probe and no live agent says NOTHING rather than zero
+     (#262): an unmeasured window and an unspent one are not the same fact. */
+  if (!usage.length) return `<div class="prov-strip">No usage window is measured. A window is read from the account probe, or from a live agent's own transcript.</div>`;
+  return `<div class="prov-strip">${usage.map((p) => {
+    const soonest = nextReset([p]);
+    return `<span class="prov"><b>${esc(p.provider)}</b>
+      ${(p.windows ?? []).map((w) => meterBar(w.label, w)).join("")}
+      ${soonest ? `<span class="pnote ${spentWindows([p]).length ? "hot" : ""}">${esc(soonest.label)} rolls ${esc(clock(soonest.at))}</span>` : ""}
+      <span class="pnote">from the ${esc(p.from)}${p.session ? ` of ${esc(p.session)}` : ""}</span></span>`;
+  }).join("")}</div>`;
+}
+function spentWindows(usage) {
+  return (usage ?? []).flatMap((p) => (p.windows ?? [])
+    .filter((w) => Number(w.pct ?? 0) >= SPENT_PCT)
+    .map((w) => ({ provider: p.provider, label: w.label, pct: w.pct, at: w.resets_at })));
+}
+/* The soonest window still ahead of us, which is the one the operator waits on. */
+function nextReset(usage) {
+  const all = (usage ?? []).flatMap((p) => (p.windows ?? [])
+    .filter((w) => w.resets_at && Date.parse(w.resets_at) > Date.now())
+    .map((w) => ({ provider: p.provider, label: w.label, at: w.resets_at })));
+  all.sort((a, b) => Date.parse(a.at) - Date.parse(b.at));
+  return all[0] ?? null;
+}
+
+/* ---- the attention list ---------------------------------------------------- */
+
+/* Everything that wants the operator, in one column, warn-marked because that
+   is what the color is for. The verbs — answer, approve, reject, cross-check —
+   land on #266; what this ticket owes is the question itself, whole. */
+function attentionList(o) {
+  const items = [
+    ...(o.escalations ?? []).map((r) => `<div class="att-item">
+      <span class="who">${esc(r.agent)}</span>${esc(snip(r.prompt, 260))}
+      <div class="dim">${esc(r.kind)} · ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}${r.agent_died ? " · the agent died holding it" : ""}${r.rendered ? "" : " · not rendered in Discord yet"}</div>
+      ${r.options?.length ? `<div class="opts">${r.options.map((x) => esc(x)).join(" · ")}</div>` : ""}
+      ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview it asks about</a></div>` : ""}</div>`),
+    ...(o.review_gate ?? []).map((r) => `<div class="att-item gate">
+      <span class="who">${esc(r.agent)}</span>review gate — ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}
+      <div class="dim">${esc(snip(r.prompt, 220))}</div>
+      ${r.pull_request ? `<div class="opts"><a href="${esc(r.pull_request)}">${esc(r.pull_request)}</a></div>` : `<div class="opts">no pull request on this gate</div>`}</div>`),
+    ...spentWindows(o.usage).map((w) => `<div class="att-item limit">
+      <span class="who">${esc(w.provider)}</span>the ${esc(w.label)} window is spent at ${esc(w.pct)}%
+      <div class="dim">${w.at ? `it rolls at ${esc(clock(w.at))}` : "no reset instant is stated"}</div></div>`),
+  ];
+  return { count: items.length, html: items.length ? items.join("") : `<div class="empty">Nothing wants you.</div>` };
+}
+
+/* ---- the feed -------------------------------------------------------------- */
+
+/* The journal speaks in types and fields. The page speaks in sentences.
+   A type this table does not name still reads: the fallback says the type in
+   words and names whatever subject the event carries, so an event the daemon
+   grows tomorrow is legible the day it ships instead of rendering blank. */
+const who = (e) => (e.agent ? `<b>${esc(e.agent)}</b>` : "");
+const tkt = (e) => (e.ticket == null || e.ticket === "" ? "" : `<span class="mono">${esc(ticketName(e.repo, e.ticket))}</span>`);
+const subject = (e) => [who(e), tkt(e)].filter(Boolean).join(" · ");
+
+const EVENTS = {
+  dispatch_claimed: ["claim", "", (e) => `${tkt(e)} claimed for ${who(e)} by ${esc(e.by)}`],
+  dispatch_unclaimed: ["claim", "", (e) => `${tkt(e)} unclaimed — back on the frontier`],
+  dispatch_exhausted: ["cooling", "bad", (e) => `${tkt(e)} could not be dispatched — every model is cooling${e.earliest_reset ? `, the earliest rolls ${esc(clock(e.earliest_reset))}` : ""}`],
+  agent_spawned: ["spawn", "", (e) => `${who(e)} spawned on ${esc(e.model)}${e.harness ? ` — ${esc(e.harness)}` : ""}${e.kind ? `, ${esc(e.kind)}` : ""} · ${tkt(e)}`],
+  agent_ready: ["spawn", "", (e) => `${who(e)} is at work on ${tkt(e)}`],
+  agent_done: ["ending", "", (e) => `${who(e)} ended its turn`],
+  agent_died: ["death", "bad", (e) => `${who(e)} died — ${tkt(e)}${e.kind ? ` (${esc(e.kind)})` : ""}`],
+  agent_cancelled: ["cancel", "bad", (e) => `${who(e)} cancelled by ${esc(e.by)} — ${tkt(e)} back on the frontier`],
+  agent_abnormal_exit: ["death", "bad", (e) => `${who(e)} exited abnormally — ${tkt(e)}`],
+  agent_blocked_on_human: ["escalation", "warn", (e) => `${who(e)} is blocked on you — ${tkt(e)}`],
+  agent_note: ["note", "", (e) => `note for ${who(e)}: ${esc(snip(e.text, 120))}`],
+  agent_notes_drained: ["note", "", (e) => `${who(e)} took ${esc(e.count)} queued note(s)`],
+  esc_open: ["escalation", "warn", (e) => `${who(e)} asks — ${esc(e.kind)}: ${esc(snip(e.prompt, 160))}`],
+  esc_answer: ["answer", "", (e) => `escalation ${esc(e.id)} answered by ${esc(e.by)}${e.via ? ` via ${esc(e.via)}` : ""}`],
+  esc_cancel: ["answer", "", (e) => `escalation ${esc(e.id)} cancelled by ${esc(e.by)}`],
+  esc_lapse: ["answer", "", (e) => `escalation ${esc(e.id)} lapsed — ${esc(e.reason)}`],
+  esc_supersede: ["escalation", "", (e) => `escalation ${esc(e.id)} superseded by ${esc(e.successor)}`],
+  review_requested: ["gate", "warn", (e) => `review gate opened for ${tkt(e)} by ${who(e)}`],
+  review_answered: ["gate", "", (e) => `${tkt(e)} ${e.approved ? "approved" : "rejected"} at the gate${e.outcome ? ` — ${esc(e.outcome)}` : ""}`],
+  cross_check_requested: ["cross-check", "", (e) => `cross-check pressed on ${tkt(e)} — ${who(e)} parks`],
+  reviewer_spawned: ["cross-check", "", (e) => `${who(e)} spawned to read ${tkt(e)}${e.builder ? ` for ${esc(e.builder)}` : ""}`],
+  cross_check_returned: ["cross-check", "", (e) => `cross-check on ${tkt(e)} returned${e.ok === false ? ` — it carried no verdict${e.why ? `: ${esc(e.why)}` : ""}` : ""}`],
+  verdict_captured: ["cross-check", "", (e) => `verdict captured for ${tkt(e)} from ${esc(e.model)}`],
+  verdict_commented: ["cross-check", "", (e) => `verdict posted on ${tkt(e)}`],
+  verdict_failed: ["cross-check", "bad", (e) => `the cross-check of ${tkt(e)} failed`],
+  verdict_undelivered: ["cross-check", "bad", (e) => `a verdict for ${tkt(e)} reached no reader`],
+  ticket_resolved: ["resolve", "", (e) => `${tkt(e)} resolved by ${who(e)}${e.pr ? ` — ${esc(e.pr)}` : ""}`],
+  lifecycle_closed: ["ending", "", (e) => `${who(e)} finished ${tkt(e)}`],
+  land_failed: ["landing", "bad", (e) => `${tkt(e)} could not land — ${esc(snip(e.error, 120))}`],
+  result: ["result", "", (e) => `${who(e)} reported ${esc(e.status ?? "a result")}${e.summary ? ` — ${esc(snip(e.summary, 120))}` : ""}`],
+  result_parked: ["result", "", (e) => `${who(e)} parked its ending — ${esc(e.reason)}`],
+  notify: ["notify", "", (e) => `${who(e)}: ${esc(snip(e.message, 160))}`],
+  preview: ["preview", "", (e) => `${who(e)} published a preview${e.path ? ` at ${esc(e.path)}` : ""}${e.ok === false ? ` — refused: ${esc(e.reason)}` : ""}`],
+  model_cooling: ["cooling", "bad", (e) => `${esc(e.model)} is cooling${e.reset_at ? ` — it rolls ${esc(clock(e.reset_at))}` : ""}`],
+  provider_cooling: ["cooling", "bad", (e) => `${esc(e.provider)} is cooling${e.reset_at ? ` — it rolls ${esc(clock(e.reset_at))}` : ""}`],
+  deploy_requested: ["deploy", "", (e) => `deploy ordered by ${esc(e.by)}`],
+  deploy_landed: ["deploy", "", (e) => `deploy landed${e.next ? ` at ${esc(String(e.next).slice(0, 7))}` : ""}`],
+  deploy_rolled_back: ["deploy", "bad", (e) => `deploy rolled back — ${esc(e.reason ?? "the health check failed")}`],
+  bridge_wedged: ["bridge", "bad", (e) => `the Discord bridge is wedged`],
+  bridge_recovered: ["bridge", "", (e) => `the Discord bridge is back`],
+  bridge_health: ["bridge", "", (e) => `bridge ${esc(e.previous)} → ${esc(e.state)} — ${esc(e.reason)}`],
+  reconcile: ["reconcile", "", (e) => `reconcile pass${e.boot ? " at boot" : ""}`],
+  command: ["command", "", (e) => `${esc(snip(e.canonical, 120))} — by ${esc(e.by)}`],
+  map_adopted: ["charting", "", (e) => `${who(e)} adopted map ${esc(e.map)} — ${esc(snip(e.title, 80))}`],
+  charting_finished: ["charting", "", (e) => `${who(e)} finished charting ${tkt(e)} — ${esc(e.status)}`],
+};
+
+function eventLine(e) {
+  const spec = EVENTS[e.type];
+  if (spec) return { tag: spec[0], cls: spec[1], html: spec[2](e) };
+  const s = subject(e);
+  return { tag: String(e.type ?? "event").replace(/_/g, " "), cls: "", html: s || "—" };
+}
+/* Newest first: the operator reads the top of the page, so the last thing that
+   happened must be the first thing there. */
+function feedList(events, limit) {
+  const rows = [...(events ?? [])].reverse().slice(0, limit ?? undefined);
+  if (!rows.length) return `<div class="empty">The journal tail is empty.</div>`;
+  return `<ul class="feed-list">${rows.map((e) => {
+    const l = eventLine(e);
+    return `<li class="${l.cls}"><time>${esc(clock(e.ts))}</time>
+      <span class="ev"><span class="tag">${esc(l.tag)}</span> — ${l.html}</span></li>`;
+  }).join("")}</ul>`;
+}
+
+/* ---- home ------------------------------------------------------------------ */
+
 function tile(v, l, warn) {
   const none = v === "—" || v === 0 ? " none" : "";
-  return `<div class="tile${warn && v ? " warn" : ""}"><div class="v${none}">${esc(v)}</div><div class="l">${esc(l)}</div></div>`;
+  return `<div class="tile${warn && v ? " warn" : ""}"><div class="v num${none}">${esc(v)}</div><div class="l">${esc(l)}</div></div>`;
+}
+function statTiles(o) {
+  const reset = nextReset(o.usage);
+  return `<div class="stat-tiles">
+    ${tile(needsYou(o), "needs you", true)}
+    ${tile(o.agents == null ? "—" : o.agents.length, "agents live")}
+    ${tile(o.review_gate?.length ?? 0, "review gate", true)}
+    ${tile(reset ? clock(reset.at) : "—", reset ? `${reset.provider} ${reset.label} rolls` : "next reset")}
+  </div>`;
 }
 
-function screenHome() {
-  const o = payload?.overview;
-  if (!o) return `<div class="screen-head"><h2>Home</h2></div>${readbar()}
-    <div class="later">No snapshot yet. The sidecar is up and has not read the daemon successfully even once.</div>`;
-  const f = o.frontier;
-  return `<div class="screen-head"><h2>Home</h2></div>
-    ${readbar()}
-    <div class="tiles">
-      ${tile(o.agents == null ? "—" : o.agents.length, "agents live")}
-      ${tile(needsYou(), "needs you", true)}
-      ${tile(o.review_gate?.length ?? 0, "review gate", true)}
-      ${tile(o.events?.length ?? 0, "events held")}
-    </div>
-    <div class="facts">
-      <h3>The daemon</h3>
-      <dl>
-        <dt>port</dt><dd>${esc(o.daemon?.port)}</dd>
-        <dt>uptime</dt><dd>${esc(dur(o.daemon?.uptime_s))}</dd>
-        <dt>auto dispatch</dt><dd>${o.daemon?.auto_dispatch ? "on" : "off"}</dd>
-        <dt>max concurrent</dt><dd>${esc(o.daemon?.max_concurrent)}</dd>
-        <dt>bridge</dt><dd>${esc(o.bridge)}</dd>
-        <dt>frontier</dt><dd>${f ? `${esc(f.repos?.length ?? 0)} repo(s), computed ${esc(ago(f.computed_at))}` : "not computed yet"}</dd>
-        ${o.fleet_error ? `<dt>fleet</dt><dd>unreadable — ${esc(o.fleet_error)}</dd>` : ""}
-      </dl>
-    </div>
-    <p class="later" style="margin-top:16px">The <b>shell</b> is what this ticket owes. The screens it links to land next:
-      the read screens on #264, the settings on #265, the verbs on #266, the chat on #267.</p>`;
+/* The all-three home (#248): tiles across the top, the attention list left, the
+   fleet right, the provider strip said once under it. */
+function screenHome(p) {
+  const o = p?.overview;
+  if (!o) return noSnapshot(p, "Home");
+  const att = attentionList(o);
+  return `${head(p, "Home")}
+    ${statTiles(o)}
+    <div class="split-cols">
+      <div>
+        <div class="h-sect"><h3><span class="${att.count ? "hot" : ""}">Needs you</span> (${att.count})</h3>${att.html}</div>
+        <div class="h-sect"><h3>Last events</h3>${feedList(o.events, 4)}
+          <a class="more" href="#feed">all events →</a></div>
+      </div>
+      <div>
+        <div class="h-sect"><h3>Fleet${o.agents == null ? "" : ` (${o.agents.length})`}</h3>${fleetTable(o)}</div>
+        ${provStrip(o)}
+      </div>
+    </div>`;
 }
 
-function later(what, ticket) {
-  return `<div class="screen-head"><h2>${esc(SCREENS[screen][0])}</h2></div>
-    ${readbar()}
-    <div class="later"><b>${esc(what)}</b> lands on ${esc(ticket)}. The sidecar, its identity gate and this
-      shell are ${esc("#263")}; the screens are built on top of the same snapshot the bar above reads.</div>`;
+/* ---- agents ---------------------------------------------------------------- */
+
+function screenAgents(p) {
+  const o = p?.overview;
+  if (!o) return noSnapshot(p, "Agents");
+  const d = o.daemon ?? {};
+  const live = o.agents == null ? "—" : o.agents.length;
+  const bar = `<div class="statusbar">
+    <span>agents ${esc(live)}/${esc(d.max_concurrent ?? "?")}</span>
+    <span>auto dispatch ${d.auto_dispatch ? "on" : "off"}</span>
+    <span>bridge ${esc(o.bridge)}</span>
+    <span>daemon :${esc(d.port)} up ${esc(dur(d.uptime_s))}</span>
+  </div>`;
+  return `${head(p, "Agents")}${bar}${agentsTable(o)}${untrackedLine(o)}${recentLine(o)}`;
 }
+
+function agentsTable(o) {
+  if (o.agents == null) {
+    return `<div class="unread">the fleet could not be read${o.fleet_error ? ` — ${esc(o.fleet_error)}` : ""}. This is an unreadable tmux, not an idle box.</div>`;
+  }
+  if (!o.agents.length) return `<div class="empty">No agent is running.</div>`;
+  const rows = [...o.agents].sort((a, b) => (wantsYou(b) ? 1 : 0) - (wantsYou(a) ? 1 : 0));
+  return `<div class="tbl-wrap"><table class="agents wide">
+    <tr><th>session</th><th>state</th><th>ticket</th><th>model</th><th>ctx</th><th>up</th><th>waiting on</th></tr>
+    ${rows.map((a) => `<tr class="${wantsYou(a) ? "esc-row" : ""}">
+      <td class="sess">${esc(a.session)}${a.reviewer ? ` <span class="dim-note">reviewer</span>` : ""}</td>
+      <td><span class="state">${agentDot(a)} ${esc(stateWord(a))}</span>${a.tmux_live ? "" : `<div class="dim-note">no tmux session</div>`}</td>
+      <td><span class="t">${esc(ticketName(a.repo, a.ticket))}</span>${esc(a.title ?? "")}</td>
+      <td class="mono">${esc(a.model ?? "—")}</td>
+      <td class="num">${ctxCell(a)}</td>
+      <td class="num">${esc(dur(a.uptime_s))}</td>
+      <td>${waitingCell(a)}</td></tr>`).join("")}
+  </table></div>`;
+}
+function waitingCell(a) {
+  const open = a.waiting_on ?? [];
+  if (!open.length) return `<span class="dim-note">${a.result_received ? "its result is in" : "nothing"}</span>`;
+  return open.map((w) => `<span class="mono">${esc(w.kind)}</span>`).join(" · ");
+}
+/* A tmux session curia does not track. It is an anomaly reconcile owns, so the
+   page states it and spends no color on it. */
+function untrackedLine(o) {
+  if (!o.untracked?.length) return "";
+  return `<p class="dim-note">Untracked sessions: <span class="mono">${o.untracked.map((s) => esc(s)).join(", ")}</span>. Reconcile adopts or sweeps these.</p>`;
+}
+function recentLine(o) {
+  if (!o.recent?.length) return "";
+  return `<p class="dim-note">Recently: ${o.recent.map((r) => `${esc(r.kind)} ${esc(ticketName(r.repo, r.ticket))}`).join(" · ")}</p>`;
+}
+
+/* ---- frontier -------------------------------------------------------------- */
+
+/* The ticket type is the `wayfinder:` label and nothing else — a ticket with no
+   such label has no type, and saying so beats guessing one from another label. */
+function typeOf(item) {
+  const l = (item.labels ?? []).find((x) => String(x).startsWith("wayfinder:"));
+  return l ? String(l).slice("wayfinder:".length) : "untyped";
+}
+const shortRepo = (r) => String(r).split("/").pop();
+
+/* The filter runs over the snapshot, never over the wire: the frontier is
+   reconcile's reading and the page must not re-ask for a narrower one. */
+function frFiltered(snap) {
+  const f = UI.fr;
+  return (snap?.repos ?? [])
+    .filter((r) => f.repo === "all" || r.repo === f.repo)
+    .map((r) => (r.error ? r : { ...r, items: (r.items ?? []).filter((i) => f.type === "all" || typeOf(i) === f.type) }));
+}
+function frTypes(snap) {
+  const all = new Set();
+  for (const r of snap?.repos ?? []) for (const i of r.items ?? []) all.add(typeOf(i));
+  return [...all].sort();
+}
+
+function frCards(repos) {
+  const bigs = repos.filter((r) => !r.error).flatMap((r) => (r.items ?? []).map((i) => ({ ...i, repo: r.repo })));
+  const kids = repos.filter((r) => !r.error).flatMap((r) => (r.items ?? []).flatMap((i) => (i.unblocks ?? []).map((k) => ({ ...k, repo: r.repo, from: i.number }))));
+  return `${repos.filter((r) => r.error).map(frError).join("")}
+    <div class="frx-sect"><span class="eyebrow">takeable now (${bigs.length})</span>
+      ${bigs.length ? `<div class="frx-big">${bigs.map((n) => `<div class="frx-card">
+        <div class="head"><span class="t">#${esc(n.number)}</span><span class="typ">${esc(typeOf(n))}</span></div>
+        <div class="title">${esc(n.title)}</div>
+        <div class="foot"><span>${esc(n.repo)}</span><span>${n.unblocks?.length ? `unblocks ${n.unblocks.length}` : "unblocks nothing yet"}</span></div>
+        ${n.mapTitle ? `<div class="dim-note">${esc(n.mapTitle)}</div>` : ""}
+      </div>`).join("")}</div>` : `<div class="empty">Nothing is takeable under this filter.</div>`}
+    </div>
+    <div class="frx-sect"><span class="eyebrow">unblocked next (${kids.length})</span>
+      ${kids.length ? `<div class="frx-dim">${kids.map((k) => `<div class="frx-dimcard"><span class="t">#${esc(k.number)}</span>${esc(k.title)}
+        <span class="from">↖ #${esc(k.from)} · ${esc(k.repo)}</span></div>`).join("")}</div>`
+        : `<div class="empty">These tickets unblock nothing that is not already takeable.</div>`}
+    </div>`;
+}
+function frTree(repos) {
+  return repos.map((r) => {
+    if (r.error) return frError(r);
+    if (!r.items?.length) return `<div class="fr-repo"><span class="eyebrow mono">${esc(r.repo)}</span>
+      <div class="empty">Nothing is takeable under this filter.</div></div>`;
+    return `<div class="fr-repo"><span class="eyebrow mono">${esc(r.repo)}</span>
+      ${r.items.map((n) => `<div class="fr-group">
+        <div class="fr-node"><span class="typ">${esc(typeOf(n))}</span><span class="t">#${esc(n.number)}</span>${esc(n.title)}</div>
+        ${n.unblocks?.length ? `<div class="fr-kids">${n.unblocks.map((k) => `<div class="fr-kid"><span class="t">#${esc(k.number)}</span>${esc(k.title)}</div>`).join("")}</div>` : ""}
+      </div>`).join("")}</div>`;
+  }).join("");
+}
+function frError(r) {
+  return `<div class="unread"><span class="mono">${esc(r.repo)}</span> could not be read — ${esc(r.error)}. This is not an empty frontier: there may be takeable tickets there.</div>`;
+}
+
+const FR_VIEWS = { cards: ["Cards", frCards], tree: ["Tree", frTree] };
+
+function screenFrontier(p) {
+  const o = p?.overview;
+  if (!o) return noSnapshot(p, "Frontier");
+  const snap = o.frontier;
+  const right = `<span class="seg">${Object.entries(FR_VIEWS).map(([k, v]) =>
+    `<button class="${UI.fr.view === k ? "on" : ""}" onclick="frSet('view','${k}')">${esc(v[0])}</button>`).join("")}</span>`;
+  if (!snap || !snap.computed_at) {
+    return `${head(p, "Frontier — two levels", right)}
+      <div class="later">No frontier has been computed yet. Reconcile computes it on the credentials that pass already holds, and stamps the instant it did.</div>`;
+  }
+  const types = frTypes(snap);
+  const filter = `<div class="frx-filter">
+    <button class="fchip ${UI.fr.repo === "all" ? "on" : ""}" onclick="frSet('repo','all')">all projects</button>
+    ${(snap.repos ?? []).map((r) => `<button class="fchip ${UI.fr.repo === r.repo ? "on" : ""}" onclick="frSet('repo','${esc(r.repo)}')">${esc(shortRepo(r.repo))}</button>`).join("")}
+    <span class="sep">·</span>
+    <select onchange="frSet('type',this.value)">
+      <option value="all"${UI.fr.type === "all" ? " selected" : ""}>all types</option>
+      ${types.map((t) => `<option${UI.fr.type === t ? " selected" : ""}>${esc(t)}</option>`).join("")}
+    </select>
+    <span class="dim-note">computed ${esc(ago(snap.computed_at))}</span>
+  </div>`;
+  return `${head(p, "Frontier — two levels", right)}${filter}${FR_VIEWS[UI.fr.view][1](frFiltered(snap))}`;
+}
+function frSet(key, value) {
+  UI.fr[key] = value;
+  /* A repo that leaves the filter takes its types with it — an unreachable
+     type filter would show an empty page and name no reason. */
+  if (key === "repo") UI.fr.type = "all";
+  render();
+}
+
+/* ---- feed ------------------------------------------------------------------ */
+
+function screenFeed(p) {
+  const o = p?.overview;
+  if (!o) return noSnapshot(p, "Feed");
+  const n = o.events?.length ?? 0;
+  return `${head(p, "Feed", `<span class="dim-note">the journal's last ${esc(n)} event(s)</span>`)}
+    <div style="max-width:720px">${feedList(o.events)}</div>`;
+}
+
+/* ---- the shell ------------------------------------------------------------- */
 
 function render() {
-  const n = needsYou();
+  const n = needsYou(payload?.overview);
   document.getElementById("app").innerHTML = `<div class="shell">
     <nav><span class="brand">curia</span>
-      ${NAMES.map((k) => `<button class="${screen === k ? "on" : ""}" onclick="goto('${k}')">${SCREENS[k][0]}${
+      ${NAMES.map((k) => `<button class="${UI.screen === k ? "on" : ""}" onclick="goto('${k}')">${SCREENS[k][0]}${
         k === "home" && n ? ` <span class="n">${n}</span>` : ""}</button>`).join("")}
     </nav>
-    <main>${SCREENS[screen][1]()}</main>
+    <main>${SCREENS[UI.screen][1](payload)}</main>
   </div>`;
   document.title = (n ? `(${n}) ` : "") + "curia";
 }
-function goto(k) { screen = k; location.hash = k; render(); }
+function goto(k) { UI.screen = k; location.hash = k; render(); }
 window.addEventListener("hashchange", () => {
   const k = location.hash.slice(1);
-  if (NAMES.includes(k) && k !== screen) { screen = k; render(); }
+  if (NAMES.includes(k) && k !== UI.screen) { UI.screen = k; render(); }
 });
 
 /* ---- the poll -------------------------------------------------------------
@@ -262,6 +763,12 @@ document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "visible") tick(); else clearTimeout(timer);
 });
 
-render();
-tick();
+/* The page boots itself only in a browser. Its test loads the same source into
+   a vm to call the screens directly, and a boot there would fetch nothing and
+   render into no document. */
+if (typeof document !== "undefined" && document.getElementById("app")) {
+  UI.screen = NAMES.includes(location.hash.slice(1)) ? location.hash.slice(1) : "home";
+  render();
+  tick();
+}
 </script>

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -53,7 +53,7 @@ import { detectHarness } from './transcript.mjs'
 import { promptTitle, elapsedLabel, speakerName } from './messaging.mjs'
 import { StatusLine } from './statusline.mjs'
 import { remainingRenderRetries } from './renderretry.mjs'
-import { AccountUsage, ModelWindows, agentMeters } from './usage.mjs'
+import { AccountUsage, ModelWindows, agentMeters, ctxOnWire } from './usage.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.join(DIR, '..')
@@ -1270,7 +1270,12 @@ async function overview() {
     },
     // Null, never empty, when the read above failed: an unreadable fleet and an
     // idle box are opposite facts and must never render the same.
-    agents: fleet?.agents ?? null,
+    //
+    // The context meter joins here (#264). `status()` reads tmux and the
+    // journal and never a transcript, so the ctx column the dashboard's two
+    // tables carry has to be added on the route. It costs one transcript tail
+    // read per live agent per refresh, which the poll interval bounds (#263).
+    agents: fleet?.agents?.map((a) => ({ ...a, ...ctxOnWire(() => metersFor(a.session, a.model)) })) ?? null,
     untracked: fleet?.untracked ?? null,
     recent: fleet?.recent ?? null,
     fleet_error: fleetError,

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -810,6 +810,28 @@ export function agentMeters({ harness, cfgDir, model, routing, account, models, 
   return out
 }
 
+// What `GET /overview` says about one agent's context (#264).
+//
+// The fleet table and the agents table both carry a ctx column, and
+// `dispatcher.status()` cannot fill it: that read asks tmux and the journal,
+// never a transcript. So the meter joins on the route, through the same
+// `agentMeters` the status line reads — one agent is never measured two ways on
+// two surfaces.
+//
+// The read is passed in as a thunk, and a throw from it costs this ONE column.
+// Every section of that route is independently nullable, and a missing
+// transcript must not take an agent's row off a page with it. `ctx_pct` is null
+// when there is no reading — which the page prints as "—", never as 0%.
+export function ctxOnWire(read) {
+  let m = null
+  try {
+    m = read()
+  } catch {
+    return { ctx_pct: null, ctx_over: false }
+  }
+  return { ctx_pct: m?.ctxPct ?? null, ctx_over: Boolean(m?.ctxOver) }
+}
+
 // Ordered most valuable first: the status line appends what fits and drops the
 // rest from the tail (#146 — state and escalation title win over the meters).
 // The window label carries bold because it is the thing the eye lands on when

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1,0 +1,360 @@
+// The four read screens (#264) — home, agents, frontier, feed.
+//
+// The page has no build step: the file the sidecar serves IS the reviewed
+// source. So its test loads that same file, lifts its one script into a vm, and
+// calls the screens with a payload — no browser, no headless render, no eyes on
+// pixels. What is pinned here is what the screens SAY, which is the half a
+// human reading the preview cannot check by looking: that a null fleet reads as
+// unreadable rather than idle, that an unstamped frontier reads as uncomputed
+// rather than empty, that the tab title carries the needs-you count, and that a
+// journal event nobody wrote prose for is still legible.
+//
+// The screens take the payload as an argument for exactly this reason. A screen
+// that read a global would be a screen this file could not drive.
+
+import { test, describe, before } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import vm from 'node:vm'
+import { DEFAULT_DASHBOARD_INDEX } from '../src/dashboard.mjs'
+
+// The page boots itself only when a real document holds `#app`, so this fake
+// one keeps the load inert: no render, no poll, no timer. `fetch` never settles
+// on purpose — a rejection would flip the offline marker and every screen below
+// would be testing that instead.
+function loadPage() {
+  const html = fs.readFileSync(DEFAULT_DASHBOARD_INDEX, 'utf8')
+  const script = /<script>([\s\S]*)<\/script>/.exec(html)
+  assert.ok(script, 'the page carries its script inline — there is no build step')
+  const ctx = vm.createContext({
+    document: { title: '', getElementById: () => null, addEventListener() {}, visibilityState: 'hidden' },
+    window: { addEventListener() {} },
+    location: { hash: '' },
+    fetch: () => new Promise(() => {}),
+    setTimeout,
+    clearTimeout,
+    console,
+  })
+  vm.runInContext(script[1], ctx)
+  return ctx
+}
+
+// The wire shape of `GET /overview` (#262), with the ctx meter #264 joins onto
+// each agent. Every fixture below starts from this and overrides one section.
+const at = (secondsAgo) => new Date(Date.now() - secondsAgo * 1000).toISOString()
+const ahead = (minutes) => new Date(Date.now() + minutes * 60_000).toISOString()
+
+const OVERVIEW = () => ({
+  at: at(0),
+  daemon: { port: 4271, uptime_s: 7200, auto_dispatch: true, max_concurrent: 3 },
+  agents: [
+    {
+      session: 'curia-263', repo: 'alp82/curia', ticket: '263', title: 'The sidecar stands up',
+      model: 'claude-opus-5', reviewer: false, state: 'ready', uptime_s: 900,
+      result_received: false, tmux_live: true, waiting_on: [], ctx_pct: 41, ctx_over: false,
+    },
+    {
+      session: 'curia-255', repo: 'alp82/curia', ticket: '255', title: 'The note queue drains in order',
+      model: 'gpt-5.6-sol', reviewer: false, state: 'ready', uptime_s: 3600,
+      result_received: false, tmux_live: true, waiting_on: [{ id: 'esc-7', kind: 'choice' }],
+      ctx_pct: 68, ctx_over: false,
+    },
+    {
+      session: 'curia-review-263', repo: 'alp82/curia', ticket: '263', title: 'Cross-check of curia-263',
+      model: 'gpt-5.6-sol', reviewer: true, state: 'ready', uptime_s: 120,
+      result_received: false, tmux_live: true, waiting_on: [], ctx_pct: null, ctx_over: false,
+    },
+  ],
+  untracked: [],
+  recent: [{ kind: 'finished', repo: 'alp82/curia', ticket: '261' }],
+  fleet_error: null,
+  escalations: [{
+    id: 'esc-7', agent: 'curia-255', ticket: '255', kind: 'choice',
+    prompt: 'Two notes race the same expiry line. Drop the older note, or post both with stamps?',
+    options: ['Drop the older note', 'Post both with stamps'], preview_url: null,
+    opened_at: at(720), agent_died: false, rendered: true, thread_id: '99',
+  }],
+  review_gate: [{
+    id: 'esc-9', agent: 'curia-261', ticket: '261', kind: 'review-gate', prompt: 'is this done?',
+    options: null, preview_url: null, opened_at: at(300), agent_died: false, rendered: true,
+    thread_id: '98', pull_request: 'https://github.com/alp82/curia/pull/262',
+  }],
+  bridge: 'up',
+  bridge_health: { state: 'up', since: at(9000), unhealthy_for_s: 0, last_error: null },
+  usage: [
+    { provider: 'anthropic', from: 'account', session: null, windows: [
+      { label: '5h', pct: 58, elapsed_pct: 48, resets_at: ahead(90), fresh: true },
+      { label: '7d', pct: 22, elapsed_pct: 41, resets_at: ahead(4000), fresh: true },
+    ] },
+    { provider: 'openai', from: 'transcript', session: 'curia-255', windows: [
+      { label: '5h', pct: 97, elapsed_pct: 48, resets_at: ahead(30), fresh: true },
+    ] },
+  ],
+  events: [
+    { ts: at(600), type: 'agent_spawned', agent: 'curia-255', repo: 'alp82/curia', ticket: '255', model: 'gpt-5.6-sol', harness: 'codex' },
+    { ts: at(400), type: 'esc_open', id: 'esc-7', agent: 'curia-255', ticket: '255', kind: 'choice', prompt: 'Two notes race the same expiry line.' },
+    { ts: at(60), type: 'credentials_swept', agent: 'curia-263', ticket: '263', repo: 'alp82/curia' },
+  ],
+  frontier: {
+    computed_at: at(120),
+    repos: [
+      { repo: 'alp82/curia', lane: 'map', numbers: [265, 266], agentOnly: 2, items: [
+        { number: 265, title: 'The settings write', labels: ['wayfinder:task'], map: 244, mapTitle: 'Curia gets a face', unblocks: [
+          { number: 267, title: 'The chat embeds the timeline attach', labels: ['wayfinder:task'] },
+        ] },
+        { number: 266, title: 'The verbs reach the browser', labels: ['wayfinder:grilling'], map: 244, mapTitle: 'Curia gets a face', unblocks: [] },
+      ] },
+      { repo: 'alp82/aistack', error: 'gh api failed: HTTP 502' },
+    ],
+  },
+})
+
+const payload = (overrides = {}) => ({
+  poll_interval_s: 5,
+  read_at: at(2),
+  daemon_up: true,
+  daemon_port: 4271,
+  error: null,
+  error_since: null,
+  overview: { ...OVERVIEW(), ...overrides },
+})
+
+// What a reader sees, with the markup taken out.
+const text = (html) => html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+
+describe('the read screens (#264)', () => {
+  let page
+  before(() => { page = loadPage() })
+
+  describe('home — the all-three (#248)', () => {
+    test('the tiles, the attention list and the fleet all draw one snapshot', () => {
+      const html = page.screenHome(payload())
+      const t = text(html)
+      // Two things want the operator: one question and one gate.
+      assert.match(t, /2 needs you/)
+      assert.match(t, /3 agents live/)
+      assert.match(t, /1 review gate/)
+      assert.match(t, /Needs you \(3\)/, 'the list adds the spent window the count does not')
+      assert.match(t, /Two notes race the same expiry line/, 'the question is shown whole, not summarized')
+      assert.match(t, /Drop the older note · Post both with stamps/, 'and its options are named')
+      assert.match(t, /review gate — #261/)
+      assert.match(t, /pull\/262/, 'the gate carries the pull request nothing else carries')
+      assert.match(t, /Fleet \(3\)/)
+      assert.match(t, /curia-263/)
+      assert.match(t, /Last events/)
+    })
+
+    test('the provider strip says each window once, and no agent row repeats it', () => {
+      const html = page.screenHome(payload())
+      assert.equal((html.match(/class="prov"/g) ?? []).length, 2, 'one reading per provider')
+      assert.match(text(html), /anthropic 5h 58% 7d 22%/)
+      // The windows are an account fact. A per-agent copy would be the thing
+      // #248 removed from the fleet.
+      assert.equal(/<td[^>]*>[^<]*7d/.test(html), false)
+    })
+
+    test('a spent window joins the attention list and says when it rolls', () => {
+      const t = text(page.screenHome(payload()))
+      assert.match(t, /openai the 5h window is spent at 97%/)
+      assert.match(t, /it rolls at \d\d:\d\d/)
+    })
+
+    test('the needs-you count is escalations plus the gate, and the tab title carries it', () => {
+      assert.equal(page.needsYou(payload().overview), 2)
+      assert.equal(page.needsYou(payload({ escalations: [], review_gate: [] }).overview), 0)
+      // The tab title is written in render(), off that same function.
+      page.payload = payload()
+      const el = { innerHTML: '' }
+      page.document.getElementById = () => el
+      page.render()
+      assert.equal(page.document.title, '(2) curia')
+      page.payload = payload({ escalations: [], review_gate: [] })
+      page.render()
+      assert.equal(page.document.title, 'curia')
+      page.document.getElementById = () => null
+    })
+
+    test('an unreadable fleet is not an idle box', () => {
+      const t = text(page.screenHome(payload({ agents: null, untracked: null, recent: null, fleet_error: 'tmux is indeterminate' })))
+      assert.match(t, /the fleet could not be read — tmux is indeterminate/)
+      assert.doesNotMatch(t, /No agent is running/)
+      assert.match(t, /Two notes race the same expiry line/, 'and every other section still draws')
+    })
+
+    test('an idle box says so, and says it plainly', () => {
+      const t = text(page.screenHome(payload({ agents: [] })))
+      assert.match(t, /No agent is running/)
+      assert.match(t, /0 agents live/)
+    })
+
+    test('with no snapshot at all the page says that, and invents none', () => {
+      const t = text(page.screenHome({ poll_interval_s: 5, read_at: null, daemon_up: false, overview: null }))
+      assert.match(t, /No snapshot yet/)
+    })
+  })
+
+  describe('agents', () => {
+    test('the table names the state in words and the meters in numbers', () => {
+      const t = text(page.screenAgents(payload()))
+      assert.match(t, /agents 3\/3/)
+      assert.match(t, /bridge up/)
+      assert.match(t, /curia-255 waiting/, 'an open question makes an agent waiting, whatever its record says')
+      assert.match(t, /curia-263 working/, 'ready and working are one state')
+      assert.match(t, /curia-review-263 reviewer/)
+      assert.match(t, /claude-opus-5/)
+      assert.match(t, /Recently: finished alp82\/curia#261/)
+    })
+
+    test('the ctx column reads the meter, and a missing meter is not zero', () => {
+      const t = text(page.screenAgents(payload()))
+      assert.match(t, /41%/)
+      assert.match(t, /68%/)
+      // curia-review-263 has no transcript reading. "—" is the honest cell.
+      assert.doesNotMatch(t, /0%/)
+      const over = payload()
+      over.overview.agents[0].ctx_pct = 118
+      over.overview.agents[0].ctx_over = true
+      assert.match(text(page.screenAgents(over)), /118% ⚠/, 'over 100% is a complaint about the denominator, and is marked')
+    })
+
+    test('only the agent that wants you is marked, and the mark is the only color', () => {
+      const html = page.screenAgents(payload())
+      const rows = html.split('<tr').filter((r) => r.includes('class="sess"'))
+      const marked = rows.filter((r) => r.includes('esc-row'))
+      assert.equal(marked.length, 1)
+      assert.match(marked[0], /curia-255/)
+    })
+
+    test('an unreadable fleet says so here too', () => {
+      const t = text(page.screenAgents(payload({ agents: null, fleet_error: 'tmux is indeterminate' })))
+      assert.match(t, /could not be read — tmux is indeterminate/)
+      assert.match(t, /agents —\/3/)
+    })
+  })
+
+  describe('frontier — two levels', () => {
+    test('cards draw the takeable set and what it unblocks', () => {
+      page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
+      const t = text(page.screenFrontier(payload()))
+      assert.match(t, /takeable now \(2\)/)
+      assert.match(t, /#265 task The settings write/)
+      assert.match(t, /unblocks 1/)
+      assert.match(t, /#266 grilling The verbs reach the browser/)
+      assert.match(t, /unblocks nothing yet/)
+      assert.match(t, /unblocked next \(1\)/)
+      assert.match(t, /#267 The chat embeds the timeline attach ↖ #265/)
+      assert.match(t, /computed \d+m ago/, 'the page states the age of the reading')
+    })
+
+    test('a repo whose read failed is not an empty frontier', () => {
+      const t = text(page.screenFrontier(payload()))
+      assert.match(t, /alp82\/aistack could not be read — gh api failed: HTTP 502/)
+      assert.match(t, /there may be takeable tickets there/)
+    })
+
+    test('the tree says the same two levels', () => {
+      page.UI.fr = { view: 'tree', repo: 'all', type: 'all' }
+      const t = text(page.screenFrontier(payload()))
+      assert.match(t, /alp82\/curia/)
+      assert.match(t, /task #265 The settings write/)
+      assert.match(t, /#267 The chat embeds the timeline attach/)
+      page.UI.fr.view = 'cards'
+    })
+
+    test('the project filter narrows to one repo, and the type filter to one type', () => {
+      page.UI.fr = { view: 'cards', repo: 'alp82/curia', type: 'all' }
+      let t = text(page.screenFrontier(payload()))
+      assert.doesNotMatch(t, /aistack could not be read/, 'a repo out of the filter is out of the page')
+      page.UI.fr.type = 'grilling'
+      t = text(page.screenFrontier(payload()))
+      assert.match(t, /takeable now \(1\)/)
+      assert.match(t, /#266/)
+      assert.doesNotMatch(t, /#265 /)
+      // A filter that matches nothing says so rather than drawing a blank page.
+      page.UI.fr.type = 'research'
+      assert.match(text(page.screenFrontier(payload())), /Nothing is takeable under this filter/)
+      page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
+    })
+
+    test('picking a project resets the type — an unreachable filter draws an empty page and names no reason', () => {
+      page.UI.fr = { view: 'cards', repo: 'all', type: 'grilling' }
+      page.document.getElementById = () => ({ innerHTML: '' })
+      page.frSet('repo', 'alp82/curia')
+      assert.deepEqual(page.UI.fr, { view: 'cards', repo: 'alp82/curia', type: 'all' })
+      page.document.getElementById = () => null
+      page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
+    })
+
+    test('a frontier nobody has computed is not an empty frontier', () => {
+      const t = text(page.screenFrontier(payload({ frontier: { computed_at: null, repos: [] } })))
+      assert.match(t, /No frontier has been computed yet/)
+      assert.match(t, /Reconcile computes it/)
+    })
+
+    test('a ticket with no wayfinder label has no type, and none is guessed for it', () => {
+      const p = payload()
+      p.overview.frontier.repos[0].items[0].labels = ['bug']
+      assert.match(text(page.screenFrontier(p)), /#265 untyped/)
+    })
+  })
+
+  describe('feed', () => {
+    test('the journal reads as sentences, newest first', () => {
+      const t = text(page.screenFeed(payload()))
+      const spawn = t.indexOf('spawned on gpt-5.6-sol')
+      const ask = t.indexOf('asks — choice')
+      assert.ok(ask > -1 && spawn > ask, 'the last thing that happened is the first thing on the page')
+      assert.match(t, /curia-255 spawned on gpt-5.6-sol — codex · alp82\/curia#255/)
+    })
+
+    test('an event nobody wrote prose for is still legible', () => {
+      // `credentials_swept` has no line in the table on purpose: the daemon
+      // grows event types, and the page must not go blank on the day one ships.
+      const t = text(page.screenFeed(payload()))
+      assert.match(t, /credentials swept — curia-263 · alp82\/curia#263/)
+    })
+
+    test('color marks the events that mean attention, and no others', () => {
+      const html = page.screenFeed(payload())
+      const rows = html.split('<li').slice(1)
+      assert.equal(rows.length, 3)
+      assert.equal(rows.filter((r) => r.startsWith(' class="warn"')).length, 1, 'the open question')
+      assert.equal(rows.filter((r) => r.startsWith(' class="bad"')).length, 0)
+    })
+
+    test('an empty journal tail says so', () => {
+      assert.match(text(page.screenFeed(payload({ events: [] }))), /The journal tail is empty/)
+    })
+
+    test('the home carries the last four events and links to the rest', () => {
+      const p = payload()
+      p.overview.events = Array.from({ length: 9 }, (_, i) => ({ ts: at(600 - i * 10), type: 'reconcile', boot: false }))
+      const html = page.screenHome(p)
+      const col = html.slice(html.indexOf('Last events'))
+      assert.equal((col.match(/<li/g) ?? []).length, 4)
+      assert.match(col, /href="#feed"/)
+    })
+  })
+
+  describe('the marker every screen carries (#263)', () => {
+    test('a daemon that is not answering shows the age of the held snapshot', () => {
+      page.reachable = true
+      const p = payload()
+      p.daemon_up = false
+      p.error = 'connect ECONNREFUSED'
+      p.error_since = at(30)
+      p.read_at = at(90)
+      const t = text(page.screenHome(p))
+      assert.match(t, /daemon restarting/)
+      assert.match(t, /showing the snapshot from 2m ago/)
+      assert.match(t, /connect ECONNREFUSED/)
+      assert.match(t, /Fleet \(3\)/, 'and the held snapshot is still drawn')
+    })
+
+    test('a sidecar this page cannot reach is a different fact, and says so', () => {
+      page.reachable = false
+      assert.match(text(page.screenFeed(payload())), /the console is offline/)
+      page.reachable = true
+    })
+  })
+})

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -27,6 +27,7 @@ import { Dispatcher } from '../src/dispatch.mjs'
 import { directUnblocks } from '../src/github.mjs'
 import { EscalationStore, RECENT_EVENTS } from '../src/store.mjs'
 import { REVIEW_KIND } from '../src/lifecycle.mjs'
+import { ctxOnWire } from '../src/usage.mjs'
 import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
 import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
 import { sandboxYaml, TEST_PINS } from './fixtures/sandbox.mjs'
@@ -250,6 +251,28 @@ describe('GET /overview (index.mjs, real boot)', () => {
     const cross = await request(port, 'GET', '/overview', { headers: { origin: 'http://evil.com' } })
     assert.equal(cross.status, 403, 'the CSRF gate covers the whole surface, this route included')
     assert.equal(AGENT_ROUTES.has('/overview'), false, 'an agent container cannot reach the operator\'s own read')
+  })
+})
+
+describe('the context meter on the wire (#264)', () => {
+  // The dashboard's fleet table and agents table both carry a ctx column, and
+  // `dispatcher.status()` cannot fill it: that read asks tmux and the journal,
+  // never a transcript. So the route joins the meter on, and the join is the
+  // thing that must not cost a row.
+  test('a reading crosses as a percentage, and the over-100 mark crosses with it', () => {
+    assert.deepEqual(ctxOnWire(() => ({ ctxPct: 41, ctxOver: false })), { ctx_pct: 41, ctx_over: false })
+    // Over 100% is the daemon's complaint about the denominator (#146), not a
+    // reading about the agent. It travels rather than being flattened here.
+    assert.deepEqual(ctxOnWire(() => ({ ctxPct: 118, ctxOver: true })), { ctx_pct: 118, ctx_over: true })
+  })
+
+  test('no reading is null, never zero — an unmeasured context and an empty one are not one fact', () => {
+    assert.deepEqual(ctxOnWire(() => ({ ctxPct: null, ctxOver: false })), { ctx_pct: null, ctx_over: false })
+    assert.deepEqual(ctxOnWire(() => null), { ctx_pct: null, ctx_over: false })
+  })
+
+  test('a meter that throws costs this one column and never the agent', () => {
+    assert.deepEqual(ctxOnWire(() => { throw new Error('no transcript on disk') }), { ctx_pct: null, ctx_over: false })
   })
 })
 


### PR DESCRIPTION
Ticket: alp82/curia#264 — [The read screens land: home, agents, frontier, feed](https://github.com/alp82/curia/issues/264)

The four read screens on the settled prototype designs (#248), drawing one payload: the sidecar's held snapshot of `GET /overview`.

- **Home** — the all-three: stat tiles, attention list left, fleet right, provider strip said once under it. The tab title and the nav badge read the same needs-you function.
- **Agents** — the table: state in the status line's own words, model, ctx, uptime, what it waits on. Untracked sessions and recent outcomes below.
- **Frontier** — the two levels as Cards or Tree, with project chips and a type filter. The type is the `wayfinder:` label and nothing else. The page states the age of reconcile's reading.
- **Feed** — the journal tail as sentences, newest first. A type the prose table does not name still reads.

Two rules across all four. Color marks attention only: an open question, the review gate, a spent window. Null is not empty: an unreadable fleet, an uncomputed frontier and a repo whose `gh` read failed each say which they are.

One daemon change, on the operator's call: the ctx column the settled tables carry. `dispatcher.status()` cannot fill it, so `ctxOnWire` joins the meter on the route through the same `agentMeters` the status line reads. A meter that throws costs that one column, never the row.

The page has no build step, so its test loads the shipped file, lifts its script into a vm, and calls the screens with a payload. npm test green at 1486.

---

Dispatched by the curia daemon — session `curia-264`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `6065258` The read screens land: home, agents, frontier, feed (wayfinder #264)