### PR TITLE
The read-only GitHub token (alp82/curia#313)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -147,6 +147,10 @@ _Avoid_: private clone (that is an agent's, per ticket, and it is a place to com
 **Checkout pass**:
 What the overseer container runs at the start of every turn, before the model: clone every watched repo that is missing, delete the clone of one nobody watches, and fetch the rest in parallel. It is the whole reason every read inside one turn is consistent. The daemon asserts nothing about this tree. A repo whose fetch fails does not refuse the turn — the pass returns a verdict per repo, and the turn tells the model which checkout is stale and how old it is.
 
+**Overseer token**:
+The read-only GitHub token the overseer container holds, one fine-grained PAT per resource owner. It is the control that replaces the seam: the container has a shell, and a shell cannot mint a token. It lives in `daemon/.env.overseer` as `CURIA_OVERSEER_GH_TOKEN_<OWNER>`, a second env file the overseer service loads whole and the daemon only reads. See [ADR-0014](docs/adr/0014-the-overseer-in-its-own-container.md) and the [live checks](docs/live-checks/313-overseer-github-token.md).
+_Avoid_: agent token (that one is per resource owner too, but it is read-write and it reaches an agent as `GH_TOKEN`).
+
 **The verbs**:
 `tickets`, `next`, `status`, `start`, `map`, `cancel`, `resume`, `attach`, `review`. The whole command surface, identical over Discord and REST. Each verb has one meaning. `start` works a thing, and `map` updates a map.
 _Avoid_: the five verbs (the pre-#81 count, wrong since `next`, `resume` and `review` joined).
@@ -418,7 +422,7 @@ The model a takeable ticket gets if it starts now. Reconcile computes it with th
 The operator's Tailscale login, taken from the header the sidecar's identity check already reads and passed to the daemon as the `by` of every verb. Before the console, every REST verb journalled the word `rest`. The feed now names a person rather than a transport.
 
 **Sidecar**:
-The process that serves the dashboard. It runs beside the daemon and never inside it, so it stays up while the daemon restarts. It holds no secret: its container mounts the code and the config directory, and neither the journal nor the `.env`.
+The process that serves the dashboard. It runs beside the daemon and never inside it, so it stays up while the daemon restarts. It holds no secret: its container mounts the code and the config directory, and neither the journal nor the `.env.daemon`.
 
 **Settings screen**:
 The one dashboard screen that writes. Three sections, Routing first, then Projects and Dispatch. It reads `curia.yaml` and `routing.yaml` off disk on arrival, never from the poll snapshot, and posts back only what the operator changed.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd curia/daemon
 npm install
 ```
 
-## 7. `daemon/.env`
+## 7. `daemon/.env.daemon`
 
 ```
 DISCORD_BOT_TOKEN=<the bot token>
@@ -106,6 +106,16 @@ Optional: `CURIA_GUILD_ID`, `CURIA_CHANNEL` (default `curia`), `PORT` (4271),
 `OVERSEER_MODEL`, `OVERSEER_FALLBACK_MODEL`.
 
 Run one daemon per bot token.
+
+### `daemon/.env.overseer`
+
+```
+CURIA_OVERSEER_GH_TOKEN_<OWNER>=<a fine-grained GitHub PAT, read-only>
+```
+
+The overseer runs in a container with a shell, so its own token is read-only (#313). Mint one fine-grained PAT per resource owner you watch, with **Contents**, **Issues**, **Pull requests** and **Commit statuses** at read, plus **Metadata** read. Nothing at write. An organization can cap the token lifetime, so a token for an org owner needs an expiry inside that cap.
+
+Keep these keys in this second file. The overseer service loads the file whole, and `daemon/.env.daemon` holds the read-write tokens the overseer must never get.
 
 ## 8. `config/curia.yaml`
 

--- a/daemon/.gitignore
+++ b/daemon/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 data/
 .env
+.env.*

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -15,14 +15,15 @@ The daemon expects these on the box before the first boot:
 - **`tmux`** — the agent host. Under compose (#260) the server lives in the `tmux` service and the daemon is a client over `CURIA_TMUX_SOCKET`. Unset, the default socket serves a dev box.
 - **`ttyd` on port 7681** for the browser terminal. The compose `ttyd` service runs it. The daemon health-checks the port and does not spawn ttyd.
 - **Tailscale** with Serve available. Attach links and preview links publish through `tailscale serve`.
-- **A Discord bot** in one guild, with the message-content intent, and its token in `.env`.
+- **A Discord bot** in one guild, with the message-content intent, and its token in `.env.daemon`.
 
-`.env` (never committed):
+`.env.daemon` (never committed). One env file per container that holds secrets, and the pair reads as a pair: this one and `.env.overseer` (#313):
 
 - `DISCORD_BOT_TOKEN` — CuriaBot token. Omit to run REST-only (escalations stay answerable via `POST /answer`).
 - `DISCORD_ALLOWED_USERS` — comma-separated Discord user ids; the auth gate. The bridge refuses to start if empty.
 - `CURIA_AGENT_GH_TOKEN_<OWNER>` — the scoped GitHub token an agent gets as `GH_TOKEN` (#155). One key per resource owner, uppercased, hyphens folded to underscores: `alp82/curia` reads `CURIA_AGENT_GH_TOKEN_ALP82`. See [the agent's GitHub authority](#the-agents-github-authority-155) below.
 - `CURIA_GUILD_ID` (optional — defaults to the bot's first guild), `CURIA_CHANNEL` (default `curia`), `PORT` (default 4271).
+- The overseer's own tokens are **not** in this file. They live in `.env.overseer` beside it, one `CURIA_OVERSEER_GH_TOKEN_<OWNER>` per resource owner, read-only (#313). That second file is the boundary: the overseer service loads it whole and never loads `.env`. See [the overseer's GitHub authority](#the-overseers-github-authority-313) below.
 - `OVERSEER_MODEL` (default `claude-haiku-4-5`) and `OVERSEER_FALLBACK_MODEL` (default `claude-sonnet-5`) — the overseer session models (#92).
 
 Config (validated on load; a bad shape refuses the boot): `../config/curia.yaml` (watch list, dispatch settings — `auto_dispatch` ships `false` — attach ports, preview range, agent skill set) and `../config/routing.yaml` (label-only model routing, fallback chains, harness command templates). Override the directory with `CURIA_CONFIG_DIR`.
@@ -33,7 +34,7 @@ Each of those two files takes an override beside it — `curia.local.yaml` and `
 
 ```
 npm install
-npm start          # reads daemon/.env
+npm start          # reads daemon/.env.daemon
 npm test           # unit tests
 ```
 
@@ -206,7 +207,7 @@ An agent used to reach GitHub through the host's `~/.config/gh/hosts.yml` login,
 
 The permissions are **Contents**, **Issues** and **Pull requests** read/write, plus **Commit statuses** read so `gh pr checks` answers. Nothing else. The rule is grant content, never execution or persistence: Secrets, Variables, Webhooks, Workflows, Environments and Actions-write each hand a compromised agent either a way to run code or a way to keep reach after it dies.
 
-The daemon is deliberately **not** on this token. Its own `gh` keeps the host login, because it must reach every watched repo, and a repo added to `curia.yaml` but left off a token would break dispatch with no signal. A bare `GH_TOKEN` in `.env` would re-authenticate the daemon too, silently, by sitting in its environment.
+The daemon is deliberately **not** on this token. Its own `gh` keeps the host login, because it must reach every watched repo, and a repo added to `curia.yaml` but left off a token would break dispatch with no signal. A bare `GH_TOKEN` in `.env.daemon` would re-authenticate the daemon too, silently, by sitting in its environment.
 
 The value is read at boot, so a quoted or padded token refuses the boot instead of reaching an agent as a 401 mid-resolve. Boot also asks GitHub once per watched repo, with the token that repo's agent would get, and warns when the token cannot reach it or expires within 14 days. An expired token does not degrade to the host login. It fails every `gh` call, so the warning is the whole defense.
 
@@ -215,6 +216,24 @@ That probe has one blind spot, measured rather than assumed: **a public repo lef
 Note for org repos: an organization can cap fine-grained PAT lifetime, and `getalfredo` caps it at 366 days. So an org token cannot be permanent, and its expiry is a calendar item until the GitHub App lands. The full transcript is in [docs/live-checks/155-agent-github-token.md](../docs/live-checks/155-agent-github-token.md).
 
 A GitHub App with one-hour installation tokens is the later, cleaner form, and it stays in the map's fog. It is not a drop-in: an installation token dies after an hour and `GH_TOKEN` is fixed at pane spawn, so the daemon would have to refresh into a per-agent `gh` config dir that `gh` re-reads on each call.
+
+## The overseer's GitHub authority (#313)
+
+The overseer container holds a shell. The read-only token is the control that replaces the `/command` seam, because a standing order cannot hold a shell and a shell cannot mint a token. See [ADR-0014](../docs/adr/0014-the-overseer-in-its-own-container.md).
+
+**One token per resource owner**, the same rule and the same spelling as the agent token, one prefix over: `CURIA_OVERSEER_GH_TOKEN_<OWNER>`, uppercased, hyphens folded to underscores. An operator who has written one pair of keys has written the other.
+
+**The keys live in `daemon/.env.overseer`, never in `daemon/.env`.** The overseer service loads that file whole, so every key in it is a key a shell in that container holds. `daemon/.env` carries the agents' read-WRITE tokens and the Discord bot token, and compose cannot filter an env file. So the file itself is the boundary. The daemon parses this file and never loads it into its own environment. A bare token in the daemon environment would re-authenticate the daemon's own `gh`, which is the trap #155 named.
+
+The permissions are **Contents**, **Issues**, **Pull requests** and **Commit statuses** at read, plus **Metadata** read. Nothing at write, and nothing else at all. Agents write, and they write through pull requests.
+
+**The expiry follows the owner**, exactly as the agent tokens do. The `alp82` token has none. The `getalfredo` token expires after 366 days, because the organization refuses any fine-grained token with a longer life, and that refusal hits a public repo read too.
+
+Boot states each token, then asks GitHub once per watched repo with the token that repo would be read with. It warns when a token cannot reach a repo, when a token expires within 14 days, and when an owner on the watch list has no key. An expired token does not degrade to anything. The container mounts no `~/.config/gh`, so the reach falls back to what GitHub gives an anonymous caller. The boot warning is the whole defense.
+
+The probe has the same blind spot as the agent one, and it is measured, not assumed: a public repo left off the token's selection cannot be detected by any read. The full transcript is in [docs/live-checks/313-overseer-github-token.md](../docs/live-checks/313-overseer-github-token.md).
+
+`gh` reads one `GH_TOKEN`, and the container holds one token per owner, so something must pick. git picks by itself: one `credential.https://github.com/<owner>.helper` line per owner, because git prefix-matches the owner path (measured). `gh` needs a shim that reads the owner off the command line or off the checkout directory name. [#327](https://github.com/alp82/curia/issues/327) installs both, because it owns the image.
 
 ## What an agent knows (#57)
 

--- a/daemon/src/github.mjs
+++ b/daemon/src/github.mjs
@@ -152,12 +152,13 @@ export async function deleteRemoteBranch(repo, branch) {
   }
 }
 
-// ---- the agent token's boot probe (#155) ------------------------------------
+// ---- the boot probe for a scoped token (#155, #313) -------------------------
 //
-// An agent token's repository list is edited on GitHub, not in `daemon/.env`, so
-// a repo added to the watch list and forgotten on the token leaves no trace here.
-// This asks GitHub at boot instead, once per watched repo, with the token that
-// repo's agent would actually get.
+// A token's repository list is edited on GitHub, not in an env file, so a repo
+// added to the watch list and forgotten on the token leaves no trace here. This
+// asks GitHub at boot instead, once per watched repo, with the token that repo
+// would actually be read with. It serves both holders: the agent's read-write
+// token (#155) and the overseer's read-only one (#313).
 //
 // What it CAN catch: a private repo missing from the token's selection (404), an
 // org policy refusal (403 carrying its own reason), a revoked or expired token
@@ -173,7 +174,7 @@ export async function deleteRemoteBranch(repo, branch) {
 //
 // fetch rather than `gh`, because the answer is in a HEADER and `gh api -i`
 // would mean parsing a child process's stdout to get it.
-export async function probeAgentToken(repo, token, { fetchImpl = globalThis.fetch } = {}) {
+export async function probeRepoToken(repo, token, { fetchImpl = globalThis.fetch } = {}) {
   const res = await fetchImpl(`https://api.github.com/repos/${repo}`, {
     headers: {
       authorization: `Bearer ${token}`,

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -44,8 +44,12 @@ import { SelfDeploy } from './deploy.mjs'
 import { OverseerHost, CONSOLE_SESSION } from './overseer.mjs'
 import { hasSession } from './tmux.mjs'
 import { assertGhTokens, ghTokenKeyFor, agentGhToken } from './workspace.mjs'
+import {
+  OVERSEER_ENV_FILE, overseerEnvPath, loadOverseerEnv, assertOverseerTokens,
+  overseerGhToken, overseerTokenKeyFor, daemonOnlyKeys,
+} from './overseertoken.mjs'
 import { TOKEN_HEADER, AGENT_ROUTES, tokensDir, agentTokenMatches } from './agenttoken.mjs'
-import { probeAgentToken, tokenExpiryDays, viewerLogin, ghJSONL } from './github.mjs'
+import { probeRepoToken, tokenExpiryDays, viewerLogin, ghJSONL } from './github.mjs'
 import { probeTtyd, assertServe, serveOff, attachBase, attachSessionUrl, validSessionName } from './attach.mjs'
 import { TimelineSurface } from './timeline.mjs'
 import { IdentityProxy, identityRefusal, hostsForPorts, tailnetSelf } from './identity.mjs'
@@ -58,14 +62,27 @@ import { AccountUsage, ModelWindows, agentMeters, ctxOnWire } from './usage.mjs'
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.join(DIR, '..')
 
-// minimal .env loader (daemon/.env, never committed)
-const envFile = path.join(ROOT, '.env')
-if (fs.existsSync(envFile)) {
-  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+// minimal env loader (daemon/.env.daemon, never committed)
+//
+// The name gained its suffix with #313, which gave the overseer container an env
+// file of its own. Two files, one per container that holds secrets, and the pair
+// reads as a pair: `.env.daemon` and `.env.overseer`.
+//
+// The old name is still loaded, and it says so. A box that has not been renamed
+// yet keeps booting, and the line names the one move that silences it. In the
+// container the rename is not optional — compose refuses a missing `env_file` —
+// so this branch is for a dev box and for the moment between the rename and the
+// deploy.
+const envFile = path.join(ROOT, '.env.daemon')
+const legacyEnvFile = path.join(ROOT, '.env')
+const loadFrom = fs.existsSync(envFile) ? envFile : (fs.existsSync(legacyEnvFile) ? legacyEnvFile : null)
+if (loadFrom) {
+  for (const line of fs.readFileSync(loadFrom, 'utf8').split('\n')) {
     const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/)
     if (m && !(m[1] in process.env)) process.env[m[1]] = m[2]
   }
 }
+if (loadFrom === legacyEnvFile) log('WARNING: daemon/.env is the old name — rename it to daemon/.env.daemon, beside daemon/.env.overseer (#313)')
 
 const PORT = Number(process.env.PORT ?? 4271)
 // CURIA_DATA_DIR mirrors CURIA_CONFIG_DIR: the boot test points both at a
@@ -104,38 +121,72 @@ const SANDBOXED_HARNESSES = Object.keys(routingConfig.harnesses)
 // watched owner, because an owner with no token silently keeps the host's
 // account-wide login and that is the thing this ticket exists to end. The daemon
 // itself never uses these (see agentGhToken).
+const WATCHED_OWNERS = new Set(curiaConfig.watch.map((w) => w.repo.split('/')[0]))
 for (const { key, token } of assertGhTokens()) log(`agent GitHub token ${key} (…${token.slice(-4)})`)
-for (const owner of new Set(curiaConfig.watch.map((w) => w.repo.split('/')[0]))) {
+for (const owner of WATCHED_OWNERS) {
   const key = ghTokenKeyFor(owner)
   if (!agentGhToken(`${owner}/x`)) log(`WARNING: no ${key} — agents on ${owner}/* inherit the host gh login (account-wide)`)
 }
 
+// #313: the overseer's own GitHub authority — the same shape one prefix over,
+// READ-ONLY, and in a second env file. The overseer container loads that file
+// whole, so what is in it is what a shell in that container holds. The daemon
+// only reads it, and never into `process.env`: a bare token there would
+// re-authenticate the daemon's own `gh`.
+const overseerEnv = loadOverseerEnv(overseerEnvPath(ROOT))
+for (const key of daemonOnlyKeys(overseerEnv)) {
+  log(`WARNING: ${key} is in daemon/${OVERSEER_ENV_FILE} — that file is the overseer's read-only boundary, and its container gets every key in it`)
+}
+for (const { key, token } of assertOverseerTokens(overseerEnv)) log(`overseer GitHub token ${key} (…${token.slice(-4)})`)
+for (const owner of WATCHED_OWNERS) {
+  const key = overseerTokenKeyFor(owner)
+  if (!overseerGhToken(`${owner}/x`, overseerEnv)) log(`WARNING: no ${key} — the overseer holds no credential for ${owner}/*`)
+}
+
 // And the same tokens against GitHub itself, once per watched repo. A token's
-// repository list lives on GitHub rather than in `.env`, so nothing local can
-// tell that a newly watched repo was left off it. Detached from the boot chain
-// on purpose: this is one network round-trip per repo, and GitHub being slow or
-// down must never hold up a daemon whose other duties do not need it. See
-// probeAgentToken for the one case it cannot see.
+// repository list lives on GitHub rather than in an env file, so nothing local
+// can tell that a newly watched repo was left off it. Detached from the boot
+// chain on purpose: this is one network round-trip per repo, and GitHub being
+// slow or down must never hold up a daemon whose other duties do not need it.
+// See probeRepoToken for the one case it cannot see.
+//
+// One pass per holder. The overseer's token is the one whose expiry is a
+// certainty rather than a risk — an org caps its lifetime — so the same warning
+// has to speak for both.
 const TOKEN_EXPIRY_WARN_DAYS = 14
-Promise.all(curiaConfig.watch.map(async ({ repo }) => {
-  const token = agentGhToken(repo)
-  if (!token) return
-  try {
-    const { ok, message, expiresAt } = await probeAgentToken(repo, token)
-    const key = ghTokenKeyFor(repo)
-    if (!ok) {
-      log(`WARNING: ${key} cannot reach ${repo} (${message}) — an agent on it will fail at its first gh call`)
-      return
+function probeWatchedTokens({ holder, tokenFor, keyFor, refusal }) {
+  Promise.all(curiaConfig.watch.map(async ({ repo }) => {
+    const token = tokenFor(repo)
+    if (!token) return
+    const key = keyFor(repo)
+    try {
+      const { ok, message, expiresAt } = await probeRepoToken(repo, token)
+      if (!ok) {
+        log(`WARNING: ${key} cannot reach ${repo} (${message}) — ${refusal}`)
+        return
+      }
+      const days = tokenExpiryDays(expiresAt)
+      if (days === null) return
+      if (days <= TOKEN_EXPIRY_WARN_DAYS) log(`WARNING: ${key} expires in ${days} day(s), on ${expiresAt} — mint a new one before it dies`)
+      else log(`${key} reaches ${repo}, expires in ${days} days`)
+    } catch (e) {
+      // A network failure is a fact about the network, not about the token.
+      log(`could not check the ${holder} token for ${repo} (${e.message}) — not treating that as a bad token`)
     }
-    const days = tokenExpiryDays(expiresAt)
-    if (days === null) return
-    if (days <= TOKEN_EXPIRY_WARN_DAYS) log(`WARNING: ${key} expires in ${days} day(s), on ${expiresAt} — mint a new one before it dies`)
-    else log(`${key} reaches ${repo}, expires in ${days} days`)
-  } catch (e) {
-    // A network failure is a fact about the network, not about the token.
-    log(`could not check the agent token for ${repo} (${e.message}) — not treating that as a bad token`)
-  }
-})).catch(() => {})
+  })).catch(() => {})
+}
+probeWatchedTokens({
+  holder: 'agent',
+  tokenFor: (repo) => agentGhToken(repo),
+  keyFor: ghTokenKeyFor,
+  refusal: 'an agent on it will fail at its first gh call',
+})
+probeWatchedTokens({
+  holder: 'overseer',
+  tokenFor: (repo) => overseerGhToken(repo, overseerEnv),
+  keyFor: overseerTokenKeyFor,
+  refusal: 'the overseer cannot read it',
+})
 
 const store = new EscalationStore(DATA)
 

--- a/daemon/src/overseertoken.mjs
+++ b/daemon/src/overseertoken.mjs
@@ -1,0 +1,110 @@
+// The overseer's GitHub authority (#313, building ADR-0014's "its GitHub token
+// is read-only").
+//
+// The overseer container holds a shell. That shell is the whole point of the
+// move, and a read-only token is the control that replaces the `/command` seam:
+// a standing order cannot hold a shell, and a shell cannot mint a token. So the
+// container gets one FINE-GRAINED PAT PER RESOURCE OWNER, carrying Contents,
+// Issues, Pull requests, Commit statuses and Metadata at READ, and nothing else.
+// Agents keep the read-write tokens of #155, and they write through pull
+// requests.
+//
+// THE SECOND ENV FILE IS THE BOUNDARY. There is one env file per container that
+// holds secrets, and the pair reads as a pair: `daemon/.env.daemon` and
+// `daemon/.env.overseer`. These keys live in the second one, and the overseer
+// service loads that file and never the first.
+//
+// `.env.daemon` carries the agents' read-WRITE tokens and the Discord bot token,
+// and compose cannot filter an env file: `env_file: ../daemon/.env.daemon` on
+// the overseer service would hand every one of those values to a container with
+// a shell, where `export` undoes the whole read-only posture in one command. A
+// file the overseer may hold whole is the only form of that boundary a static
+// compose file can express.
+//
+// THE DAEMON READS THIS FILE AND NEVER LOADS IT. `parseEnv` rather than
+// `process.loadEnvFile`: a value here must never reach `process.env`, because a
+// bare `GH_TOKEN` sitting in the daemon's environment would silently
+// re-authenticate the daemon's own `gh` — the same trap #155 named when it chose
+// a prefixed key. What the daemon does with what it reads is say it out loud at
+// boot: one line per token, and a warning when a token cannot reach a watched
+// repo or is about to die.
+//
+// THE EXPIRY IS A CALENDAR ITEM, not a detail. An organization can cap
+// fine-grained PAT lifetime, and `getalfredo` caps it at 366 days — measured
+// again for this ticket, and the refusal hits a PUBLIC repo read too, so a
+// longer-lived token is not merely narrower there, it is refused outright. An
+// expired token does not degrade to anything. It fails every call with a 401, so
+// the boot warning is the whole defense.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { parseEnv } from 'node:util'
+import { AGENT_TOKEN_KEY, ownerSlug, readGhToken } from './workspace.mjs'
+
+export const OVERSEER_TOKEN_KEY = 'CURIA_OVERSEER_GH_TOKEN'
+
+// Beside `daemon/.env.daemon`, and spelled the same way, because the two are one
+// operator habit: an env file the deploy copies to the box and never commits.
+export const OVERSEER_ENV_FILE = '.env.overseer'
+
+export function overseerEnvPath(daemonRoot) {
+  return path.join(daemonRoot, OVERSEER_ENV_FILE)
+}
+
+// `alp82/curia` → `CURIA_OVERSEER_GH_TOKEN_ALP82`, the agent key's shape one
+// prefix over. One spelling rule for both, so an operator who has written one
+// pair of keys has written the other.
+export function overseerTokenKeyFor(repo) {
+  const slug = ownerSlug(repo)
+  return slug ? `${OVERSEER_TOKEN_KEY}_${slug}` : null
+}
+
+// The file, parsed, or an empty environment when it is not there. Absent is the
+// pre-#313 state and stays legal: nothing reads these tokens until the overseer
+// container exists, and the boot warning is what asks for them.
+//
+// A file that exists and cannot be read is a different thing from one that is
+// missing, and it throws rather than reading as empty — an unreadable file would
+// otherwise silence every warning below at the moment it matters most.
+export function loadOverseerEnv(file) {
+  let raw
+  try {
+    raw = fs.readFileSync(file, 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') return {}
+    throw e
+  }
+  return parseEnv(raw)
+}
+
+// The overseer's token for one repo, or null. Null means the container has no
+// credential for that owner. Unlike an agent's null (#155), it is NOT a fallback
+// to the host login: the container mounts no `~/.config/gh`, so the reach is
+// simply whatever GitHub gives an anonymous caller.
+export function overseerGhToken(repo, env) {
+  const key = overseerTokenKeyFor(repo)
+  return key ? readGhToken(env, key, `daemon/${OVERSEER_ENV_FILE}`) : null
+}
+
+// Every overseer token in the file, validated. A malformed value throws here, at
+// boot, rather than reaching the container as a 401 in the middle of a turn.
+export function assertOverseerTokens(env) {
+  return Object.keys(env)
+    .filter((k) => k.startsWith(`${OVERSEER_TOKEN_KEY}_`))
+    .map((k) => ({ key: k, token: readGhToken(env, k, `daemon/${OVERSEER_ENV_FILE}`) }))
+    .filter(({ token }) => token !== null)
+}
+
+// Keys that must never sit in this file, because the file is the boundary and
+// every key in it reaches a container holding a shell. The daemon's own secrets
+// are the ones an operator would copy in by hand while setting the file up, so
+// they are the ones worth naming back.
+//
+// A WARNING, NOT A REFUSAL: #327 has still to decide how the model credential
+// reaches the container, and a boot that refuses an unknown key would refuse
+// that answer before it is written. What this catches is the real accident —
+// `cp daemon/.env.daemon daemon/.env.overseer` — which hands the read-only
+// container every read-write token on the box.
+export function daemonOnlyKeys(env) {
+  return Object.keys(env).filter((k) => k.startsWith(`${AGENT_TOKEN_KEY}_`) || k.startsWith('DISCORD_'))
+}

--- a/daemon/src/sandbox.mjs
+++ b/daemon/src/sandbox.mjs
@@ -308,7 +308,7 @@ export function modelCredential(harness, { env = process.env, home = null } = {}
   if (env.CLAUDE_CODE_OAUTH_TOKEN) return { CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN }
   const stored = readStoredOauth(home)
   if (stored) return { CLAUDE_CODE_OAUTH_TOKEN: stored }
-  throw new Error('no anthropic credential for the container: set CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY) in daemon/.env, or run `claude /login` on this box — a sandboxed claude agent cannot reach the host credential store')
+  throw new Error('no anthropic credential for the container: set CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY) in daemon/.env.daemon, or run `claude /login` on this box — a sandboxed claude agent cannot reach the host credential store')
 }
 
 function readStoredOauth(home) {

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -394,36 +394,48 @@ export function hostStorageDir(harness = 'claude') {
 // The DAEMON is deliberately not on this token. Its own `gh` keeps the host
 // login, because it must reach every watched repo, and a repo added to
 // `curia.yaml` but left off a token would break dispatch with no signal. A bare
-// `GH_TOKEN` in `daemon/.env` would re-authenticate the daemon too, silently, by
-// sitting in its environment — hence a prefixed key.
+// `GH_TOKEN` in `daemon/.env.daemon` would re-authenticate the daemon too,
+// silently, by sitting in its environment — hence a prefixed key.
 //
 // The key says AGENT where the rest of this file still says agent: it is
 // operator-facing config, and renaming it later would cost a coordinated edit of
-// every `.env` plus a restart. The code sweep is #184.
-const GH_TOKEN_KEY = 'CURIA_AGENT_GH_TOKEN'
+// every env file plus a restart. The code sweep is #184.
+//
+// Exported because the overseer's own keys are the same shape one prefix over
+// (#313), and the two prefixes have to be told apart in one place.
+export const AGENT_TOKEN_KEY = 'CURIA_AGENT_GH_TOKEN'
 
 // A GitHub token as GitHub writes one — `github_pat_…`, `ghp_…`, `gho_…`: word
 // characters and nothing else. The value travels as `env K=V` in tmux argv (and
 // as `-e` on the container's command line later), so a stray quote or space from
-// a hand-edited `.env` line has to be refused where it is read. `gh` answers a
+// a hand-edited env line has to be refused where it is read. `gh` answers a
 // quoted token with a plain 401, and nothing on the box would name the quote.
 const GH_TOKEN_RE = /^[A-Za-z0-9_]+$/
 
-// `alp82/curia` → `CURIA_AGENT_GH_TOKEN_ALP82`. An owner is a GitHub login, so
-// the only character to fold is the hyphen.
-export function ghTokenKeyFor(repo) {
+// `alp82/curia` → `ALP82`. An owner is a GitHub login, so the only character to
+// fold is the hyphen. The overseer's keys are built from the same slug (#313).
+export function ownerSlug(repo) {
   const owner = String(repo ?? '').split('/')[0]
   if (!owner) return null
-  return `${GH_TOKEN_KEY}_${owner.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`
+  return owner.toUpperCase().replace(/[^A-Z0-9]/g, '_')
 }
 
-function readGhToken(env, key) {
+// `alp82/curia` → `CURIA_AGENT_GH_TOKEN_ALP82`.
+export function ghTokenKeyFor(repo) {
+  const slug = ownerSlug(repo)
+  return slug ? `${AGENT_TOKEN_KEY}_${slug}` : null
+}
+
+// `where` names the file in the refusal, because #313 puts the overseer's own
+// tokens in a second one and a message naming the wrong file sends the operator
+// to the wrong line.
+export function readGhToken(env, key, where = 'daemon/.env.daemon') {
   const raw = env[key]
   if (raw === undefined) return null
   const token = raw.trim()
   if (!token) return null
   if (!GH_TOKEN_RE.test(token)) {
-    throw new Error(`bad ${key} in daemon/.env: a GitHub token is word characters only — drop the quotes and any trailing text`)
+    throw new Error(`bad ${key} in ${where}: a GitHub token is word characters only — drop the quotes and any trailing text`)
   }
   return token
 }
@@ -441,7 +453,7 @@ export function agentGhToken(repo, env = process.env) {
 // the owners that are scoped, for the boot line.
 export function assertGhTokens(env = process.env) {
   return Object.keys(env)
-    .filter((k) => k.startsWith(`${GH_TOKEN_KEY}_`))
+    .filter((k) => k.startsWith(`${AGENT_TOKEN_KEY}_`))
     .filter((k) => readGhToken(env, k) !== null)
     .map((k) => ({ key: k, token: readGhToken(env, k) }))
 }

--- a/daemon/test/frontier.test.mjs
+++ b/daemon/test/frontier.test.mjs
@@ -48,7 +48,7 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { filterTakeable, selectLane, frontierForRepo, agentOnlyChainCount, probeAgentToken, tokenExpiryDays } from '../src/github.mjs'
+import { filterTakeable, selectLane, frontierForRepo, agentOnlyChainCount, probeRepoToken, tokenExpiryDays } from '../src/github.mjs'
 
 // Small fixture builder -- keeps the field-notes ground truth readable below.
 // assignees/labels use the real gh shape: arrays of objects, not strings.
@@ -303,7 +303,7 @@ describe('the agent token boot probe (#155)', () => {
 
   test('a reachable repo answers ok, and carries the token expiry when there is one', async () => {
     let seen = null
-    const res = await probeAgentToken('getalfredo/landing-page', 'github_pat_x', {
+    const res = await probeRepoToken('getalfredo/landing-page', 'github_pat_x', {
       fetchImpl: async (url, opts) => {
         seen = { url, auth: opts.headers.authorization }
         return reply(200, { full_name: 'getalfredo/landing-page' },
@@ -318,7 +318,7 @@ describe('the agent token boot probe (#155)', () => {
   // The header is ABSENT on a no-expiration token — that absence is the fact,
   // not a missing reading.
   test('a token that never expires carries no expiry header', async () => {
-    const res = await probeAgentToken('alp82/curia', 'github_pat_x',
+    const res = await probeRepoToken('alp82/curia', 'github_pat_x',
       { fetchImpl: async () => reply(200, { full_name: 'alp82/curia' }) })
     assert.deepEqual(res, { ok: true, expiresAt: null })
     assert.equal(tokenExpiryDays(res.expiresAt), null)
@@ -332,7 +332,7 @@ describe('the agent token boot probe (#155)', () => {
       [401, 'Bad credentials', /HTTP 401: Bad credentials/],
     ]
     for (const [status, message, expected] of cases) {
-      const res = await probeAgentToken('alp82/x', 'github_pat_x',
+      const res = await probeRepoToken('alp82/x', 'github_pat_x',
         { fetchImpl: async () => reply(status, { message }) })
       assert.equal(res.ok, false)
       assert.equal(res.status, status)
@@ -341,7 +341,7 @@ describe('the agent token boot probe (#155)', () => {
   })
 
   test('a non-JSON body still reports its status rather than throwing', async () => {
-    const res = await probeAgentToken('alp82/x', 'github_pat_x', {
+    const res = await probeRepoToken('alp82/x', 'github_pat_x', {
       fetchImpl: async () => ({
         ok: false, status: 502, headers: { get: () => null },
         json: async () => { throw new Error('not json') },

--- a/daemon/test/overseertoken.test.mjs
+++ b/daemon/test/overseertoken.test.mjs
@@ -1,0 +1,112 @@
+// #313: the overseer's read-only GitHub token — the keys, the second env file,
+// and the boundary that file exists to be.
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  OVERSEER_TOKEN_KEY, OVERSEER_ENV_FILE, overseerEnvPath, overseerTokenKeyFor,
+  loadOverseerEnv, overseerGhToken, assertOverseerTokens, daemonOnlyKeys,
+} from '../src/overseertoken.mjs'
+import { ghTokenKeyFor } from '../src/workspace.mjs'
+
+describe('the overseer token keys (#313)', () => {
+  test('the key carries the owner, spelled exactly as the agent key spells it', () => {
+    assert.equal(overseerTokenKeyFor('alp82/curia'), 'CURIA_OVERSEER_GH_TOKEN_ALP82')
+    assert.equal(overseerTokenKeyFor('getalfredo/landing-page'), 'CURIA_OVERSEER_GH_TOKEN_GETALFREDO')
+    // an owner is a GitHub login, so the hyphen is the only character to fold
+    assert.equal(overseerTokenKeyFor('some-org/repo'), 'CURIA_OVERSEER_GH_TOKEN_SOME_ORG')
+    assert.equal(overseerTokenKeyFor(''), null)
+  })
+
+  // One spelling rule for both holders: an operator who has written one pair of
+  // keys has written the other. A drift here is an operator editing the wrong
+  // line and getting no signal.
+  test('the two prefixes differ and nothing else does', () => {
+    for (const repo of ['alp82/curia', 'getalfredo/landing-page', 'some-org/repo']) {
+      assert.equal(
+        overseerTokenKeyFor(repo).replace(`${OVERSEER_TOKEN_KEY}_`, ''),
+        ghTokenKeyFor(repo).replace('CURIA_AGENT_GH_TOKEN_', ''))
+    }
+  })
+
+  test('the token is picked by the repo owner, and an owner with no key gets null', () => {
+    const env = {
+      CURIA_OVERSEER_GH_TOKEN_ALP82: 'github_pat_11ALP82',
+      CURIA_OVERSEER_GH_TOKEN_GETALFREDO: 'github_pat_11ORG',
+    }
+    assert.equal(overseerGhToken('alp82/curia', env), 'github_pat_11ALP82')
+    assert.equal(overseerGhToken('getalfredo/landing-page', env), 'github_pat_11ORG')
+    assert.equal(overseerGhToken('stranger/repo', env), null)
+    // a blank value is no token, not an empty one
+    assert.equal(overseerGhToken('alp82/curia', { CURIA_OVERSEER_GH_TOKEN_ALP82: '   ' }), null)
+  })
+
+  test('a malformed value refuses, and the refusal names the OVERSEER file', () => {
+    for (const bad of ['"quoted"', 'github_pat_x github_pat_y', "'single'"]) {
+      assert.throws(
+        () => overseerGhToken('alp82/curia', { CURIA_OVERSEER_GH_TOKEN_ALP82: bad }),
+        new RegExp(`CURIA_OVERSEER_GH_TOKEN_ALP82 in daemon/${OVERSEER_ENV_FILE.replace('.', '\\.')}`),
+        'a message naming daemon/.env.daemon would send the operator to the wrong file')
+    }
+  })
+
+  test('assertOverseerTokens returns every overseer token and nothing beside it', () => {
+    const env = {
+      CURIA_OVERSEER_GH_TOKEN_ALP82: ' github_pat_11ALP82 \n',
+      CURIA_OVERSEER_GH_TOKEN_BLANK: '',
+      CURIA_AGENT_GH_TOKEN_ALP82: 'github_pat_11WRITE',
+      CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-x',
+    }
+    assert.deepEqual(assertOverseerTokens(env), [{ key: 'CURIA_OVERSEER_GH_TOKEN_ALP82', token: 'github_pat_11ALP82' }])
+  })
+})
+
+// The file IS the boundary: the overseer service loads it whole, so a key in it
+// is a key a shell in that container holds.
+describe('the overseer env file (#313)', () => {
+  let tmp
+  before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-ovt-')) })
+  after(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
+
+  test('it sits beside daemon/.env.daemon', () => {
+    assert.equal(overseerEnvPath('/home/alp/curia/daemon'), `/home/alp/curia/daemon/${OVERSEER_ENV_FILE}`)
+  })
+
+  test('a missing file is an empty environment, not a failure', () => {
+    assert.deepEqual(loadOverseerEnv(path.join(tmp, 'nothing-here')), {})
+  })
+
+  test('the file is parsed, and nothing in it reaches process.env', () => {
+    const file = path.join(tmp, OVERSEER_ENV_FILE)
+    fs.writeFileSync(file, [
+      '# the overseer\'s read-only tokens (#313)',
+      'CURIA_OVERSEER_GH_TOKEN_ALP82=github_pat_11ALP82',
+      'CURIA_OVERSEER_GH_TOKEN_GETALFREDO=github_pat_11ORG',
+      '',
+    ].join('\n'))
+
+    const env = loadOverseerEnv(file)
+    assert.equal(env.CURIA_OVERSEER_GH_TOKEN_ALP82, 'github_pat_11ALP82')
+    assert.equal(env.CURIA_OVERSEER_GH_TOKEN_GETALFREDO, 'github_pat_11ORG')
+
+    // A bare token in the daemon's own environment re-authenticates the daemon's
+    // `gh` silently — the trap #155 named. Parsing, never loading, is what keeps
+    // this file out of that.
+    assert.equal('CURIA_OVERSEER_GH_TOKEN_ALP82' in process.env, false)
+  })
+
+  test('a copied daemon/.env.daemon is named back, key by key', () => {
+    const copied = {
+      DISCORD_BOT_TOKEN: 'x',
+      DISCORD_ALLOWED_USERS: '1',
+      CURIA_AGENT_GH_TOKEN_ALP82: 'github_pat_11WRITE',
+      CURIA_OVERSEER_GH_TOKEN_ALP82: 'github_pat_11READ',
+    }
+    assert.deepEqual(daemonOnlyKeys(copied).sort(),
+      ['CURIA_AGENT_GH_TOKEN_ALP82', 'DISCORD_ALLOWED_USERS', 'DISCORD_BOT_TOKEN'])
+    assert.deepEqual(daemonOnlyKeys({ CURIA_OVERSEER_GH_TOKEN_ALP82: 'github_pat_11READ' }), [])
+  })
+})

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -46,8 +46,12 @@ services:
     environment:
       HOME: /home/alp
       CURIA_TMUX_SOCKET: /run/curia-tmux/default
+    # Renamed by #313, which gave the overseer container its own `.env.overseer`
+    # beside this one. Compose refuses a missing env_file, so a box that still
+    # carries the old `daemon/.env` fails this recreate and rolls back, rather
+    # than starting a daemon with no Discord token.
     env_file:
-      - ../daemon/.env
+      - ../daemon/.env.daemon
     volumes:
       # docker-outside-of-docker: agent containers are siblings on host dockerd.
       - /var/run/docker.sock:/var/run/docker.sock
@@ -158,7 +162,7 @@ services:
     volumes:
       - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
       # THE MOUNT LIST IS THE SECRET-FREE CLAIM, so it names files rather than
-      # trees. `daemon/` as a whole would carry `.env` (the Discord token) and
+      # trees. `daemon/` as a whole would carry `.env.daemon` (the Discord token) and
       # `data/` (the journal #249 keeps daemon-private) into a process that must
       # hold neither. So: the code it runs, the page it serves, and nothing
       # else. `node_modules` is baked into the image for the same reason.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,7 +31,8 @@ DOCKER_GID=<output of: getent group docker | cut -d: -f3>
 | Item | Path |
 | --- | --- |
 | Checkout | `/home/alp/curia` (clone of this repo) |
-| Env file | `/home/alp/curia/daemon/.env` (mode 600, never committed) |
+| Env file | `/home/alp/curia/daemon/.env.daemon` (mode 600, never committed) |
+| Overseer env file | `/home/alp/curia/daemon/.env.overseer` (mode 600, never committed, #313) |
 | Compose env | `/home/alp/curia/deploy/.env` (`DOCKER_GID`, never committed) |
 | Box settings | `/home/alp/curia/config/curia.local.yaml`, `routing.local.yaml` (never committed) |
 | Worktrees | `/home/alp/curia-work` |
@@ -65,11 +66,26 @@ tailscale status --json | jq -r '.User[].LoginName'
 
 Getting it wrong 403s every attach. Fixing it is an edit plus a restart, over ssh, so a wrong list locks nobody out of the box.
 
-## The env file
+## The env file, `daemon/.env.daemon`
+
+**This file was called `daemon/.env` until [#313](https://github.com/alp82/curia/issues/313).** There is one env file per container that holds secrets now, so the pair reads as a pair. Rename it on the box **before** you deploy that change:
+
+```
+mv /home/alp/curia/daemon/.env /home/alp/curia/daemon/.env.daemon
+```
+
+Compose refuses a missing `env_file`, so a deploy that arrives first fails its health check and rolls back. The running daemon is not touched in between: its environment is already in the process.
 
 - `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USERS` — copied from the dev box.
 - `CURIA_AGENT_GH_TOKEN_ALP82`, `CURIA_AGENT_GH_TOKEN_GETALFREDO` — the scoped GitHub tokens agents get as `GH_TOKEN` ([#155](https://github.com/alp82/curia/issues/155)). One per resource owner, because a fine-grained PAT has exactly one. Adding a repo to an owner already covered is an edit on the token page and does **not** change the value, so it costs no edit here and no restart. A new owner needs a new token and a new key.
 - `CLAUDE_CODE_OAUTH_TOKEN` — a long-lived subscription token from `claude setup-token` (decision [#100](https://github.com/alp82/curia/issues/100)). Compose loads the file with `env_file:`, so the token reaches the daemon and flows into every agent.
+
+## The second env file, `daemon/.env.overseer`
+
+- `CURIA_OVERSEER_GH_TOKEN_ALP82`, `CURIA_OVERSEER_GH_TOKEN_GETALFREDO` — the overseer's own GitHub tokens ([#313](https://github.com/alp82/curia/issues/313)). One per resource owner, read-only, and 366 days or less.
+- **The overseer service loads this file and never `daemon/.env.daemon`.** That is the whole reason there are two files. The overseer container holds a shell, and a shell exports whatever the container is given. `daemon/.env.daemon` carries the agents' read-write tokens and the Discord bot token, and compose cannot filter an env file.
+- The daemon reads this file to state each token at boot, and never loads it into its own environment.
+- Boot warns when a key that belongs in `daemon/.env.daemon` turns up here. A copy of the wrong file is the accident this catches.
 
 **One daemon at a time.** The Discord bot token must live in exactly one running daemon. Before you start the local daemon for development, stop the service: `ssh alp@coinmatica.net docker compose -f curia/deploy/compose.yaml stop daemon`.
 

--- a/docs/live-checks/313-overseer-github-token.md
+++ b/docs/live-checks/313-overseer-github-token.md
@@ -1,0 +1,52 @@
+# Live checks: the overseer's read-only GitHub token (#313)
+
+Run 2026-08-11. Sections 1 to 3 are measurements against the real API and against real git. They were taken from inside an agent container, which carries the agent token `CURIA_AGENT_GH_TOKEN_ALP82`. The overseer's own tokens did not exist when these ran, because no agent can mint one. Section 4 is the mint record the operator reported.
+
+## 1. The org lifetime cap is a refusal, not a narrowing
+
+| Check | Result |
+| --- | --- |
+| `gh api repos/getalfredo/landing-page` with the alp82 agent token | `403` — the `getalfredo` organization forbids access via a fine-grained personal access token if the token's lifetime is greater than 366 days |
+| the same repo, with no credential at all (`curl`) | `200` |
+
+The alp82 agent token has no expiration, which is why the org refuses it. [#155](https://github.com/alp82/curia/issues/155) measured that refusal on a private org repo. This run shows it also refuses a **public** one.
+
+**So a token that lives longer than 366 days reads less of that org than no token at all.** The overseer's `getalfredo` token therefore carries a 366-day life. Its `alp82` token has no expiration, and it never touches an org repo, because the routing in section 3 picks by owner.
+
+## 2. Every watched repo is public today
+
+| Repo | `private` |
+| --- | --- |
+| `alp82/curia` | `false` |
+| `alp82/aistack` | `false` |
+| `alp82/alperortac.com` | `false` |
+| `getalfredo/landing-page` | `false` (read with no credential — the alp82 token is refused by the cap above) |
+
+Every fine-grained PAT reads public repositories, whether or not they are in its selection ([#155](https://github.com/alp82/curia/issues/155) section 4). So one token would read the whole watch list today, except at the `getalfredo` org, where the lifetime cap decides instead of the selection. One token per owner is what keeps the read working when a private repo joins the list.
+
+## 3. git picks the owner's token by itself
+
+git 2.39.5, two helpers, one per owner, and no `credential.useHttpPath`:
+
+```
+git config --global 'credential.https://github.com/alp82.helper'      '!<prints the alp82 token>'
+git config --global 'credential.https://github.com/getalfredo.helper' '!<prints the org token>'
+```
+
+| Check | Helper consulted |
+| --- | --- |
+| `git credential fill` for `path=alp82/curia.git` | alp82 |
+| `git credential fill` for `path=getalfredo/landing-page.git` | org |
+| `git credential fill` for `path=stranger/repo.git` | none — no helper answers |
+| a real `git ls-remote https://github.com/alp82/curia-private-probe.git` | alp82, and only alp82 |
+| a real `git ls-remote https://github.com/getalfredo/private-probe.git` | org, and only org |
+
+The last two rows are the ones that matter. They are a real network fetch, so the path git matches on is the one it parses out of the remote URL, not one typed into a test. git prefix-matches the owner and never offers the other owner's token.
+
+**So git needs no shim, and `credential.useHttpPath` is not needed either.** One config line per owner routes every clone and every fetch in the overseer's checkouts.
+
+`gh` is the other half, and it does need one: it reads a single `GH_TOKEN`. [#327](https://github.com/alp82/curia/issues/327) installs both halves, because it owns the image.
+
+## 4. The mint record
+
+<!-- filled in when the operator reports -->

--- a/docs/live-checks/313-overseer-github-token.md
+++ b/docs/live-checks/313-overseer-github-token.md
@@ -49,4 +49,15 @@ The last two rows are the ones that matter. They are a real network fetch, so th
 
 ## 4. The mint record
 
-<!-- filled in when the operator reports -->
+Minted by the operator on 2026-08-13. The values never left the box, so this section is their report, not a measurement of mine.
+
+| Token | Resource owner | Key in `daemon/.env.overseer` | Expires |
+| --- | --- | --- | --- |
+| `curia-overseer-alp82` | `alp82` | `CURIA_OVERSEER_GH_TOKEN_ALP82` | never |
+| `curia-overseer-getalfredo` | `getalfredo` | `CURIA_OVERSEER_GH_TOKEN_GETALFREDO` | **2027-08-14** |
+
+Both carry Contents, Issues, Pull requests and Commit statuses at read, plus Metadata read. Nothing at write. Each one selects only the watched repos of its owner.
+
+**Where they land.** `/home/alp/curia/daemon/.env.overseer` on the box, mode 600, beside `daemon/.env.daemon`. The overseer service loads that file whole, and that file is the container environment: the two keys arrive inside under their own names. The daemon parses the same file to state each token at boot, and never loads it.
+
+**The calendar item.** The `getalfredo` token dies on 2027-08-14. Boot starts warning 14 days out, on 2027-07-31. An expired token does not degrade to anything, so that warning is the whole defense.


### PR DESCRIPTION
Ticket: alp82/curia#313 — [The read-only GitHub token](https://github.com/alp82/curia/issues/313)

#313 — the overseer's read-only GitHub token.

One read-only fine-grained PAT per resource owner, `CURIA_OVERSEER_GH_TOKEN_<OWNER>`, in `daemon/.env.overseer`.

- **The second env file is the boundary.** Compose hands a container a whole env file, so loading `daemon/.env.daemon` in the overseer service would give a container with a shell every agent read-write token and the Discord bot token.
- The daemon **parses** that file and never loads it. A bare token in the daemon environment would re-authenticate the daemon's own `gh`.
- Boot states each token, warns when one cannot reach a watched repo or dies within 14 days, and warns when a daemon key turns up in the overseer's file.
- `daemon/.env` is renamed to `daemon/.env.daemon`, so the pair reads as a pair. The daemon still loads the old name and says so.
- `probeAgentToken` is now `probeRepoToken`: it serves both holders.

**Both tokens are minted.** `curia-overseer-alp82` never expires. `curia-overseer-getalfredo` dies on 2027-08-14. The record and the measurements are in `docs/live-checks/313-overseer-github-token.md`.

**The box needs one manual step before this deploys:** `mv daemon/.env daemon/.env.daemon`.

Suite: 1733 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-313`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `b6fdfda` Record the two minted overseer tokens and their expiry (#313)
- `a8dd6d5` The overseer's read-only GitHub token (#313)