### PR TITLE
A note at an agent curia is not running must refuse at the source (alp82/curia#299)

### DIFF
--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -447,23 +447,20 @@ const gate = {
   // how fast, and only the mode failed.
   async noteAgent(agent, text, { by = null, mode = 'queue' } = {}) {
     const live = dispatcher.agents.get(agent)
+    // The record is read here for the TICKET only. The console names the agent,
+    // so it can name one curia is not running — which the thread path never
+    // could, because a thread only ever resolves to a live agent. That is the
+    // same refusal as a failed agent, so `noteDisposition` gives it (#299) and
+    // this door does not check existence a second time.
     const ticket = live?.ticket ?? String(agent).replace(/^curia-/, '')
-    // The console names the agent, so it can name one that does not exist —
-    // which the thread path never could, because a thread only ever resolves to
-    // an agent curia is running. `noteDisposition` answers about a live record
-    // and reads an absent one as "not failed", so the existence check is HERE,
-    // in the one door that can be handed a name out of a browser.
-    if (!live) {
-      log(`agent note refused for ${agent} — curia is not running that agent`)
-      store.logEvent('agent_note_refused', { agent, ticket, by, reason: 'agent not running' })
+    const queued = gate.queueNoteFor(agent, text, { by, ticket })
+    // The console's own way back, which is not the thread's: the browser has
+    // cleared the box, so the words have to be typed again after the resume.
+    if (!queued.reads) {
       return {
-        agent, ticket, reads: false, id: null, after: null, ok: false, mode,
+        ...queued, ok: false, mode,
         why: `curia is not running \`${agent}\`, so nothing was queued — \`resume ${ticket}\` puts an agent back on the ticket, then say the words again`,
       }
-    }
-    const queued = gate.queueNoteFor(agent, text, { by, ticket })
-    if (!queued.reads) {
-      return { ...queued, ok: false, mode, why: `\`${agent}\` is not running, so nothing was queued — \`resume ${ticket}\` puts an agent back on the ticket` }
     }
     if (mode !== 'interrupt') return { ...queued, ok: true, mode: 'queue' }
     const out = await dispatcher.interruptNote(queued.id, { by })

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -96,9 +96,16 @@ export function normalizeEvent(ev) {
 //
 // `reads` keeps its one meaning (#170): the agent is running. A `failed`
 // record is the early exit (#169), the ready timeout, the result-less exit.
+//
+// #299: NO record is the same fact. Every caller before the console resolved
+// the agent through its thread, so the name always answered to a live record;
+// the console's `POST /note` (#266) is handed a name out of a browser, and it
+// can name an agent curia is not running. That is not a second rule, so it is
+// not a second check at that one door: for the queue, "curia is not running
+// that agent" and "that agent has failed" are the same answer.
 export function noteDisposition(agent) {
-  const reads = agent?.state !== 'failed'
-  return { reads, instance: reads ? agent?.instance ?? null : null }
+  const reads = Boolean(agent) && agent.state !== 'failed'
+  return { reads, instance: reads ? agent.instance ?? null : null }
 }
 
 // The events lastAgentEvent must not count (#236) — see _apply.

--- a/daemon/test/agentnotes.test.mjs
+++ b/daemon/test/agentnotes.test.mjs
@@ -275,6 +275,14 @@ describe('agent-note queue', () => {
       assert.deepEqual(noteDisposition({ state: 'failed', instance: 'curia-166@1' }), { reads: false, instance: null })
     })
 
+    // #299: the console can name an agent curia is not running, and the queue
+    // reads that as the same fact as a failed one. The rule sits here, so the
+    // door does not carry a second existence check of its own.
+    test('an agent curia is not running queues nothing either — no record is the same answer as failed', () => {
+      assert.deepEqual(noteDisposition(undefined), { reads: false, instance: null })
+      assert.deepEqual(noteDisposition(null), { reads: false, instance: null })
+    })
+
     test('a running agent queues, stamped with the instance the words were typed at', () => {
       assert.deepEqual(noteDisposition({ state: 'ready', instance: 'curia-166@1' }), { reads: true, instance: 'curia-166@1' })
       assert.deepEqual(noteDisposition({ state: 'spawning', instance: 'curia-166@2' }), { reads: true, instance: 'curia-166@2' })


### PR DESCRIPTION
Ticket: alp82/curia#299 — [A note at an agent curia is not running must refuse at the source](https://github.com/alp82/curia/issues/299)

Closes #299.

`noteDisposition(agent)` in `daemon/src/store.mjs` read an ABSENT agent as `reads: true`, because it only tested for the `failed` state. The predicate now tests for the record too: no record is the same answer as failed.

`gate.noteAgent` (the console's `POST /note`, #266) loses its own existence check. It still reads the dispatch record, but only for the ticket the refusal names.

The console keeps its own refusal wording, because it names a different way back than the thread does. The browser cleared the box, so the words have to be typed again after the resume.

One new pure test on the predicate. The daemon suite is green: 1704 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-299`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `62ea998` A note at an agent curia is not running refuses at the source (#299)