### PR TITLE
The verbs reach the browser: start, answer, gate, note, cancel (alp82/curia#266)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -280,7 +280,7 @@ A fire-and-forget line of agent prose into the ticket thread.
 _Avoid_: status line (that names the daemon's own line, below).
 
 **Operator note**:
-Text the operator types in an agent's thread while no escalation is open. It belongs to the instance it was typed at and dies with it. It has two delivery modes, and the operator picks.
+Text the operator sends to one agent while no escalation is open. It belongs to the instance it was sent to and dies with it. It has two delivery modes, and the operator picks. A note typed in Discord is keyed on the thread it was typed in. A note sent from the console names the agent, because a browser has no thread. Both keyings reach one queue.
 _Avoid_: message, comment.
 
 **Queued**:
@@ -361,7 +361,19 @@ The daemon's one loopback read of itself, `GET /overview`. It joins every sectio
 The browser console for the box, on loopback `4273` and Serve `8445`. It draws the overview behind the same identity check every other surface uses.
 
 **Read screen**:
-A dashboard screen that only draws the overview: home, agents, frontier, feed. The settings screen is the one that also writes. Two rules hold across all four. Color marks attention and nothing else, so a state, a ticket type and a repo are told in words. Null is not empty, so an unreadable fleet never renders as an idle box and an uncomputed frontier never renders as an empty one.
+A dashboard screen whose facts all come from the overview: home, agents, frontier, feed. The settings screen is the one that reads its own files. Two rules hold across all four. Color marks attention and nothing else, so a state, a ticket type and a repo are told in words. Null is not empty, so an unreadable fleet never renders as an idle box and an uncomputed frontier never renders as an empty one.
+
+**Answer surface**:
+The Needs-you list on the home screen. It is the one place a question or the review gate is answered from the console. The agents table states what an agent waits on and answers none of it, so no operator has to remember which of two surfaces they are looking at.
+
+**Operator verb**:
+An act the console carries: start, answer, the review gate, note, cancel, teleport. Each one is a POST to the sidecar, which composes the daemon call from the fields the page sends. A browser never hands over a command line. Start, cancel and teleport go through the command seam the slash verbs use, so a press from the console journals the same event a typed command does.
+
+**Routed model**:
+The model a takeable ticket gets if it starts now. Reconcile computes it with the daemon's own precedence rule and joins it onto each frontier item, so the console names the account a press spends before spending it. It states what routing decides, not what a spawn does: cooling is read at the spawn, and the feed reports the chain it walked.
+
+**Who pressed**:
+The operator's Tailscale login, taken from the header the sidecar's identity check already reads and passed to the daemon as the `by` of every verb. Before the console, every REST verb journalled the word `rest`. The feed now names a person rather than a transport.
 
 **Sidecar**:
 The process that serves the dashboard. It runs beside the daemon and never inside it, so it stays up while the daemon restarts. It holds no secret: its container mounts the code and the config directory, and neither the journal nor the `.env`.

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <meta charset="utf-8">
-<!-- The console (#263 the shell, #264 the read screens), on the look settled by
-     the prototype (#248): dark-first tokens, system mono for data, one accent.
+<!-- The console (#263 the shell, #264 the read screens, #265 the settings write,
+     #266 the operator verbs), on the look settled by the prototype (#248):
+     dark-first tokens, system mono for data, one accent.
 
      THE STAMP BELOW IS LOAD-BEARING. This page and daemon/src/dashboard.mjs are
      two halves of one protocol, and there is no build step — the file on disk IS
@@ -11,9 +12,12 @@
      carries it).
 
      The four read screens draw one payload: `GET /api/overview`, which is the
-     sidecar's held snapshot of the daemon's own `GET /overview` (#262). They
-     write nothing. The operator verbs land in #266, the settings in #265 and the
-     chat in #267.
+     sidecar's held snapshot of the daemon's own `GET /overview` (#262). The
+     chat lands in #267.
+
+     THE VERBS (#266) POST to the sidecar, never to the daemon. It composes each
+     daemon call from the fields the page sends, so this page names a ticket, an
+     escalation id or an agent — never a command line.
 
      TWO RULES RUN THROUGH EVERY SCREEN HERE.
 
@@ -23,7 +27,7 @@
      2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
         nobody has computed is not an empty frontier. Every section that can fail
         on its own says which of the two it is. -->
-<meta name="curia-dashboard" content="proto=1">
+<meta name="curia-dashboard" content="proto=2">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>curia</title>
 <style>
@@ -264,6 +268,31 @@
   .save-banner.refused .toast { color: var(--bad); }
   .save-banner .toast.why { font-family: ui-monospace, Menlo, monospace; font-size: 12px; flex-basis: 100%; }
 
+  /* ---------- the operator verbs (#266, on the #248 shapes) ----------
+     No new color. A verb sits inside the card that already carries the fact it
+     acts on, so the attention marking around it is the marking rule's, not a
+     second one this section invents. */
+  .act-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 7px; }
+  .act-row input[type=text] { flex: 1; min-width: 130px; }
+  .act-box { margin-top: 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--bg-inset); padding: 9px 11px; }
+  .act-box label { font-size: 12px; color: var(--ink-dim); display: inline-flex; align-items: center; gap: 5px; }
+  .act-box .act-row:first-child { margin-top: 0; }
+  .links { display: flex; gap: 12px; flex-wrap: wrap; font-size: 12px; align-items: baseline; }
+  .links button {
+    color: var(--accent); background: none; border: 0; padding: 0;
+    font-size: 12px; text-decoration: none;
+  }
+  .links button:hover { text-decoration: underline; }
+  .links button.bad { color: var(--bad); }
+  .links button[disabled] { color: var(--ink-faint); cursor: default; text-decoration: none; }
+  /* What curia said back about the press. It is curia's OWN sentence, so it
+     sits where the press was rather than becoming a banner somewhere else. */
+  .said { margin-top: 7px; font-size: 12.5px; border-left: 3px solid var(--line); padding: 3px 0 3px 9px; white-space: pre-wrap; color: var(--ink-dim); }
+  .said.bad { border-left-color: var(--bad); color: var(--bad); }
+  .said code { background: var(--bg-inset); border-radius: 4px; padding: 0 4px; }
+  .said a { word-break: break-all; }
+  .copy { width: 100%; font: 12px ui-monospace, Menlo, monospace; }
+
   /* ---------- the screens that land later ---------- */
   .later {
     border: 1px dashed var(--line); border-radius: 9px; padding: 12px 14px;
@@ -308,6 +337,11 @@ var UI = {
      phases plus the two that can interrupt them: clean, dirty, saved,
      restarting, refused, unread. */
   set: { section: "routing", models: false, phase: "clean", error: null, busy: false, note: null },
+  /* The operator verbs (#266). `busy` names the ONE press in flight, keyed to
+     the control it came from; `said` is what curia answered, shown at that same
+     control. `note` and `tele` name the agent whose box is open, and `mode` is
+     the delivery ADR-0013 defaults to. */
+  act: { busy: null, said: null, note: null, mode: "queue", tele: null },
 };
 var payload = null;   /* the sidecar's last answer */
 var reachable = true; /* is the SIDECAR itself answering — a different fact from daemon_up */
@@ -352,6 +386,178 @@ function ticketName(repo, ticket) {
    nobody can answer it. */
 function needsYou(o) {
   return (o?.escalations?.length ?? 0) + (o?.review_gate?.length ?? 0);
+}
+
+/* ---- the operator verbs (#266) ----------------------------------------------
+
+   Every verb is ONE POST to the sidecar, which composes the daemon call from
+   the fields sent here. This page never sends a command line: it names a repo,
+   a ticket, an escalation id or an agent, and the sidecar builds the rest.
+
+   Four rules run through all of them.
+
+   1. ONE ACT AT A TIME. `UI.act.busy` names the press in flight, keyed to the
+      control it came from, so a second press starts nothing and the control
+      that is working says so.
+   2. CURIA'S OWN WORDS ARE THE OUTCOME. A command reply is a sentence the
+      daemon composed. It is shown where the press was, as it stands. This page
+      never writes its own account of what an act did.
+   3. THE READING MOVES AT ONCE. The sidecar drops its snapshot age on every
+      verb, so the poll right after a press is a fresh read rather than the held
+      one. A button that appears to do nothing for five seconds is a button
+      pressed twice.
+   4. A REFUSAL IS A FACT. First-valid-wins, an agent that is not running, a
+      ticket already claimed: each comes back in words, under the control that
+      asked, and none of them is a failure of this page. */
+
+/* The literal answers every surface sends. The daemon classifies the ANSWER
+   (lifecycle.mjs classifyReviewAnswer, bridge.mjs #buttons), so this page must
+   not teach it a second vocabulary for the same act. */
+const APPROVE = "approve";
+const REJECT = "reject";
+const CROSS_CHECK = "cross-check";
+const ALL_AS_RECOMMENDED = "all-as-recommended";
+
+/* A value going into an onclick handler crosses TWO escapings: the HTML
+   attribute, and the single-quoted JS string inside it. `esc` answers only the
+   first. An escalation option is an agent's own words — the one value on this
+   page that can carry a quote — and a bare `esc` would leave it able to close
+   that string and open code instead. So the JS escaping runs first and the HTML
+   escaping over it. */
+const js = (s) => esc(String(s ?? "").replace(/\\/g, "\\\\").replace(/'/g, "\\'"));
+
+const busy = (key) => UI.act.busy === key;
+const anyBusy = () => UI.act.busy !== null;
+function said(key) {
+  const s = UI.act.said;
+  return s && s.key === key ? `<div class="said${s.ok ? "" : " bad"}">${mdLite(s.text)}</div>` : "";
+}
+/* Curia speaks Discord markdown everywhere else, and one reply reaching two
+   surfaces is the point of the command seam — so the page renders the little of
+   it a reply uses rather than asking the daemon for a second wording. */
+function mdLite(s) {
+  return esc(s)
+    .replace(/`([^`]+)`/g, (_, x) => `<code>${x}</code>`)
+    .replace(/\*\*([^*]+)\*\*/g, (_, x) => `<b>${x}</b>`)
+    .replace(/(https?:\/\/[^\s<]+)/g, (u) => `<a href="${u}">${u}</a>`);
+}
+
+async function verb(key, path, body) {
+  if (anyBusy()) return null;
+  UI.act.busy = key;
+  UI.act.said = null;
+  render();
+  let out = null;
+  try {
+    const res = await fetch(path, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+    const b = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(b.error || ("the console answered " + res.status));
+    out = b;
+    UI.act.said = { key, text: outcome(b), ok: b.ok !== false };
+  } catch (e) {
+    UI.act.said = { key, text: e.message, ok: false };
+  }
+  UI.act.busy = null;
+  render();
+  tick();
+  return out;
+}
+function refuse(key, text) {
+  UI.act.said = { key, text, ok: false };
+  render();
+}
+
+function outcome(b) {
+  if (typeof b.reply === "string") return b.reply;
+  if (b.mode) return noteOutcome(b);
+  if (b.ok) return "Answered — it is with the agent.";
+  return "Done.";
+}
+/* A note says which delivery it got, because the delivery is the half the
+   operator chose. An interrupt curia refused leaves the words QUEUED — the
+   operator asked for these words to reach the agent, and only the speed of it
+   failed (ADR-0013). */
+function noteOutcome(b) {
+  if (b.ok === false) {
+    const why = b.why ?? "curia could not put those words to the agent.";
+    return b.still_queued ? `${why}\nThe words stay queued: the agent reads them with its next tool result.` : why;
+  }
+  if (b.mode === "interrupt") {
+    return `Interrupting \`${b.session ?? b.agent}\` — ${Math.round((b.graceMs ?? 0) / 1000)}s of grace, then the words land as a user turn.`;
+  }
+  return `Queued for \`${b.agent}\` — it reads this with its next tool result${b.after ? ` (noted as after ${b.after})` : ""}.`;
+}
+
+/* What the operator typed. It is NOT cleared here: a refused answer has to
+   leave its words on screen, or the operator types them twice. */
+function typed(id) {
+  const el = document.getElementById(id);
+  return el ? String(el.value ?? "").trim() : "";
+}
+
+/* ---- the verbs themselves ---- */
+
+const startTicket = (repo, ticket) => verb(`start:${repo}#${ticket}`, "/api/start", { repo, ticket: String(ticket) });
+const answerEsc = (id, answer) => verb("esc:" + id, "/api/answer", { id, answer });
+
+function answerTyped(id, field) {
+  const v = typed(field);
+  if (!v) return refuse("esc:" + id, "Type the answer first — an empty reply answers nothing.");
+  answerEsc(id, v);
+}
+/* A rejection IS feedback (#48): the agent gets the operator's own words and
+   fixes what they name. So an empty one is refused here rather than sent as a
+   rejection nobody can act on. */
+function rejectGate(id, field) {
+  const v = typed(field);
+  if (!v) return refuse("esc:" + id, "A rejection carries your words — say what to change, then press Reject.");
+  answerEsc(id, v);
+}
+
+/* Cancel names its consequences before it runs. They are the teardown's own
+   (dispatch.mjs #teardown), not a warning this page invented. */
+function cancelAgent(session, repo, ticket) {
+  const ask = `Cancel ${session}?\n\n`
+    + `• The tmux session is killed and its worktree removed. Anything uncommitted there is lost.\n`
+    + `• The claim on ${ticketName(repo, ticket) || "its ticket"} is released, so the ticket returns to the frontier.\n`
+    + `• Any question it is holding closes unanswered.\n`
+    + `• A cross-check reviewer on the same ticket ends too.`;
+  if (typeof confirm === "function" && !confirm(ask)) return;
+  verb("agent:" + session, "/api/cancel", { ticket: String(ticket) });
+}
+
+/* Teleport. The two links are curia's own (#68): `attach <n>` composes them
+   from its records, so the page asks for them instead of building a URL it
+   cannot vouch for. The shell line beside them is for a terminal on the box —
+   the tmux server lives in its own container (#260), so the command goes in
+   through that one. */
+function teleport(session, ticket) {
+  UI.act.tele = UI.act.tele === session ? null : session;
+  UI.act.said = null;
+  render();
+  if (UI.act.tele) verb("agent:" + session, "/api/teleport", { ticket: String(ticket) });
+}
+function attachCmd(session) {
+  return `docker compose -f deploy/compose.yaml exec tmux tmux -S /run/curia-tmux/default attach -t ${session}`;
+}
+
+function noteBox(session) {
+  UI.act.note = UI.act.note === session ? null : session;
+  UI.act.said = null;
+  render();
+}
+function noteMode(mode) { UI.act.mode = mode; render(); }
+async function sendNote(session, field) {
+  const text = typed(field);
+  if (!text) return refuse("agent:" + session, "A note with no words is not a note.");
+  const out = await verb("agent:" + session, "/api/note", { agent: session, text, mode: UI.act.mode });
+  /* Queued or interrupted, the words are with curia — so the box closes. It
+     stays open only when nothing was taken at all. */
+  if (out && out.id) { UI.act.note = null; render(); }
 }
 
 /* ---- the reading's own age ------------------------------------------------- */
@@ -485,19 +691,75 @@ function nextReset(usage) {
 /* ---- the attention list ---------------------------------------------------- */
 
 /* Everything that wants the operator, in one column, warn-marked because that
-   is what the color is for. The verbs — answer, approve, reject, cross-check —
-   land on #266; what this ticket owes is the question itself, whole. */
+   is what the color is for — and the ONE place an open question is answered
+   (#266). The Agents table states the same questions and answers none of them:
+   one answer surface, so no operator has to remember which of two they are
+   looking at. */
+
+/* The buttons a kind carries, in the vocabulary every other surface sends
+   (bridge.mjs #buttons). A choice sends its option's own label; an
+   approve-reject pair sends the two literals; a recommended round sends the one
+   fixed word its ✅ carries (#285), and it has no ❌ beside it because the
+   opposite of that tap is the operator's own reply. */
+function answerButtons(r) {
+  const key = "esc:" + r.id;
+  const btn = (label, answer, cls) => `<button class="btn sm${cls ? " " + cls : ""}"
+    ${anyBusy() ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${js(answer)}')">${esc(label)}</button>`;
+  const b = [];
+  if (r.kind === "approve-reject" || r.kind === "preview-review") {
+    b.push(btn("✅ Approve", APPROVE, "primary"), btn("❌ Reject", REJECT, "danger"));
+  }
+  if (r.kind === "confirm") b.push(btn("✅ Approve", APPROVE, "danger"), btn("❌ Decline", REJECT));
+  if (r.kind === "choice") for (const o of r.options ?? []) b.push(btn(snip(o, 80), o));
+  if (r.kind === "free-text" && r.recommended) b.push(btn("✅ All as recommended", ALL_AS_RECOMMENDED, "primary"));
+  return b.length ? `<div class="act-row">${b.join("")}</div>` : "";
+}
+
+/* Free-form, on every kind. A choice can be answered in words the options do
+   not carry, and a round is answered by naming the exceptions (#285) — so the
+   field is never the fallback for a kind, it is the reply. */
+function answerField(r) {
+  const id = "ans-" + r.id;
+  return `<div class="act-row">
+    <input type="text" id="${esc(id)}" placeholder="answer in your own words…" ${anyBusy() ? "disabled" : ""}>
+    <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}')">Answer</button>
+  </div>`;
+}
+
+function escCard(r) {
+  return `<div class="att-item">
+    <span class="who">${esc(r.agent)}</span>${esc(snip(r.prompt, 260))}
+    <div class="dim">${esc(r.kind)} · ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}${r.agent_died ? " · the agent died holding it" : ""}${r.rendered ? "" : " · not rendered in Discord yet"}</div>
+    ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview it asks about</a></div>` : ""}
+    ${answerButtons(r)}${answerField(r)}${said("esc:" + r.id)}</div>`;
+}
+
+/* The gate's three answers (#165, ADR-0010). Approve merges and resolves;
+   cross-check answers NOTHING and puts a reviewer on the other provider onto
+   the diff, with the builder parked where it stands; a rejection carries the
+   operator's words back to the builder. */
+function gateCard(r) {
+  const id = "rej-" + r.id;
+  return `<div class="att-item gate">
+    <span class="who">${esc(r.agent)}</span>review gate — ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}
+    <div class="dim">${esc(snip(r.prompt, 220))}</div>
+    ${r.pull_request ? `<div class="opts"><a href="${esc(r.pull_request)}">${esc(r.pull_request)}</a></div>` : `<div class="opts">no pull request on this gate</div>`}
+    ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview</a></div>` : ""}
+    <div class="act-row">
+      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${APPROVE}')">✅ Approve · merge</button>
+      <button class="btn sm" ${anyBusy() ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${CROSS_CHECK}')">🔎 Cross-check</button>
+    </div>
+    <div class="act-row">
+      <input type="text" id="${esc(id)}" placeholder="what to change — a rejection carries your words…" ${anyBusy() ? "disabled" : ""}>
+      <button class="btn sm danger" ${anyBusy() ? "disabled" : ""} onclick="rejectGate('${js(r.id)}','${js(id)}')">Reject</button>
+    </div>
+    ${said("esc:" + r.id)}</div>`;
+}
+
 function attentionList(o) {
   const items = [
-    ...(o.escalations ?? []).map((r) => `<div class="att-item">
-      <span class="who">${esc(r.agent)}</span>${esc(snip(r.prompt, 260))}
-      <div class="dim">${esc(r.kind)} · ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}${r.agent_died ? " · the agent died holding it" : ""}${r.rendered ? "" : " · not rendered in Discord yet"}</div>
-      ${r.options?.length ? `<div class="opts">${r.options.map((x) => esc(x)).join(" · ")}</div>` : ""}
-      ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview it asks about</a></div>` : ""}</div>`),
-    ...(o.review_gate ?? []).map((r) => `<div class="att-item gate">
-      <span class="who">${esc(r.agent)}</span>review gate — ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}
-      <div class="dim">${esc(snip(r.prompt, 220))}</div>
-      ${r.pull_request ? `<div class="opts"><a href="${esc(r.pull_request)}">${esc(r.pull_request)}</a></div>` : `<div class="opts">no pull request on this gate</div>`}</div>`),
+    ...(o.escalations ?? []).map(escCard),
+    ...(o.review_gate ?? []).map(gateCard),
     ...spentWindows(o.usage).map((w) => `<div class="att-item limit">
       <span class="who">${esc(w.provider)}</span>the ${esc(w.label)} window is spent at ${esc(w.pct)}%
       <div class="dim">${w.at ? `it rolls at ${esc(clock(w.at))}` : "no reset instant is stated"}</div></div>`),
@@ -526,8 +788,13 @@ const EVENTS = {
   agent_cancelled: ["cancel", "bad", (e) => `${who(e)} cancelled by ${esc(e.by)} — ${tkt(e)} back on the frontier`],
   agent_abnormal_exit: ["death", "bad", (e) => `${who(e)} exited abnormally — ${tkt(e)}`],
   agent_blocked_on_human: ["escalation", "warn", (e) => `${who(e)} is blocked on you — ${tkt(e)}`],
-  agent_note: ["note", "", (e) => `note for ${who(e)}: ${esc(snip(e.text, 120))}`],
+  agent_note: ["note", "", (e) => `note for ${who(e)}${e.by ? ` from ${esc(e.by)}` : ""}: ${esc(snip(e.text, 120))}`],
   agent_notes_drained: ["note", "", (e) => `${who(e)} took ${esc(e.count)} queued note(s)`],
+  agent_note_refused: ["note", "warn", (e) => `a note for ${who(e)} was refused — ${esc(e.reason)}`],
+  agent_notes_expired: ["note", "", (e) => `${esc(e.count ?? "some")} note(s) for ${who(e)} died with the agent they were typed at`],
+  note_interrupt: ["note", "warn", (e) => `${who(e)} interrupted by ${esc(e.by)} — ${esc(Math.round((e.grace_ms ?? 0) / 1000))}s of grace, then the words land`],
+  note_interrupt_delivered: ["note", "", (e) => `the interrupted words are in ${who(e)}'s pane`],
+  note_interrupt_failed: ["note", "bad", (e) => `the interrupt of ${who(e)} failed — ${esc(e.reason)}`],
   esc_open: ["escalation", "warn", (e) => `${who(e)} asks — ${esc(e.kind)}: ${esc(snip(e.prompt, 160))}`],
   esc_answer: ["answer", "", (e) => `escalation ${esc(e.id)} answered by ${esc(e.by)}${e.via ? ` via ${esc(e.via)}` : ""}`],
   esc_cancel: ["answer", "", (e) => `escalation ${esc(e.id)} cancelled by ${esc(e.by)}`],
@@ -642,7 +909,7 @@ function agentsTable(o) {
   if (!o.agents.length) return `<div class="empty">No agent is running.</div>`;
   const rows = [...o.agents].sort((a, b) => (wantsYou(b) ? 1 : 0) - (wantsYou(a) ? 1 : 0));
   return `<div class="tbl-wrap"><table class="agents wide">
-    <tr><th>session</th><th>state</th><th>ticket</th><th>model</th><th>ctx</th><th>up</th><th>waiting on</th></tr>
+    <tr><th>session</th><th>state</th><th>ticket</th><th>model</th><th>ctx</th><th>up</th><th>waiting on</th><th>do</th></tr>
     ${rows.map((a) => `<tr class="${wantsYou(a) ? "esc-row" : ""}">
       <td class="sess">${esc(a.session)}${a.reviewer ? ` <span class="dim-note">reviewer</span>` : ""}</td>
       <td><span class="state">${agentDot(a)} ${esc(stateWord(a))}</span>${a.tmux_live ? "" : `<div class="dim-note">no tmux session</div>`}</td>
@@ -650,8 +917,65 @@ function agentsTable(o) {
       <td class="mono">${esc(a.model ?? "—")}</td>
       <td class="num">${ctxCell(a)}</td>
       <td class="num">${esc(dur(a.uptime_s))}</td>
-      <td>${waitingCell(a)}</td></tr>`).join("")}
+      <td>${waitingCell(a)}</td>
+      <td>${agentVerbs(a)}</td></tr>
+    ${agentBoxes(a)}`).join("")}
   </table></div>`;
+}
+
+/* The three per-agent verbs (#266). They sit in the row that already names the
+   agent, and the boxes they open sit under it — so the words the operator types
+   are beside the agent they are for.
+
+   An answer is NOT here. The Needs-you list on Home is the one answer surface,
+   and the `waiting on` cell beside this says where to go. */
+function agentVerbs(a) {
+  const key = "agent:" + a.session;
+  const b = (label, call, cls) => `<button class="${cls ?? ""}" ${anyBusy() ? "disabled" : ""} onclick="${call}">${label}</button>`;
+  const s = `'${js(a.session)}'`;
+  return `<div class="links">
+    ${b("note", `noteBox(${s})`)}
+    ${b("teleport", `teleport(${s},'${js(a.ticket ?? "")}')`)}
+    ${b("cancel", `cancelAgent(${s},'${js(a.repo ?? "")}','${js(a.ticket ?? "")}')`, "bad")}
+  </div>${busy(key) ? `<div class="dim-note">working…</div>` : ""}`;
+}
+
+/* One full-width row under the agent, carrying whatever it has open: the note
+   box, the teleport lines, and what curia said about the last press. */
+function agentBoxes(a) {
+  const key = "agent:" + a.session;
+  const parts = [
+    UI.act.note === a.session ? noteBoxHtml(a) : "",
+    UI.act.tele === a.session ? teleportHtml(a) : "",
+    said(key),
+  ].filter(Boolean);
+  if (!parts.length) return "";
+  return `<tr><td colspan="8">${parts.join("")}</td></tr>`;
+}
+
+/* The two delivery modes, in ADR-0013's own words. Queued is the default and
+   costs the agent nothing until its next tool result. Interrupt aborts the call
+   in flight after a grace, which is why it is the one the operator has to
+   choose. */
+function noteBoxHtml(a) {
+  const id = "note-" + a.session;
+  const radio = (mode, label) => `<label><input type="radio" name="nm-${esc(a.session)}"
+    ${UI.act.mode === mode ? "checked" : ""} onchange="noteMode('${mode}')"> ${esc(label)}</label>`;
+  return `<div class="act-box">
+    <div class="act-row"><input type="text" id="${esc(id)}" placeholder="say something to ${esc(a.session)}…"></div>
+    <div class="act-row">
+      ${radio("queue", "queue — it reads this with its next tool result")}
+      ${radio("interrupt", "interrupt — a short grace, then the words land as a user turn")}
+      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="sendNote('${js(a.session)}','${js(id)}')">Send</button>
+    </div>
+  </div>`;
+}
+
+function teleportHtml(a) {
+  return `<div class="act-box">
+    <div class="dim-note">On the box itself, in a terminal:</div>
+    <input class="copy" type="text" readonly value="${esc(attachCmd(a.session))}" onclick="this.select()">
+  </div>`;
 }
 function waitingCell(a) {
   const open = a.waiting_on ?? [];
@@ -693,7 +1017,37 @@ function frTypes(snap) {
   return [...all].sort();
 }
 
-function frCards(repos) {
+/* Start (#266). The dispatch order — claim, prepare, spawn — is `start`'s own,
+   and the reply that comes back is curia's sentence about what it did.
+
+   Two facts ride beside the button. The ROUTED MODEL is the daemon's
+   `resolveModel` answer, joined onto the item by reconcile, so the operator
+   knows which account this press spends before spending it. And an agent
+   ALREADY on this ticket replaces the button, because a second start on it is
+   refused anyway and a button that only ever refuses is a worse way to say so.
+
+   When the fleet could not be read, neither is claimed: the button stands, and
+   the line under it says curia cannot tell. Null is not empty here either. */
+function agentOn(o, repo, number) {
+  if (o?.agents == null) return undefined;
+  return o.agents.find((a) => String(a.ticket) === String(number) && (!a.repo || a.repo === repo)) ?? null;
+}
+function startRow(o, repo, n) {
+  const live = agentOn(o, repo, n.number);
+  const key = `start:${repo}#${n.number}`;
+  if (live) return `<div class="act-row"><span class="dim-note mono">⧗ dispatched — ${esc(live.session)}</span></div>`;
+  const model = n.model
+    ? `<span class="dim-note mono">→ ${esc(n.model)} (${esc(typeOf(n))} default)</span>`
+    : `<span class="dim-note">the routed model is not on this reading</span>`;
+  return `<div class="act-row">
+      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="startTicket('${js(repo)}','${js(n.number)}')">${
+        busy(key) ? "Starting…" : "Start"}</button>${model}
+    </div>
+    ${live === undefined ? `<div class="dim-note">the fleet could not be read, so curia cannot say whether this one is already running</div>` : ""}
+    ${said(key)}`;
+}
+
+function frCards(repos, o) {
   const bigs = repos.filter((r) => !r.error).flatMap((r) => (r.items ?? []).map((i) => ({ ...i, repo: r.repo })));
   const kids = repos.filter((r) => !r.error).flatMap((r) => (r.items ?? []).flatMap((i) => (i.unblocks ?? []).map((k) => ({ ...k, repo: r.repo, from: i.number }))));
   return `${repos.filter((r) => r.error).map(frError).join("")}
@@ -703,6 +1057,7 @@ function frCards(repos) {
         <div class="title">${esc(n.title)}</div>
         <div class="foot"><span>${esc(n.repo)}</span><span>${n.unblocks?.length ? `unblocks ${n.unblocks.length}` : "unblocks nothing yet"}</span></div>
         ${n.mapTitle ? `<div class="dim-note">${esc(n.mapTitle)}</div>` : ""}
+        ${startRow(o, n.repo, n)}
       </div>`).join("")}</div>` : `<div class="empty">Nothing is takeable under this filter.</div>`}
     </div>
     <div class="frx-sect"><span class="eyebrow">unblocked next (${kids.length})</span>
@@ -711,14 +1066,15 @@ function frCards(repos) {
         : `<div class="empty">These tickets unblock nothing that is not already takeable.</div>`}
     </div>`;
 }
-function frTree(repos) {
+function frTree(repos, o) {
   return repos.map((r) => {
     if (r.error) return frError(r);
     if (!r.items?.length) return `<div class="fr-repo"><span class="eyebrow mono">${esc(r.repo)}</span>
       <div class="empty">Nothing is takeable under this filter.</div></div>`;
     return `<div class="fr-repo"><span class="eyebrow mono">${esc(r.repo)}</span>
       ${r.items.map((n) => `<div class="fr-group">
-        <div class="fr-node"><span class="typ">${esc(typeOf(n))}</span><span class="t">#${esc(n.number)}</span>${esc(n.title)}</div>
+        <div class="fr-node"><span class="typ">${esc(typeOf(n))}</span><span class="t">#${esc(n.number)}</span>${esc(n.title)}
+          ${startRow(o, r.repo, n)}</div>
         ${n.unblocks?.length ? `<div class="fr-kids">${n.unblocks.map((k) => `<div class="fr-kid"><span class="t">#${esc(k.number)}</span>${esc(k.title)}</div>`).join("")}</div>` : ""}
       </div>`).join("")}</div>`;
   }).join("");
@@ -750,7 +1106,7 @@ function screenFrontier(p) {
     </select>
     <span class="dim-note">computed ${esc(ago(snap.computed_at))}</span>
   </div>`;
-  return `${head(p, "Frontier — two levels", right)}${filter}${FR_VIEWS[UI.fr.view][1](frFiltered(snap))}`;
+  return `${head(p, "Frontier — two levels", right)}${filter}${FR_VIEWS[UI.fr.view][1](frFiltered(snap), o)}`;
 }
 function frSet(key, value) {
   UI.fr[key] = value;

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -29,7 +29,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse } from 'yaml'
 import { assertServe, serveOff, attachBase } from './attach.mjs'
-import { identityRefusal, readAllow, serveHosts, tailnetSelf } from './identity.mjs'
+import { identityRefusal, readAllow, serveHosts, tailnetSelf, LOGIN_HEADER } from './identity.mjs'
 import { readSettings, saveSettings } from './settings.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
@@ -47,7 +47,10 @@ export const daemonPort = () => Number(process.env.PORT ?? DEFAULT_DAEMON_PORT)
 // against the disk when a pull changes both halves with no restart. The page
 // declares what it speaks, the server compares, and a mismatch refuses loudly
 // rather than serving a surface nobody agreed to.
-export const DASHBOARD_PROTO = 1
+// Bumped to 2 by #266: the page now POSTs to verb routes an older sidecar does
+// not serve, so an old server must refuse the new page rather than serve one
+// whose every button answers 404.
+export const DASHBOARD_PROTO = 2
 export const STAMP_NAME = 'curia-dashboard'
 const STAMP_RE = new RegExp(`<meta name="${STAMP_NAME}" content="proto=(\\d+)">`)
 
@@ -153,6 +156,48 @@ export const POLL_TIMEOUT_MS = 10_000
 // The biggest settings patch this surface will read. The screen writes a watch
 // list and a handful of numbers, so anything near this is not a settings save.
 export const MAX_BODY = 256 * 1024
+
+// What the page may name on a verb route (#266).
+//
+// Each field is checked HERE rather than trusted, because two of them are
+// composed into a command line the daemon parses. A ticket is an issue number
+// or a chat handle (#241), a repo is `owner/name`, a session is a curia one.
+// The words the operator types are bounded only in length: they are text for a
+// person or an agent to read, and curia never interprets them.
+const VERB_REPO_RE = /^[\w.-]+\/[\w.-]+$/
+const VERB_TICKET_RE = /^(\d+|chat-\d+)$/
+const VERB_SESSION_RE = /^curia-[\w.-]+$/
+const VERB_ESC_RE = /^[\w.-]+$/
+export const MAX_WORDS = 4000
+
+// Why an answer did not land (#266). The store refuses in ONE WORD — `unknown`,
+// or whatever status the record holds instead of open — because that word is
+// for a caller. The operator gets the sentence it stands for, since every one
+// of these is first-valid-wins or supersede doing exactly its job.
+export const ANSWER_REFUSAL = {
+  unknown: 'curia has no record of that question',
+  answered: 'that question was already answered — the first valid answer wins',
+  cancelled: 'that question was cancelled, so nobody is waiting for an answer to it',
+  lapsed: 'that question lapsed with the agent that asked it',
+  superseded: 'that question was superseded by a newer one',
+}
+
+// A refusal about what the PAGE sent, in the same vocabulary a refused save
+// carries: the operator can see it and fix it, so it answers 409 rather than
+// reading as this process failing.
+const refuse = (msg) => Object.assign(new Error(msg), { refusal: true })
+
+function field(value, re, what) {
+  const s = String(value ?? '').trim()
+  if (!re.test(s)) throw refuse(`"${s}" is not ${what}`)
+  return s
+}
+function words(value, what) {
+  const s = String(value ?? '').trim()
+  if (!s) throw refuse(`${what} with no words is not ${what}`)
+  if (s.length > MAX_WORDS) throw refuse(`${what} may not exceed ${MAX_WORDS} characters`)
+  return s
+}
 
 export class DashboardSurface {
   constructor({
@@ -299,7 +344,11 @@ export class DashboardSurface {
   // loopback tooling on the daemon's side of that gate, and it earns that by
   // building each call from a route it names in code, never from a URL a
   // browser handed it.
-  #daemon({ method = 'GET', path: route, body = null }) {
+  // `accept` widens what counts as an answer rather than a failure (#266). The
+  // answer route needs it: a question that is no longer open comes back 409
+  // with the REASON in the body, and that reason is the whole point — it is
+  // what first-valid-wins looks like from the console.
+  #daemon({ method = 'GET', path: route, body = null, accept = [200] }) {
     return new Promise((resolve, reject) => {
       const payload = body === null ? null : Buffer.from(JSON.stringify(body))
       const req = http.request({
@@ -313,7 +362,7 @@ export class DashboardSurface {
         res.on('data', (c) => chunks.push(c))
         res.on('end', () => {
           const text = Buffer.concat(chunks).toString('utf8')
-          if (res.statusCode !== 200) return reject(new Error(`the daemon answered ${res.statusCode} on ${route}`))
+          if (!accept.includes(res.statusCode)) return reject(new Error(`the daemon answered ${res.statusCode} on ${route}`))
           try {
             resolve(JSON.parse(text))
           } catch (e) {
@@ -443,11 +492,11 @@ export class DashboardSurface {
     })
   }
 
-  // Everything the settings screen writes runs through here, so the refusal
-  // vocabulary is one thing: a SettingsRefusal is the operator's own config
-  // being wrong and answers 409, and anything else is this process failing and
-  // answers 500. The two must not read the same — the first is fixed on the
-  // page, the second on the box.
+  // Everything this surface WRITES runs through here — the settings save (#265)
+  // and every operator verb (#266) — so the refusal vocabulary is one thing: a
+  // refusal is something the operator can see and fix and answers 409, and
+  // anything else is this process failing and answers 500. The two must not
+  // read the same. The first is fixed on the page, the second on the box.
   #write(res, work) {
     return Promise.resolve().then(work).then(
       (out) => this.#json(res, 200, out),
@@ -460,6 +509,28 @@ export class DashboardSurface {
         return this.#json(res, 500, { error: e.message })
       },
     )
+  }
+
+  // A verb (#266): the same refusal vocabulary a save carries, plus the one
+  // thing a save does not need. The held snapshot is now behind the box — an
+  // agent has spawned, a question has closed, a ticket has left the frontier —
+  // so its age is dropped and the next page read is a fresh one. Without this
+  // the operator presses a button and watches nothing change for the rest of
+  // the poll interval.
+  #verb(res, work) {
+    return this.#write(res, async () => {
+      const out = await work()
+      this.snapshotAt = 0
+      return out
+    })
+  }
+
+  // The command seam (#33 step 9), reached with text this file composed. Every
+  // verb that has a word in the operator's own catalogue goes through it rather
+  // than around it, so a press from the console journals the same `command`
+  // event a typed one does and lands in the feed for free.
+  #command(text, by) {
+    return this.#daemon({ method: 'POST', path: '/command', body: { text, by } })
   }
 
   #handle(req, res) {
@@ -505,6 +576,87 @@ export class DashboardSurface {
           // the interval lasts, at the one moment that is false.
           this.snapshotAt = 0
           return out
+        })
+      }
+      // ---- the operator verbs (#266) ---------------------------------------
+      //
+      // Every one of them is a call this file COMPOSES. The browser hands over
+      // typed fields — a repo, a ticket number, an escalation id, some words —
+      // and each route below builds the daemon call out of a shape it names in
+      // code. Nothing a browser sends is forwarded as command TEXT: `POST
+      // /command` runs the whole operator catalogue, and passing a string
+      // through would make this surface a way to type anything at the daemon.
+      // The sidecar sits on the daemon's side of the loopback gate, and this is
+      // what it earns that with.
+      //
+      // `by` is the operator's own Tailscale login, read off the header the
+      // identity gate above already checked. The journal and the feed then name
+      // who pressed, instead of saying `dashboard` about every act.
+      const by = String(req.headers[LOGIN_HEADER] ?? '')
+
+      // Start, from a frontier card. The dispatch order (claim, prepare, spawn)
+      // is `start`'s and nothing here repeats it — the reply is curia's own
+      // sentence about what happened, shown as it stands.
+      if (url.pathname === '/api/start') {
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const repo = field(b.repo, VERB_REPO_RE, 'an owner/name repo')
+          const ticket = field(b.ticket, VERB_TICKET_RE, 'a ticket number')
+          return this.#command(`start ${repo}#${ticket}`, by)
+        })
+      }
+
+      // Cancel. The page confirms it with its consequences before it presses;
+      // this is the immediate teardown, the same one `cancel <n>` runs from the
+      // command channel. NOT the interpreted cancel: that opens a Discord
+      // confirm card, and a button press in the console is already the
+      // operator's own act, typed by nobody's model.
+      if (url.pathname === '/api/cancel') {
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const ticket = field(b.ticket, VERB_TICKET_RE, 'a ticket number')
+          return this.#command(`cancel ${ticket}`, by)
+        })
+      }
+
+      // Teleport. `attach <n>` composes the timeline link and the terminal link
+      // from curia's own records (#68), which is why the press asks for them
+      // rather than the page building a URL it cannot vouch for.
+      if (url.pathname === '/api/teleport') {
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const ticket = field(b.ticket, VERB_TICKET_RE, 'a ticket number')
+          return this.#command(`attach ${ticket}`, by)
+        })
+      }
+
+      // An answer, for an escalation or for the review gate — one route,
+      // because they are one act. First-valid-wins and supersede are the
+      // store's, so an answer that arrives second comes back 409 with the
+      // reason, and the page says which.
+      if (url.pathname === '/api/answer') {
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const id = field(b.id, VERB_ESC_RE, 'an escalation id')
+          const answer = words(b.answer, 'an answer')
+          const out = await this.#daemon({
+            method: 'POST', path: '/answer', body: { id, answer, by, via: 'dashboard' }, accept: [200, 409],
+          })
+          if (out.ok === false) throw refuse(ANSWER_REFUSAL[out.reason] ?? `that question is ${out.reason}`)
+          return out
+        })
+      }
+
+      // A note to one agent, in either delivery mode (ADR-0013). Queued is the
+      // default and rides the agent's next tool result; interrupt is #252's
+      // second mode, and its refusals are the daemon's.
+      if (url.pathname === '/api/note') {
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const agent = field(b.agent, VERB_SESSION_RE, 'a curia session name')
+          const text = words(b.text, 'a note')
+          const mode = b.mode === 'interrupt' ? 'interrupt' : 'queue'
+          return this.#daemon({ method: 'POST', path: '/note', body: { agent, text, mode, by } })
         })
       }
       return this.#json(res, 404, { error: `no route ${url.pathname} on the dashboard` })

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -438,10 +438,20 @@ export class Dispatcher {
       agentOnly: this.#agentOnlyCount(lane, pool, edges, numbers),
       items: numbers.map((n) => {
         const e = index.get(n)
+        const labels = (e?.item?.labels ?? []).map((l) => l.name)
         return {
           number: n,
           title: e?.item?.title ?? '',
-          labels: (e?.item?.labels ?? []).map((l) => l.name),
+          labels,
+          // The model this ticket gets if it starts now (#266). The console
+          // shows it beside its start button, and it is `resolveModel` — the
+          // daemon's OWN precedence rule — rather than a second copy of that
+          // rule inside a page. It costs no call: the labels are already here.
+          //
+          // It names what routing decides, not what a spawn will do. Cooling is
+          // read at the spawn, and the chain it walks then is reported by the
+          // feed rather than guessed at here.
+          model: resolveModel(this.routing, labels, null),
           map: e?.map ?? null,
           mapTitle: e?.map != null ? mapTitle.get(e.map) ?? '' : '',
           // Level two (#262): the tickets this one directly unblocks, which is

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -383,19 +383,12 @@ const gate = {
   queueAgentNote(threadId, text, by) {
     const agent = gate.agentForThread(threadId)
     if (!agent || !text?.trim()) return null
-    // `reads` is what the bridge promises the operator (#170), and #208 makes
-    // it the same flag that decides whether anything queues at all.
-    const { reads, instance } = noteDisposition(dispatcher.agents.get(agent))
     // the ticket rides along so the bridge can spell out `cancel <n>` when the
     // note is command-shaped (#108 item 23, #170)
     const ticket = store.ticketForThread(threadId) ?? null
-    if (!reads) {
-      log(`agent note refused for ${agent} — that agent is not running, so nothing was queued`)
-      store.logEvent('agent_note_refused', { agent, ticket, by, reason: 'agent not running' })
-      return { agent, after: null, reads, ticket }
-    }
-    const { id, after } = store.queueAgentNote(agent, text.trim(), { by, instance })
-    log(`agent note queued for ${agent}${after ? ` (after ${after})` : ''}`)
+    const queued = gate.queueNoteFor(agent, text, { by, ticket })
+    if (!queued.reads) return { agent, after: null, reads: false, ticket }
+    const { id, after } = queued
     // #236: the facts a status question needs, gathered from records the
     // daemon already holds — the status line's state machine, the dispatch
     // record's spawn time, the journal's last word about the agent. The bridge
@@ -415,7 +408,58 @@ const gate = {
     // `id` is what the interrupt button under this receipt points at (#252):
     // queued is the default mode, and the button is how the operator picks the
     // other one for these exact words.
-    return { agent, id, after, reads, ticket, status }
+    return { agent, id, after, reads: true, ticket, status }
+  },
+  // The queue itself, under both keyings (#266). Discord names the THREAD the
+  // words were typed in; the console has no thread and names the agent. The
+  // queue, the #208 instance rule and the refusal are one fact either way, so
+  // they are written once here rather than twice at the two doors.
+  //
+  // `reads` is what the bridge promises the operator (#170), and #208 makes it
+  // the same flag that decides whether anything queues at all.
+  queueNoteFor(agent, text, { by = null, ticket = null } = {}) {
+    const { reads, instance } = noteDisposition(dispatcher.agents.get(agent))
+    if (!reads) {
+      log(`agent note refused for ${agent} — that agent is not running, so nothing was queued`)
+      store.logEvent('agent_note_refused', { agent, ticket, by, reason: 'agent not running' })
+      return { agent, ticket, reads: false, id: null, after: null }
+    }
+    const { id, after } = store.queueAgentNote(agent, String(text).trim(), { by, instance })
+    log(`agent note queued for ${agent}${after ? ` (after ${after})` : ''}`)
+    return { agent, ticket, reads: true, id, after }
+  },
+  // The console's note (#266), and BOTH delivery modes behind one call. The
+  // browser has no thread to type in, so it names the agent — but what happens
+  // to the words after that is ADR-0013 unchanged: queued is the default and
+  // rides the next tool result, and an interrupt is #252's second mode, with
+  // the same grace and the same three refusals.
+  //
+  // An interrupt that refuses leaves the words QUEUED rather than dropping
+  // them. The operator asked for these words to reach the agent; the mode was
+  // how fast, and only the mode failed.
+  async noteAgent(agent, text, { by = null, mode = 'queue' } = {}) {
+    const live = dispatcher.agents.get(agent)
+    const ticket = live?.ticket ?? String(agent).replace(/^curia-/, '')
+    // The console names the agent, so it can name one that does not exist —
+    // which the thread path never could, because a thread only ever resolves to
+    // an agent curia is running. `noteDisposition` answers about a live record
+    // and reads an absent one as "not failed", so the existence check is HERE,
+    // in the one door that can be handed a name out of a browser.
+    if (!live) {
+      log(`agent note refused for ${agent} — curia is not running that agent`)
+      store.logEvent('agent_note_refused', { agent, ticket, by, reason: 'agent not running' })
+      return {
+        agent, ticket, reads: false, id: null, after: null, ok: false, mode,
+        why: `curia is not running \`${agent}\`, so nothing was queued — \`resume ${ticket}\` puts an agent back on the ticket, then say the words again`,
+      }
+    }
+    const queued = gate.queueNoteFor(agent, text, { by, ticket })
+    if (!queued.reads) {
+      return { ...queued, ok: false, mode, why: `\`${agent}\` is not running, so nothing was queued — \`resume ${ticket}\` puts an agent back on the ticket` }
+    }
+    if (mode !== 'interrupt') return { ...queued, ok: true, mode: 'queue' }
+    const out = await dispatcher.interruptNote(queued.id, { by })
+    return { ...queued, ...out, mode: 'interrupt', still_queued: !out.ok }
   },
   // #252, ADR-0013: the second delivery mode. The bridge presses this from the
   // button under a receipt; the dispatcher owns the grace and the keystrokes.
@@ -1204,6 +1248,12 @@ const wireEscalation = (r) => ({
   prompt: r.prompt,
   options: r.options ?? null,
   preview_url: r.preview_url ?? null,
+  // #266: the console draws the same buttons the Discord card draws, so it
+  // needs the one field that decides whether a free-text round carries the ✅
+  // All as recommended tap (#285). Without it the console would offer a
+  // recommended round a plain text box, and the operator would have to type
+  // the fixed word the button sends.
+  recommended: Boolean(r.recommended),
   opened_at: r.opened_at,
   agent_died: Boolean(r.agent_died),
   rendered: Boolean(r.discord),
@@ -1240,6 +1290,14 @@ function providerUsage() {
 // only long enough for the answer already written to leave the socket.
 const RESTART_EXIT_CODE = 75
 const RESTART_DELAY_MS = 50
+
+// Who a loopback caller says it is (#266). Every REST verb already journalled a
+// `by`, and every one of them journalled the same word: `rest`. The console
+// passes the operator's own Tailscale login instead — the one its identity gate
+// checked before the request got this far — so the feed names a person rather
+// than a transport. Absent or empty stays `rest`, which is what every caller
+// before this one sent. Bounded, because it is written into the journal.
+const named = (by) => (typeof by === 'string' && by.trim() ? by.trim().slice(0, 120) : 'rest')
 
 // The watchable repos, cached. `gh repo list` names only what the login OWNS,
 // and the watch list already carries a repo under another owner, so this asks
@@ -1458,15 +1516,33 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   }
 
   if (url.pathname === '/answer' && req.method === 'POST') {
-    const { id, answer, attachments } = await readBody(req)
+    const { id, answer, attachments, by, via } = await readBody(req)
     // Attachment paths get read and inlined into an agent's context, so they
     // pass the same containment gate as outbound images rather than being
     // trusted because the caller reached loopback.
     const { files } = outboundImages('rest', attachments)
+    // #266: the console names the operator who pressed and the surface they
+    // pressed on, so the journal and the feed say `answered by <login> via
+    // dashboard` rather than attributing every browser answer to `rest`. The
+    // default is what every caller before this one already sent.
     const result = gate.answer(id, {
-      answer: String(answer), attachments: files.map((f) => f.attachment), by: 'rest', via: 'rest',
+      answer: String(answer), attachments: files.map((f) => f.attachment), by: named(by), via: named(via),
     })
     return json(result.ok ? 200 : 409, result)
+  }
+
+  // The console's note (#266). A note in Discord is any message in an agent's
+  // thread, so it has no verb and the command surface carries none; the browser
+  // has no thread at all, and names the agent instead. What happens after that
+  // is ADR-0013 unchanged — see gate.noteAgent.
+  if (url.pathname === '/note' && req.method === 'POST') {
+    const body = await readBody(req)
+    const agent = String(body.agent ?? '')
+    const text = String(body.text ?? '')
+    const mode = body.mode === 'interrupt' ? 'interrupt' : 'queue'
+    if (!validSessionName(agent)) return json(400, { error: `\`${agent}\` is not a curia session name` })
+    if (!text.trim()) return json(400, { error: 'a note with no words is not a note' })
+    return json(200, await gate.noteAgent(agent, text, { mode, by: named(body.by) }))
   }
 
   if (url.pathname === '/cancel' && req.method === 'POST') {
@@ -1523,9 +1599,9 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   // seam Discord uses — two hand-rolled copies of log+journal+dispatch had
   // already drifted apart.
   if (url.pathname === '/command' && req.method === 'POST') {
-    const { text } = await readBody(req)
+    const { text, by } = await readBody(req)
     if (typeof text !== 'string' || !text.trim()) return json(400, { error: 'body must carry {text}' })
-    const reply = await gate.command(text, 'rest')
+    const reply = await gate.command(text, named(by))
     return json(200, { reply })
   }
 

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -16,7 +16,7 @@ import path from 'node:path'
 
 import {
   DashboardSurface, DEFAULT_DASHBOARD, DEFAULT_DASHBOARD_INDEX, DASHBOARD_PROTO,
-  loadDashboardConfig, pageRefusal, readDashboard, daemonPort,
+  loadDashboardConfig, pageRefusal, readDashboard, daemonPort, ANSWER_REFUSAL, MAX_WORDS,
 } from '../src/dashboard.mjs'
 import { loadCuriaConfig } from '../src/config.mjs'
 import { serveHosts, LOGIN_HEADER, FUNNEL_HEADER } from '../src/identity.mjs'
@@ -611,5 +611,220 @@ describe('the settings write and the restart (#265)', () => {
     const body = JSON.parse((await req(surface.port, '/api/repos', { headers: served() })).text)
     assert.equal(body.repos, null, 'an empty list would read as "you have no repos"')
     assert.ok(body.error)
+  })
+})
+
+// The operator verbs (#266). What is pinned here is the seam, not the screen:
+// the sidecar COMPOSES every daemon call from the fields the page sends, and a
+// browser never hands it a command line. That is the whole reason this process
+// may sit on the daemon's side of the loopback gate, so it is checked with a
+// stand-in daemon that records what actually crossed the wire.
+describe('the operator verbs (#266)', () => {
+  let surface
+  let daemon
+  let calls // one entry per call the sidecar made, with the body it composed
+  let reply // what the stand-in daemon answers, per route
+
+  const ALLOW = ['alp@example.com']
+  const SERVE_PORT = 8445
+  const ORIGIN = 'https://box.tail1234.ts.net:8445'
+  const served = (extra = {}) => ({ host: 'box.tail1234.ts.net:8445', [LOGIN_HEADER]: 'alp@example.com', ...extra })
+  const press = (p, body, extra = {}) => req(surface.port, p, {
+    method: 'POST',
+    headers: served({ origin: ORIGIN, 'content-type': 'application/json', ...extra }),
+    body,
+  })
+  const sent = (route) => calls.find((c) => c.url === route)
+
+  beforeEach(async () => {
+    calls = []
+    reply = {
+      '/command': [200, { reply: '⚙️ `curia-266` spawned on claude-opus-5' }],
+      '/answer': [200, { ok: true, record: { id: 'esc-7' } }],
+      '/note': [200, { ok: true, agent: 'curia-266', id: 'note-3', after: null, mode: 'queue' }],
+    }
+    daemon = http.createServer((r, res) => {
+      let buf = ''
+      r.on('data', (d) => { buf += d })
+      r.on('end', () => {
+        calls.push({ method: r.method, url: r.url, origin: r.headers.origin ?? null, body: buf ? JSON.parse(buf) : null })
+        const [code, body] = reply[r.url] ?? [404, { error: 'no such route' }]
+        res.writeHead(code, { 'content-type': 'application/json' })
+        res.end(JSON.stringify(body))
+      })
+    })
+    await new Promise((done) => daemon.listen(0, '127.0.0.1', done))
+
+    surface = new DashboardSurface({
+      port: 0,
+      servePort: SERVE_PORT,
+      index: DEFAULT_DASHBOARD_INDEX,
+      allow: ALLOW,
+      pollIntervalS: 5,
+      daemonPort: daemon.address().port,
+      log: () => {},
+      deps: {
+        fetchOverview: async () => ({ daemon: { port: 4271 } }),
+        assertServe: async () => {},
+        serveOff: async () => {},
+        tailnetSelf: async () => ({ dnsName: 'box.tail1234.ts.net', ips: ['100.98.118.33'] }),
+      },
+    })
+    await surface.start()
+    await surface.resolveHosts()
+  })
+
+  afterEach(() => {
+    surface?.stop()
+    daemon?.close()
+  })
+
+  // ---- what crosses the wire -----------------------------------------------
+
+  test('start composes the command — the browser names a repo and a number, never a line of text', async () => {
+    const res = await press('/api/start', { repo: 'alp82/curia', ticket: '266' })
+    assert.equal(res.status, 200)
+    assert.deepEqual(sent('/command').body.text, 'start alp82/curia#266')
+    assert.equal(sent('/command').origin, null, 'the daemon refuses every request carrying one')
+    assert.match(JSON.parse(res.text).reply, /spawned/, "curia's own sentence comes back whole")
+  })
+
+  test('cancel and teleport go through the same seam, so both land in the journal', async () => {
+    await press('/api/cancel', { ticket: '266' })
+    assert.equal(sent('/command').body.text, 'cancel 266')
+    calls = []
+    await press('/api/teleport', { ticket: '266' })
+    assert.equal(sent('/command').body.text, 'attach 266')
+  })
+
+  test('a chat handle is a ticket too — an agent no issue answers for is still cancellable (#241)', async () => {
+    await press('/api/cancel', { ticket: 'chat-1' })
+    assert.equal(sent('/command').body.text, 'cancel chat-1')
+  })
+
+  test('the operator who pressed rides every verb, so the feed names a person not a transport', async () => {
+    await press('/api/start', { repo: 'o/r', ticket: '9' })
+    assert.equal(sent('/command').body.by, 'alp@example.com')
+    calls = []
+    await press('/api/answer', { id: 'esc-7', answer: 'approve' })
+    assert.equal(sent('/answer').body.by, 'alp@example.com')
+    assert.equal(sent('/answer').body.via, 'dashboard', 'the surface is a fact of its own')
+    calls = []
+    await press('/api/note', { agent: 'curia-266', text: 'look again' })
+    assert.equal(sent('/note').body.by, 'alp@example.com')
+  })
+
+  test('the note carries the mode the operator chose, and queued is what an unnamed one means', async () => {
+    await press('/api/note', { agent: 'curia-266', text: 'look again', mode: 'interrupt' })
+    assert.equal(sent('/note').body.mode, 'interrupt')
+    calls = []
+    await press('/api/note', { agent: 'curia-266', text: 'look again' })
+    assert.equal(sent('/note').body.mode, 'queue')
+    calls = []
+    await press('/api/note', { agent: 'curia-266', text: 'look again', mode: 'nonsense' })
+    assert.equal(sent('/note').body.mode, 'queue', 'anything that is not the second mode is the default')
+  })
+
+  // ---- what may not cross it -----------------------------------------------
+
+  test('a field the daemon would parse as something else is refused HERE, before the wire', async () => {
+    for (const [route, body, why] of [
+      ['/api/start', { repo: 'alp82/curia; rm -rf /', ticket: '1' }, /owner\/name repo/],
+      ['/api/start', { repo: 'alp82/curia', ticket: '1 model=x' }, /ticket number/],
+      ['/api/cancel', { ticket: 'all' }, /ticket number/],
+      ['/api/teleport', { ticket: '../1' }, /ticket number/],
+      ['/api/note', { agent: 'rm -rf /', text: 'x' }, /curia session name/],
+      ['/api/answer', { id: 'esc 7 x', answer: 'approve' }, /escalation id/],
+    ]) {
+      const res = await press(route, body)
+      assert.equal(res.status, 409, `${route} ${JSON.stringify(body)}`)
+      assert.match(JSON.parse(res.text).error, why)
+    }
+    assert.deepEqual(calls, [], 'not one of them reached the daemon')
+  })
+
+  test('`cancel all` cannot be reached from a browser — the console cancels one agent at a time', async () => {
+    assert.equal((await press('/api/cancel', { ticket: 'all' })).status, 409)
+    assert.deepEqual(calls, [])
+  })
+
+  test('an answer and a note with no words are refused, and neither is written', async () => {
+    assert.match(JSON.parse((await press('/api/answer', { id: 'esc-7', answer: '  ' })).text).error, /no words/)
+    assert.match(JSON.parse((await press('/api/note', { agent: 'curia-1', text: '' })).text).error, /no words/)
+    assert.deepEqual(calls, [])
+  })
+
+  test('words longer than the bound are refused — a verb must not write an unbounded journal line', async () => {
+    const res = await press('/api/note', { agent: 'curia-1', text: 'x'.repeat(MAX_WORDS + 1) })
+    assert.equal(res.status, 409)
+    assert.match(JSON.parse(res.text).error, /may not exceed/)
+    assert.deepEqual(calls, [])
+  })
+
+  // ---- the two gates in front ----------------------------------------------
+
+  test('a verb needs the Origin this surface serves, exactly as a save does', async () => {
+    const noOrigin = await req(surface.port, '/api/start', {
+      method: 'POST', headers: served({ 'content-type': 'application/json' }), body: { repo: 'o/r', ticket: '1' },
+    })
+    assert.equal(noOrigin.status, 403)
+    const otherOrigin = await press('/api/start', { repo: 'o/r', ticket: '1' }, { origin: 'https://evil.example' })
+    assert.equal(otherOrigin.status, 403)
+    assert.deepEqual(calls, [], 'a verb the gate refused reaches nothing')
+  })
+
+  test('the identity gate runs first: a stranger with a good Origin presses nothing', async () => {
+    const res = await req(surface.port, '/api/start', {
+      method: 'POST',
+      headers: { host: 'box.tail1234.ts.net:8445', [LOGIN_HEADER]: 'stranger@example.com', origin: ORIGIN, 'content-type': 'application/json' },
+      body: { repo: 'o/r', ticket: '1' },
+    })
+    assert.equal(res.status, 403)
+    assert.deepEqual(calls, [])
+  })
+
+  test('a route this surface does not carry is a 404, not a silent nothing', async () => {
+    assert.equal((await press('/api/resume', { ticket: '1' })).status, 404)
+  })
+
+  // ---- first-valid-wins, seen from a browser -------------------------------
+
+  test('a question that is no longer open comes back as the REASON, not as a 500', async () => {
+    for (const [reason, why] of Object.entries(ANSWER_REFUSAL)) {
+      reply['/answer'] = [409, { ok: false, reason }]
+      const res = await press('/api/answer', { id: 'esc-7', answer: 'approve' })
+      assert.equal(res.status, 409, reason)
+      assert.equal(JSON.parse(res.text).error, why)
+      assert.equal(JSON.parse(res.text).refused, true, 'the operator fixes this, not the box')
+    }
+  })
+
+  test('a reason nobody wrote a sentence for still reads, rather than rendering blank', async () => {
+    reply['/answer'] = [409, { ok: false, reason: 'something-new' }]
+    assert.match(JSON.parse((await press('/api/answer', { id: 'esc-7', answer: 'x' })).text).error, /something-new/)
+  })
+
+  test('a daemon that is down makes the press an error the operator can read', async () => {
+    await new Promise((done) => daemon.close(done))
+    daemon = null
+    const res = await press('/api/start', { repo: 'o/r', ticket: '1' })
+    assert.equal(res.status, 500, 'this is the box failing, not the operator')
+    assert.ok(JSON.parse(res.text).error)
+  })
+
+  // ---- the reading moves ---------------------------------------------------
+
+  test('a verb drops the held snapshot, so the poll after a press is a fresh read', async () => {
+    await surface.payload()
+    assert.ok(surface.snapshotAt > 0)
+    await press('/api/start', { repo: 'o/r', ticket: '1' })
+    assert.equal(surface.snapshotAt, 0, 'a button that seems to do nothing for one interval is a button pressed twice')
+  })
+
+  test('a REFUSED verb leaves the snapshot alone — nothing happened to re-read', async () => {
+    await surface.payload()
+    const at = surface.snapshotAt
+    await press('/api/start', { repo: 'not a repo', ticket: '1' })
+    assert.equal(surface.snapshotAt, at)
   })
 })

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -99,10 +99,10 @@ const OVERVIEW = () => ({
     computed_at: at(120),
     repos: [
       { repo: 'alp82/curia', lane: 'map', numbers: [265, 266], agentOnly: 2, items: [
-        { number: 265, title: 'The settings write', labels: ['wayfinder:task'], map: 244, mapTitle: 'Curia gets a face', unblocks: [
+        { number: 265, title: 'The settings write', labels: ['wayfinder:task'], model: 'claude-opus-5', map: 244, mapTitle: 'Curia gets a face', unblocks: [
           { number: 267, title: 'The chat embeds the timeline attach', labels: ['wayfinder:task'] },
         ] },
-        { number: 266, title: 'The verbs reach the browser', labels: ['wayfinder:grilling'], map: 244, mapTitle: 'Curia gets a face', unblocks: [] },
+        { number: 266, title: 'The verbs reach the browser', labels: ['wayfinder:grilling'], model: 'gpt-5.6-sol', map: 244, mapTitle: 'Curia gets a face', unblocks: [] },
       ] },
       { repo: 'alp82/aistack', error: 'gh api failed: HTTP 502' },
     ],
@@ -140,7 +140,10 @@ describe('the read screens (#264)', () => {
       assert.match(t, /1 review gate/)
       assert.match(t, /Needs you \(3\)/, 'the list adds the spent window the count does not')
       assert.match(t, /Two notes race the same expiry line/, 'the question is shown whole, not summarized')
-      assert.match(t, /Drop the older note · Post both with stamps/, 'and its options are named')
+      // #266 turned the options from named text into the buttons that send
+      // them. The labels are still the whole set — that is what this pins.
+      assert.match(t, /Drop the older note/, 'and its options are named')
+      assert.match(t, /Post both with stamps/)
       assert.match(t, /review gate — #261/)
       assert.match(t, /pull\/262/, 'the gate carries the pull request nothing else carries')
       assert.match(t, /Fleet \(3\)/)
@@ -557,5 +560,291 @@ describe('the settings screen (#265)', () => {
   test('a restart the journal recorded reads as a sentence in the feed', () => {
     const p = payload({ events: [{ ts: at(30), type: 'restart_requested', by: 'dashboard', exit_code: 75 }] })
     assert.match(text(page.screenFeed(p)), /restart ordered by dashboard — the daemon exits 75/)
+  })
+})
+
+// The operator verbs on the page (#266). What a human looking at the preview
+// can judge is that a button is there and reads well. What they cannot judge by
+// looking is the half pinned here: that the words a button SENDS are the words
+// every other surface sends, that a verb appears exactly where the ticket put
+// it and nowhere else, and that a refusal reads as a fact rather than as a
+// broken page.
+describe('the operator verbs (#266)', () => {
+  let page
+  before(() => { page = loadPage() })
+  beforeEach(() => {
+    page.UI.act = { busy: null, said: null, note: null, mode: 'queue', tele: null }
+    page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
+  })
+
+  // ---- start ---------------------------------------------------------------
+
+  describe('start, on the frontier', () => {
+    test('the button carries the routed model, so the account is named before it is spent', () => {
+      const t = text(page.screenFrontier(payload()))
+      assert.match(t, /Start → claude-opus-5 \(task default\)/)
+      assert.match(t, /Start → gpt-5\.6-sol \(grilling default\)/)
+    })
+
+    test('it names the repo and the number, and the sidecar composes the rest', () => {
+      const html = page.screenFrontier(payload())
+      assert.match(html, /startTicket\('alp82\/curia','265'\)/)
+    })
+
+    test('a ticket an agent already holds shows the agent instead of a button that only refuses', () => {
+      const p = payload()
+      p.overview.agents[0].ticket = '265'
+      const t = text(page.screenFrontier(p))
+      assert.match(t, /⧗ dispatched — curia-263/)
+      assert.equal(/startTicket\('alp82\/curia','265'\)/.test(page.screenFrontier(p)), false)
+    })
+
+    test('an unreadable fleet is not an idle one: the button stands and says curia cannot tell', () => {
+      const p = payload({ agents: null, fleet_error: 'tmux is wedged' })
+      const t = text(page.screenFrontier(p))
+      assert.match(t, /Start/)
+      assert.match(t, /cannot say whether this one is already running/)
+    })
+
+    test('an item carrying no routed model says so, rather than naming a model nobody chose', () => {
+      const p = payload()
+      delete p.overview.frontier.repos[0].items[0].model
+      assert.match(text(page.screenFrontier(p)), /the routed model is not on this reading/)
+    })
+
+    test('the tree view starts a ticket too — the view is a way of reading, not a way of acting', () => {
+      page.UI.fr.view = 'tree'
+      assert.match(page.screenFrontier(payload()), /startTicket\('alp82\/curia','266'\)/)
+    })
+
+    test('a repo whose frontier could not be read offers no button there', () => {
+      const t = text(page.screenFrontier(payload()))
+      assert.match(t, /alp82\/aistack could not be read/)
+      assert.match(t, /there may be takeable tickets there/)
+    })
+  })
+
+  // ---- answer --------------------------------------------------------------
+
+  describe('an answer, on the one answer surface', () => {
+    test('a choice offers its own options, and the button sends the option verbatim', () => {
+      const html = page.screenHome(payload())
+      assert.match(html, /answerEsc\('esc-7','Drop the older note'\)/)
+      assert.match(html, /answerEsc\('esc-7','Post both with stamps'\)/)
+    })
+
+    // An option is an AGENT's own words, and it lands inside an onclick
+    // handler. A quote in it would close the JS string and open code, which
+    // makes it the one value on this page that could ever do that.
+    test('an option carrying a quote is escaped for the handler it sits in, not only for the html', () => {
+      const raw = "x'),alert(1),('"
+      const p = payload()
+      p.overview.escalations[0].options = ["it's fine", raw]
+      const html = page.screenHome(p)
+      assert.ok(html.includes("answerEsc('esc-7','it\\'s fine')"), 'the quote is escaped, and the label still reads')
+      assert.equal(html.includes(`,'${raw}')`), false, 'the raw option never reaches the handler')
+      assert.ok(html.includes("x\\'),alert(1),(\\'"), 'every quote in it stays inside the string it was given')
+    })
+
+    test('every kind still takes words: an option list is not the only way to answer', () => {
+      assert.match(page.screenHome(payload()), /answerTyped\('esc-7','ans-esc-7'\)/)
+    })
+
+    test('an approve-reject pair sends the two literals the daemon classifies', () => {
+      const p = payload()
+      p.overview.escalations[0].kind = 'approve-reject'
+      p.overview.escalations[0].options = null
+      const html = page.screenHome(p)
+      assert.match(html, /answerEsc\('esc-7','approve'\)/)
+      assert.match(html, /answerEsc\('esc-7','reject'\)/)
+    })
+
+    test('a recommended round carries its one tap, and nothing beside it (#285)', () => {
+      const p = payload()
+      Object.assign(p.overview.escalations[0], { kind: 'free-text', options: null, recommended: true })
+      const html = page.screenHome(p)
+      assert.match(html, /answerEsc\('esc-7','all-as-recommended'\)/)
+      assert.match(text(html), /All as recommended/)
+      assert.equal(/answerEsc\('esc-7','reject'\)/.test(html), false, 'the opposite of that tap is your reply')
+    })
+
+    test('a free-text round with no recommendation gets the field and no tap', () => {
+      const p = payload()
+      Object.assign(p.overview.escalations[0], { kind: 'free-text', options: null, recommended: false })
+      const html = page.screenHome(p)
+      assert.equal(/all-as-recommended/.test(html), false)
+      assert.match(html, /answerTyped/)
+    })
+
+    test('the Agents table states the question and answers none of it — one answer surface', () => {
+      const html = page.screenAgents(payload())
+      assert.equal(/answerEsc/.test(html), false)
+      assert.match(text(html), /choice/, 'it still says what the agent waits on')
+    })
+  })
+
+  // ---- the review gate -----------------------------------------------------
+
+  describe('the review gate card', () => {
+    test('it carries the three the gate has, and cross-check is one of them', () => {
+      const html = page.screenHome(payload())
+      assert.match(html, /answerEsc\('esc-9','approve'\)/)
+      assert.match(html, /answerEsc\('esc-9','cross-check'\)/)
+      assert.match(html, /rejectGate\('esc-9','rej-esc-9'\)/)
+      assert.match(text(html), /Approve · merge/)
+    })
+
+    test('a rejection is a field, not a bare button: the agent gets your words (#48)', () => {
+      assert.match(page.screenHome(payload()), /placeholder="what to change — a rejection carries your words/)
+    })
+
+    test('an empty rejection is refused on the page, and nothing is sent', () => {
+      page.document.getElementById = () => ({ value: '   ' })
+      page.rejectGate('esc-9', 'rej-esc-9')
+      assert.equal(page.UI.act.said.ok, false)
+      assert.match(page.UI.act.said.text, /A rejection carries your words/)
+      page.document.getElementById = () => null
+    })
+
+    test('the pull request stays the one thing this card carries that no other does', () => {
+      assert.match(text(page.screenHome(payload())), /pull\/262/)
+    })
+  })
+
+  // ---- note, teleport, cancel ----------------------------------------------
+
+  describe('the three per-agent verbs', () => {
+    test('every live agent row carries them', () => {
+      const html = page.screenAgents(payload())
+      assert.match(html, /noteBox\('curia-263'\)/)
+      assert.match(html, /teleport\('curia-263','263'\)/)
+      assert.match(html, /cancelAgent\('curia-263','alp82\/curia','263'\)/)
+    })
+
+    test('the note box states both delivery modes in ADR-0013\'s own terms', () => {
+      page.UI.act.note = 'curia-263'
+      const t = text(page.screenAgents(payload()))
+      assert.match(t, /queue — it reads this with its next tool result/)
+      assert.match(t, /interrupt — a short grace, then the words land as a user turn/)
+      assert.match(page.screenAgents(payload()), /placeholder="say something to curia-263/)
+    })
+
+    test('queued is the default, so the mode nobody chose is the safe one', () => {
+      assert.equal(page.UI.act.mode, 'queue')
+      page.UI.act.note = 'curia-263'
+      const html = page.screenAgents(payload())
+      assert.match(html, /value="queue"|noteMode\('queue'\)/)
+      assert.match(html, /name="nm-curia-263"[^>]*checked[^>]*onchange="noteMode\('queue'\)"/)
+    })
+
+    test('a note with no words is refused on the page, and nothing is sent', () => {
+      page.document.getElementById = () => ({ value: '' })
+      page.sendNote('curia-263', 'note-curia-263')
+      assert.equal(page.UI.act.said.ok, false)
+      assert.match(page.UI.act.said.text, /not a note/)
+      page.document.getElementById = () => null
+    })
+
+    test('one box at a time, and pressing the same verb again closes it', () => {
+      page.noteBox('curia-263')
+      assert.equal(page.UI.act.note, 'curia-263')
+      page.noteBox('curia-263')
+      assert.equal(page.UI.act.note, null)
+    })
+
+    test('teleport shows the copyable command for the box, beside curia\'s own links', () => {
+      page.UI.act.tele = 'curia-263'
+      page.UI.act.said = { key: 'agent:curia-263', text: '🔗 timeline https://box.ts.net:8444/t/263', ok: true }
+      const t = text(page.screenAgents(payload()))
+      assert.match(t, /On the box itself, in a terminal:/)
+      assert.match(page.screenAgents(payload()), /attach -t curia-263/)
+      assert.match(t, /timeline/)
+    })
+
+    test('the copyable line goes in through the tmux container, which is where the server lives (#260)', () => {
+      assert.match(page.attachCmd('curia-263'), /^docker compose .* exec tmux tmux -S \/run\/curia-tmux\/default attach -t curia-263$/)
+    })
+  })
+
+  // ---- what curia said -----------------------------------------------------
+
+  describe('the outcome of a press', () => {
+    test('a command reply is curia\'s own sentence, rendered where the press was', () => {
+      page.UI.act.said = { key: 'start:alp82/curia#265', text: '⚙️ `curia-265` spawned on **claude-opus-5**', ok: true }
+      const html = page.screenFrontier(payload())
+      assert.match(html, /<code>curia-265<\/code>/, 'the markdown curia speaks everywhere else reads here too')
+      assert.match(html, /<b>claude-opus-5<\/b>/)
+    })
+
+    test('a refusal is marked, and it is not a broken page', () => {
+      page.UI.act.said = { key: 'esc:esc-7', text: 'that question was already answered — the first valid answer wins', ok: false }
+      const html = page.screenHome(payload())
+      assert.match(html, /class="said bad"/)
+      assert.match(text(html), /first valid answer wins/)
+    })
+
+    test('what curia said lands under the control that asked, never on another one', () => {
+      page.UI.act.said = { key: 'esc:esc-7', text: 'answered', ok: true }
+      assert.equal(/class="said/.test(page.screenAgents(payload())), false)
+    })
+
+    test('a queued note says when the agent reads it; an interrupt says what it costs', () => {
+      assert.match(page.outcome({ mode: 'queue', ok: true, agent: 'curia-263' }), /next tool result/)
+      assert.match(page.outcome({ mode: 'interrupt', ok: true, session: 'curia-263', graceMs: 5000 }), /5s of grace/)
+    })
+
+    test('an interrupt curia refused still delivered the words — queued, which is the default anyway', () => {
+      const said = page.outcome({ mode: 'interrupt', ok: false, why: 'curia-263 is waiting on esc-7', still_queued: true })
+      assert.match(said, /waiting on esc-7/)
+      assert.match(said, /stay queued/)
+    })
+
+    test('a note nothing took says only that, with no promise of delivery', () => {
+      const said = page.outcome({ mode: 'queue', ok: false, why: 'curia is not running `curia-9`' })
+      assert.match(said, /not running/)
+      assert.equal(/queued/.test(said), false)
+    })
+
+    test('one act at a time: while a press is in flight every other control is disabled', () => {
+      page.UI.act.busy = 'esc:esc-7'
+      assert.match(page.screenFrontier(payload()), /button class="btn sm primary" disabled/)
+      assert.match(page.screenAgents(payload()), /disabled/)
+    })
+  })
+
+  // ---- the feed ------------------------------------------------------------
+
+  describe('every verb lands in the feed', () => {
+    const feed = (e) => text(page.screenFeed(payload({ events: [{ ts: at(30), ...e }] })))
+
+    test('a note names who sent it and what it said', () => {
+      assert.match(feed({ type: 'agent_note', agent: 'curia-263', by: 'alp@example.com', text: 'look again' }),
+        /note for curia-263 from alp@example.com: look again/)
+    })
+
+    test('an interrupt says the grace it gave, because that is the operator\'s own choice', () => {
+      assert.match(feed({ type: 'note_interrupt', agent: 'curia-263', by: 'alp@example.com', grace_ms: 5000 }),
+        /curia-263 interrupted by alp@example.com — 5s of grace/)
+    })
+
+    test('an interrupt that failed is marked bad and says why', () => {
+      assert.match(feed({ type: 'note_interrupt_failed', agent: 'curia-263', reason: 'the agent exited during the grace' }),
+        /the interrupt of curia-263 failed — the agent exited during the grace/)
+    })
+
+    test('a note curia refused is a fact in the feed, not a silence', () => {
+      assert.match(feed({ type: 'agent_note_refused', agent: 'curia-263', reason: 'agent not running' }),
+        /a note for curia-263 was refused — agent not running/)
+    })
+
+    test('an answer names the operator and the surface it came from', () => {
+      assert.match(feed({ type: 'esc_answer', id: 'esc-7', by: 'alp@example.com', via: 'dashboard' }),
+        /escalation esc-7 answered by alp@example.com via dashboard/)
+    })
+
+    test('a start pressed here reads exactly as one typed in Discord — one seam, one event', () => {
+      assert.match(feed({ type: 'command', canonical: 'start alp82/curia#266', by: 'alp@example.com' }),
+        /start alp82\/curia#266 — by alp@example.com/)
+    })
   })
 })

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -716,3 +716,145 @@ describe('POST /restart: the daemon journals and exits nonzero (#265, real boot)
     assert.equal(logged[0].by, 'dashboard')
   })
 })
+
+// The console's verbs reach the daemon (#266). Two of the three seams they use
+// are new, and neither is visible from any surface but a browser:
+//
+//   POST /note   — a note KEYED ON THE AGENT. Discord keys one on the thread it
+//                  was typed in, and the console has no thread at all.
+//   `by`         — every REST verb journalled the word `rest`. The console
+//                  passes the operator's own login instead, so the feed names a
+//                  person rather than a transport.
+//
+// Real boot, because both are route code and an extraction would prove nothing
+// about the shipped path. No agent is running against these fixtures, which is
+// itself the case worth pinning: a note at an agent that is not there queues
+// nothing and says so, rather than being lost into a queue nobody drains.
+describe('the console verbs on the loopback surface (#266, real boot)', () => {
+  let tmp
+  let child
+  let port
+  let dataDir
+  let watch
+
+  const journal = () => fs.readFileSync(path.join(dataDir, 'events.jsonl'), 'utf8')
+    .split('\n').filter(Boolean).map((l) => JSON.parse(l))
+  const post = (route, body) => request(port, 'POST', route, {
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  before(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-index-verbs-test-'))
+    const cfgDir = path.join(tmp, 'config')
+    dataDir = path.join(tmp, 'data')
+    const shim = path.join(tmp, 'shim')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    fs.mkdirSync(shim, { recursive: true })
+    for (const bin of ['gh', 'tmux', 'tailscale']) {
+      const p = path.join(shim, bin)
+      fs.writeFileSync(p, '#!/bin/sh\nexit 1\n')
+      fs.chmodSync(p, 0o755)
+    }
+    const [daemonPort, ttydPort, servePort, proxyPort, tlPort, tlServePort] = [
+      await freePort(), await freePort(), await freePort(), await freePort(), await freePort(), await freePort(),
+    ]
+    port = daemonPort
+    fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
+      'watch:', '  - repo: example/fixture', '    mode: ready-for-agent',
+      'dispatch:',
+      '  auto_dispatch: false', '  max_concurrent: 1', '  poll_interval_s: 60',
+      `  workspace_root: ${path.join(tmp, 'work')}`, '  ready_timeout_s: 5',
+      'attach:', `  ttyd_port: ${ttydPort}`, `  serve_port: ${servePort}`,
+      'identity:', '  allow: [tester@example.com]', `  proxy_port: ${proxyPort}`,
+      'timeline:', `  port: ${tlPort}`, `  serve_port: ${tlServePort}`,
+      ...skillsYaml(seedSkillsRoot(tmp)),
+      ...sandboxYaml(),
+      '',
+    ].join('\n'))
+    fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
+      'defaults:', '  untyped: sonnet',
+      'models:', '  sonnet: { provider: anthropic, harness: claude }',
+      'harnesses:', '  claude:',
+      '    template: claude --model {model} "$(cat {prompt_file})"',
+      "    ready: '⏵⏵|bypass permissions'",
+      '    tool_channel_grace_s: 15',
+      '',
+    ].join('\n'))
+
+    child = spawn(process.execPath, [DAEMON], {
+      env: {
+        ...process.env,
+        PORT: String(daemonPort),
+        CURIA_CONFIG_DIR: cfgDir,
+        CURIA_DATA_DIR: dataDir,
+        PATH: `${shim}:${process.env.PATH}`,
+        DISCORD_BOT_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    watch = watchDaemon(child)
+    await waitForBoot(watch, async () => {
+      try { return (await request(port, 'GET', '/state')).status === 200 } catch { return false }
+    }, 'the /state route')
+  })
+
+  after(() => {
+    if (child && child.exitCode === null) child.kill('SIGKILL')
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  test('a note at an agent that is not running queues nothing, and says which verb puts one back', async () => {
+    const res = await post('/note', { agent: 'curia-4242', text: 'have another look at the migration', by: 'alp@example.com' })
+    assert.equal(res.status, 200)
+    const body = JSON.parse(res.body)
+    assert.equal(body.ok, false)
+    assert.equal(body.reads, false, 'nothing queued — #208: words typed at a dead agent die with it')
+    assert.equal(body.id, null)
+    assert.match(body.why, /resume 4242/, 'the way out is named, not left to be guessed')
+    const refused = journal().filter((e) => e.type === 'agent_note_refused')
+    assert.equal(refused.at(-1).agent, 'curia-4242')
+    assert.equal(refused.at(-1).by, 'alp@example.com', 'the refusal names who tried, not the transport')
+  })
+
+  test('the interrupt mode is refused the same way, and refuses on the daemon\'s own words', async () => {
+    const res = await post('/note', { agent: 'curia-4242', text: 'stop that', mode: 'interrupt', by: 'alp@example.com' })
+    assert.equal(res.status, 200)
+    const body = JSON.parse(res.body)
+    assert.equal(body.ok, false)
+    assert.equal(body.mode, 'interrupt')
+  })
+
+  test('a session name this daemon would never mint is refused before anything is written', async () => {
+    for (const agent of ['', 'curia-263; rm -rf /', '../../etc/passwd', 'notcuria-1']) {
+      const res = await post('/note', { agent, text: 'hello' })
+      assert.equal(res.status, 400, `${agent} is not a curia session name`)
+      assert.match(JSON.parse(res.body).error, /not a curia session name/)
+    }
+  })
+
+  test('a note with no words is not a note', async () => {
+    const res = await post('/note', { agent: 'curia-1', text: '   ' })
+    assert.equal(res.status, 400)
+    assert.match(JSON.parse(res.body).error, /no words/)
+  })
+
+  test('a command carries the operator who pressed into the journal', async () => {
+    const res = await post('/command', { text: 'status', by: 'alp@example.com' })
+    assert.equal(res.status, 200)
+    const logged = journal().filter((e) => e.type === 'command').at(-1)
+    assert.equal(logged.canonical, 'status')
+    assert.equal(logged.by, 'alp@example.com')
+  })
+
+  test('a caller that names nobody is still `rest` — every seam before this one sent that', async () => {
+    await post('/command', { text: 'status' })
+    assert.equal(journal().filter((e) => e.type === 'command').at(-1).by, 'rest')
+  })
+
+  test('an answer to a question curia does not hold refuses with the reason, never a silent 200', async () => {
+    const res = await post('/answer', { id: 'esc-nope', answer: 'approve', by: 'alp@example.com', via: 'dashboard' })
+    assert.equal(res.status, 409)
+    assert.equal(JSON.parse(res.body).reason, 'unknown')
+  })
+})

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -390,6 +390,38 @@ describe('the two-level frontier, and reconcile\'s stamp (#262)', () => {
     assert.equal(repo.items.some((i) => i.unblocks.some((u) => u.number === 23)), false)
   })
 
+  // #266: the console shows the routed model beside its start button, so the
+  // operator knows which account a press spends before spending it. It is
+  // `resolveModel` — the daemon's own precedence rule, computed where the labels
+  // already are — never a second copy of that rule inside the page.
+  test('every takeable ticket carries the model it would get if it started now', async () => {
+    const d = makeDispatcher()
+    d.routing = {
+      ...d.routing,
+      defaults: { untyped: 'sonnet', task: 'opus', grilling: 'gpt' },
+    }
+    const byNumber = Object.fromEntries((await d.frontier())[0].items.map((i) => [i.number, i.model]))
+    assert.equal(byNumber[11], 'opus', 'the wayfinder:task default')
+    assert.equal(byNumber[12], 'gpt', 'the wayfinder:grilling default')
+  })
+
+  test('a `model:` label on the ticket beats the type default, exactly as a dispatch would', async () => {
+    const d = makeDispatcher({
+      mapFrontier: async () => [child(11, 'pinned to one model', { labels: ['wayfinder:task', 'model:fable'] })],
+      blockedByOf: async () => [],
+    })
+    d.routing = { ...d.routing, defaults: { untyped: 'sonnet', task: 'opus' } }
+    assert.equal((await d.frontier())[0].items[0].model, 'fable')
+  })
+
+  test('a ticket with no wayfinder label falls to the untyped default, never to nothing', async () => {
+    const d = makeDispatcher({
+      mapFrontier: async () => [child(11, 'no type on it')],
+      blockedByOf: async () => [],
+    })
+    assert.equal((await d.frontier())[0].items[0].model, 'sonnet')
+  })
+
   test('reconcile computes the frontier and stamps when it did', async () => {
     const d = makeDispatcher()
     assert.deepEqual(d.frontierSnapshot(), { computed_at: null, repos: [] }, 'nothing is stamped before a pass runs')


### PR DESCRIPTION
Ticket: alp82/curia#266 — [The verbs reach the browser: start, answer, gate, note, cancel](https://github.com/alp82/curia/issues/266)

The console carries the operator verbs (#266).

**The page.** Start sits on every frontier card and tree node, with the routed model beside it; a ticket an agent already holds shows the agent instead. The Needs-you list on Home is the one answer surface — option buttons, the approve/reject pair, the ✅ round tap, and a free-form field on every kind. The review gate card carries approve-merge, cross-check and a rejection that must carry words. Every agent row carries note (queue or interrupt), teleport and cancel, and cancel confirms with the teardown's own consequences.

**The seam.** Every verb is a POST to the sidecar, which composes the daemon call from the fields the page sends. A browser never hands over a command line. Start, cancel and teleport go through the command seam the slash verbs use, so a press journals the same `command` event a typed one does. Writes pass the identity gate and the Origin gate #265 built.

**The daemon.** Three changes. `POST /note` keys a note on the agent, because a browser has no thread, and both delivery modes of ADR-0013 sit behind it. Reconcile joins the routed model onto each frontier item with `resolveModel`, so the page states a fact rather than copying the precedence rule. Every verb carries the operator's Tailscale login as its `by`, so the feed names a person instead of the word `rest`.

The page stamp goes to proto 2: an old sidecar must refuse the new page rather than serve one whose buttons all answer 404.

Tests: 1632 pass. New cover the sidecar's composition and its two gates, the daemon's note route and `by` plumbing, the routed model on the frontier, and what each control says and sends.

---

Dispatched by the curia daemon — session `curia-266`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `8f0d864` The verbs reach the browser (wayfinder #266)