### PR TITLE
The domain doc still defines the nudge that #261 deleted (alp82/curia#294)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -254,8 +254,9 @@ The answer rule. The first valid answer closes the escalation atomically. Any de
 **Supersede**:
 A re-asked question closes the older record and routes late answers to the live one.
 
-**Nudge**:
-The half-hour re-post of an open escalation into its thread.
+**Render retry**:
+The escalation's own second try at a Discord render that failed (#261). It runs at 1 minute, 5 minutes and 15 minutes after the record opened, then never again. The offsets count from `esc_open`, not from the failure, so a restart re-arms only the tries still ahead. After the last one the record stays open and REST-answerable, and the dashboard shows it either way.
+_Avoid_: nudge (the half-hour re-post of an open escalation, deleted whole by #261).
 
 **Bridge**:
 The Discord module. It renders and captures. It never interprets.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ CURIA_AGENT_GH_TOKEN_<OWNER>=<a fine-grained GitHub PAT>
 - `DISCORD_ALLOWED_USERS` is the whole access check. Everyone on it can send agents at your repos.
 - `CURIA_AGENT_GH_TOKEN_<OWNER>` is what an agent uses to reach GitHub. Without it the agent inherits your own `gh` login, which is your whole account. Mint one [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) per resource owner you watch, with **Contents**, **Issues** and **Pull requests** read/write plus **Commit statuses** read. Put the owner in the key, uppercased: `alp82/curia` reads `CURIA_AGENT_GH_TOKEN_ALP82`.
 
-Optional: `CURIA_GUILD_ID`, `CURIA_CHANNEL` (default `curia`), `PORT` (4271), `NUDGE_MS` (30 min),
+Optional: `CURIA_GUILD_ID`, `CURIA_CHANNEL` (default `curia`), `PORT` (4271),
 `OVERSEER_MODEL`, `OVERSEER_FALLBACK_MODEL`.
 
 Run one daemon per bot token.

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -279,7 +279,7 @@ export class Dispatcher {
     this.overseerNote = overseerNote ?? (() => {})
     // askReview(agent, ticket, promptText) → { text, status } — the review gate
     // (#54 item 2), injected by index.mjs on the same escalation machinery every
-    // ask_human uses, so first-valid-wins, the ~30-min re-nudge, the MCP
+    // ask_human uses, so first-valid-wins, the bounded render retry, the MCP
     // keepalive and restart survival all come free. Absent in tests that never
     // reach the gate.
     this.askReview = askReview ?? (async () => ({ text: 'reject', status: 'answered' }))

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -468,10 +468,9 @@ function curiaMcpUrl(daemonPort, agent, ticket, host = LOOPBACK) {
 //
 // A day, not a literal infinity: codex wants a number, and this is the one place
 // #11's "blocks for as long as the human takes" is bounded. It is ~3x the
-// longest real block on record (7 h 53 m, #56), the ~30-min re-nudge keeps
-// running underneath it, and a block that outlives it re-dispatches rather than
-// resolving anything (#11/#12). The keepalive stays on for the claude harness and
-// costs nothing here.
+// longest real block on record (7 h 53 m, #56), and a block that outlives it
+// re-dispatches rather than resolving anything (#11/#12). The keepalive stays on
+// for the claude harness and costs nothing here.
 const CODEX_TOOL_TIMEOUT_S = 86_400
 
 // The Stop hook, identical on both harnesses: POST the hook's own stdin payload to


### PR DESCRIPTION
Ticket: alp82/curia#294 — [The domain doc still defines the nudge that #261 deleted](https://github.com/alp82/curia/issues/294)

`CONTEXT.md` defined **Nudge**, the half-hour re-post that [#261](https://github.com/alp82/curia/issues/261) deleted whole. It never defined the bounded render retry that replaced it. So the "Human in the loop" block held a name with no thing, and left the real thing unnamed.

## What changed

- **`CONTEXT.md`** — delete **Nudge**, add **Render retry** in its place. The entry states the 1m/5m/15m schedule, why the offsets count from `esc_open` (a restart re-arms only the tries still ahead), and what holds after the last try. An `_Avoid_: nudge` line keeps the dead word out.
- **`README.md`** — drop `NUDGE_MS` from the optional env vars. Nothing reads it.
- **`daemon/src/workspace.mjs`** — a comment said the ~30-min re-nudge keeps running under the codex tool timeout. It does not.
- **`daemon/src/dispatch.mjs`** — a comment listed the re-nudge among what the review gate gets free. Now it names the render retry.

The two code edits are comment text only.

## The rest of the block

Checked every other entry in "Human in the loop" against the daemon. All hold:

| Entry | Checked against |
| --- | --- |
| ask_human kinds | `index.mjs:1001` |
| Round, `recommended`, ✅ button | `bridge.mjs:1095`, `index.mjs:1008` |
| Held clear, two minutes | `CLEAR_DELAY_MS = 120_000` |
| Settling, 2 per 10 minutes | `RENAME_LIMIT`, `RENAME_WINDOW_MS` |
| Ask now, a few seconds | `INTERRUPT_GRACE_MS = 5_000` |
| Parked, start notice, verdict carrier | `dispatch.mjs`, `resolve.mjs` |
| First-valid-wins, supersede | `dashboard.mjs`, `bridge.mjs:1384` |

The daemon suite is green: 1666 pass, 0 fail, 0 cancelled.

Resolves #294

---

Dispatched by the curia daemon — session `curia-294`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `261d69f` The nudge leaves the domain doc, and the render retry takes its place