### PR TITLE
A charting session burns down its research tickets (alp82/curia#297)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,7 +48,13 @@ The act that gives a new-map dispatch its map. The agent calls `map_created` wit
 
 **Charting agent**:
 The agent of a map dispatch. It edits the map and its tickets, and it never closes the map. On a new-map dispatch it creates the map first.
-Ruled by #286 and **not built yet**: it also burns down the research tickets it just created, one `/research` subagent each, and takes the ordinary ending for them: one pull request on `curia/<map>`, the review gate, the merge, then the close. It resolves nothing else. Until that build merges, the daemon still refuses `open_pull_request` and `request_review` on a map dispatch.
+It also burns down the research tickets it just created, one `/research` subagent each. For those tickets it takes the ordinary ending: one pull request on `curia/<map>`, the review gate, the merge, then the close. It resolves nothing else, and it closes nothing before the merge.
+
+**Burn-down**:
+What a charting session does with the research tickets it just created. One `/research` subagent per ticket, claimed before its subagent starts and released if that subagent fails. Every subagent works in the charting agent's own worktree, writes one note under `docs/research/`, and never runs git. The charting agent commits once, writes the index rows itself, and reads the findings together before the gate.
+
+**Charting write bound**:
+`docs/research/` and nothing else on disk. The charting worktree is writable, narrowed to that one directory. Curia refuses a pull request from a charting agent whose branch touches any other file.
 
 **Instruction**:
 The operator's sentence on a map dispatch, in their own words. It rides the `map` verb last, and reaches the charting agent as the first thing it reads. It needs no separator: the arguments come first, and the sentence runs from the first plain word to the end of the line. On an existing map it is optional: with none, the agent asks what should change. On a new map it is mandatory, because nothing else says what to chart. No other verb takes one.
@@ -73,6 +79,7 @@ The assignee on a ticket. A claim removes the ticket from every frontier. The da
 
 **Map lock**:
 What stops a second charting agent from editing one map body: the session name. A charting agent on map #147 is `curia-147`, and `map 147` is refused while that session lives. The check asks tmux, so it survives a daemon restart. It is per box, and there is one box.
+A charting session that researched holds this lock, and an agent slot, through its whole review. Charting is no longer a fast act. The operator accepted that price ([ADR-0008](docs/adr/0008-resolved-means-merged.md)).
 
 **Watched repo**:
 A repo on the watch list in `config/curia.yaml`. Curia dispatches only against watched repos.
@@ -307,10 +314,10 @@ The ordered close-out of a ticket: commit, pull request, preview, review gate, m
 The one CuriaBot message that ends a ticket thread. In small print, it merges what the tracker step did with what the session teardown did. It carries no bare link. The agent's own report is the message before it, and that report is where the pull request unfurls. See [ADR-0013](docs/adr/0013-one-voice-per-fact.md).
 
 **Charting ending**:
-The ending of a map dispatch: edit the map, then report the result. Curia posts the summary on the map. No unassign, no pull request, no review gate, no close.
+The ending of a map dispatch. It forks on one fact: did the session write a file? A session that wrote none ends on two steps. It edits the map, then it reports the result. A session whose research subagents wrote findings takes the ordinary ending for them: commit, pull request, review gate, merge, then close those research tickets. The Stop hook holds a session whose findings sit uncommitted under `docs/research/`, because an uncommitted file dies with the workspace. Curia posts the summary on the map either way. That comment states whether the findings reached the default branch. No unassign, and the map itself never closes.
 
 **New-map ending**:
-The charting ending with one step in front: create the map, adopt it with `map_created`, then report the result. The Stop hook holds the agent to the adoption, because it is the one fact the daemon cannot read for itself.
+The charting ending with one step in front: create the map, adopt it with `map_created`, then report the result. The Stop hook holds the agent to the adoption, because it is the one fact the daemon cannot read for itself. Its research tickets land the same way a map dispatch's do.
 
 **Stop hook**:
 The enforcement hook that fires at the end of every agent turn. It refuses a stop that leaves ending steps open, up to the stop budget, then lets go and reports the ticket unfinished.

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -32,7 +32,8 @@ import {
   createPrivateClone, removeWorkspace,
   removeConfigDir, removeCredentials, createReviewCheckout, reviewPathFor, writeReviewPrompt,
   seedConfigDir, writeConnectionSettings, writePrompt, worktreePathFor, cfgDirFor,
-  branchFor, defaultBranchOf, commitsOnBranch, pushBranch, hasUnpushedWork, agentEnv,
+  branchFor, defaultBranchOf, commitsOnBranch, changedFilesOnBranch, uncommittedFiles,
+  pushBranch, hasUnpushedWork, agentEnv,
   untrustedProjectConfig, plantedSkills,
 } from './workspace.mjs'
 import { ensureAgentImage } from './image.mjs'
@@ -183,8 +184,17 @@ const DEFAULT_DEPS = {
   // resolve + land (#41), merge-gated (#54)
   commentIssue, closeIssue, setIssueBody, issueComments, findPullRequest, createPullRequest,
   setPullRequestBody, deleteRemoteBranch,
-  defaultBranchOf, commitsOnBranch, pushBranch, hasUnpushedWork,
+  defaultBranchOf, commitsOnBranch, changedFilesOnBranch, uncommittedFiles, pushBranch, hasUnpushedWork,
 }
+
+// The one directory a charting session may write (#297, ADR-0008). Its research
+// subagents put one note each under here, and the agent writes the index row
+// beside them — nothing else on disk is a charting output.
+//
+// It is a curia path, said once, in the daemon that watches curia. A watched
+// repo that keeps its research notes somewhere else needs this widened, and
+// the refusal it drives says so plainly enough for an operator to act on.
+export const CHARTING_WRITE_PREFIX = 'docs/research/'
 
 // How many trailing pane lines the two pane classifiers are allowed to see.
 const PANE_TAIL_LINES = 20
@@ -2204,6 +2214,24 @@ export class Dispatcher {
     return { w, ticket, repo, wtPath, branch: branchFor(ticket) }
   }
 
+  // The files a charting branch carries that a charting session is not allowed
+  // to write (#297). Empty means the branch is clean by this bound.
+  //
+  // Fails OPEN: a diff curia could not read drops the check rather than trapping
+  // an agent whose findings would then have no way to land at all. The human
+  // gate still stands in front of the merge, and the failure is journalled — so
+  // the worst case here is one unenforced bound, loudly, not a lost session.
+  async #strayChartingPaths(wtPath) {
+    try {
+      const files = await this.deps.changedFilesOnBranch(wtPath, await this.deps.defaultBranchOf(wtPath))
+      return files.filter((f) => !f.startsWith(CHARTING_WRITE_PREFIX))
+    } catch (e) {
+      this.store.logEvent('charting_paths_unread', { wtPath, error: e.message })
+      this.log(`charting path check on ${wtPath} failed (${e.message}) — not refusing the push`)
+      return []
+    }
+  }
+
   // `open_pull_request` (#54 item 1). Landing left report_result because the
   // pull request is now what a human reviews BEFORE anything is resolved — so it
   // has to be openable in the middle of a ticket, and re-openable after every
