### PR TITLE
The checkouts: every watched repo, every ref, one fetch per turn (alp82/curia#312)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,6 +140,13 @@ The rule that a conversation thread carries one thing. Work dispatched from a co
 One operator message, answered. It is the unit the overseer works in, and nothing of the overseer runs between turns. One turn at a time per conversation, and no cap across conversations.
 _Avoid_: using it for the model's own steps inside one message (`maxTurns` counts those).
 
+**Overseer checkout**:
+The overseer's own blobless clone of one watched repo, at `<workspace_root>/overseer/repos/<owner>__<repo>`. It is a mirror of origin and holds nothing of its own: no git identity, no local commit, no branch to commit onto. It carries every ref — every branch, so `curia/<n>` is there while an agent works, plus every pull-request head, which is what stays readable after a merge deletes the branch. See [ADR-0014](docs/adr/0014-the-overseer-in-its-own-container.md) and the [live checks](docs/live-checks/312-overseer-checkouts.md).
+_Avoid_: private clone (that is an agent's, per ticket, and it is a place to commit).
+
+**Checkout pass**:
+What the overseer container runs at the start of every turn, before the model: clone every watched repo that is missing, delete the clone of one nobody watches, and fetch the rest in parallel. It is the whole reason every read inside one turn is consistent. The daemon asserts nothing about this tree. A repo whose fetch fails does not refuse the turn — the pass returns a verdict per repo, and the turn tells the model which checkout is stale and how old it is.
+
 **The verbs**:
 `tickets`, `next`, `status`, `start`, `map`, `cancel`, `resume`, `attach`, `review`. The whole command surface, identical over Discord and REST. Each verb has one meaning. `start` works a thing, and `map` updates a map.
 _Avoid_: the five verbs (the pre-#81 count, wrong since `next`, `resume` and `review` joined).
@@ -510,7 +517,7 @@ One box runs everything. Phones and PCs are pure clients on the tailnet.
 - **Verdicts** (`daemon/data/verdicts/`): one captured cross-check verdict per ticket, held for the return path.
 - **tmux**: the live agent sessions.
 - **tailscaled**: the Serve rules for attach, timeline, the dashboard, and previews.
-- **Workspace root** (`~/curia-work`): private clones, review checkouts, agent config dirs.
+- **Workspace root** (`~/curia-work`): private clones, review checkouts, agent config dirs, and the overseer's checkouts under `overseer/repos/`. Those last are a cache of origin and nothing else, so deleting one costs a re-clone and no work.
 - **Host credential stores** (`~/.claude`, `~/.codex`): the overseer's, which runs on the host and holds no copy. A dispatched agent is in a container and cannot reach them, so it gets the model credential copied into its container environment.
 - **docker**: the live agent containers and the two shared cache volumes.
 

--- a/daemon/bin/curia-checkouts.mjs
+++ b/daemon/bin/curia-checkouts.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// The turn-start pass over the overseer's checkouts (#312), as a command.
+//
+// The overseer container runs this before the model runs, once per turn:
+//
+//   node daemon/bin/curia-checkouts.mjs > checkouts.json
+//
+// It reads the watch list, clones what is missing, deletes the clone of a repo
+// nobody watches, and fetches every ref of the rest in parallel. It prints one
+// JSON object on stdout — the verdict per repo, which #314 turns into the lines
+// the model reads about which checkout is fresh and which is stale. Progress
+// goes to stderr, so a caller can read stdout alone.
+//
+// A COMMAND RATHER THAN A DAEMON ROUTE, because ADR-0014 makes this a turn-
+// scoped act and the turn belongs to the container. The daemon asserts nothing
+// about this tree. #327 decides how the container reaches this file and the
+// config, the way `deploy/compose.yaml` already mounts `daemon/src` into the
+// dashboard.
+//
+// EXIT CODES. 0 when the pass ran, WHATEVER any single repo did — a repo whose
+// fetch failed is a verdict, not a crash, and the turn goes ahead reading the
+// rest. 1 only when the pass itself could not run: no config, no watch list, an
+// unwritable root. Then there are no checkouts at all, and the caller has a
+// stdout that says so once instead of per repo.
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { loadCuriaConfig } from '../src/config.mjs'
+import { syncCheckouts } from '../src/checkouts.mjs'
+
+const DIR = path.dirname(fileURLToPath(import.meta.url))
+const CONFIG = process.env.CURIA_CONFIG ?? path.resolve(DIR, '..', '..', 'config', 'curia.yaml')
+
+const arg = (name) => {
+  const i = process.argv.indexOf(`--${name}`)
+  return i === -1 ? null : process.argv[i + 1] ?? null
+}
+
+const log = (...a) => console.error(`[${new Date().toISOString()}]`, ...a)
+
+try {
+  // `checkPaths: false`: those rules ask about the daemon's own filesystem —
+  // the skills root, the attach index — and this container mounts none of them.
+  // The watch list and `workspace_root` are the only keys read here.
+  const cfg = loadCuriaConfig(CONFIG, { checkPaths: false })
+  const repos = (arg('repos') ?? '').trim()
+    ? arg('repos').split(',').map((r) => r.trim()).filter(Boolean)
+    : cfg.watch.map((w) => w.repo)
+  const root = arg('root') ?? cfg.dispatch.workspace_root
+
+  if (!repos.length) throw new Error(`${CONFIG} names no watched repo, so there is nothing to check out`)
+
+  log(`fetching ${repos.length} checkout${repos.length === 1 ? '' : 's'} under ${root}`)
+  const result = await syncCheckouts(root, repos)
+
+  for (const r of result.repos) {
+    if (r.ok) log(`  ${r.repo}: ${r.cloned ? 'cloned, ' : ''}${r.branch} at ${r.head.slice(0, 8)}`)
+    else log(`  ${r.repo}: FAILED — ${r.error}${r.staleSince ? ` (last good fetch ${r.staleSince})` : ' (no checkout)'}`)
+  }
+  for (const name of result.removed) log(`  removed ${name}: no longer watched`)
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+} catch (e) {
+  log(`the checkout pass could not run: ${e.message}`)
+  process.stdout.write(`${JSON.stringify({ error: e.message, repos: [] }, null, 2)}\n`)
+  process.exit(1)
+}

--- a/daemon/src/checkouts.mjs
+++ b/daemon/src/checkouts.mjs
@@ -1,0 +1,300 @@
+// The overseer's checkouts (#312, building ADR-0014's "it reads a persistent
+// checkout of every watched repo").
+//
+// One blobless clone per watched repo, under the workspace root:
+//
+//   <workspace_root>/overseer/repos/<owner>__<repo>
+//
+// ONE HOST TREE, NOT A VOLUME PER REPO. ADR-0014 says "its own volume", and a
+// named docker volume per repo has to be declared in `compose.yaml`, which is
+// static. The watch list is not: the settings screen rewrites it. So the tree
+// is one bind mount at its identical path inside the container — the same-path
+// principle every other mount already follows — and the set of clones inside it
+// moves with the config. #327 writes that mount line, because it owns the
+// service.
+//
+// ONE OWNER: THE OVERSEER CONTAINER. The pass below runs at the start of every
+// turn, inside that container, on its own read-only token. It clones what is
+// missing, deletes the clone of a repo nobody watches, and fetches the rest in
+// parallel. The daemon asserts nothing about this tree. Two owners would race
+// on one fetch per turn, and the turn is the container's to define.
+//
+// THE CHECKOUT IS A MIRROR OF ORIGIN, and it holds nothing of its own. No git
+// identity is configured, so a commit here fails by naming the missing name.
+// Nothing local ever lives here, which is what makes both destructive moves in
+// this file safe: the working tree is force-reset to the fetched default branch
+// on every pass, and the clone of an unwatched repo is deleted whole. Re-watch
+// the repo and the next turn clones it again.
+//
+// WHY THE FORCE-RESET. `git fetch` moves `refs/remotes/origin/*` and leaves the
+// working tree where it was. A checkout cloned a month ago would then answer
+// `cat README.md` from a month-old commit, while `git log origin/main` answered
+// from today. That is the one failure ADR-0014's "one fetch per turn makes
+// every read inside that turn consistent" exists to prevent, so the pass moves
+// the working tree too.
+//
+// A FAILED FETCH DOES NOT REFUSE THE TURN. The pass returns a verdict per repo,
+// and a repo whose fetch failed carries the instant of its last good one. The
+// caller (#314) tells the model which checkout is stale and how old it is.
+// Refusing a whole turn on one network stall would make the chat useless. The
+// model reading a stale checkout believing it is fresh is the real failure, and
+// the verdict is what prevents it.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileP } from './exec.mjs'
+
+// A fetch over the network is not fast, and a first clone is slower still.
+// Both still need a ceiling: a wedged child must never hold a turn open
+// forever. SIGTERM rather than the wrapper's SIGKILL default, for the reason
+// workspace.mjs states — git removes its lock files on SIGTERM, and a clone
+// killed hard leaves `.git/index.lock` behind for a human to delete.
+const GIT_TIMEOUT_MS = 120_000
+const CLONE_TIMEOUT_MS = 600_000
+
+function git(cwd, args, options = {}) {
+  return execFileP('git', ['-C', cwd, ...args], {
+    maxBuffer: 16 * 1024 * 1024, timeout: GIT_TIMEOUT_MS, killSignal: 'SIGTERM', ...options,
+  })
+}
+
+// EVERY REF, as ADR-0014 states it. Three refspecs, and each one answers a
+// question an operator asks this chat:
+//
+//   heads — every branch, so `curia/<n>` is there. "What is this agent doing."
+//   pull  — pull-request HEADS, as `origin/pr/<n>`. A pull request from a FORK
+//           reaches this clone no other way, and "what did this agent change"
+//           is the first thing asked. The MERGE refs are deliberately absent:
+//           GitHub computes those against a moving base, so they answer a
+//           different question and go stale without anything changing.
+//   tags  — a release is a thing to be asked about.
+//
+// Written into `remote.origin.fetch` as well as passed on the command line. The
+// command line is what the turn-start pass uses, so the pass never depends on
+// the config being right. The config is what a mid-turn `git fetch` or
+// `git pull` reads, and ADR-0014 keeps `git pull` available for the case where
+// the overseer must be exact inside a turn.
+export const FETCH_REFSPECS = [
+  '+refs/heads/*:refs/remotes/origin/*',
+  '+refs/pull/*/head:refs/remotes/origin/pr/*',
+  '+refs/tags/*:refs/tags/*',
+]
+
+// Where the tree sits under the workspace root. `overseer/` beside `repos/` and
+// `cfg/`, rather than inside `repos/`: that directory is keyed by ticket number
+// under each repo, and these clones belong to no ticket.
+export function checkoutsRootFor(root) {
+  return path.join(root, 'overseer', 'repos')
+}
+
+// `alp82/curia` → `alp82__curia`, the same spelling `worktreePathFor` uses. The
+// inverse is never taken: the prune below compares against the set of names the
+// watch list generates, so a repo name holding `__` costs nothing.
+export function checkoutDirNameFor(repo) {
+  return String(repo).replace('/', '__')
+}
+
+export function checkoutPathFor(root, repo) {
+  return path.join(checkoutsRootFor(root), checkoutDirNameFor(repo))
+}
+
+// The instant of the last good fetch, kept inside `.git` so it is neither in
+// the working tree nor in anything `git status` reports. It is what a repo
+// whose fetch just failed reports its age from.
+const STAMP = 'curia-fetched-at'
+
+function stampFile(wt) {
+  return path.join(wt, '.git', STAMP)
+}
+
+export function readFetchStamp(wt) {
+  try {
+    return fs.readFileSync(stampFile(wt), 'utf8').trim() || null
+  } catch {
+    return null
+  }
+}
+
+// `gh repo clone` rather than `git clone`, for the reason createPrivateClone
+// states: it carries whatever login the environment holds, so a private watched
+// repo clones with no credential helper set up first. In the overseer container
+// that login is the read-only token of #313.
+//
+// `--filter=blob:none` is ADR-0014's blobless clone. Commits and trees now,
+// blobs on demand — so a checkout of every watched repo costs seconds rather
+// than a full history download each.
+//
+// Injectable because no unit test can reach `gh`. The suite passes a clone that
+// runs `git clone` against a local origin instead.
+async function ghClone(repo, wt) {
+  await execFileP('gh', ['repo', 'clone', repo, wt, '--', '--filter=blob:none'], {
+    maxBuffer: 16 * 1024 * 1024, timeout: CLONE_TIMEOUT_MS,
+  })
+}
+
+// Is there a USABLE clone here? Not `does .git exist` — `git clone` writes
+// `.git` early and fills it as it goes, so a clone this pass's timeout killed
+// leaves a directory that looks like a repository and answers nothing. That
+// shape would then fail its fetch on every later turn and never be repaired,
+// because nothing would ever decide to clone over it.
+//
+// So the question asked is the one that matters: can this clone resolve a
+// commit? A repository with no commits at all answers no and gets re-cloned
+// each turn — that is one wasted clone per turn on a repo that holds nothing to
+// read, and curia cannot dispatch against one either.
+async function isUsableClone(wt) {
+  if (!fs.existsSync(path.join(wt, '.git'))) return false
+  try {
+    await git(wt, ['rev-parse', '--verify', '--quiet', 'HEAD'], { timeout: 30_000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Where a checkout points. gh follows the box's `git_protocol`, which may be
+// ssh, and this container holds no ssh key — so HTTPS with the token in the
+// environment is the one way out of here, exactly as it is for an agent's
+// private clone.
+//
+// Injectable for the same reason the clone is: the suite drives real git
+// against a local origin, and a checkout that rewrote itself back to
+// github.com would make every case in it a live network read.
+export const githubUrlFor = (repo) => `https://github.com/${repo}.git`
+
+// What every checkout must say about itself, re-asserted on every pass rather
+// than only at clone time, so a clone a hand edit broke heals on the next turn.
+async function configure(wt, repo, urlFor) {
+  await git(wt, ['remote', 'set-url', 'origin', urlFor(repo)])
+  await git(wt, ['config', 'credential.helper', '!gh auth git-credential'])
+
+  // A MANNER, NOT A CONTROL. The read-only token is what makes a push fail, and
+  // ADR-0014 is explicit that no standing order holds a shell. This states the
+  // posture where a reader meets it, and a shell can undo it in one command.
+  await git(wt, ['config', 'remote.origin.pushurl', 'no_push://the-overseer-checkout-is-read-only'])
+
+  // No user.name and no user.email, deliberately. Nothing here is ever
+  // committed, and a commit that fails with "please tell me who you are" says
+  // so louder than a comment does.
+
+  await git(wt, ['config', '--replace-all', 'remote.origin.fetch', FETCH_REFSPECS[0]])
+  for (const spec of FETCH_REFSPECS.slice(1)) {
+    await git(wt, ['config', '--add', 'remote.origin.fetch', spec])
+  }
+}
+
+// origin's default branch, read from the tracking ref the clone wrote.
+async function defaultBranch(wt) {
+  const { stdout } = await git(wt, ['symbolic-ref', 'refs/remotes/origin/HEAD'])
+  return stdout.trim().replace('refs/remotes/origin/', '')
+}
+
+// Fetch every ref, then put the working tree on the fetched default branch.
+//
+// `--prune` against these three refspecs is what makes this a mirror: a branch
+// deleted on origin, a closed pull request's head, and a deleted tag all go.
+// Without it the chat would answer from refs that no longer exist anywhere.
+//
+// `checkout --force -B` throws away local modifications to tracked files and
+// moves the branch to the fetched tip. Untracked files survive, because a
+// previous turn may have left one on purpose and this pass has no business
+// judging that.
+async function fetchAndReset(wt) {
+  await git(wt, ['fetch', '--prune', '--quiet', 'origin', ...FETCH_REFSPECS], { timeout: CLONE_TIMEOUT_MS })
+  // The default branch can be renamed. This is an ls-remote, so it carries no
+  // objects, and a failure leaves the tracking ref the clone wrote.
+  try {
+    await git(wt, ['remote', 'set-head', 'origin', '--auto'])
+  } catch { /* keep whatever origin/HEAD already says */ }
+  const branch = await defaultBranch(wt)
+  await git(wt, ['checkout', '--force', '-B', branch, `refs/remotes/origin/${branch}`])
+  const { stdout } = await git(wt, ['rev-parse', 'HEAD'])
+  return { branch, head: stdout.trim() }
+}
+
+// One repo: clone it if it is not there, then bring it up to date. Returns what
+// the turn needs to describe this checkout to the model.
+export async function ensureCheckout(root, repo, { clone = ghClone, now = () => new Date(), urlFor = githubUrlFor } = {}) {
+  const wt = checkoutPathFor(root, repo)
+  let cloned = false
+  if (!await isUsableClone(wt)) {
+    fs.rmSync(wt, { recursive: true, force: true })
+    fs.mkdirSync(path.dirname(wt), { recursive: true })
+    await clone(repo, wt)
+    cloned = true
+  }
+  await configure(wt, repo, urlFor)
+  const { branch, head } = await fetchAndReset(wt)
+  const at = now().toISOString()
+  fs.writeFileSync(stampFile(wt), `${at}\n`)
+  return { repo, path: wt, ok: true, cloned, branch, head, fetchedAt: at }
+}
+
+// THE TURN-START PASS. Every watched repo, in parallel, before the model runs.
+//
+// Parallel with no cap: the watch list is a handful of repos an operator typed
+// by hand, and a cap would only slow the one case this pass has to be fast in.
+//
+// It never throws for a repo. A clone that failed and a fetch that failed both
+// come back as `ok: false` with the error and the age of the last good fetch,
+// and the turn goes ahead. What it does throw for is a root it cannot create,
+// because then there are no checkouts at all and saying so once beats saying it
+// per repo.
+export async function syncCheckouts(root, repos, { clone = ghClone, now = () => new Date(), urlFor = githubUrlFor } = {}) {
+  const base = checkoutsRootFor(root)
+  fs.mkdirSync(base, { recursive: true })
+
+  const removed = pruneUnwatched(base, repos)
+
+  const results = await Promise.all(repos.map(async (repo) => {
+    try {
+      return await ensureCheckout(root, repo, { clone, now, urlFor })
+    } catch (e) {
+      const wt = checkoutPathFor(root, repo)
+      const last = readFetchStamp(wt)
+      return {
+        repo,
+        path: wt,
+        ok: false,
+        cloned: false,
+        // The first line only: a git failure's later lines are progress noise,
+        // and this string is read by a model inside a prompt. `||` rather than
+        // `??`: a timeout kill gives an EMPTY stderr, and an empty error would
+        // tell the model a checkout is stale without saying what happened.
+        error: String(e.stderr || e.message || e).trim().split('\n')[0] || 'the fetch failed with no message',
+        // null means there is no checkout at all, which is a different thing
+        // from a stale one, and the turn has to be able to say which.
+        fetchedAt: null,
+        staleSince: last,
+      }
+    }
+  }))
+
+  return { root: base, at: now().toISOString(), removed, repos: results }
+}
+
+// The clone of a repo nobody watches is DELETED (#312's open thread). It is a
+// mirror of origin and holds nothing unique — no local commit can exist here —
+// so the delete loses nothing, and watching the repo again re-clones it in
+// seconds. The alternative was to keep it, and that lets the chat read a repo
+// the operator removed, at an age nobody states.
+//
+// It compares against the names the watch list generates rather than parsing a
+// directory name back into a repo, so a name that does not round-trip cannot
+// cause a delete.
+export function pruneUnwatched(base, repos) {
+  const keep = new Set(repos.map(checkoutDirNameFor))
+  const removed = []
+  let entries = []
+  try {
+    entries = fs.readdirSync(base, { withFileTypes: true })
+  } catch {
+    return removed
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || keep.has(entry.name)) continue
+    fs.rmSync(path.join(base, entry.name), { recursive: true, force: true })
+    removed.push(entry.name)
+  }
+  return removed
+}

--- a/daemon/test/checkouts.test.mjs
+++ b/daemon/test/checkouts.test.mjs
@@ -1,0 +1,361 @@
+// #312: the overseer's checkouts — one blobless clone per watched repo, every
+// ref, one fetch per turn.
+//
+// These drive REAL git against a local origin. `gh repo clone` is the one thing
+// no unit test can reach, so `syncCheckouts` takes the clone as an argument and
+// the fixture below passes a `git clone` of a directory. Everything after the
+// clone — the refspecs, the prune, the force-reset, the stamp, the verdict — is
+// the code that ships.
+
+import { test, describe, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+import {
+  syncCheckouts, ensureCheckout, pruneUnwatched, readFetchStamp,
+  checkoutsRootFor, checkoutPathFor, checkoutDirNameFor, FETCH_REFSPECS,
+} from '../src/checkouts.mjs'
+
+const git = (cwd, ...args) => execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+const commit = (cwd, msg) => git(cwd, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', msg)
+
+describe('the overseer checkouts (#312)', () => {
+  let tmp, origin, seed, root
+
+  // A bare origin carrying what ADR-0014 calls "every ref": the default branch,
+  // a `curia/<n>` branch, a tag, and a pull-request head under refs/pull — the
+  // shape GitHub publishes, written by hand because no local remote grows one.
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-checkouts-'))
+    origin = path.join(tmp, 'origin.git')
+    seed = path.join(tmp, 'seed')
+    root = path.join(tmp, 'work')
+
+    execFileSync('git', ['init', '--bare', '-b', 'main', origin])
+    execFileSync('git', ['init', '-b', 'main', seed])
+    git(seed, 'remote', 'add', 'origin', origin)
+    fs.writeFileSync(path.join(seed, 'README.md'), 'first\n')
+    git(seed, 'add', '.')
+    commit(seed, 'base')
+    git(seed, 'push', 'origin', 'main')
+    git(seed, 'tag', 'v1')
+    git(seed, 'push', 'origin', 'v1')
+
+    git(seed, 'checkout', '-b', 'curia/42')
+    fs.writeFileSync(path.join(seed, 'work.txt'), 'agent work\n')
+    git(seed, 'add', '.')
+    commit(seed, 'what the agent changed')
+    git(seed, 'push', 'origin', 'curia/42')
+    // The pull-request head GitHub would publish for that branch.
+    git(seed, 'push', 'origin', 'curia/42:refs/pull/7/head')
+    git(seed, 'checkout', 'main')
+
+    // A bare repo has no HEAD symref a clone can read unless it is set.
+    execFileSync('git', ['-C', origin, 'symbolic-ref', 'HEAD', 'refs/heads/main'])
+  })
+  after(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
+
+  beforeEach(() => { fs.rmSync(path.join(root, 'overseer'), { recursive: true, force: true }) })
+
+  // Stands in for `gh repo clone`. Blobless is dropped: a local-path clone
+  // cannot serve a partial clone without `uploadpack.allowFilter` on the
+  // origin, and the filter is not what any case here is about.
+  //
+  // `urlFor` goes with it. `configure` re-points origin on every pass, so
+  // without it every case below would be a live read of the real github.com.
+  const clone = (repo, wt) => {
+    execFileSync('git', ['clone', origin, wt])
+    return Promise.resolve()
+  }
+  const urlFor = () => origin
+
+  const REPOS = ['alp82/curia', 'alp82/aistack']
+
+  const sync = async (repos = REPOS, opts = {}) => syncCheckouts(root, repos, { clone, urlFor, ...opts })
+
+  test('the layout is one tree, one directory per repo, keyed the way worktrees are', () => {
+    assert.equal(checkoutsRootFor('/w'), '/w/overseer/repos')
+    assert.equal(checkoutPathFor('/w', 'alp82/curia'), '/w/overseer/repos/alp82__curia')
+    assert.equal(checkoutDirNameFor('getalfredo/landing-page'), 'getalfredo__landing-page')
+  })
+
+  test('a first pass clones every watched repo, in its own directory', async () => {
+    const result = await sync()
+    assert.deepEqual(result.repos.map((r) => r.repo).sort(), [...REPOS].sort())
+    for (const r of result.repos) {
+      assert.equal(r.ok, true, r.error)
+      assert.equal(r.cloned, true)
+      assert.ok(fs.existsSync(path.join(r.path, '.git')))
+      assert.equal(r.path, checkoutPathFor(root, r.repo))
+    }
+  })
+
+  // The claim ADR-0014 makes in one line, asserted ref by ref.
+  test('the checkout holds EVERY ref: branches, curia/<n>, pull-request heads and tags', async () => {
+    const { repos } = await sync(['alp82/curia'])
+    const wt = repos[0].path
+    const refs = git(wt, 'for-each-ref', '--format=%(refname)')
+    assert.match(refs, /refs\/remotes\/origin\/main/)
+    assert.match(refs, /refs\/remotes\/origin\/curia\/42/, 'a `curia/<n>` branch is the first thing asked about')
+    assert.match(refs, /refs\/remotes\/origin\/pr\/7/, 'a fork pull request reaches this clone no other way')
+    assert.match(refs, /refs\/tags\/v1/)
+    assert.doesNotMatch(refs, /pr\/7\/merge/, 'the merge refs answer a different question and go stale')
+  })
+
+  // ADR-0014 keeps `git pull` available mid-turn, and a pull reads the
+  // CONFIGURED refspec rather than the one the pass puts on the command line.
+  test('the configured refspec matches the pass, so a mid-turn fetch sees everything too', async () => {
+    const { repos } = await sync(['alp82/curia'])
+    const configured = git(repos[0].path, 'config', '--get-all', 'remote.origin.fetch').trim().split('\n')
+    assert.deepEqual(configured, FETCH_REFSPECS)
+  })
+
+  // The other half of "`git pull` stays available". A pull with no upstream
+  // refuses by asking which branch it is for, and the force-reset each pass
+  // runs is what could quietly drop one.
+  test('the default branch keeps its upstream across the force-reset, so `git pull` answers', async () => {
+    const { repos } = await sync(['alp82/curia'])
+    const wt = repos[0].path
+    await sync(['alp82/curia'])
+    assert.equal(git(wt, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}').trim(), 'origin/main')
+    assert.match(git(wt, 'pull'), /Already up to date/)
+  })
+
+  test('the checkout is a mirror: no git identity, and a push url that refuses', async () => {
+    const { repos } = await sync(['alp82/curia'])
+    const wt = repos[0].path
+    assert.throws(() => git(wt, 'config', '--get', 'user.email'),
+      'no identity is deliberate — a commit here must fail by naming what is missing')
+    assert.match(git(wt, 'config', '--get', 'remote.origin.pushurl'), /^no_push:/)
+  })
+
+  // The failure the force-reset exists for. Without it `cat README.md` answers
+  // from the commit the clone was taken at, while `git log origin/main` answers
+  // from today — and ADR-0014's "every read inside a turn is consistent" is a
+  // claim about exactly this file read.
+  test('a second pass moves the WORKING TREE onto the fetched tip, not just the tracking ref', async () => {
+    const first = await sync(['alp82/curia'])
+    const wt = first.repos[0].path
+    assert.equal(fs.readFileSync(path.join(wt, 'README.md'), 'utf8'), 'first\n')
+
+    fs.writeFileSync(path.join(seed, 'README.md'), 'second\n')
+    git(seed, 'add', '.')
+    commit(seed, 'moved on')
+    git(seed, 'push', 'origin', 'main')
+
+    const second = await sync(['alp82/curia'])
+    assert.equal(second.repos[0].cloned, false, 'an existing clone is fetched, never re-cloned')
+    assert.equal(fs.readFileSync(path.join(wt, 'README.md'), 'utf8'), 'second\n')
+    assert.equal(git(wt, 'rev-parse', '--abbrev-ref', 'HEAD').trim(), 'main')
+  })
+
+  test('a turn left on another branch comes back to the default branch', async () => {
+    const first = await sync(['alp82/curia'])
+    const wt = first.repos[0].path
+    git(wt, 'checkout', 'curia/42')
+    assert.ok(fs.existsSync(path.join(wt, 'work.txt')))
+
+    await sync(['alp82/curia'])
+    assert.equal(git(wt, 'rev-parse', '--abbrev-ref', 'HEAD').trim(), 'main')
+    assert.equal(fs.existsSync(path.join(wt, 'work.txt')), false)
+  })
+
+  test('a tracked file a turn edited is reset; an untracked file it left is kept', async () => {
+    const first = await sync(['alp82/curia'])
+    const wt = first.repos[0].path
+    // Read rather than asserted against a literal: an earlier case may have
+    // moved origin on, and the property here is "back to what origin says".
+    const onOrigin = fs.readFileSync(path.join(wt, 'README.md'), 'utf8')
+    fs.writeFileSync(path.join(wt, 'README.md'), 'scribbled over\n')
+    fs.writeFileSync(path.join(wt, 'scratch.txt'), 'a turn left this\n')
+
+    await sync(['alp82/curia'])
+    assert.equal(fs.readFileSync(path.join(wt, 'README.md'), 'utf8'), onOrigin)
+    assert.equal(fs.existsSync(path.join(wt, 'scratch.txt')), true,
+      'this pass has no business judging what a previous turn left')
+  })
+
+  // Its OWN origin: this case deletes refs, and every other case reads the
+  // shared one. A restore afterwards would make the suite order-dependent.
+  test('a branch and a tag deleted on origin are pruned, so the chat cannot answer from them', async () => {
+    const own = path.join(tmp, 'prunable.git')
+    const ownSeed = path.join(tmp, 'prunable-seed')
+    execFileSync('git', ['init', '--bare', '-b', 'main', own])
+    execFileSync('git', ['init', '-b', 'main', ownSeed])
+    git(ownSeed, 'remote', 'add', 'origin', own)
+    fs.writeFileSync(path.join(ownSeed, 'a.txt'), 'a\n')
+    git(ownSeed, 'add', '.')
+    commit(ownSeed, 'base')
+    git(ownSeed, 'push', 'origin', 'main')
+    git(ownSeed, 'branch', 'curia/42')
+    git(ownSeed, 'push', 'origin', 'curia/42')
+    git(ownSeed, 'tag', 'v1')
+    git(ownSeed, 'push', 'origin', 'v1')
+    execFileSync('git', ['-C', own, 'symbolic-ref', 'HEAD', 'refs/heads/main'])
+
+    const opts = {
+      clone: (repo, wt) => { execFileSync('git', ['clone', own, wt]); return Promise.resolve() },
+      urlFor: () => own,
+    }
+    const first = await syncCheckouts(root, ['alp82/prunable'], opts)
+    const wt = first.repos[0].path
+    assert.match(git(wt, 'for-each-ref', '--format=%(refname)'), /origin\/curia\/42/)
+
+    git(ownSeed, 'push', 'origin', '--delete', 'curia/42')
+    git(ownSeed, 'push', 'origin', '--delete', 'v1')
+
+    await syncCheckouts(root, ['alp82/prunable'], opts)
+    const refs = git(wt, 'for-each-ref', '--format=%(refname)')
+    assert.doesNotMatch(refs, /origin\/curia\/42/)
+    assert.doesNotMatch(refs, /refs\/tags\/v1/)
+  })
+
+  // #312's open thread, answered.
+  test('the clone of a repo nobody watches is deleted', async () => {
+    await sync(REPOS)
+    const dropped = checkoutPathFor(root, 'alp82/aistack')
+    assert.ok(fs.existsSync(dropped))
+
+    const result = await sync(['alp82/curia'])
+    assert.equal(fs.existsSync(dropped), false)
+    assert.deepEqual(result.removed, ['alp82__aistack'])
+  })
+
+  test('watching it again clones it back', async () => {
+    await sync(['alp82/curia'])
+    const result = await sync(REPOS)
+    const back = result.repos.find((r) => r.repo === 'alp82/aistack')
+    assert.equal(back.cloned, true)
+    assert.equal(back.ok, true)
+  })
+
+  // The prune compares against the names the watch list generates. It never
+  // parses a directory name back into a repo, so a name that does not
+  // round-trip can never cause a delete.
+  test('the prune keeps exactly the watched names and touches nothing else', () => {
+    const base = path.join(tmp, 'prune-only')
+    fs.mkdirSync(path.join(base, 'alp82__curia'), { recursive: true })
+    fs.mkdirSync(path.join(base, 'alp82__a__b'), { recursive: true })
+    fs.mkdirSync(path.join(base, 'old__gone'), { recursive: true })
+    fs.writeFileSync(path.join(base, 'notes.txt'), 'a file, not a clone\n')
+
+    const removed = pruneUnwatched(base, ['alp82/curia', 'alp82/a__b'])
+    assert.deepEqual(removed, ['old__gone'])
+    assert.ok(fs.existsSync(path.join(base, 'alp82__a__b')))
+    assert.ok(fs.existsSync(path.join(base, 'notes.txt')))
+  })
+
+  test('a pass over a root that does not exist yet makes it', async () => {
+    const fresh = path.join(tmp, 'brand-new')
+    const result = await syncCheckouts(fresh, ['alp82/curia'], { clone, urlFor })
+    assert.equal(result.repos[0].ok, true)
+    assert.equal(result.root, checkoutsRootFor(fresh))
+  })
+
+  // #312's answer to "a repo whose fetch fails": the turn runs anyway, and the
+  // verdict is what stops the model reading a stale checkout as a fresh one.
+  test('one repo failing does not refuse the turn — the others still fetch', async () => {
+    const result = await syncCheckouts(root, REPOS, {
+      urlFor,
+      clone: (repo, wt) => (repo === 'alp82/aistack'
+        ? Promise.reject(new Error('could not resolve host github.com'))
+        : clone(repo, wt)),
+    })
+    const bad = result.repos.find((r) => r.repo === 'alp82/aistack')
+    const good = result.repos.find((r) => r.repo === 'alp82/curia')
+    assert.equal(good.ok, true)
+    assert.equal(bad.ok, false)
+    assert.match(bad.error, /could not resolve host/)
+  })
+
+  test('a failed fetch reports the age of the last good one; a repo never cloned reports none', async () => {
+    const at = new Date('2026-08-11T09:00:00.000Z')
+    const first = await sync(['alp82/curia'], { now: () => at })
+    const wt = first.repos[0].path
+    assert.equal(first.repos[0].fetchedAt, at.toISOString())
+    assert.equal(readFetchStamp(wt), at.toISOString())
+
+    // origin goes away under an existing clone: the fetch fails, the checkout
+    // stays on disk, and its age is the thing the turn has to be able to state.
+    const second = await syncCheckouts(root, ['alp82/curia'], {
+      clone: () => Promise.reject(new Error('unreachable')),
+      urlFor: () => path.join(tmp, 'no-such-origin.git'),
+    })
+    assert.equal(second.repos[0].ok, false)
+    assert.equal(second.repos[0].fetchedAt, null)
+    assert.equal(second.repos[0].staleSince, at.toISOString())
+    assert.ok(fs.existsSync(path.join(wt, '.git')), 'a failed fetch must not destroy the checkout')
+
+    const never = await syncCheckouts(path.join(tmp, 'empty-root'), ['alp82/curia'], {
+      clone: () => Promise.reject(new Error('unreachable')), urlFor,
+    })
+    assert.equal(never.repos[0].fetchedAt, null)
+    assert.equal(never.repos[0].staleSince, null, 'no checkout at all is not the same as a stale one')
+  })
+
+  test('a directory left behind by a dead pass is re-cloned, not read', async () => {
+    const wt = checkoutPathFor(root, 'alp82/curia')
+    fs.mkdirSync(wt, { recursive: true })
+    fs.writeFileSync(path.join(wt, 'leftover.txt'), 'from a pass that died\n')
+
+    const result = await sync(['alp82/curia'])
+    assert.equal(result.repos[0].ok, true)
+    assert.equal(result.repos[0].cloned, true)
+    assert.equal(fs.existsSync(path.join(wt, 'leftover.txt')), false)
+  })
+
+  // The nastier half of the same failure. `git clone` writes `.git` early, so a
+  // clone the timeout killed leaves something that LOOKS like a repository.
+  // Testing only for `.git` would leave it there to fail its fetch on every
+  // later turn, with nothing ever deciding to clone over it.
+  test('a clone killed part-way is re-cloned, not fetched into forever', async () => {
+    const wt = checkoutPathFor(root, 'alp82/curia')
+    fs.mkdirSync(path.join(wt, '.git', 'objects'), { recursive: true })
+    fs.mkdirSync(path.join(wt, '.git', 'refs'), { recursive: true })
+    fs.writeFileSync(path.join(wt, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+    fs.writeFileSync(path.join(wt, '.git', 'config'), '[core]\n\trepositoryformatversion = 0\n')
+    assert.throws(() => git(wt, 'rev-parse', '--verify', 'HEAD'), 'the fixture must be a repo that answers nothing')
+
+    const result = await sync(['alp82/curia'])
+    assert.equal(result.repos[0].ok, true, result.repos[0].error)
+    assert.equal(result.repos[0].cloned, true, 'the skeleton must be replaced, not fetched into')
+    assert.match(git(wt, 'rev-parse', '--abbrev-ref', 'HEAD').trim(), /^main$/)
+  })
+
+  test('ensureCheckout heals a clone whose config a hand edit broke', async () => {
+    await sync(['alp82/curia'])
+    const wt = checkoutPathFor(root, 'alp82/curia')
+    git(wt, 'config', '--replace-all', 'remote.origin.fetch', '+refs/heads/main:refs/remotes/origin/main')
+    git(wt, 'config', '--unset', 'remote.origin.pushurl')
+
+    await ensureCheckout(root, 'alp82/curia', { clone: () => { throw new Error('must not re-clone') }, urlFor })
+    assert.deepEqual(git(wt, 'config', '--get-all', 'remote.origin.fetch').trim().split('\n'), FETCH_REFSPECS)
+    assert.match(git(wt, 'config', '--get', 'remote.origin.pushurl'), /^no_push:/)
+  })
+
+  test('the default branch is read from origin, not assumed to be main', async () => {
+    const other = path.join(tmp, 'other.git')
+    execFileSync('git', ['init', '--bare', '-b', 'trunk', other])
+    const otherSeed = path.join(tmp, 'other-seed')
+    execFileSync('git', ['init', '-b', 'trunk', otherSeed])
+    git(otherSeed, 'remote', 'add', 'origin', other)
+    fs.writeFileSync(path.join(otherSeed, 'a.txt'), 'a\n')
+    git(otherSeed, 'add', '.')
+    commit(otherSeed, 'base')
+    git(otherSeed, 'push', 'origin', 'trunk')
+    execFileSync('git', ['-C', other, 'symbolic-ref', 'HEAD', 'refs/heads/trunk'])
+
+    const result = await syncCheckouts(root, ['alp82/other'], {
+      clone: (repo, wt) => { execFileSync('git', ['clone', other, wt]); return Promise.resolve() },
+      urlFor: () => other,
+    })
+    assert.equal(result.repos[0].branch, 'trunk')
+    assert.equal(git(result.repos[0].path, 'rev-parse', '--abbrev-ref', 'HEAD').trim(), 'trunk')
+    // The branch the pass makes here never existed locally, so this is the path
+    // where a lost upstream would be silent.
+    assert.equal(git(result.repos[0].path, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}').trim(), 'origin/trunk')
+  })
+})

--- a/docs/live-checks/312-overseer-checkouts.md
+++ b/docs/live-checks/312-overseer-checkouts.md
@@ -1,0 +1,52 @@
+# Live checks: the overseer's checkouts (#312)
+
+Run 2026-08-11 with `daemon/bin/curia-checkouts.mjs` against the real `github.com`, with a real `gh` login and a scratch workspace root. Every number below is a measurement. The unit suite (`daemon/test/checkouts.test.mjs`) drives a local origin, so these are the claims no local fixture can prove.
+
+## 1. What a cold pass costs
+
+| Check | Result |
+| --- | --- |
+| First pass, `alp82/curia` alone | cloned, `main` at `6820d4a5`, **4.0 s** |
+| On-disk size of that checkout | **8.4 MB** |
+| `git config remote.origin.partialclonefilter` | `blob:none` |
+| Second pass, `alp82/curia` cached plus `alp82/aistack` cold | 4.8 s |
+| Third pass, both cached | **1.5 s** |
+
+1.5 s is the per-turn cost for two repos, and it is what ADR-0014's "it costs nothing while nobody asks" buys. A cold clone is seconds, which is what makes it safe to let the container clone a newly watched repo inside a turn rather than have the daemon pre-clone it.
+
+## 2. Every ref, measured against what GitHub actually publishes
+
+| Check | Result |
+| --- | --- |
+| `refs/remotes/origin/pr/*` in the checkout | **68 heads** |
+| `git log -1 origin/pr/325` | `e8f6f4b Point the single-use thread rule at its own ticket (#326)` |
+| Branches in the checkout, excluding `pr/*` | `origin/HEAD`, `origin/main` |
+| `gh api repos/alp82/curia/branches` | `main` |
+| `pr/*/merge` refs | absent, as intended |
+
+**The finding: on this repo the pull-request heads are what answer "what did this agent change".** A merge runs `--delete-branch`, so a finished ticket leaves no `curia/<n>` branch at all — the checkout above holds `main` and nothing else, and it matches GitHub exactly. The branch refspec catches the live ones while an agent is working. The head refspec is what keeps every finished one readable. Neither refspec alone answers the question ADR-0014 says an operator asks first.
+
+## 3. A blobless clone still reads a file
+
+| Check | Result |
+| --- | --- |
+| `git show origin/pr/325:CONTEXT.md` | the file, first line `# Curia` |
+
+The blob is not in the 8.4 MB. git fetched it on demand from a ref that is not the working tree's own branch. So "read the file this agent changed" works, and it costs one round trip rather than a full history download per repo.
+
+## 4. The read-only posture, refused rather than asked
+
+| Check | Result |
+| --- | --- |
+| `git commit` in a checkout | `Author identity unknown. *** Please tell me who you are.` |
+| `git push origin HEAD:refs/heads/smoke-must-not-land` | `fatal: protocol 'no_push' is not supported` |
+
+Both are manners, not controls: a shell undoes either in one command. ADR-0014 is explicit that the read-only token of [#313](https://github.com/alp82/curia/issues/313) is the control. What these buy is that an accident fails loudly and names itself, and the push never reached the network to be refused by GitHub.
+
+## 5. The pass that could not run
+
+| Check | Result |
+| --- | --- |
+| A config with no `identity:` section | exit 1, and stdout carries the loader's own message |
+
+The command reads the watch list through `loadCuriaConfig`, the same loader that decides whether the daemon boots, rather than a second parser of its own. A config it refuses is a config the daemon refuses too.


### PR DESCRIPTION
Ticket: alp82/curia#312 — [The checkouts: every watched repo, every ref, one fetch per turn](https://github.com/alp82/curia/issues/312)

Builds what ADR-0014 states the overseer reads: one blobless clone per watched repo, every ref, one fetch per turn.

**The layout.** `<workspace_root>/overseer/repos/<owner>__<repo>`. ADR-0014 says "its own volume", and a named docker volume per repo has to be declared in a static `compose.yaml` while the watch list is not static. So it is one host tree, one bind mount at its identical path, and the set of clones inside moves with the config. #327 writes that mount line, because it owns the service.

**The owner.** The overseer container, alone, in one pass at the start of every turn. It clones what is missing, deletes the clone of a repo nobody watches, and fetches the rest in parallel. The daemon asserts nothing about this tree.

**Every ref.** Three refspecs: branches (so `curia/<n>` is there while an agent works), pull-request heads (which stay readable after a merge deletes the branch), and tags. Not the merge refs — GitHub computes those against a moving base. The refspecs are written into `remote.origin.fetch` as well, so a mid-turn `git pull` sees everything too.

**The working tree moves with the fetch.** A fetch alone leaves the tree at the commit the clone was taken at, so `cat README.md` would answer from a month ago while `git log origin/main` answered from today. That is the one failure "every read inside a turn is consistent" exists to prevent.

**A failed fetch does not refuse the turn.** The pass returns a verdict per repo, carrying the instant of the last good fetch, so #314 can tell the model which checkout is stale and how old it is.

**The unwatched clone is deleted** (the thread the ticket names). It is a mirror of origin holding nothing unique, so the delete loses nothing and re-watching re-clones in seconds. Keeping it would let the chat read a repo the operator removed, at an age nobody states.

Files: `daemon/src/checkouts.mjs`, `daemon/bin/curia-checkouts.mjs` (the turn-start command), `daemon/test/checkouts.test.mjs` (20 cases against a local origin), `docs/live-checks/312-overseer-checkouts.md`, and the CONTEXT.md vocabulary.

Suite: 1724 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-312`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `c884c79` Build the overseer's checkouts (#312)