### PR TITLE
The chat embeds the timeline attach (alp82/curia#267)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -340,6 +340,15 @@ The grid-free attach surface. It reads the agent's transcript and writes with tm
 **Transcript**:
 The harness's own append-only run log. It carries no geometry, so any device lays it out at its own width.
 
+**Driven session**:
+A timeline session that is no tmux pane. It names its own config dir and it takes a message as a turn rather than as keystrokes. The console chat is the first one. A driven session has no dialog guard and takes no key, because neither has a pane to reach.
+
+**Console chat**:
+The Chat screen of the dashboard. It is the timeline attach of the overseer's browser thread, served under the console's own address. The console draws no chat of its own and frames none: there is one chat surface, and it is the timeline.
+
+**Browser thread**:
+The overseer conversation the console chat speaks to, keyed `console` rather than on a Discord thread. One brain answers both surfaces. The answer is never posted, because the transcript already carries it to the page. Its verbs run with no origin thread, so a confirm goes where a REST press sends it.
+
 **Preview**:
 A tailnet HTTPS link to an agent's running dev server. The daemon allocates the public port and composes the link.
 

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -13,7 +13,7 @@
 
      The four read screens draw one payload: `GET /api/overview`, which is the
      sidecar's held snapshot of the daemon's own `GET /overview` (#262). The
-     chat lands in #267.
+     chat (#267) draws nothing: it is the timeline page, served at /chat.
 
      THE VERBS (#266) POST to the sidecar, never to the daemon. It composes each
      daemon call from the fields the page sends, so this page names a ticket, an
@@ -27,7 +27,7 @@
      2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
         nobody has computed is not an empty frontier. Every section that can fail
         on its own says which of the two it is. -->
-<meta name="curia-dashboard" content="proto=2">
+<meta name="curia-dashboard" content="proto=3">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>curia</title>
 <style>
@@ -293,6 +293,16 @@
   .said a { word-break: break-all; }
   .copy { width: 100%; font: 12px ui-monospace, Menlo, monospace; }
 
+  /* ---------- the chat (#267) ----------
+     A door, not a room: the chat itself is the timeline page, served under this
+     surface's own address. Nothing here draws a message. */
+  .door { max-width: 620px; border: 1px solid var(--line); border-radius: 9px; background: var(--bg-raise); padding: 14px 16px; }
+  .door p { margin: 0 0 10px; font-size: 13.5px; color: var(--ink-dim); }
+  .door p.lead { color: var(--ink); }
+  .door a.btn { display: inline-block; text-decoration: none; }
+  .door a.btn:hover { text-decoration: none; }
+  .door .cannot { font-size: 12.5px; color: var(--ink-faint); margin: 10px 0 0; }
+
   /* ---------- the screens that land later ---------- */
   .later {
     border: 1px dashed var(--line); border-radius: 9px; padding: 12px 14px;
@@ -317,7 +327,7 @@ const SCREENS = {
   agents:   ["Agents",   screenAgents],
   frontier: ["Frontier", screenFrontier],
   feed:     ["Feed",     screenFeed],
-  chat:     ["Chat",     (p) => later(p, "The chat", "#267")],
+  chat:     ["Chat",     screenChat],
   settings: ["Settings", screenSettings],
 };
 const NAMES = Object.keys(SCREENS);
@@ -1309,6 +1319,38 @@ function setDispatch() {
       <span class="hint" style="display:block;margin:2px 0 0">On, curia starts the next takeable ticket by itself. Off, every dispatch is one the operator ordered.</span></td>
       <td><input type="checkbox" id="set-auto" ${auto ? "checked" : ""} onchange="setDispatchField('auto_dispatch', this.checked)"></td></tr>
     ${rows}</table>`);
+}
+
+/* ---- the chat (#267) -------------------------------------------------------
+
+   The console draws no chat of its own and frames none. The chat IS the
+   timeline attach — the same page a phone opens against an agent — pointed at
+   the overseer's browser thread and served under this address. One chat
+   surface: the composer, the history and every future thing the timeline grows
+   arrive here for free, and there is no second one to keep in step.
+
+   So this screen is a door. It says who is on the other side, whether the
+   process holding them is answering, and it opens. */
+const CHAT_PAGE = "/chat";
+const CHAT_SESSION = "curia-overseer";
+const chatHref = () => CHAT_PAGE + "?session=" + encodeURIComponent(CHAT_SESSION);
+
+function screenChat(p) {
+  /* The overseer runs INSIDE the daemon, so a daemon that is not answering is a
+     chat that is not there. The bar above says why; this says what it means. */
+  const down = p && !p.daemon_up;
+  return `${head(p, "Chat", `<span class="dim-note mono">${esc(CHAT_SESSION)}</span>`)}
+    <div class="door">
+      <p class="lead">This is the overseer — the same curia that answers your prose in Discord, in a
+        thread of its own. It sees every watched repo, and it holds the verbs: ask it what to start,
+        then say <code>start 256</code> and it dispatches.</p>
+      ${down ? `<p class="unread">The chat is down while the daemon restarts. The overseer runs inside it.</p>` : ""}
+      <p><a class="btn primary" href="${esc(chatHref())}">Open the chat</a></p>
+      <p>It opens at this same address, so the phone reaches it the same way. A destructive verb still
+        posts its ✅/❌ card, and that card lands on Home.</p>
+      <p class="cannot">It has no shell and no checkout, so it cannot read a file or a diff. It tells
+        you what curia knows, and it acts.</p>
+    </div>`;
 }
 
 function screenSettings(p) {

--- a/daemon/bin/curia-dashboard.mjs
+++ b/daemon/bin/curia-dashboard.mjs
@@ -27,7 +27,7 @@ const CONFIG = process.env.CURIA_CONFIG ?? path.resolve(DIR, '..', '..', 'config
 
 const log = (...a) => console.log(`[${new Date().toISOString()}]`, ...a)
 
-const { dashboard, allow } = loadDashboardConfig(CONFIG)
+const { dashboard, allow, timelinePort } = loadDashboardConfig(CONFIG)
 
 const surface = new DashboardSurface({
   port: dashboard.port,
@@ -36,6 +36,10 @@ const surface = new DashboardSurface({
   pollIntervalS: dashboard.poll_interval_s,
   allow,
   daemonPort: daemonPort(),
+  // The chat (#267) is the daemon's timeline surface, served under this
+  // address. Both containers share the host network, so the port is the same
+  // number the daemon binds.
+  timelinePort,
   // The two files the settings screen writes (#265). `routing.yaml` sits beside
   // `curia.yaml` by construction — the daemon reads both out of one directory
   // (CURIA_CONFIG_DIR), so naming a second path here would be a second way to

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -50,7 +50,9 @@ export const daemonPort = () => Number(process.env.PORT ?? DEFAULT_DAEMON_PORT)
 // Bumped to 2 by #266: the page now POSTs to verb routes an older sidecar does
 // not serve, so an old server must refuse the new page rather than serve one
 // whose every button answers 404.
-export const DASHBOARD_PROTO = 2
+// Bumped to 3 by #267: the Chat screen sends the operator to `/chat`, which an
+// older sidecar does not serve either.
+export const DASHBOARD_PROTO = 3
 export const STAMP_NAME = 'curia-dashboard'
 const STAMP_RE = new RegExp(`<meta name="${STAMP_NAME}" content="proto=(\\d+)">`)
 
@@ -135,7 +137,21 @@ export function loadDashboardConfig(file) {
     fail(`dashboard.index resolves to ${dashboard.index}, which does not exist — it ships committed in daemon/assets/`)
   }
   const allow = readAllow(cfg.identity, fail)
-  return { dashboard, allow }
+  return { dashboard, allow, timelinePort: readTimelinePort(cfg, fail) }
+}
+
+// The chat (#267) is the timeline, served under this surface's own address, so
+// the sidecar needs the one number that says where the timeline listens. It is
+// the daemon's own loopback port and both containers share the host network.
+//
+// Read here rather than through loadCuriaConfig for the #263 reason: that
+// loader checks the timeline PAGE on the daemon's filesystem, which this
+// container does not mount. This process validates the one key it uses.
+export function readTimelinePort(cfg, fail) {
+  const port = cfg.timeline?.port
+  if (port === undefined) return null // no timeline block: the chat says so rather than guessing
+  if (!(Number.isInteger(port) && port > 0 && port < 65536)) fail('timeline.port must be a port number')
+  return port
 }
 
 // ---------------------------------------------------------------------------
@@ -199,14 +215,31 @@ function words(value, what) {
   return s
 }
 
+// The chat (#267). The console does not draw a chat of its own and it does not
+// frame one: it SERVES the timeline, under its own address, and hands the four
+// routes that page speaks straight through to the daemon.
+//
+//   browser ──Serve(:8445)──> sidecar ──> daemon timeline(:4272)
+//
+// Nothing is rewritten on the way. The Host and the operator's login travel as
+// they arrived, so the timeline applies the #151 predicate in-process to the
+// evidence the browser actually sent — the sidecar carries the bytes and
+// vouches for nothing. The daemon's own host allowlist admits this surface's
+// name, which is what makes that pass (index.mjs resolveServeHosts).
+export const CHAT_PAGE = '/chat'
+const CHAT_ROUTES = new Set(['/events', '/send', '/draft', '/key'])
+
 export class DashboardSurface {
   constructor({
     port, servePort, index, allow, daemonPort: dPort = daemonPort(),
     pollIntervalS = DEFAULT_DASHBOARD.poll_interval_s,
-    curiaFile = null, routingFile = null,
+    curiaFile = null, routingFile = null, timelinePort = null,
     log = console.log, deps = {},
   }) {
     this.port = port
+    // Where the timeline listens on loopback. Null means this sidecar was
+    // started against a config with no timeline block, and the chat says so.
+    this.timelinePort = timelinePort
     this.servePort = servePort
     this.index = index
     // The two files the settings screen writes (#265). They are the only
@@ -533,6 +566,33 @@ export class DashboardSurface {
     return this.#daemon({ method: 'POST', path: '/command', body: { text, by } })
   }
 
+  // The chat, piped (#267). Headers travel unchanged in both directions, and
+  // the body streams — the timeline's read is server-sent events, which a
+  // buffering proxy would turn into a page that never updates.
+  #chat(req, res, upstreamPath) {
+    if (!this.timelinePort) {
+      res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'no-store' })
+      return res.end('this sidecar was started against a config with no `timeline:` block, so it cannot reach the chat\n')
+    }
+    const up = http.request({
+      host: '127.0.0.1', port: this.timelinePort, method: req.method, path: upstreamPath, headers: req.headers,
+    }, (upRes) => {
+      res.writeHead(upRes.statusCode, upRes.statusMessage, upRes.headers)
+      upRes.pipe(res)
+    })
+    up.on('error', (e) => {
+      this.log(`dashboard: the chat could not reach the timeline on :${this.timelinePort} (${e.message})`)
+      if (res.headersSent) return res.destroy()
+      res.writeHead(502, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'no-store' })
+      res.end(`the chat is the daemon's timeline surface, and it is not answering on :${this.timelinePort} (${e.message})\n`)
+    })
+    // A reader that closes the tab must not leave an event stream open on the
+    // daemon: the timeline counts its clients, and a phantom one keeps a
+    // session pumping forever.
+    res.on('close', () => up.destroy())
+    req.pipe(up)
+  }
+
   #handle(req, res) {
     const reason = this.#refusal(req)
     if (reason) {
@@ -548,6 +608,10 @@ export class DashboardSurface {
         this.log(`dashboard: REFUSED ${req.method} ${req.url} — ${crossSite}`)
         return this.#json(res, 403, { error: crossSite })
       }
+      // The chat's three writes (#267): the composer, the shared draft and the
+      // key the timeline page sends. They pass the cross-site check above like
+      // every other write here, and the timeline applies its own on top.
+      if (CHAT_ROUTES.has(url.pathname)) return this.#chat(req, res, url.pathname + url.search)
       // The save (#265). The sidecar writes the file itself: it holds the only
       // read-write mount in this container, and #249 put the edit here so that
       // a config the daemon refuses to boot on can still be fixed from the page
@@ -663,6 +727,12 @@ export class DashboardSurface {
     }
 
     if (req.method !== 'GET') return this.#json(res, 405, { error: 'this surface answers GET and POST' })
+
+    // The chat page and its event stream (#267). `/chat` serves the timeline's
+    // own page — the daemon re-reads and stamp-checks it per request, so the
+    // bytes the console hands out are the ones the daemon agreed to serve.
+    if (url.pathname === CHAT_PAGE) return this.#chat(req, res, '/')
+    if (CHAT_ROUTES.has(url.pathname)) return this.#chat(req, res, url.pathname + url.search)
 
     if (url.pathname === '/api/overview') {
       return this.payload().then(

--- a/daemon/src/identity.mjs
+++ b/daemon/src/identity.mjs
@@ -118,6 +118,24 @@ export function serveHosts({ dnsName, ips = [], servePort }) {
   return set
 }
 
+// Every name one surface may legitimately be reached by (#267). Until the
+// console chat that was one published port per surface, so `serveHosts` alone
+// answered. It no longer is: the chat IS the timeline, reached through the
+// console's own address, so a request arrives at the timeline carrying the
+// console's Host — a name this box serves, on a port it publishes, but not the
+// timeline's own.
+//
+// Admitting a second published port costs nothing this set buys. It exists to
+// refuse a name this box does NOT answer to (the rebinding shape, fact 4), and
+// every name here still comes from tailscale's own word about this node.
+export function hostsForPorts(self, servePorts) {
+  const set = new Set()
+  for (const servePort of servePorts) {
+    for (const h of serveHosts({ ...self, servePort })) set.add(h)
+  }
+  return set
+}
+
 // The box's own tailnet names, from tailscale itself — never hardcoded, the
 // same rule attachBase() follows. Cached: the node's name and addresses do not
 // change under a running daemon, and every request would otherwise shell out.

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -41,14 +41,14 @@ import { Dispatcher } from './dispatch.mjs'
 import { REVIEW_KIND } from './lifecycle.mjs'
 import { CommandRouter } from './commands.mjs'
 import { SelfDeploy } from './deploy.mjs'
-import { OverseerHost } from './overseer.mjs'
+import { OverseerHost, CONSOLE_SESSION } from './overseer.mjs'
 import { hasSession } from './tmux.mjs'
 import { assertGhTokens, ghTokenKeyFor, agentGhToken } from './workspace.mjs'
 import { TOKEN_HEADER, AGENT_ROUTES, tokensDir, agentTokenMatches } from './agenttoken.mjs'
 import { probeAgentToken, tokenExpiryDays, viewerLogin, ghJSONL } from './github.mjs'
 import { probeTtyd, assertServe, serveOff, attachBase, attachSessionUrl, validSessionName } from './attach.mjs'
 import { TimelineSurface } from './timeline.mjs'
-import { IdentityProxy, identityRefusal, serveHosts, tailnetSelf } from './identity.mjs'
+import { IdentityProxy, identityRefusal, hostsForPorts, tailnetSelf } from './identity.mjs'
 import { detectHarness } from './transcript.mjs'
 import { promptTitle, elapsedLabel, speakerName } from './messaging.mjs'
 import { StatusLine } from './statusline.mjs'
@@ -616,12 +616,17 @@ const timelineHosts = new Set()
 
 async function resolveServeHosts() {
   const self = await tailnetSelf()
-  for (const [set, servePort] of [
-    [attachHosts, curiaConfig.attach.serve_port],
-    [timelineHosts, curiaConfig.timeline.serve_port],
+  for (const [set, ports] of [
+    [attachHosts, [curiaConfig.attach.serve_port]],
+    // TWO ports for the timeline (#267): its own, and the console's. The chat
+    // is this surface, served under the sidecar's address, so those requests
+    // arrive here carrying the console's Host. The alternative was for the
+    // sidecar to REWRITE Host on the way through, which would have made a proxy
+    // the author of the very evidence this check reads.
+    [timelineHosts, [curiaConfig.timeline.serve_port, curiaConfig.dashboard.serve_port]],
   ]) {
     set.clear()
-    for (const h of serveHosts({ ...self, servePort })) set.add(h)
+    for (const h of hostsForPorts(self, ports)) set.add(h)
   }
   return self
 }
@@ -766,6 +771,14 @@ const timeline = new TimelineSurface({
     // The #151 identity check. The timeline is the daemon's own server, so it
     // carries the same predicate the terminal's proxy does, in-process.
     identityCheck: timelineIdentityCheck,
+    // The console chat (#267): one session on this surface is not a pane. It is
+    // the overseer's browser thread — its transcript is the SDK session the
+    // overseer host already keeps, and a message to it is a turn rather than a
+    // keystroke. `overseer` is const below and read at request time, never at
+    // construction.
+    driverFor: (session) => (session === CONSOLE_SESSION
+      ? { cfgDir: overseer.configDir, send: (text) => overseer.browserTurn(text) }
+      : null),
   },
 })
 dispatcher.timeline = timeline // reconcile asserts/withdraws its serve rule alongside attach's

--- a/daemon/src/overseer.mjs
+++ b/daemon/src/overseer.mjs
@@ -23,6 +23,21 @@ import { SIGNALS, smallPrint } from './messaging.mjs'
 export const OVERSEER_MODEL = 'claude-haiku-4-5'
 export const OVERSEER_FALLBACK_MODEL = 'claude-sonnet-5'
 
+// The browser thread (#267). The console chat is the overseer in a thread of
+// its own: one brain, two surfaces, and no second chat anywhere.
+//
+// The key is a plain word rather than a Discord snowflake, and that is the
+// whole distinction it carries — `store.overseerSession` keys the conversation
+// on it, so the browser thread resumes across a daemon restart exactly as a
+// Discord thread does, and it can never collide with one.
+//
+// The SESSION name is what the timeline surface serves this conversation under.
+// It reads as a curia session (attach.mjs validSessionName) because the
+// timeline admits nothing else, and it names the overseer rather than a number
+// because no ticket answers for it.
+export const CONSOLE_THREAD = 'console'
+export const CONSOLE_SESSION = 'curia-overseer'
+
 // The tool → router contract, pure: what canonical text each verb tool posts
 // to /command. One string builder rather than seven inline template literals,
 // so the mapping is testable without the SDK in the loop.
@@ -209,6 +224,38 @@ export class OverseerHost {
     this.busy = new Set() // thread ids with a turn in flight
   }
 
+  // ---- the browser thread (#267) -------------------------------------------
+  //
+  // The console chat is this same overseer, in a thread of its own. One brain
+  // answers the operator on Discord and in the browser, and neither surface
+  // holds a second one.
+  //
+  // Two things differ from a Discord turn, and both follow from there being no
+  // Discord thread here.
+  //
+  //   1. The ANSWER is not posted. The SDK writes every turn to the session
+  //      transcript, and the timeline surface tails that file (#74), so the
+  //      words reach the page by the same path an agent's words do. A `say`
+  //      that also posted would say one fact twice (ADR-0013).
+  //   2. The verb tools run with NO origin thread. A confirm this turn opens
+  //      is the one thing a browser turn cannot render — there is no thread to
+  //      put the buttons in — so it takes the same route a REST press takes and
+  //      lands in the channel, plus the console's own needs-you list.
+  //
+  // What comes back is the failure, and only the failure: a turn that ends
+  // without an answer must not read as silence on the page.
+  async browserTurn(text) {
+    const said = []
+    const out = await this.runTurn(CONSOLE_THREAD, text, {
+      say: (t) => { said.push(t) },
+      status: () => {},
+      routeThreadId: null,
+    })
+    if (out.busy) throw new Error('curia is still on your last message — one turn at a time')
+    if (!out.ok) throw new Error(said.join('\n') || `the turn ended without an answer (${out.why})`)
+    return out
+  }
+
   // One in-process MCP server per turn, so the verb tools carry the thread
   // they run in (#93): the router binds `start` to that thread. Cheap — the
   // server is a plain object over the same seven handlers. `interpreted`
@@ -231,7 +278,12 @@ export class OverseerHost {
   // (#95, per #89): status(text) upserts the single small-print status line —
   // the caller sends it once and edits it in place — and say(text) posts the
   // answer. Failures land in the answer slot; everything meta lands in status.
-  async runTurn(threadId, prompt, { say, status }) {
+  //
+  // `routeThreadId` (#267) is the thread the VERB TOOLS run in, which is the
+  // session key everywhere until the browser thread: a console turn keys its
+  // conversation on `console` and routes its verbs with no thread at all,
+  // because `console` is not a thread the bridge can post buttons into.
+  async runTurn(threadId, prompt, { say, status, routeThreadId = threadId }) {
     if (this.busy.has(threadId)) {
       await say(smallPrint(`${SIGNALS.warn} still on your last message — one turn at a time per thread`))
       return { ok: false, busy: true }
@@ -254,7 +306,7 @@ export class OverseerHost {
       const fullPrompt = notes.length
         ? `${notes.map((t) => `[curia: ${t}]`).join('\n')}\n\n${prompt}`
         : prompt
-      const first = await this.#turn(threadId, fullPrompt, this.model, { say, step })
+      const first = await this.#turn(threadId, fullPrompt, this.model, { say, step, routeThreadId })
       if (first.ok) return first
       // Sonnet fallback (#82) — but only when the failed turn executed
       // nothing: a turn that died after a tool call may already have
@@ -262,7 +314,7 @@ export class OverseerHost {
       // effect. That failure goes to the operator instead.
       if (first.toolCalls === 0 && this.fallbackModel && this.fallbackModel !== this.model) {
         await step(`${SIGNALS.warn} ${this.model} turn failed (${first.why}) — retrying on ${this.fallbackModel}`)
-        const second = await this.#turn(threadId, fullPrompt, this.fallbackModel, { say, step })
+        const second = await this.#turn(threadId, fullPrompt, this.fallbackModel, { say, step, routeThreadId })
         if (second.ok) return second
         await say(`${SIGNALS.warn} session ended without an answer (${second.why})`)
         return second
@@ -274,7 +326,7 @@ export class OverseerHost {
     }
   }
 
-  async #turn(threadId, prompt, model, { say, step }) {
+  async #turn(threadId, prompt, model, { say, step, routeThreadId = threadId }) {
     const resume = this.store.overseerSession(threadId)
     this.log(`[overseer] turn thread=${threadId} resume=${resume ?? 'fresh'} model=${model}`)
     const t0 = Date.now()
@@ -307,7 +359,7 @@ export class OverseerHost {
           model,
           resume,
           systemPrompt: SYSTEM_PROMPT,
-          mcpServers: { curia: this.#mcpFor(threadId, narrate) },
+          mcpServers: { curia: this.#mcpFor(routeThreadId, narrate) },
           allowedTools: ALLOWED_TOOLS,
           disallowedTools: DISALLOWED_TOOLS,
           maxTurns: this.maxTurns,

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -17,6 +17,14 @@
 // both harnesses (the codex harness shows the call natively; the overlay adds the
 // answer-surface state either way).
 //
+// THE DRIVEN SESSION (#267). Every session here was a tmux pane until the
+// console chat: read a transcript under the workspace, write with send-keys.
+// The chat is the OVERSEER, which has neither — it keeps its transcript in the
+// daemon's data dir and it takes words as a turn. So a session may carry a
+// DRIVER that names both, and the surface stays one surface: the same page,
+// the same SSE, the same composer, the same escalation overlay. That is what
+// "no second chat surface" costs — one seam, not a second server.
+//
 // IDENTITY (#151 — the deferral #74 item 6 restated is now CLOSED). Every
 // request, read and write alike, must carry a `Tailscale-User-Login` on the
 // allowlist and a Host this box actually serves (identity.mjs holds the
@@ -157,6 +165,14 @@ export class TimelineSurface {
       // harnessFor(session): the dispatcher's word, with detectHarness as the
       // on-disk fallback for re-adopted and lab sessions.
       harnessFor: (session) => detectHarness(this.#cfgDir(session)),
+      // driverFor(session): the #267 seam. Every session until now was a tmux
+      // pane, so the surface could read one config dir and write with
+      // send-keys. The console chat is the overseer, which has neither: it
+      // keeps its transcript in the daemon's own data dir and it takes words as
+      // a TURN rather than as keystrokes. A driver names both, and a session
+      // with no driver is a pane exactly as before.
+      //   { cfgDir, send(text) -> Promise, harness? }
+      driverFor: () => null,
       // escalationsFor(session): open escalation records for this agent.
       escalationsFor: () => [],
       // escalationHistoryFor(session): every escalation record for this
@@ -176,8 +192,22 @@ export class TimelineSurface {
     this.timer = null
   }
 
+  // A driven session (#267) or a pane. Read per call rather than cached: the
+  // set is fixed at construction, so this is a map lookup either way.
+  #driver(session) {
+    return this.deps.driverFor(session) ?? null
+  }
+
   #cfgDir(session) {
-    return path.join(this.workspaceRoot, 'cfg', session)
+    return this.#driver(session)?.cfgDir ?? path.join(this.workspaceRoot, 'cfg', session)
+  }
+
+  // The dispatcher's word is about agents it spawned, and it spawned no driven
+  // session — so a driver answers from its own config dir instead.
+  #harnessFor(session) {
+    const driver = this.#driver(session)
+    if (driver) return driver.harness ?? detectHarness(this.#cfgDir(session))
+    return this.deps.harnessFor(session)
   }
 
   // Bind the loopback listener. A port that will not bind (a foreign process
@@ -313,7 +343,7 @@ export class TimelineSurface {
     const s = this.#state(name)
     // The dispatcher's word wins; on-disk evidence covers sessions it never
     // spawned. Re-probed while null so a harness that appears later is picked up.
-    if (!s.harness) s.harness = this.deps.harnessFor(name)
+    if (!s.harness) s.harness = this.#harnessFor(name)
     if (!s.harness) return
     const file = findTranscript(s.harness, this.#cfgDir(name))
     if (file !== s.file) {
@@ -402,7 +432,7 @@ export class TimelineSurface {
   // The composer veto's regex, resolved through the same harness probe #pump
   // uses (the dispatcher's word, on-disk evidence as fallback).
   #composerRe(name, s) {
-    if (!s.harness) s.harness = this.deps.harnessFor(name)
+    if (!s.harness) s.harness = this.#harnessFor(name)
     return s.harness ? this.deps.composerFor(s.harness) : null
   }
 
@@ -431,6 +461,10 @@ export class TimelineSurface {
   }
 
   #pumpDialog(name, s) {
+    // A driven session has no pane to capture, so there is no dialog it could
+    // ever be in (#267). Probing one would ask tmux about a session that does
+    // not exist and read the failure as "indeterminate" forever.
+    if (this.#driver(name)) return
     const now = Date.now()
     if (s.dialogProbing || now - s.dialogAt < this.dialogProbeMs) return
     s.dialogProbing = true
@@ -553,6 +587,26 @@ export class TimelineSurface {
       if (!text.trim()) return json(400, { error: 'empty' })
       const s = this.#state(b.session)
       const by = b.client ?? null
+      // A driven session takes the words as a TURN (#267). There is no pane, so
+      // the #75 dialog guard has nothing to guard: it exists because keystrokes
+      // land wherever the pane's focus is, and a turn lands in exactly one
+      // place. The call runs to completion — an overseer turn is seconds, and
+      // the failure is the whole reason this waits: a turn that ends with no
+      // answer must reach the operator as words, not as silence on the page.
+      const driver = this.#driver(b.session)
+      if (driver) {
+        try {
+          await driver.send(text)
+        } catch (e) {
+          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'failed', error: e.message, text: clip(text) })
+          return json(502, { error: e.message })
+        }
+        this.deps.journal('timeline_send', { session: b.session, by, outcome: 'sent', text: clip(text) })
+        s.draft = ''
+        this.#broadcast(s, 'draft', { text: '', by })
+        this.#broadcast(s, 'sent', { text, by })
+        return json(200, { ok: true })
+      }
       // The #75 guard: fresh capture, positive evidence only. Typing into a
       // dialog answers it blind or vanishes without a trace — refusing keeps
       // the text in the composer, and the broadcast pins the banner on every
@@ -598,6 +652,13 @@ export class TimelineSurface {
       if (!key) return json(400, { error: 'unknown key' })
       const s = this.#state(b.session)
       const by = b.client ?? null
+      // No pane, no keys (#267). This is the one thing the console chat cannot
+      // do, and it says so rather than reporting a key nothing received: an
+      // overseer turn runs to its end, so there is nothing here to interrupt.
+      if (this.#driver(b.session)) {
+        this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_no_pane' })
+        return json(409, { error: `${b.session} is not a terminal — it takes words, and a turn runs to its end, so there is no key to send it` })
+      }
       if (!DIALOG_SAFE_KEYS.has(key)) {
         const dialog = await this.#probeDialog(b.session, s)
         if (dialog) {

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -16,7 +16,7 @@ import path from 'node:path'
 
 import {
   DashboardSurface, DEFAULT_DASHBOARD, DEFAULT_DASHBOARD_INDEX, DASHBOARD_PROTO,
-  loadDashboardConfig, pageRefusal, readDashboard, daemonPort, ANSWER_REFUSAL, MAX_WORDS,
+  loadDashboardConfig, pageRefusal, readDashboard, daemonPort, ANSWER_REFUSAL, MAX_WORDS, CHAT_PAGE,
 } from '../src/dashboard.mjs'
 import { loadCuriaConfig } from '../src/config.mjs'
 import { serveHosts, LOGIN_HEADER, FUNNEL_HEADER } from '../src/identity.mjs'
@@ -826,5 +826,146 @@ describe('the operator verbs (#266)', () => {
     const at = surface.snapshotAt
     await press('/api/start', { repo: 'not a repo', ticket: '1' })
     assert.equal(surface.snapshotAt, at)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// the chat (#267)
+// ---------------------------------------------------------------------------
+//
+// The console serves no chat of its own. It hands the timeline's own page and
+// the four routes that page speaks straight through to the daemon, under this
+// surface's address. What matters here is what the pipe does NOT do: it changes
+// no header, so the identity the timeline checks in-process is the identity the
+// browser sent, and it buffers nothing, so an event stream is still a stream.
+
+describe('the chat (#267)', () => {
+  let surface
+  let timeline
+  let seen // one entry per request the fake timeline received
+
+  const ALLOW = ['alp@example.com']
+  const SERVE_PORT = 8445
+  const ORIGIN = 'https://box.tail1234.ts.net:8445'
+  const served = (extra = {}) => ({ host: 'box.tail1234.ts.net:8445', [LOGIN_HEADER]: 'alp@example.com', ...extra })
+
+  async function makeSurface({ timelinePort }) {
+    const s = new DashboardSurface({
+      port: 0,
+      servePort: SERVE_PORT,
+      index: DEFAULT_DASHBOARD_INDEX,
+      allow: ALLOW,
+      pollIntervalS: 5,
+      timelinePort,
+      log: () => {},
+      deps: {
+        fetchOverview: async () => ({ daemon: { port: 4271 } }),
+        assertServe: async () => {},
+        serveOff: async () => {},
+        tailnetSelf: async () => ({ dnsName: 'box.tail1234.ts.net', ips: ['100.98.118.33'] }),
+      },
+    })
+    await s.start()
+    await s.resolveHosts()
+    return s
+  }
+
+  beforeEach(async () => {
+    seen = []
+    timeline = http.createServer((r, res) => {
+      let buf = ''
+      r.on('data', (d) => { buf += d })
+      r.on('end', () => {
+        seen.push({ method: r.method, url: r.url, headers: r.headers, body: buf })
+        if (r.url === '/') {
+          res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' })
+          return res.end('<meta name="curia-timeline" content="proto=3">')
+        }
+        if (r.url.startsWith('/events')) {
+          res.writeHead(200, { 'content-type': 'text/event-stream' })
+          return res.end('event: hello\ndata: {"session":"curia-overseer"}\n\n')
+        }
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: true }))
+      })
+    })
+    await new Promise((done) => timeline.listen(0, '127.0.0.1', done))
+    surface = await makeSurface({ timelinePort: timeline.address().port })
+  })
+
+  afterEach(() => {
+    surface?.stop()
+    timeline?.close()
+  })
+
+  test('/chat serves the timeline\'s own page — the daemon stamp-checks it, this pipe does not', async () => {
+    const res = await req(surface.port, '/chat?session=curia-overseer', { headers: served() })
+    assert.equal(res.status, 200)
+    assert.match(res.text, /name="curia-timeline"/)
+    assert.equal(seen.at(-1).url, '/', 'the page is one page; the session rides the browser\'s own query')
+  })
+
+  test('the four routes the page speaks reach the timeline with their query intact', async () => {
+    await req(surface.port, '/events?session=curia-overseer&client=ab12', { headers: served() })
+    assert.equal(seen.at(-1).url, '/events?session=curia-overseer&client=ab12')
+    for (const route of ['/send', '/draft', '/key']) {
+      await req(surface.port, route, {
+        method: 'POST',
+        headers: served({ origin: ORIGIN, 'content-type': 'application/json' }),
+        body: { session: 'curia-overseer', text: 'start 267' },
+      })
+      const last = seen.at(-1)
+      assert.equal(last.url, route)
+      assert.equal(JSON.parse(last.body).text, 'start 267', 'the words cross unread')
+    }
+  })
+
+  test('NOTHING is rewritten: the timeline judges the Host and the login the browser sent', async () => {
+    await req(surface.port, '/events?session=curia-overseer', { headers: served() })
+    const h = seen.at(-1).headers
+    assert.equal(h.host, 'box.tail1234.ts.net:8445')
+    assert.equal(h[LOGIN_HEADER], 'alp@example.com')
+  })
+
+  test('the identity gate runs FIRST — an unstamped request never reaches the timeline', async () => {
+    const res = await req(surface.port, '/chat', { headers: { host: 'box.tail1234.ts.net:8445' } })
+    assert.equal(res.status, 403)
+    assert.equal(seen.length, 0)
+  })
+
+  test('a write from another origin is refused here, before the pipe', async () => {
+    const res = await req(surface.port, '/send', {
+      method: 'POST',
+      headers: served({ origin: 'https://evil.example', 'content-type': 'application/json' }),
+      body: { session: 'curia-overseer', text: 'x' },
+    })
+    assert.equal(res.status, 403)
+    assert.equal(seen.length, 0)
+  })
+
+  test('a timeline that is not answering says so — the console itself is still up', async () => {
+    await new Promise((done) => timeline.close(done))
+    timeline = null
+    const res = await req(surface.port, '/chat', { headers: served() })
+    assert.equal(res.status, 502)
+    assert.match(res.text, /not answering/)
+    // the rest of the console is unharmed by a dead chat
+    assert.equal((await req(surface.port, '/api/overview', { headers: served() })).status, 200)
+  })
+
+  test('a sidecar with no timeline port says that, rather than guessing one', async () => {
+    const s2 = await makeSurface({ timelinePort: null })
+    try {
+      const res = await req(s2.port, '/chat', { headers: served() })
+      assert.equal(res.status, 503)
+      assert.match(res.text, /no `timeline:` block/)
+    } finally {
+      s2.stop()
+    }
+  })
+
+  test('the page and the sidecar agree on the address the Chat screen opens', () => {
+    const page = fs.readFileSync(DEFAULT_DASHBOARD_INDEX, 'utf8')
+    assert.match(page, new RegExp(`const CHAT_PAGE = "${CHAT_PAGE}"`))
   })
 })

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -848,3 +848,46 @@ describe('the operator verbs (#266)', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// the chat (#267)
+// ---------------------------------------------------------------------------
+//
+// The screen draws no message and frames nothing: the chat is the timeline
+// page, served at /chat. So what a test can pin is what the door SAYS — who is
+// behind it, where it goes, and that a daemon which is not answering is a chat
+// that is not there, because the overseer lives inside the daemon.
+
+describe('the chat screen (#267)', () => {
+  let page
+  before(() => { page = loadPage() })
+
+  test('the door names the overseer and opens the timeline at /chat', () => {
+    const html = page.screenChat(payload())
+    assert.match(html, /href="\/chat\?session=curia-overseer"/)
+    const t = text(html)
+    assert.match(t, /This is the overseer/)
+    assert.match(t, /every watched repo/)
+    assert.match(t, /curia-overseer/)
+  })
+
+  test('it states the one thing the overseer cannot do, rather than leaving it to be found', () => {
+    assert.match(text(page.screenChat(payload())), /no shell and no checkout/)
+  })
+
+  test('a daemon that is not answering is a chat that is not there, and says which', () => {
+    const p = payload()
+    p.daemon_up = false
+    p.error = 'connect ECONNREFUSED'
+    p.error_since = at(30)
+    const t = text(page.screenChat(p))
+    assert.match(t, /The chat is down while the daemon restarts/)
+    assert.match(t, /daemon restarting/, 'and the reading marker still says why')
+  })
+
+  test('the chat is a screen of the shell now, and no longer the one that lands later', () => {
+    const src = fs.readFileSync(DEFAULT_DASHBOARD_INDEX, 'utf8')
+    assert.match(src, /chat:\s*\["Chat",\s*screenChat\]/)
+    assert.doesNotMatch(text(page.screenChat(payload())), /#267/, 'the placeholder is gone')
+  })
+})

--- a/daemon/test/identity.test.mjs
+++ b/daemon/test/identity.test.mjs
@@ -16,7 +16,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import {
-  identityRefusal, serveHosts, IdentityProxy, LOGIN_HEADER, FUNNEL_HEADER,
+  identityRefusal, serveHosts, hostsForPorts, IdentityProxy, LOGIN_HEADER, FUNNEL_HEADER,
 } from '../src/identity.mjs'
 import { TimelineSurface, DEFAULT_TIMELINE_INDEX } from '../src/timeline.mjs'
 
@@ -64,6 +64,20 @@ describe('serveHosts: every name this box legitimately answers to (#151)', () =>
     const tl = serveHosts({ dnsName: 'box.tail1234.ts.net', ips: [], servePort: 8444 })
     assert.ok(tl.has('box.tail1234.ts.net:8444'))
     assert.ok(!tl.has('box.tail1234.ts.net:8443'))
+  })
+
+  // #267: the chat is the timeline, reached through the console's own address,
+  // so the timeline answers to two published ports now. It is still a closed
+  // set of names this box owns — which is the whole thing this check buys.
+  test('hostsForPorts admits every port that proxies to one surface, and nothing else', () => {
+    const self = { dnsName: 'box.tail1234.ts.net', ips: ['100.98.118.33'] }
+    const hosts = hostsForPorts(self, [8444, 8445])
+    assert.ok(hosts.has('box.tail1234.ts.net:8444'), 'its own published port')
+    assert.ok(hosts.has('box.tail1234.ts.net:8445'), 'and the console that serves the chat')
+    assert.ok(hosts.has('box:8445'), 'the short name on both')
+    assert.ok(hosts.has('100.98.118.33:8444'))
+    assert.ok(!hosts.has('box.tail1234.ts.net:8443'), 'never a port nobody proxies from')
+    assert.ok(!hosts.has('evil.example:8445'), 'and never a name this box does not answer to')
   })
 })
 

--- a/daemon/test/overseer.test.mjs
+++ b/daemon/test/overseer.test.mjs
@@ -12,8 +12,10 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { EscalationStore } from '../src/store.mjs'
 import { parseCommand } from '../src/commands.mjs'
+import { validSessionName } from '../src/attach.mjs'
 import {
   OverseerHost, canonicalFor, buildVerbTools, ALLOWED_TOOLS, DISALLOWED_TOOLS, SYSTEM_PROMPT,
+  CONSOLE_THREAD, CONSOLE_SESSION,
 } from '../src/overseer.mjs'
 
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'overseer-test-'))
@@ -518,5 +520,74 @@ describe('EscalationStore overseer sessions', () => {
     assert.equal(replayed.overseerSession('thread-1'), 'sess-2')
     const lines = fs.readFileSync(path.join(dir, 'events.jsonl'), 'utf8').trim().split('\n').map(JSON.parse)
     assert.equal(lines.filter((l) => l.type === 'overseer_session').length, 3)
+  })
+})
+
+// ---- the browser thread (#267) ----------------------------------------------
+//
+// The console chat is this same overseer in a thread of its own. What these
+// pin is the two things that differ, and why each one has to: the answer is not
+// posted, because the transcript already carries it to the page, and the verbs
+// run with no origin thread, because `console` is not a thread the bridge can
+// put buttons in.
+
+describe('the browser thread (#267)', () => {
+  test('it is one brain in a thread of its own: the conversation resumes on the console key', async () => {
+    const queryFn = scriptedQuery([init('sess-c1'), success('#267 is first')], [init('sess-c2'), success('started')])
+    const { host, store } = makeHost({ queryFn })
+    await host.browserTurn('what is next?')
+    assert.equal(store.overseerSession(CONSOLE_THREAD), 'sess-c1')
+    await host.browserTurn('start it')
+    assert.equal(queryFn.calls[1].options.resume, 'sess-c1', 'the second turn continues the first')
+  })
+
+  test('the verbs run with NO origin thread — a confirm goes where a REST press sends it', async () => {
+    const queryFn = scriptedQuery([init('sess-c1'), call('cancel', { ticket: '263' }), success('confirm posted')])
+    const seen = []
+    const { host } = makeHost({
+      queryFn,
+      command: async (text, ctx) => { seen.push({ text, ctx }); return 'ok' },
+    })
+    await host.browserTurn('cancel 263')
+    assert.equal(seen.at(-1).text, 'cancel 263')
+    assert.equal(seen.at(-1).ctx.threadId, null, 'there is no console thread for the bridge to post into')
+    assert.equal(seen.at(-1).ctx.interpreted, true, 'a model composed it, so the confirm still stands between it and the teardown')
+  })
+
+  test('the answer leaves by the transcript, not by this call — one fact, said once', async () => {
+    const queryFn = scriptedQuery([init('sess-c1'), success('all quiet')])
+    const { host } = makeHost({ queryFn })
+    const out = await host.browserTurn('what runs?')
+    assert.equal(out.ok, true)
+    // Nothing carries the words back here. The SDK wrote them to the session
+    // transcript, and the timeline tails that file (#74) — a second copy
+    // returned through this path would be the same fact said twice (ADR-0013).
+    assert.equal(JSON.stringify(out).includes('all quiet'), false)
+  })
+
+  test('the console session is a name the timeline admits', () => {
+    assert.ok(validSessionName(CONSOLE_SESSION), 'the surface refuses anything else')
+    assert.notEqual(CONSOLE_SESSION, CONSOLE_THREAD, 'the session is what the page names, the thread is what the conversation keys on')
+  })
+
+  test('a turn that ends without an answer throws its words, so the page can say them', async () => {
+    const queryFn = scriptedQuery([init('sess-c1'), failure('error_max_turns')], [init('sess-c1'), failure('error_max_turns')])
+    const { host } = makeHost({ queryFn })
+    await assert.rejects(() => host.browserTurn('loop forever'), /without an answer/)
+  })
+
+  test('one turn at a time: a second message while the first runs is refused in words', async () => {
+    let release
+    const held = new Promise((done) => { release = done })
+    const queryFn = ({ options }) => (async function* () {
+      yield init('sess-c1')
+      await held
+      yield success('done')
+    })(options)
+    const { host } = makeHost({ queryFn })
+    const first = host.browserTurn('slow one')
+    await assert.rejects(() => host.browserTurn('impatient'), /one turn at a time/)
+    release()
+    await first
   })
 })

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -382,6 +382,12 @@ describe('TimelineSurface', () => {
   let escHistory = []
   let pane = PANE_COMPOSER // what capturePane returns; a function to throw
   const workspaceRoot = () => path.join(tmp, 'work')
+  // The driven session (#267): the console chat is the overseer, whose
+  // transcript sits outside the workspace and whose composer is a turn.
+  const DRIVEN = 'curia-overseer'
+  const drivenCfg = () => path.join(tmp, 'overseer-config')
+  const turns = [] // every text handed to the driver
+  let turnFails = null // a message to throw from send()
 
   before(async () => {
     fs.mkdirSync(path.join(tmp, 'work', 'cfg'), { recursive: true })
@@ -406,6 +412,15 @@ describe('TimelineSurface', () => {
         assertServe: async () => {},
         serveOff: async () => {},
         attachBase: async () => 'box.tailnet.ts.net',
+        driverFor: (session) => (session === DRIVEN
+          ? {
+            cfgDir: drivenCfg(),
+            send: async (text) => {
+              if (turnFails) throw new Error(turnFails)
+              turns.push(text)
+            },
+          }
+          : null),
       },
     })
     const { verified } = await surface.start()
@@ -620,6 +635,78 @@ describe('TimelineSurface', () => {
       })
       assert.equal(d.up, true)
       assert.match(d.hint, /Enter to set as default/)
+    } finally {
+      pane = PANE_COMPOSER
+    }
+  })
+
+  // ---- the driven session: the console chat (#267) --------------------------
+  //
+  // One surface, two kinds of session. What these pin is that the difference
+  // stays where the driver is: the same page, the same stream, the same
+  // composer — and no tmux anywhere near it.
+
+  test('a driven session reads its transcript from the DRIVER\'s config dir, not the workspace', async () => {
+    const proj = path.join(drivenCfg(), 'projects', 'home')
+    fs.mkdirSync(proj, { recursive: true })
+    fs.writeFileSync(path.join(proj, 'console.jsonl'), [
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: 'what is next?' }] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: '#267 is first on the curia frontier' }] } }),
+    ].join('\n') + '\n')
+
+    const { events } = await sse(port, `session=${DRIVEN}`)
+    const hello = events.find((e) => e.event === 'hello')
+    assert.equal(hello.data.harness, 'claude', 'the harness is probed in the driver\'s own dir')
+    const items = events.filter((e) => e.event === 'items').flatMap((e) => e.data)
+    assert.ok(items.some((i) => i.kind === 'say' && /#267 is first/.test(i.text)))
+  })
+
+  test('a message to a driven session is a TURN — nothing reaches send-keys', async () => {
+    const before = sent.length
+    const r = await fetch(`http://127.0.0.1:${port}/send`, {
+      method: 'POST', body: JSON.stringify({ session: DRIVEN, text: 'start 267' }),
+    })
+    assert.equal(r.status, 200)
+    assert.equal(turns.at(-1), 'start 267')
+    assert.equal(sent.length, before, 'tmux is not in this path at all')
+    const j = journal.findLast((x) => x.type === 'timeline_send')
+    assert.equal(j.session, DRIVEN)
+    assert.equal(j.outcome, 'sent')
+  })
+
+  test('a turn that ends without an answer comes back as WORDS, never as silence', async () => {
+    turnFails = 'the turn ended without an answer (max turns)'
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/send`, {
+        method: 'POST', body: JSON.stringify({ session: DRIVEN, text: 'anything' }),
+      })
+      assert.equal(r.status, 502)
+      assert.match((await r.json()).error, /without an answer/)
+      const j = journal.findLast((x) => x.type === 'timeline_send')
+      assert.equal(j.outcome, 'failed')
+    } finally {
+      turnFails = null
+    }
+  })
+
+  test('a key is refused on a driven session, and the refusal says why', async () => {
+    const r = await fetch(`http://127.0.0.1:${port}/key`, {
+      method: 'POST', body: JSON.stringify({ session: DRIVEN, key: 'escape' }),
+    })
+    assert.equal(r.status, 409)
+    assert.match((await r.json()).error, /not a terminal/)
+    const j = journal.findLast((x) => x.type === 'timeline_key')
+    assert.equal(j.outcome, 'refused_no_pane')
+  })
+
+  test('the dialog guard never asks tmux about a session that has no pane', async () => {
+    pane = () => { throw new Error('capturePane must not run for a driven session') }
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/send`, {
+        method: 'POST', body: JSON.stringify({ session: DRIVEN, text: 'still fine' }),
+      })
+      assert.equal(r.status, 200)
+      assert.equal(turns.at(-1), 'still fine')
     } finally {
       pane = PANE_COMPOSER
     }


### PR DESCRIPTION
Ticket: alp82/curia#267 — [The chat embeds the timeline attach](https://github.com/alp82/curia/issues/267)

The Chat screen is the timeline attach of the overseer's browser thread, served under the console's own address. No iframe and no second chat surface.

- **overseer**: `browserTurn` runs a turn on the `console` thread key. One brain answers Discord and the browser. The answer is not posted — the SDK transcript carries it to the page, so one fact is said once (ADR-0013). The verbs run with no origin thread, so a confirm takes the route a REST press takes and lands in the channel and on Home.
- **timeline**: a session may carry a DRIVER, which names its own config dir and takes a message as a turn rather than as keystrokes. No pane means no dialog guard and no key, and both refusals say why.
- **sidecar**: `/chat` and the four routes the timeline page speaks, piped to the daemon. Every header travels unchanged, so the timeline applies the identity check in-process to the evidence the browser sent.
- **daemon**: the timeline's host allowlist admits the console's published names. That is what lets the pipe rewrite nothing.

1661 tests pass.

---

Dispatched by the curia daemon — session `curia-267`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `4363f95` The chat is the overseer, on the timeline (wayfinder #267)