@@ -2219,15 +2247,39 @@ export class Dispatcher {
     const b = this.#bindingFor(agentName)
     if (b.error) return `❌ ${b.error} — nothing was pushed`
     const { w, ticket, repo, wtPath, branch } = b
-    // #160: a map dispatch produces tracker writes, not code. Refused rather
-    // than left to the prompt, because this call PUSHES — and a charting agent
-    // that has misread its own kind must not be one tool call away from putting
-    // a branch on the remote.
-    if (this.#epochCharting(ticket, agentName).charting) {
-      this.store.logEvent('charting_tool_refused', { repo, ticket, agent: agentName, tool: 'open_pull_request' })
-      return `❌ \`${agentName}\` is a CHARTING agent on map ${repo}#${ticket}. A map dispatch opens no pull request: your work is the map itself, and it is already written. Update the map, then call report_result.`
-    }
     if (!fs.existsSync(wtPath)) return `❌ the worktree ${wtPath} is gone — nothing was pushed`
+    // #297, ADR-0008: a charting agent may push now — its research subagents
+    // write files, and a pull request on `curia/<map>` is what keeps those
+    // findings off main until a human approves them. What it may NOT push is
+    // anything else. The bound is enforced HERE rather than left to the prompt,
+    // for the reason the refusal it replaces was: this call pushes, and a
+    // charting agent that has misread its own bounds must not be one tool call
+    // away from putting daemon code on the remote.
+    const mapDispatch = this.#epochCharting(ticket, agentName).charting
+    // Which issue this pull request BELONGS to, for its body and its link
+    // comment. On a map dispatch that is the map — and on a new-map dispatch the
+    // bound ticket is a chat handle, which is no issue at all, so a body built
+    // from it would carry a link that 404s. The JOURNAL keeps the bound ticket
+    // either way: every epoch reader is keyed by it.
+    const onIssue = mapDispatch ? (this.#chartedMap(agentName, ticket, w) ?? ticket) : ticket
+    if (mapDispatch) {
+      const stray = await this.#strayChartingPaths(wtPath)
+      if (stray.length) {
+        this.store.logEvent('charting_push_refused', {
+          repo, ticket, agent: agentName, tool: 'open_pull_request', paths: stray,
+        })
+        return [
+          `❌ \`${agentName}\` is a CHARTING agent on map ${repo}#${onIssue}, and a charting session commits`,
+          `research findings and nothing else. \`${branch}\` touches ${stray.length} file(s) outside`,
+          `\`${CHARTING_WRITE_PREFIX}\`:`,
+          ...stray.slice(0, 10).map((p) => `- ${p}`),
+          ...(stray.length > 10 ? [`- …and ${stray.length - 10} more`] : []),
+          '',
+          'Nothing was pushed. Take those files back out of the branch and call this again. If the map you',
+          'were sent to chart really needs one of them changed, that is an `ask_human` call, not a commit.',
+        ].join('\n')
+      }
+    }
 
     let title = w?.title
     if (!title) {
@@ -2236,7 +2288,7 @@ export class Dispatcher {
     let out
     try {
       out = await landBranch({
-        repo, ticket, title, summary, agent: agentName, model: w?.model ?? null,
+        repo, ticket, onIssue, title, summary, agent: agentName, model: w?.model ?? null,
         wtPath, branch, deps: this.deps,
         journal: (type, data) => this.store.logEvent(type, data),
       })
@@ -2249,9 +2301,9 @@ export class Dispatcher {
       return `❌ nothing to open a pull request from — \`${branch}\` carries no commits. Commit your work first.`
     }
     if (w) w.prUrl = out.url
-    await this.deps.commentIssue(repo, ticket, prLinkComment({
+    await this.deps.commentIssue(repo, onIssue, prLinkComment({
       branch, commits: out.commits, url: out.url, state: out.state,
-    })).catch((e) => this.log(`pull-request comment on ${repo}#${ticket} failed: ${e.message}`))
+    })).catch((e) => this.log(`pull-request comment on ${repo}#${onIssue} failed: ${e.message}`))
     this.notify(ticket, `🔗 \`${agentName}\` ${out.state === 'updated' ? 'updated' : 'opened'} <${out.url}> (${out.commits} commit${out.commits === 1 ? '' : 's'} on \`${branch}\`)`)
     return `${out.state === 'updated' ? 'updated' : 'opened'} ${out.url} — ${out.commits} commit${out.commits === 1 ? '' : 's'} pushed on \`${branch}\`. Next: request_review.`
   }
@@ -2271,17 +2323,12 @@ export class Dispatcher {
     const b = this.#bindingFor(agentName)
     if (b.error) return { ok: false, text: `❌ ${b.error} — no review was requested` }
     const { w, ticket, repo, branch } = b
-    // #160/#149: no review gate on a map dispatch. The gate exists to put a
-    // human in front of a DIFF before it merges; a charting agent has no diff,
-    // and the operator who dispatched it is the check. Opening one here would
-    // block the agent on a question with nothing to look at.
-    if (this.#epochCharting(ticket, agentName).charting) {
-      this.store.logEvent('charting_tool_refused', { repo, ticket, agent: agentName, tool: 'request_review' })
-      return {
-        ok: false,
-        text: `❌ \`${agentName}\` is a CHARTING agent on map ${repo}#${ticket}, and a map dispatch has no review gate — there is no pull request to show and nothing to merge. The operator who dispatched you is the check. Finish the map edits and call report_result; ask_human is how you reach them with a question.`,
-      }
-    }
+    // #297, ADR-0008: the gate is open to a charting agent now. #160 refused it
+    // because a charting agent had no diff — that stopped being true when #286
+    // gave the session research subagents that write files. The map edits are
+    // still ungated (nothing stages them, and #149 put the operator there
+    // instead); what this gate judges is the FINDINGS, and the heading says so.
+    const mapDispatch = this.#epochCharting(ticket, agentName).charting
 
     // #237: the gate must not open blind to a cross-check. A live reviewer on
     // this ticket means a verdict is coming, and the builder asking for a gate
@@ -2320,7 +2367,19 @@ export class Dispatcher {
     }
 
     const title = w?.title ?? `#${ticket}`
-    const links = [`Ticket: https://github.com/${repo}/issues/${ticket}`]
+    // #297: on a map dispatch the issue to look at is the MAP. For `map <n>`
+    // that is the bound ticket itself; for a new-map dispatch the bound ticket
+    // is a chat handle, which is no issue at all — so the link comes from what
+    // the session adopted, and a session that adopted nothing gets a line
+    // saying so rather than a URL that 404s.
+    const map = mapDispatch ? this.#chartedMap(agentName, ticket, w) : null
+    const links = [
+      mapDispatch
+        ? (map
+          ? `Map: https://github.com/${repo}/issues/${map}`
+          : '_This session has created no map yet — read the thread._')
+        : `Ticket: https://github.com/${repo}/issues/${ticket}`,
+    ]
     let pr = null
     try {
       pr = await this.deps.findPullRequest(repo, branch)
@@ -2333,10 +2392,10 @@ export class Dispatcher {
     const preview = this.previews?.get(ticket)
     if (preview?.url) links.push(`Preview: ${preview.url}`)
 
-    const { text } = reviewGateText({ repo, ticket, title, summary, charting, links })
+    const { text } = reviewGateText({ repo, ticket: map ?? ticket, title, summary, charting, links, mapDispatch })
     this.store.logEvent('review_requested', {
       repo, ticket, agent: agentName, pr: pr?.url ?? w?.prUrl ?? null,
-      preview: preview?.url ?? null,
+      preview: preview?.url ?? null, ...(mapDispatch ? { kind: 'charting' } : {}),
     })
     if (w) w.state = 'awaiting-review'
     const { text: answer, status } = await this.askReview(agentName, ticket, text)
@@ -2357,10 +2416,20 @@ export class Dispatcher {
     // the diff and hold the builder here until that model has read it.
     if (crossCheck) return await this.#runCrossCheck(agentName, { repo, ticket, w })
     if (approved) {
+      // #297: the ORDER is the answer to #48, and this is where it is said at
+      // the moment it matters. A charting agent closes research tickets, never
+      // the map — and it closes them after the merge, never before, because a
+      // ticket closed on unmerged findings is exactly the map that lies.
       return {
         ok: true,
         approved: true,
-        text: `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`), then resolve the ticket, then report_result.`,
+        text: mapDispatch
+          ? [
+            `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`),`,
+            'then resolve each research ticket you burned down — comment, close, map line — then report_result.',
+            'Nothing closes before the merge, and the map itself never closes.',
+          ].join('\n')
+          : `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`), then resolve the ticket, then report_result.`,
       }
     }
     return {
@@ -2554,7 +2623,11 @@ export class Dispatcher {
     if (this.#isReviewer(agentName)) return null
     const ticket = String(this.agents.get(agentName)?.ticket ?? String(agentName).match(SESSION_RE)?.[1] ?? '')
     if (!ticket) return null
-    if (this.#epochCharting(ticket, agentName).charting) return null
+    // #297 dropped the charting exemption that stood here. It was sound while a
+    // charting agent could not reach the gate — no gate, no press, no verdict.
+    // Now it can, so a charting session whose park a restart severed must be
+    // held by the same rule as any other. A session with no cross-check falls
+    // straight through the next line, which is every charting session there was.
     if (!this.#crossCheckInFlight(ticket)) return null
 
     const w = this.agents.get(agentName)
@@ -2596,7 +2669,8 @@ export class Dispatcher {
     if (this.#isReviewer(agentName)) return null
     const ticket = String(this.agents.get(agentName)?.ticket ?? String(agentName).match(SESSION_RE)?.[1] ?? '')
     if (!ticket) return null
-    if (this.#epochCharting(ticket, agentName).charting) return null
+    // #297: the charting exemption goes here too, and for the same reason —
+    // a gate a charting agent can open is a cross-check it can earn.
     if (this.#crossCheckInFlight(ticket)) {
       this.store.logEvent('result_refused', { ticket, agent: agentName, reason: 'cross-check in flight' })
       return [
@@ -2803,11 +2877,11 @@ export class Dispatcher {
       newMap: this.#epochCharting(ticket, agentName).newMap,
       mapAdopted: Boolean(this.#chartedMap(agentName, ticket, w)),
     }
-    // A charting agent has one daemon-visible step, and it is not in git or on
-    // GitHub — so the reads below are skipped whole. The Stop hook fires at the
-    // end of every turn, and a `git log` against a checkout that will never
-    // carry a commit is pure cost.
-    if (state.charting) return state
+    // #297 removed the charting shortcut that used to return here. A charting
+    // checkout CAN carry commits now — its research subagents write findings —
+    // so the same reads decide the same steps for both endings, and `hasCommits`
+    // is what forks them. The cost is one `git log` per turn on a session that
+    // wrote nothing, against the failure it buys: findings pushed by nobody.
     // #237: the two cross-check states the ending must name, so the Stop hook
     // holds a builder that stops instead of judging. A PARKED builder never
     // reaches this read (#humanBlockEvidence answers first); the builder that
@@ -2819,6 +2893,20 @@ export class Dispatcher {
       state.hasCommits = commits.length > 0
     } catch (e) {
       this.log(`stop hook ${agentName}: could not read commits on ${branch} (${e.message}) — not asking for a pull request`)
+    }
+    // #297: the one charting-only read. A charting session is the only agent
+    // whose ENDING branches on whether it wrote anything at all, and "no
+    // commits" cannot tell a session that researched nothing from one that
+    // wrote findings and never committed them. The second dies with the
+    // workspace, silently, which is the whole failure this ending exists to
+    // stop — so the Stop hook asks git what is sitting there.
+    if (state.charting) {
+      try {
+        const dirty = await this.deps.uncommittedFiles(wtPath)
+        state.uncommittedFindings = dirty.some((f) => f.startsWith(CHARTING_WRITE_PREFIX))
+      } catch (e) {
+        this.log(`stop hook ${agentName}: could not read the worktree status (${e.message}) — not asking for a commit`)
+      }
     }
     if (state.reviewApproved && state.prOpened) {
       try {
@@ -3070,15 +3158,20 @@ export class Dispatcher {
     return text
   }
 
-  // The map dispatch's whole ending (#160, narrowed by #221). Two acts now:
+  // The map dispatch's whole ending (#160, narrowed by #221, widened by #297):
   //
   //   1. COMMENT — curia posts the agent's summary on the map, so the change
   //      has a dated record beside the body it changed. The ticket path only
   //      comments as a repair; here it is the point.
-  //   2. Nothing else. No unclaim (#221 took the claim away, so there is
-  //      nothing to release), no close, no Decisions-so-far line, no branch,
-  //      no merge check. A map is the standing artifact, and closing it would
-  //      take the whole effort off every frontier.
+  //   2. SAY WHAT LANDED — since #297 a charting session can carry findings on
+  //      a branch, so the comment states whether they reached the default
+  //      branch. A session that pushed and never got them merged is named as
+  //      such, in the same voice `resolved_unreviewed` uses on the ticket path:
+  //      the daemon cannot undo it, and it refuses to hide it.
+  //   3. Nothing else. No unclaim (#221 took the claim away, so there is
+  //      nothing to release), no close, and no Decisions-so-far line. The
+  //      research tickets are the AGENT's to resolve — it created them, it read
+  //      the findings, and curia has no expected value for either.
   //
   // The map edits themselves are NOT verified or repaired here, and cannot be:
   // curia has no expected value for a charting session, which is the same reason
@@ -3100,11 +3193,15 @@ export class Dispatcher {
     // one has nowhere to post, and that is said out loud rather than failing
     // quietly against an issue called `chat-1`.
     const map = this.#chartedMap(agentName, ticket, w)
+    const landing = await this.#chartingLanding(agentName, repo, ticket)
+    if (landing.unreviewed) {
+      this.store.logEvent('charting_unreviewed', { repo, map: map ?? null, ticket, agent: agentName })
+    }
     let noted = false
     if (map) {
       try {
         await this.deps.commentIssue(repo, map, chartingComment({
-          agent: agentName, model: w?.model ?? null, instruction, result,
+          agent: agentName, model: w?.model ?? null, instruction, result, landing,
         }))
         noted = true
       } catch (e) {
@@ -3119,13 +3216,52 @@ export class Dispatcher {
       // #221: nothing to unassign — the dispatch never claimed the map.
       'the map was never claimed',
       map ? 'the map stays open' : 'nothing on the tracker was touched by curia',
+      landing.line,
     ]
     const what = map ? `${repo}#${map}` : `the new map in ${repo}`
     this.store.logEvent('charting_finished', {
       repo, map: map ?? null, ticket, agent: agentName, status: result.status, commented: noted,
+      pr: landing.url ?? null, pr_state: landing.state ?? null,
       summary: `${clean ? '🗺️' : '↩️'} ${what} charted (**${result.status}**) — ${bits.join('; ')}. Nobody reviewed these map edits: read them.`,
     })
-    return `charting recorded — ${bits.join('; ')}. Nothing was closed, resolved or pushed.`
+    return `charting recorded — ${bits.join('; ')}. Nothing was closed by curia, and the map stays open.`
+  }
+
+  // What this charting session put on a branch, and how far it got (#297).
+  //
+  // Read from curia's OWN records, never from the agent's account: the journal
+  // says whether a pull request was opened under this dispatch and whether a
+  // human approved at the gate, and GitHub says whether the branch merged. The
+  // three answers are what makes the map comment evidence.
+  //
+  // A session that pushed nothing is the common case and answers in one line
+  // with no network call at all.
+  async #chartingLanding(agentName, repo, ticket) {
+    const { prOpened, reviewApproved } = this.#epochScan(ticket, agentName)
+    if (!prOpened) return { landed: false, unreviewed: false, line: 'nothing was pushed' }
+    let pr = null
+    try {
+      pr = await this.deps.findPullRequest(repo, branchFor(ticket))
+    } catch (e) {
+      this.log(`charting landing for ${repo}#${ticket}: pull-request read failed (${e.message})`)
+    }
+    const state = pr?.state ?? null
+    const merged = state === 'MERGED'
+    return {
+      landed: true,
+      merged,
+      approved: reviewApproved,
+      // The #48 shape, said out loud: findings a human never approved, or
+      // approved and never merged, resolve no research ticket.
+      unreviewed: !reviewApproved || !merged,
+      url: pr?.url ?? null,
+      state,
+      line: merged
+        ? (reviewApproved
+          ? 'the research findings are merged'
+          : '⚠️ the research findings were MERGED WITHOUT an approved review gate')
+        : `⚠️ the research findings are on a pull request that is ${state ? `**${state}**` : 'in an unknown state'} — NOT in the default branch`,
+    }
   }
 
   // ---- adoption: the daemon learns the new map's number (#241) -----------------

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -99,35 +99,105 @@ export const ENDING = [
   },
 ]
 
-// ---- the charting ending (#160) ----------------------------------------------
+// ---- the charting ending (#160, grown by #297 out of #286 and ADR-0008) ------
 //
-// A map dispatch has a different ending, because it produces a different thing.
-// A ticket agent's output is CODE, so the ending is the merge gate: pull
-// request → review → merge → resolve. A charting agent's output is the MAP
-// ITSELF — issue bodies and child issues on the tracker — which is inside an
-// agent's ordinary write bounds and cannot be staged in a branch at all. There
-// is nothing to push, so there is nothing for a review gate to show, and #149
-// settled the trade: no gate, an operator in the loop, and the strongest model.
+// A map dispatch produces a different thing from a ticket one. Its first output
+// is the MAP ITSELF — issue bodies and child issues on the tracker — which is
+// inside an agent's ordinary write bounds and cannot be staged in a branch at
+// all. There is nothing to push and nothing for a review gate to show, and #149
+// settled that trade: no gate, an operator in the loop, and the strongest model.
 //
-// So four steps of ENDING are not merely skipped here — they are refused
-// (dispatch.mjs turns `open_pull_request` and `request_review` down for a
-// charting agent). What is left is the map edit, and the one call that ends
-// every dispatch.
+// #286 gave the same session a SECOND output. Version 1.2 of the wayfinder
+// skill ends charting by firing a `/research` subagent per research ticket it
+// just created, and those subagents write files. The old reasoning — no branch
+// to stage it in, nothing for a pull request to carry — is false whenever they
+// do. So the ending forks on one fact: did this session produce any file?
+//
+//   no files   edit the map, then `report_result` — the two steps #160 shipped.
+//   files      commit → open_pull_request → request_review → merge → close the
+//              research tickets → `report_result`. ADR-0008 in full: resolved
+//              means merged for a research ticket exactly as for any other, and
+//              the close comes AFTER the merge, which is the #48 failure.
+//
+// The fork lives in the `todo`s, never in the list. Every step below is prose
+// the agent reads, and `hasCommits` decides which of them the Stop hook holds it
+// to — so a session that wrote nothing is still held to `report_result` alone.
 //
 // The summary comment is deliberately NOT a step. The daemon posts it from the
 // `report_result` summary (see chartingComment in resolve.mjs), for the same
 // reason the review gate composes its own links: a record curia writes from its
 // own knowledge of what happened is evidence, and one the agent writes about
-// itself is an account. It also keeps the Stop-hook checklist off a `gh` read
-// at the end of every turn.
+// itself is an account.
+
+// The five landing steps a charting session owes ONLY when it produced files
+// (#297). Shared by both charting endings, because a new-map session fires the
+// same research subagents the moment it creates the tickets.
+const CHARTING_LANDING = [
+  {
+    key: 'commit',
+    prose: ({ branch }) => [
+      `If your research subagents wrote findings, commit them locally on \`${branch}\` — the notes under`,
+      '`docs/research/` and the index rows you wrote for them, and no other file. Never `git push`: curia',
+      'pushes for you. A session that wrote no file skips this step and the four below it.',
+    ],
+    // The one step of this ending the daemon CAN see without a commit: a
+    // finding sitting uncommitted in the worktree dies with the workspace, and
+    // "no commits" alone reads exactly like a session that researched nothing.
+    todo: (s) => (s.uncommittedFindings
+      ? 'commit the research findings sitting uncommitted under `docs/research/` — a file no commit holds dies with this workspace. Delete the ones that should not land'
+      : null),
+  },
+  {
+    key: 'pr',
+    prose: () => [
+      'If you committed anything, call `open_pull_request`. curia pushes the branch and opens the pull',
+      'request. Call it again after later commits — it updates the same pull request.',
+    ],
+    todo: (s) => (s.hasCommits && !s.prOpened
+      ? 'call `open_pull_request` — your branch holds commits that are in no pull request yet'
+      : null),
+  },
+  {
+    key: 'review',
+    prose: () => [
+      'Call `request_review`: what you charted, what the research found, and any contradiction between two',
+      'findings. It blocks until a human answers. A rejection comes back as their own words — fix, commit,',
+      'call `open_pull_request` again, then `request_review` again. The loop has no limit.',
+    ],
+    todo: (s) => (s.hasCommits && !s.reviewApproved
+      ? 'call `request_review` and get an approval — findings nobody approved resolve no research ticket'
+      : null),
+  },
+  {
+    key: 'merge',
+    prose: ({ repo }) => [
+      `Only after the approval: merge it — \`gh pr merge <url> --repo ${repo} --squash --delete-branch\`.`,
+      'This is the one write to the remote you own, and it is limited to what the human just approved.',
+    ],
+    todo: (s) => (s.hasCommits && s.reviewApproved && s.prOpened && s.prState === 'OPEN'
+      ? 'merge the approved pull request — a research ticket is not resolved until its findings are in the default branch'
+      : null),
+  },
+  {
+    key: 'close',
+    prose: () => [
+      'Only after the merge: resolve each research ticket you burned down — its resolution comment, its',
+      'close, then its line in the map\'s Decisions so far. Never close one before the merge: a ticket',
+      'closed on unmerged findings makes the map state an answer no branch carries (#48).',
+    ],
+  },
+]
+
 export const CHARTING_ENDING = [
   {
     key: 'chart',
     prose: ({ repo, ticket }) => [
       `Update the map: edit ${repo}#${ticket}'s body, and create, edit or close its child tickets.`,
-      'Those tracker writes ARE the work. Nothing here is staged, reviewed or merged.',
+      'Those tracker writes ARE the work, and nothing stages them. Burn down the research tickets you',
+      'create in the same session, one `/research` subagent each.',
     ],
   },
+  ...CHARTING_LANDING,
   {
     key: 'report',
     prose: () => [
@@ -168,6 +238,9 @@ export const NEW_MAP_ENDING = [
     ],
     todo: (s) => (s.mapAdopted ? null : 'create the `wayfinder:map` issue, then call `map_created` with its number'),
   },
+  // #297: a new-map session creates research tickets too, so it owes the same
+  // landing when its subagents wrote files.
+  ...CHARTING_LANDING,
   {
     key: 'report',
     prose: () => [
@@ -181,15 +254,24 @@ export const NEW_MAP_ENDING = [
 // What a charting agent must NOT do — one bullet per entry, its own lines.
 // Prose only: the refusals themselves live in dispatch.mjs, and this is the
 // copy the model reads.
+//
+// #297 inverted the second bullet. The gate is now this session's, for the
+// findings its subagents wrote — and what has to be said instead is the two
+// bounds that gate does not carry: whose tickets these are, and when they may
+// close.
 export const CHARTING_NEVER = [
   ['Never close the map. It is the standing artifact, not a ticket you resolve.'],
   [
-    'Never call `open_pull_request` or `request_review`, and never merge anything. curia refuses both',
-    'calls on a map dispatch. There is no review gate here: the operator who dispatched you is the check.',
+    'Resolve NOTHING you did not create. The research tickets you burned down in this session are yours',
+    'to close. Every other child of this map belongs to its own dispatch, whatever you learned about it.',
   ],
   [
-    'The resolve protocol — resolution comment, close, Decisions-so-far line — belongs to a TICKET',
-    "agent. Do not run it, and do not resolve any of the map's children yourself.",
+    'Never close a research ticket before the merge. Its findings are an answer only once they are in',
+    'the default branch, and a close ahead of that makes the map lie (#48).',
+  ],
+  [
+    'Commit nothing but the findings. `docs/research/` is the only directory a charting session writes,',
+    'and curia refuses a pull request that touches any other file.',
   ],
 ]
 
@@ -299,9 +381,16 @@ export function stopReason(items, { attempt, budget }) {
 // charting it proposes. #49: that proposal must be CONCRETE in the thread text
 // — ticket titles, the lines to be removed — or approval from a phone degrades
 // to a rubber stamp and the agent holds full map authority with no gate at all.
-export function reviewGateText({ repo, ticket, title, summary, charting, links }) {
+//
+// #297: a charting session reaches this gate too, and the question it asks is
+// NOT the map's. Approving research findings never says the map is done, so the
+// heading says what is being approved — the map stays open either way, and a
+// heading that implied otherwise would be the one thing #160 forbids.
+export function reviewGateText({ repo, ticket, title, summary, charting, links, mapDispatch = false }) {
   const parts = [
-    `**Is ${repo}#${ticket} done?** — ${title}`,
+    mapDispatch
+      ? `**Approve the research findings charted on ${repo}#${ticket}?** — ${title}`
+      : `**Is ${repo}#${ticket} done?** — ${title}`,
     '',
     '**What the agent did**',
     summary.trim() || '(nothing said)',

--- a/daemon/src/overseer.mjs
+++ b/daemon/src/overseer.mjs
@@ -119,7 +119,7 @@ export function buildVerbTools(command) {
       repo: repoArg,
       model: z.string().optional().describe('model override — the harness follows it, so there is no harness argument'),
     }, run('start')),
-    tool('map', 'Dispatch a charting agent. WITH a map number it UPDATES that map: add tickets, graduate fog, change scope, fix what the map says. WITHOUT one it charts a NEW map: the agent settles the destination and the scope with the operator, then creates the `wayfinder:map` issue itself — use that form when the operator asks for a map that does not exist yet ("make a map for the next feature"), and put their words in the instruction. It closes nothing either way.', {
+    tool('map', 'Dispatch a charting agent. WITH a map number it UPDATES that map: add tickets, graduate fog, change scope, fix what the map says. WITHOUT one it charts a NEW map: the agent settles the destination and the scope with the operator, then creates the `wayfinder:map` issue itself — use that form when the operator asks for a map that does not exist yet ("make a map for the next feature"), and put their words in the instruction. It never closes the map either way, and the only tickets it closes are the research ones it burned down itself.', {
       ticket: ticketArg.optional(),
       // #255: with a map number the repo is any unambiguous part of the name,
       // as everywhere else. With NO number the repo rides in front of a plain

--- a/daemon/src/resolve.mjs
+++ b/daemon/src/resolve.mjs
@@ -157,18 +157,32 @@ export function nonCleanComment({ agent, result, released }) {
 // The map is never closed and its `## Decisions so far` is never touched here.
 // That section indexes the route walked — one line per RESOLVED ticket — and a
 // charting session walks no step of it.
-export function chartingComment({ agent, model, instruction, result }) {
+// `landing` is what the session put on a branch (#297, ADR-0008). A charting
+// session that burned down research tickets carries findings, and the footer
+// says where they got to — merged, or sitting on a pull request nobody merged.
+// The daemon reads that from its own journal and from GitHub, so the sentence
+// is evidence rather than the agent's account of itself.
+export function chartingComment({ agent, model, instruction, result, landing = null }) {
   const clean = result.status === 'resolved'
+  const landed = landing?.landed
   return [
     `## ${clean ? 'Charting' : `Charting — **${result.status}**`} (curia session \`${agent}\`)`,
     '',
     ...(instruction ? ['The operator asked for:', '', `> ${instruction}`, ''] : ['Dispatched with no instruction.', '']),
     result.summary ?? '(no summary)',
     '',
+    ...(landed
+      ? [
+        landing.merged
+          ? `**The research findings are merged.** ${landing.url ? `Pull request: ${landing.url}. ` : ''}${landing.approved ? 'A human approved them at the review gate.' : '⚠️ NOBODY approved them at the review gate.'}`
+          : `⚠️ **The research findings are NOT in the default branch.** ${landing.url ? `Pull request (**${landing.state ?? '?'}**): ${landing.url}. ` : ''}Any research ticket closed on them is closed on an answer no branch carries — check them.`,
+        '',
+      ]
+      : []),
     '---',
     '',
     clean
-      ? `_A map dispatch: this session edited the map and its tickets. It opened no pull request and closed nothing. Model \`${model ?? '?'}\`._`
+      ? `_A map dispatch: this session edited the map and its tickets. It closed no ticket but the research ones it burned down itself, and it never closes the map. Model \`${model ?? '?'}\`._`
       : `_The charting agent stopped with status **${result.status}**. Whatever it had already written to the map STANDS — read the changes above before you dispatch another one. Model \`${model ?? '?'}\`._`,
   ].join('\n')
 }
@@ -261,12 +275,18 @@ export function prLinkComment({ branch, commits, url, state }) {
   ])
 }
 
-export function prBody({ repo, ticket, title, summary, commits, agent, model }) {
+// `onIssue` is the issue this pull request belongs to, which is the ticket for
+// every dispatch but a charting one (#297): a map dispatch's work belongs to
+// its map, and a new-map dispatch's bound "ticket" is a chat handle that no
+// issue answers to. It never changes what is journalled — the journal is keyed
+// by the bound ticket everywhere.
+export function prBody({ repo, ticket, onIssue = null, title, summary, commits, agent, model }) {
+  const n = onIssue ?? ticket
   return [
     // deliberately NOT a closing keyword: the agent closes the ticket itself
     // after the merge, and "Resolves #n" on top of that reads as if the merge
     // did it
-    `Ticket: ${repo}#${ticket} — [${title}](https://github.com/${repo}/issues/${ticket})`,
+    `Ticket: ${repo}#${n} — [${title}](https://github.com/${repo}/issues/${n})`,
     '',
     summary ?? '(no summary)',
     '',
@@ -295,7 +315,7 @@ export function prBody({ repo, ticket, title, summary, commits, agent, model }) 
 // repo whose dispatches are all sandboxed has private clones and no base clone
 // at all (#238). A worktree answers too, through its shared common dir.
 export async function landBranch({
-  repo, ticket, title, summary, agent, model, wtPath, branch, deps, journal,
+  repo, ticket, onIssue = null, title, summary, agent, model, wtPath, branch, deps, journal,
 }) {
   const defaultBranch = await deps.defaultBranchOf(wtPath)
   const commits = await deps.commitsOnBranch(wtPath, defaultBranch)
@@ -306,7 +326,7 @@ export async function landBranch({
   const sha = await deps.pushBranch(wtPath, repo, branch)
   journal('branch_pushed', { repo, ticket, agent, branch, sha, commits: commits.length })
 
-  const body = prBody({ repo, ticket, title, summary, commits, agent, model })
+  const body = prBody({ repo, ticket, onIssue, title, summary, commits, agent, model })
   const existing = await deps.findPullRequest(repo, branch)
   if (existing && existing.state === 'OPEN') {
     await deps.setPullRequestBody(repo, existing.number, body)
@@ -314,7 +334,7 @@ export async function landBranch({
     return { ok: true, state: 'updated', url: existing.url, number: existing.number, commits: commits.length, branch }
   }
   const url = await deps.createPullRequest(repo, {
-    head: branch, base: defaultBranch, title: `${title} (${repo}#${ticket})`, body,
+    head: branch, base: defaultBranch, title: `${title} (${repo}#${onIssue ?? ticket})`, body,
   })
   journal('pr_opened', { repo, ticket, agent, branch, url, commits: commits.length })
   return { ok: true, state: 'opened', url, commits: commits.length, branch }

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -146,6 +146,29 @@ export async function commitsOnBranch(wtPath, defaultBranch) {
   })
 }
 
+// Which FILES the branch touches, against the same merge base (#297). The
+// charting bound is a path bound — `docs/research/` and nothing else — and this
+// is the observation it is checked against. Read from git rather than from the
+// agent, for the reason `commitsOnBranch` above is.
+export async function changedFilesOnBranch(wtPath, defaultBranch) {
+  const { stdout } = await git(wtPath, ['diff', '--name-only', `origin/${defaultBranch}...HEAD`])
+  return stdout.split('\n').map((l) => l.trim()).filter(Boolean)
+}
+
+// What the worktree holds that no commit does (#297): tracked edits and
+// untracked files alike, as paths. The Stop hook reads it for a charting
+// session, because a finding a subagent wrote and nobody committed dies with
+// the workspace — and "no commits" alone cannot tell that case from a session
+// that researched nothing.
+export async function uncommittedFiles(wtPath) {
+  const { stdout } = await git(wtPath, ['status', '--porcelain'])
+  return stdout.split('\n').filter((l) => l.trim()).map((l) => {
+    const p = l.slice(3).trim()
+    // a rename reads `old -> new`; the new name is the one on disk
+    return p.includes(' -> ') ? p.split(' -> ').pop().trim() : p
+  })
+}
+
 // KEPT by #195, which named this for deletion and then measured it. Both
 // callers are #54 repairs in resolve.mjs — `landBranch` when the agent never
 // called `open_pull_request`, and the unmerged-at-resolve push — and neither is
@@ -1062,6 +1085,38 @@ export function writeConnectionSettings({
   })
 }
 
+// The burn-down doctrine both charting dispatches carry (#297, ADR-0008).
+//
+// Version 1.2 of the wayfinder skill ends charting by firing a `/research`
+// subagent per research ticket it just created. The operator took that shape
+// whole, so a charting session now produces FILES as well as issues — and
+// several of the skill's details do not survive the move into one worktree,
+// which is what this block says. It rides the prompt rather than the skill file:
+// `skills/` is upstream's bytes, pinned in UPSTREAM.md, and an edit there would
+// hide curia's deviation in a tree whose whole point is that a bump shows up as
+// a diff.
+const researchParams = ({ repo, branch }) => [
+  '- **The research tickets you create, you burn down in THIS session.** One `/research` subagent per',
+  '  `wayfinder:research` ticket you just created, in parallel. This is the skill\'s "Fire the research',
+  '  subagents" step, with the changes below. A research ticket you did NOT create is not yours: leave it',
+  '  alone.',
+  `- **There is no \`research/<name>\` branch.** Every subagent works in this worktree, on \`${branch}\`. A`,
+  '  pull request on that branch already keeps unreviewed findings off the default branch, which is the',
+  '  whole job the skill bought those branches for.',
+  '- **A subagent writes files and NEVER runs git.** No commit, no branch, no push, no `gh`. You commit,',
+  '  once, yourself. N agents in one worktree race on one index.',
+  '- **One subagent writes one file**: `docs/research/<name>.md`, its own. YOU write every row of',
+  '  `docs/research/README.md`, after the findings land. One index edited by N writers is N conflicts.',
+  `- **Claim each research ticket before its subagent starts**: \`gh issue edit <n> --repo ${repo}`,
+  '  --add-assignee @me`. Release it with `--remove-assignee @me` if that subagent fails. Without the',
+  '  claim a concurrent `start` dispatches the same ticket to a second agent.',
+  '- **Read the findings TOGETHER before you open the pull request.** Each subagent read its own ticket',
+  '  alone and saw no other, so two of them can disagree. State any contradiction you found in the',
+  '  `request_review` summary, and let the operator decide what happens to it.',
+  '- **A research ticket you did not burn down stays on the frontier** — one charted in an earlier',
+  '  session, one whose subagent failed. Leave it open and unclaimed, and say so in your summary.',
+]
+
 // Prompt file lives in the config dir, not the worktree.
 //
 // It supplies PARAMETERS, NOT PROCEDURE (#49 decision 2). Since #57 every agent
@@ -1196,6 +1251,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     `  > ${instruction ?? '(nothing)'}`,
     '',
     '  This is the loose idea, not a specification. It is where the grilling starts.',
+    ...researchParams({ repo, branch }),
   ]
 
   const chartingParams = [
@@ -1219,6 +1275,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
         '- **No instruction rode this dispatch.** Do not guess what should change. Your FIRST act is one',
         '  `ask_human` call: what should change on this map? Then work from the answer.',
       ]),
+    ...researchParams({ repo, branch }),
   ]
 
   const params = newMap ? newMapParams : charting ? chartingParams : [
@@ -1257,19 +1314,30 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   const bounds = [
     '- **Read anything.** Zoom into any issue, map, sibling or closed ticket you need. Nothing here limits',
     '  reading.',
+    // #297: the charting worktree is writable now, and narrowed to one
+    // directory. Its research subagents write findings there, and a pull
+    // request on this branch is what holds them off the default branch until a
+    // human approves. Everything else on disk stays out of bounds, and curia
+    // refuses the push rather than trusting the sentence.
     ...(newMap
       ? [
-        `- **Write only:** the ONE \`wayfinder:map\` issue you create in ${repo}, and its child tickets.`,
-        '  Nothing else on the tracker — no existing issue is yours to edit, whatever you find while',
-        `  reading. And nothing on disk: ${wtPath} is a read-only checkout to you. A charting session`,
-        '  produces no code, no commit and no branch.',
+        `- **Write only:** the ONE \`wayfinder:map\` issue you create in ${repo}, and its child tickets;`,
+        `  the research findings under \`${wtPath}/docs/research/\`; and the one merge a human has just`,
+        '  approved. Nothing else on the tracker — no existing issue is yours to edit, whatever you find',
+        '  while reading.',
+        '- **No other file on disk.** `docs/research/` is the only directory a charting session writes.',
+        '  curia refuses a pull request that touches any other file, so a change you think the code needs',
+        '  is an `ask_human` call, never a commit.',
         "- Do not rewrite anyone else's text.",
       ]
       : charting
       ? [
-        `- **Write only:** the map ${repo}#${n} and its child tickets. Nothing else on the tracker, and`,
-        `  nothing on disk: ${wtPath} is a read-only checkout to you. A map dispatch produces no code, no`,
-        '  commit and no branch.',
+        `- **Write only:** the map ${repo}#${n} and its child tickets; the research findings under`,
+        `  \`${wtPath}/docs/research/\`; and the one merge a human has just approved. Nothing else on the`,
+        '  tracker.',
+        '- **No other file on disk.** `docs/research/` is the only directory a charting session writes.',
+        '  curia refuses a pull request that touches any other file, so a change you think the code needs',
+        '  is an `ask_human` call, never a commit.',
         "- Do not rewrite anyone else's text. A section you did not write is edited, not replaced.",
       ]
       : [
@@ -1380,9 +1448,17 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
       '  the thread is renamed to it, `map <n>` on it is refused while you run, and your final summary',
       '  lands there. Call it once, and never before the issue exists.',
     ] : []),
+    // #297: two tools a map dispatch used to be refused. It gets them when its
+    // research subagents wrote something — and only then. A session that
+    // produced no file has nothing to push and nothing to show.
+    '- `open_pull_request` — curia pushes your branch and opens or updates the pull request. You never',
+    '  push. Only for research findings you committed.',
+    '- `request_review` — the one gate, and it judges the FINDINGS. curia shows the human the pull',
+    '  request and the map, and blocks until they approve or reject. **You never write a link yourself.**',
+    '  A rejection comes back as their own words: fix, commit, `open_pull_request` again, ask again.',
     '- `report_result` — exactly once, at the very end. Its summary becomes curia\'s comment on the map.',
-    '- `open_pull_request`, `request_review` and `publish_preview` belong to a ticket dispatch. curia',
-    '  refuses the first two on a map dispatch, and there is nothing here to preview.',
+    '- `publish_preview` belongs to a ticket dispatch. A research note is read as a diff, so there is',
+    '  nothing here to preview.',
   ] : [
     '- `ask_human` — a decision you cannot make alone. Blocks until a human answers, for as long as it',
     '  takes.',
@@ -1407,7 +1483,10 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   // #165, ADR-0010: the gate's third button. The builder is told this at spawn
   // time and told it again in the tool result that hands it the verdict, because
   // the press can land days into a ticket and this prompt may be far behind.
-  const crossCheck = charting ? [] : [
+  // #297: a charting agent reads this too now. The gate it can open is the gate
+  // the third button sits on, so a session that skipped this section would meet
+  // a cross-check verdict with no word for what it is.
+  const crossCheck = [
     '',
     '## The cross-check (a third button on the gate)',
     '',
@@ -1415,8 +1494,9 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     'operator presses it to put a reviewer on the OTHER provider onto your diff. It answers nothing:',
     'nothing merges and nothing is rejected.',
     '',
-    'The press does not end your `request_review` call. You stay in it, idle, holding your claim and your',
-    'worktree, while the reviewer reads. The call then returns with the verdict, and this is your duty:',
+    'The press does not end your `request_review` call. You stay in it, idle. Your worktree, your session',
+    'and whatever you claimed stay with you while the reviewer reads. The call then returns with the',
+    'verdict, and this is your duty:',
     '',
     ...dutyLines(),
     '',

--- a/daemon/test/crosscheck.test.mjs
+++ b/daemon/test/crosscheck.test.mjs
@@ -645,10 +645,15 @@ describe('the builder\'s duty, in its standing orders (#165)', () => {
     assert.match(p, /`gh` commands in your own shell/, 'the two acts curia holds no wire on')
   })
 
-  test('a charting agent is told none of it — it has no gate to press a button on', () => {
+  test('a charting agent is told all of it too — #297 gave it a gate to press a button on', () => {
+    // It used to be told none of this, because a map dispatch could open no
+    // gate. #286 gave the session research findings, ADR-0008 gave those
+    // findings the ordinary ending, and the third button sits on that gate — so
+    // a charting agent that met a verdict with no word for one would be the
+    // #223 shape again.
     const p = write({ mapNumber: 1, charting: true })
-    assert.ok(!p.includes('The cross-check (a third button on the gate)'))
-    assert.ok(!p.includes(CROSS_CHECK_DUTY[0][0]))
+    assert.match(p, /## The cross-check \(a third button on the gate\)/)
+    for (const line of dutyLines()) assert.ok(p.includes(line), `missing duty line: ${line}`)
   })
 
   test('one copy: the prompt and the tool result render the same list', () => {

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -239,20 +239,61 @@ describe('the charting prompt', () => {
     assert.ok(!p.includes('the whole brief'))
   })
 
-  test('the ending has no pull request, no review and no merge — and says so', () => {
+  // #297: the ending grew. It used to end at "edit the map, then
+  // report_result", and the two tools were refused outright. A session whose
+  // research subagents wrote findings takes the ordinary ending for them.
+  test('the ending carries the pull request, the gate and the merge — for the findings', () => {
     const p = write({ charting: true, instruction: 'x' })
     const ending = p.slice(p.indexOf('## How this ends'))
     assert.match(ending, /Update the map/)
     assert.match(ending, /Never close the map/)
-    assert.match(ending, /curia refuses both/)
-    assert.ok(!/Only after the approval: merge it/.test(ending), 'the merge step leaked into a map dispatch')
-    assert.ok(!/request_review`: a summary of what you did/.test(ending), 'the review step leaked into a map dispatch')
+    assert.match(ending, /open_pull_request/)
+    assert.match(ending, /request_review/)
+    assert.match(ending, /Only after the approval: merge it/)
+    assert.ok(!/curia refuses both/.test(ending), 'the old refusal survived the invert')
   })
 
-  test('the write bounds are the map and its children, and nothing on disk', () => {
+  test('the ending says a session that wrote no file skips all of it', () => {
+    // The two-step ending #160 shipped is still the answer for a charting
+    // session that researched nothing, and the prose has to say which it is.
+    const ending = write({ charting: true, instruction: 'x' }).slice(0)
+    assert.match(ending, /A session that wrote no file skips this step and the four below it/)
+  })
+
+  test('the ending orders the close AFTER the merge, and never before', () => {
+    const p = write({ charting: true, instruction: 'x' })
+    const ending = p.slice(p.indexOf('## How this ends'))
+    assert.match(ending, /Only after the merge: resolve each research ticket you burned down/)
+    assert.match(ending, /Never close one before the merge/)
+    assert.ok(ending.indexOf('Only after the approval: merge it') < ending.indexOf('Only after the merge: resolve'),
+      'the close is listed ahead of the merge')
+  })
+
+  test('the write bounds are the map, its children and docs/research — nothing else on disk', () => {
     const p = write({ charting: true, instruction: 'x' })
     assert.match(p, /\*\*Write only:\*\* the map o\/r#147 and its child tickets/)
-    assert.match(p, /read-only checkout/)
+    assert.match(p, /\/w\/147\/docs\/research\//)
+    assert.match(p, /curia refuses a pull request that touches any other file/)
+    assert.ok(!p.includes('read-only checkout'), 'the charting worktree is writable now')
+  })
+
+  test('the burn-down doctrine rides the prompt: no branch, no git, one index writer, a claim each', () => {
+    const p = write({ charting: true, instruction: 'x' })
+    assert.match(p, /One `\/research` subagent per/)
+    assert.match(p, /There is no `research\/<name>` branch/)
+    assert.match(p, /A subagent writes files and NEVER runs git/)
+    assert.match(p, /YOU write every row of\n\s*`docs\/research\/README\.md`/)
+    assert.match(p, /Claim each research ticket before its subagent starts/)
+    assert.match(p, /--remove-assignee @me` if that subagent fails/)
+    assert.match(p, /Read the findings TOGETHER before you open the pull request/)
+  })
+
+  test('the two tools are listed for a charting agent, and publish_preview is not', () => {
+    const p = write({ charting: true, instruction: 'x' })
+    const tools = p.slice(p.indexOf('## Your tools'), p.indexOf('## How this ends'))
+    assert.match(tools, /- `open_pull_request`/)
+    assert.match(tools, /- `request_review`/)
+    assert.match(tools, /nothing here to preview/)
   })
 
   test('an ordinary ticket prompt is untouched by any of it', () => {
@@ -305,7 +346,15 @@ describe('the new-map prompt (#241)', () => {
     const ending = p.slice(p.indexOf('## How this ends'))
     assert.match(ending, /map_created/)
     assert.match(ending, /report_result/)
-    assert.ok(!/Only after the approval: merge it/.test(ending))
+  })
+
+  test('a new-map session takes the same landing — it fires the same research subagents (#297)', () => {
+    const ending = write().slice(write().indexOf('## How this ends'))
+    assert.match(ending, /open_pull_request/)
+    assert.match(ending, /Only after the approval: merge it/)
+    assert.match(ending, /Only after the merge: resolve each research ticket/)
+    assert.ok(ending.indexOf('map_created') < ending.indexOf('open_pull_request'),
+      'the adoption must still come before the landing')
   })
 
   test('map_created is listed as a tool, and only here', () => {
@@ -316,11 +365,12 @@ describe('the new-map prompt (#241)', () => {
     assert.ok(!fs.readFileSync(onAMap, 'utf8').includes('map_created'))
   })
 
-  test('the write bound is the ONE map it creates, and no existing issue', () => {
+  test('the write bound is the ONE map it creates, plus docs/research and no other file', () => {
     const p = write()
     assert.match(p, /the ONE `wayfinder:map` issue you create in o\/r/)
     assert.match(p, /no existing issue is yours to edit/)
-    assert.match(p, /read-only checkout/)
+    assert.match(p, /\/w\/chat-1\/docs\/research\//)
+    assert.ok(!p.includes('read-only checkout'), 'the charting worktree is writable now')
   })
 
   test('it is told to create NO map when the grilling shows none is needed', () => {
@@ -339,11 +389,35 @@ describe('the new-map prompt (#241)', () => {
 // ---- the ending (#149 point 3) ------------------------------------------------
 
 describe('the charting checklist', () => {
-  test('a charting agent is only ever held for report_result', () => {
-    // The state below would put THREE items on a ticket agent's checklist.
-    const state = { hasResult: false, hasCommits: true, prOpened: false, reviewApproved: false, prState: null }
-    assert.equal(outstanding({ ...state, charting: false }).length, 3)
+  // #297: the checklist forks on ONE fact — did this session write a file? A
+  // charting agent that researched nothing keeps the two-step ending #160
+  // shipped, and one that produced findings is held to the whole merge gate.
+  test('a charting session that wrote NO file is only ever held for report_result', () => {
+    const state = { hasResult: false, hasCommits: false, prOpened: false, reviewApproved: false, prState: null }
     assert.deepEqual(outstanding({ ...state, charting: true }), ['call `report_result` exactly once'])
+  })
+
+  test('a charting session WITH commits is held to the pull request, the gate and the merge', () => {
+    const commits = { hasResult: false, hasCommits: true, prOpened: false, reviewApproved: false, prState: null, charting: true }
+    assert.deepEqual(outstanding(commits), [
+      'call `open_pull_request` — your branch holds commits that are in no pull request yet',
+      'call `request_review` and get an approval — findings nobody approved resolve no research ticket',
+      'call `report_result` exactly once',
+    ])
+    const approved = { ...commits, prOpened: true, reviewApproved: true, prState: 'OPEN' }
+    assert.deepEqual(outstanding(approved), [
+      'merge the approved pull request — a research ticket is not resolved until its findings are in the default branch',
+      'call `report_result` exactly once',
+    ])
+  })
+
+  test('a new-map session forks the same way, and still owes the adoption', () => {
+    const base = { newMap: true, charting: true, hasResult: false, mapAdopted: false, prState: null }
+    assert.deepEqual(outstanding({ ...base, hasCommits: false }), [
+      'create the `wayfinder:map` issue, then call `map_created` with its number',
+      'call `report_result` exactly once',
+    ])
+    assert.equal(outstanding({ ...base, mapAdopted: true, hasCommits: true }).length, 3)
   })
 
   test('a reported result ends both endings, whatever its status', () => {
@@ -353,9 +427,34 @@ describe('the charting checklist', () => {
 
   test('the charting ending states no step the daemon cannot see', () => {
     // Every `todo` is a step the Stop hook will block on, so a step with no
-    // evidence behind it would trap the agent. Only `report` has one.
-    assert.deepEqual(CHARTING_ENDING.filter((s) => s.todo).map((s) => s.key), ['report'])
+    // evidence behind it would trap the agent. The map edit and the close are
+    // prose: curia has no expected value for either.
+    assert.deepEqual(CHARTING_ENDING.filter((s) => s.todo).map((s) => s.key), ['commit', 'pr', 'review', 'merge', 'report'])
     assert.ok(ENDING.filter((s) => s.todo).length > 1, 'the ticket ending should still have several')
+  })
+
+  test('a finding written and never committed holds the stop — it would die with the workspace', () => {
+    const items = outstanding({ charting: true, hasResult: false, hasCommits: false, uncommittedFindings: true })
+    assert.match(items[0], /commit the research findings sitting uncommitted/)
+    assert.match(items[0], /Delete the ones that should not land/)
+  })
+
+  test('the Stop hook asks the worktree, and only about docs/research', async () => {
+    // #194: an agent that never opened its tool channel is not held at any
+    // ending, so the fixture states the channel the real path would have.
+    const chartLive = async (deps) => {
+      const d = makeDispatcher(deps)
+      await d.chart('147')
+      d.agents.get('curia-147').mcpSeenAt = Date.now()
+      return d
+    }
+    const held = await (await chartLive({ uncommittedFiles: async () => ['docs/research/acp.md', 'notes.txt'] })).onStopHook('curia-147')
+    assert.equal(held.decision, 'block')
+    assert.match(held.reason, /commit the research findings sitting uncommitted/)
+
+    const out = await (await chartLive({ uncommittedFiles: async () => ['notes.txt'] })).onStopHook('curia-147')
+    assert.equal(out.decision, 'block', 'the report_result step should still hold it')
+    assert.ok(!/commit the research findings/.test(out.reason), 'a file outside docs/research held the stop')
   })
 })
 
@@ -380,7 +479,8 @@ describe('report_result on a map dispatch', () => {
     assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')), 'a charting agent closed the map')
     assert.ok(!calls.some((c) => String(c).startsWith('setBody')), 'curia wrote a Decisions-so-far line for a charting session')
     assert.ok(!calls.includes('pushBranch') && !calls.includes('createPullRequest'), 'a charting session landed code')
-    assert.match(text, /Nothing was closed, resolved or pushed/)
+    assert.match(text, /Nothing was closed by curia, and the map stays open/)
+    assert.match(text, /nothing was pushed/)
   })
 
   test('the summary comment carries the operator\'s instruction and the model', async () => {
@@ -389,7 +489,7 @@ describe('report_result on a map dispatch', () => {
     assert.ok(body, 'the comment body is not a charting comment')
     assert.match(body, /curia session `curia-147`/)
     assert.match(body, /did the thing/)
-    assert.match(body, /opened no pull request and closed nothing/)
+    assert.match(body, /it never closes the map/)
   })
 
   test('a blocked charting agent says the edits stand, and still claims nothing', async () => {
@@ -409,6 +509,44 @@ describe('report_result on a map dispatch', () => {
     assert.ok(!events.some((e) => e.type === 'ticket_resolved'))
   })
 
+  // #297: a charting session can carry findings on a branch now, so the map
+  // comment says where they got to. The daemon reads that from its own journal
+  // and from GitHub — the agent's account of itself never decides it.
+  test('findings that never merged are named on the map, and journalled', async () => {
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'research: acp' }],
+      changedFilesOnBranch: async () => ['docs/research/acp.md'],
+      findPullRequest: async () => ({ number: 7, url: 'https://github.com/o/r/pull/7', state: 'OPEN' }),
+    })
+    await d.chart('147')
+    await d.openPullRequest('curia-147', { summary: 'the findings' })
+    calls.length = 0
+    const text = await d.onResult('curia-147', { ticket: '147', status: 'resolved', summary: 's' })
+    const body = calls.find((c) => typeof c === 'string' && c.startsWith('## Charting'))
+    assert.match(body, /NOT in the default branch/)
+    assert.match(body, /https:\/\/github\.com\/o\/r\/pull\/7/)
+    assert.match(text, /NOT in the default branch/)
+    assert.ok(events.some((e) => e.type === 'charting_unreviewed' && e.map === '147'))
+  })
+
+  test('merged and approved findings are named as merged', async () => {
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'research: acp' }],
+      changedFilesOnBranch: async () => ['docs/research/acp.md'],
+      findPullRequest: async () => ({ number: 7, url: 'https://github.com/o/r/pull/7', state: 'MERGED' }),
+    })
+    d.askReview = async () => ({ text: 'approve', status: 'answered' })
+    await d.chart('147')
+    await d.openPullRequest('curia-147', { summary: 'the findings' })
+    await d.requestReview('curia-147', { summary: 's', charting: 'c' })
+    calls.length = 0
+    await d.onResult('curia-147', { ticket: '147', status: 'resolved', summary: 's' })
+    const body = calls.find((c) => typeof c === 'string' && c.startsWith('## Charting'))
+    assert.match(body, /The research findings are merged/)
+    assert.match(body, /A human approved them at the review gate/)
+    assert.ok(!events.some((e) => e.type === 'charting_unreviewed'))
+  })
+
   test('an agent whose record this process never held is still read as charting', async () => {
     // The restart case: the in-memory record is gone and only the journal is
     // left. Falling back to "ticket" here would close the map.
@@ -426,34 +564,89 @@ describe('report_result on a map dispatch', () => {
   })
 })
 
-describe('the two tools a map dispatch refuses', () => {
-  test('open_pull_request is refused, and nothing is pushed', async () => {
-    const d = makeDispatcher()
+// #297, ADR-0008: these two used to be refused outright. A charting session's
+// research subagents write files, and a pull request on `curia/<map>` is what
+// keeps those findings off the default branch until a human approves them — so
+// both calls are the charting agent's now, narrowed to what it may write.
+describe('the two tools a map dispatch used to refuse', () => {
+  const RESEARCH = ['docs/research/acp.md', 'docs/research/README.md']
+
+  test('open_pull_request pushes the findings, and journals no refusal', async () => {
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'research: acp' }],
+      changedFilesOnBranch: async () => RESEARCH,
+    })
+    await d.chart('147')
+    calls.length = 0
+    const reply = await d.openPullRequest('curia-147', { summary: 'the acp findings' })
+    assert.ok(!/CHARTING agent/.test(reply), `still refused: ${reply}`)
+    assert.match(reply, /Next: request_review/)
+    assert.ok(calls.includes('pushBranch'), 'the branch was never pushed')
+    assert.ok(!events.some((e) => e.type === 'charting_tool_refused'))
+  })
+
+  test('a branch that touches anything outside docs/research is REFUSED, and nothing is pushed', async () => {
+    // The bound the writable worktree is narrowed to. A charting agent must not
+    // commit daemon code, and the push is the moment to say so.
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'fix the daemon' }],
+      changedFilesOnBranch: async () => ['docs/research/acp.md', 'daemon/src/dispatch.mjs'],
+    })
     await d.chart('147')
     calls.length = 0
     const reply = await d.openPullRequest('curia-147', { summary: 'x' })
     assert.match(reply, /CHARTING agent/)
-    assert.match(reply, /opens no pull request/)
+    assert.match(reply, /daemon\/src\/dispatch\.mjs/)
     assert.equal(calls.length, 0, 'the refusal still touched the remote')
-    assert.ok(events.some((e) => e.type === 'charting_tool_refused' && e.tool === 'open_pull_request'))
+    const ev = events.find((e) => e.type === 'charting_push_refused')
+    assert.deepEqual(ev.paths, ['daemon/src/dispatch.mjs'])
   })
 
-  test('request_review is refused, and no gate is opened', async () => {
-    let asked = 0
-    const d = makeDispatcher()
-    d.askReview = async () => { asked += 1; return { text: 'approve', status: 'answered' } }
+  test('a diff curia cannot read fails OPEN — the gate is still in front of the merge', async () => {
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'research: acp' }],
+      changedFilesOnBranch: async () => { throw new Error('git exploded') },
+    })
     await d.chart('147')
-    const r = await d.requestReview('curia-147', { summary: 'x', charting: 'y' })
-    assert.equal(r.ok, false)
-    assert.match(r.text, /no review gate/)
-    assert.equal(asked, 0, 'a review gate was opened for a map dispatch')
+    calls.length = 0
+    const reply = await d.openPullRequest('curia-147', { summary: 'x' })
+    assert.ok(!/CHARTING agent/.test(reply), 'an unreadable diff trapped the agent')
+    assert.ok(events.some((e) => e.type === 'charting_paths_unread'))
   })
 
-  test('an ordinary ticket agent reaches both as before', async () => {
-    const d = makeDispatcher({}, { issue: TICKET_ISSUE })
+  test('an ordinary ticket agent is never path-checked', async () => {
+    const d = makeDispatcher({
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'do it' }],
+      changedFilesOnBranch: async () => { throw new Error('must not be called') },
+    }, { issue: TICKET_ISSUE })
     await d.start('42')
     const reply = await d.openPullRequest('curia-42', { summary: 'x' })
     assert.ok(!/CHARTING/.test(reply))
+  })
+
+  test('request_review opens the gate, and it asks about the FINDINGS, not the map', async () => {
+    let asked = null
+    const d = makeDispatcher()
+    d.askReview = async (agent, ticket, text) => { asked = { agent, ticket, text }; return { text: 'approve', status: 'answered' } }
+    await d.chart('147')
+    const r = await d.requestReview('curia-147', { summary: 'two findings', charting: 'add ticket X' })
+    assert.equal(r.ok, true)
+    assert.equal(r.approved, true)
+    assert.match(asked.text, /Approve the research findings charted on o\/r#147\?/)
+    assert.match(asked.text, /Map: https:\/\/github\.com\/o\/r\/issues\/147/)
+    assert.ok(!/\*\*Is o\/r#147 done\?\*\*/.test(asked.text), 'the gate asked whether the MAP was done')
+    assert.ok(events.some((e) => e.type === 'review_requested' && e.kind === 'charting'))
+  })
+
+  test('the approval names the order: merge, then close the research tickets, then report', async () => {
+    // #48's failure, said at the moment it can still be avoided.
+    const d = makeDispatcher()
+    d.askReview = async () => ({ text: 'approve', status: 'answered' })
+    await d.chart('147')
+    const r = await d.requestReview('curia-147', { summary: 'x', charting: 'y' })
+    assert.match(r.text, /merge the pull request/)
+    assert.match(r.text, /then resolve each research ticket you burned down/)
+    assert.match(r.text, /Nothing closes before the merge, and the map itself never closes/)
   })
 })
 
@@ -1010,6 +1203,31 @@ describe('report_result on a new-map dispatch (#241)', () => {
     assert.ok(calls.includes('comment o/r#250'), `expected a comment on the map, got ${JSON.stringify(calls)}`)
     assert.ok(!calls.some((c) => String(c).startsWith('CLOSE')))
     assert.ok(!calls.some((c) => String(c).startsWith('unclaim')))
+  })
+
+  // #297: a new-map session burns down research tickets too, so it can carry
+  // findings. Its bound "ticket" is a chat handle that no issue answers to, so
+  // every issue link it produces has to be the map it adopted.
+  test('its pull request and its gate name the ADOPTED map, never the chat handle', async () => {
+    let asked = null
+    let prTitle = null
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...MADE }),
+      commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'research: acp' }],
+      changedFilesOnBranch: async () => ['docs/research/acp.md'],
+      createPullRequest: async (repo, opts) => { prTitle = opts.title; calls.push(opts.body); return 'https://github.com/o/r/pull/9' },
+    })
+    d.askReview = async (agent, ticket, text) => { asked = text; return { text: 'approve', status: 'answered' } }
+    await d.chartNew({ repo: 'o/r', instruction: 'chart it', by: 'u' })
+    await d.adoptMap('curia-chat-1', '250')
+    calls.length = 0
+    await d.openPullRequest('curia-chat-1', { summary: 'the findings' })
+    assert.match(prTitle, /o\/r#250/)
+    assert.ok(calls.some((c) => typeof c === 'string' && c.includes('Ticket: o/r#250')), 'the body named the handle')
+    assert.ok(calls.includes('comment o/r#250'), 'the link comment missed the map')
+    await d.requestReview('curia-chat-1', { summary: 's', charting: 'c' })
+    assert.match(asked, /Map: https:\/\/github\.com\/o\/r\/issues\/250/)
+    assert.ok(!/chat-1/.test(asked), 'the chat handle reached the gate text')
   })
 
   test('a session that created NO map says so instead of posting nowhere', async () => {

--- a/docs/adr/0008-resolved-means-merged.md
+++ b/docs/adr/0008-resolved-means-merged.md
@@ -35,7 +35,11 @@ What replaces the gate for the map itself is the operator, per [#149](https://gi
 - A research ticket the session did not burn down stays on the frontier and dispatches as its own agent. This covers one charted earlier, and one whose subagent failed.
 - The gate holds the map lock and an agent slot for its whole length. Charting is no longer a fast act, which the operator accepted as the price.
 
-The daemon refusals move with the rule: `open_pull_request` and `request_review` stop refusing a charting agent. **Not built yet.** The whole lifecycle change rides one build ticket, and until it merges the daemon still refuses both calls.
+The daemon refusals move with the rule: `open_pull_request` and `request_review` stop refusing a charting agent. Built by [#297](https://github.com/alp82/curia/issues/297). Three rules ride with them, because a writable charting worktree is new authority.
+
+- `docs/research/` is the only directory a charting session writes, and the daemon refuses a charting pull request whose branch touches any other file. A charting agent must not commit daemon code.
+- The gate a charting agent opens judges the FINDINGS, and its heading says so. Approval never says the map is done, and the map still never closes.
+- The third button rides that gate like any other. A charting session now reads the cross-check duty in its standing orders, and the same park holds it.
 
 **The verb and the claim ([#221](https://github.com/alp82/curia/issues/221)).** #160 put charting on `start`, which gave one word two meanings: `start <n>` worked a ticket and `start <map>` charted. The operator ruled the overload confusing after using it. `start` now has one meaning everywhere — work the thing — and on a map number it dispatches that map's next takeable ticket. Charting has its own verb.
 


### PR DESCRIPTION
Ticket: alp82/curia#297 — [A charting session burns down its research tickets](https://github.com/alp82/curia/issues/297)

A map dispatch produces files now, so the daemon gives it the ordinary ending for them (ADR-0008, #286).

- The two refusals invert: `open_pull_request` and `request_review` are the charting agent's, and the gate judges the findings rather than the map.
- The charting worktree becomes writable, narrowed to `docs/research/`. curia refuses a charting pull request whose branch touches any other file.
- The charting ending forks on whether the session wrote a file. No file keeps the two-step ending. Findings owe commit, pull request, gate, merge, then close.
- The close is ordered after the merge in the ending, in the approval text, and in the map comment, which states whether the findings merged.
- The Stop hook holds a session whose findings sit uncommitted under `docs/research/`.
- The prompt carries the burn-down doctrine: one subagent per research ticket, no second branch, no git in a subagent, one claim each, one index writer, and any contradiction stated at the gate.
- A new-map session takes the same landing, and every link names the map it adopted.

The daemon suite is green: 1681 tests, 0 failures.

---

Dispatched by the curia daemon — session `curia-297`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `d789001` A charting session burns down its research tickets (wayfinder #297)