### PR TITLE
A re-sent escalation leaves its original open forever (alp82/curia#336)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -288,7 +288,10 @@ The message curia queues at the builder the moment a reviewer spawns. It names t
 The answer rule. The first valid answer closes the escalation atomically. Any device may answer. Later answers get a refusal.
 
 **Supersede**:
-A re-asked question closes the older record and routes late answers to the live one.
+A re-asked question closes the older record and routes late answers to the live one. The key is the agent and the kind, never the wording (#336). A re-send that explains itself in its own words is the same call, so it closes the original at birth. A confirm keys on the target instance instead.
+
+**Stale question**:
+An escalation still open when its own agent reports a result (#336). The result closes it, because nothing can read an answer to it any more. Reconcile runs the same rule over the journal, and it runs the ending a Stop hook deferred to such a record. Silence closes nothing: only the agent's own result or its next call does.
 
 **Render retry**:
 The escalation's own second try at a Discord render that failed (#261). It runs at 1 minute, 5 minutes and 15 minutes after the record opened, then never again. The offsets count from `esc_open`, not from the failure, so a restart re-arms only the tries still ahead. After the last one the record stays open and REST-answerable, and the dashboard shows it either way.

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -1385,6 +1385,9 @@ export class DiscordBridge {
     switch (by) {
       case 'cancel': return 'its agent was cancelled'
       case 'agent-death': return 'its agent is gone'
+      // #336: the agent finished PAST this question. The words say so, because
+      // "cancelled" alone reads as somebody deciding against the question.
+      case 'result': return 'its agent finished and reported a result'
       case 'reconcile': return 'the daemon reconciled it away'
       case 'rest': return 'it was cancelled over the REST seam'
       default: return /^\d+$/.test(String(by)) ? `cancelled by <@${by}>` : `cancelled (${by})`

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -2991,6 +2991,7 @@ export class Dispatcher {
     }
     const w = this.agents.get(agentName)
     if (w) w.resultReceived = true
+    this.#closeQuestionsAtResult(agentName)
     if (!result) return 'result recorded'
 
     // #164: a reviewer's result IS the verdict, and nothing else happens on it.
@@ -3050,6 +3051,31 @@ export class Dispatcher {
       this.store.logEvent('resolve_failed', { repo, ticket, agent: agentName, status: result.status, error: e.message })
       this.#failureNotify(ticket, 'resolve', `⚠️ ${repo}#${ticket}: the result was recorded but curia's resolve step failed — ${failureProse(e.message)}`)
       return `result recorded — but curia's resolve step failed: ${e.message}`
+    }
+  }
+
+  // A question its own agent has finished past (#336).
+  //
+  // `report_result` is the agent's LAST call. A record still open on it can
+  // never be read: the call that opened it died, and the agent that would have
+  // resumed is at its end. Left open it does three things, all of them found
+  // live — it holds the ticket on the Needs-You list, it makes the next Stop
+  // hook mark a finished agent `blocked_on_human` (#47's evidence, reading a
+  // corpse), and through that mark it holds the container up.
+  //
+  // This closes nothing on silence (#285). The agent's own result is what
+  // closes the record, and only for the agent that reported it. A confirm
+  // belongs to the operator, never to an agent's call, so it is not one of
+  // these — `#openEscalationsFor` keys on the spawn binding.
+  //
+  // Cancel rather than lapse, for the reason every other void here cancels: it
+  // settles the dead promise and edits the card, so a question the operator can
+  // still see says it closed instead of asking on.
+  #closeQuestionsAtResult(agentName) {
+    for (const r of this.#openEscalationsFor(agentName)) {
+      this.cancelEscalation(r.id, { by: 'result' })
+      this.store.logEvent('escalation_stale_at_result', { id: r.id, agent: agentName, ticket: r.ticket })
+      this.log(`${agentName} reported a result with ${r.id} still open — the question is stale, so it is closed`)
     }
   }
 
@@ -4524,6 +4550,15 @@ export class Dispatcher {
       await this.previews.sweep(liveTickets).catch((e) => this.log(`preview sweep failed: ${e.message}`))
     }
 
+    // #336, the repair half of the result rule. `onResult` closes a stale
+    // question at the moment the result lands, and this pass closes the ones
+    // no live call could: a record whose agent reported a result under a
+    // previous daemon process, and the two the live box was still holding when
+    // this ticket was written. Journal-only evidence, so it needs neither the
+    // viewer identity nor a session list — a `result` line for that agent, and
+    // a record that opened before it.
+    await this.#reconcileStaleQuestions(ctx)
+
     if (boot) this.#voidBootConfirms()
     await this.#assertAttachSurface()
     // The timeline surface (#74) rides the same posture: asserted every
@@ -5023,6 +5058,49 @@ export class Dispatcher {
       } catch (e) {
         this.log(`reconcile: could not remove orphan container ${name} (${e.message})`)
       }
+    }
+  }
+
+  // Every open record its own agent already finished past (#336).
+  //
+  // The same rule `#closeQuestionsAtResult` runs at the result, said as a
+  // reduction over the journal so it also reaches what no live call could: a
+  // result reported under a previous daemon process, and the ghosts a box was
+  // already holding when the rule landed. Epoch-scoping is free here — a
+  // respawn clears the agent's result, so a question asked by a LATER dispatch
+  // of the same session name is never judged against an older one's ending.
+  //
+  // The second half is the container. A Stop hook that fired while the corpse
+  // was open deferred the whole ending to it (#47), and that deferral is a
+  // journal line: `agent_blocked_on_human` after the result. With the record
+  // closed, the ending it deferred has to run, or the pane and its container
+  // stay up on a ticket that merged days ago. An indeterminate session list
+  // costs only that half: the record still closes, and the next pass with a
+  // readable list ends the session.
+  async #reconcileStaleQuestions({ journal, sessions }) {
+    const results = new Map() // agent -> the ts of its last result
+    const deferred = new Set() // agents whose Stop hook then deferred to a question
+    for (const ev of journal) {
+      if (!ev.agent) continue
+      if (ev.type === 'agent_spawned') { results.delete(ev.agent); deferred.delete(ev.agent) }
+      else if (ev.type === 'result') { results.set(ev.agent, ev.ts); deferred.delete(ev.agent) }
+      else if (ev.type === 'agent_blocked_on_human' && results.has(ev.agent)) deferred.add(ev.agent)
+    }
+    const toEnd = new Set()
+    for (const r of this.store.openEscalations()) {
+      const reportedAt = Date.parse(results.get(r.agent) ?? '')
+      const openedAt = Date.parse(r.opened_at ?? '')
+      // An unreadable stamp on either side is not evidence, and the safe
+      // direction for a question is to leave it asking.
+      if (Number.isNaN(reportedAt) || Number.isNaN(openedAt) || openedAt >= reportedAt) continue
+      this.cancelEscalation(r.id, { by: 'result' })
+      this.store.logEvent('escalation_stale_at_result', { id: r.id, agent: r.agent, ticket: r.ticket, by: 'reconcile' })
+      this.log(`reconcile: ${r.id} was still open on ${r.agent}, which reported a result — the question is stale, so it is closed`)
+      if (deferred.has(r.agent) && sessions?.includes(r.agent)) toEnd.add(r.agent)
+    }
+    for (const session of toEnd) {
+      this.log(`reconcile: ${session} ended its turn on a stale question — running the ending that was deferred`)
+      await this.onAgentDone(session).catch((e) => this.log(`reconcile: the deferred ending of ${session} failed (${e.message}) — the next pass retries`))
     }
   }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -312,12 +312,14 @@ async function renderEscalation(record, files = []) {
 // Open + render + block until answered. Every ask_human and synthetic escalation
 // funnels through here.
 function openEscalation({ agent, ticket, kind, prompt, options, preview_url, recommended, files }) {
-  const { record, superseded } = store.open({ agent, ticket, kind, prompt, options, preview_url, recommended })
-  log(`escalation ${record.id} open (${kind}) agent=${agent} ticket=${ticket}${superseded ? ` supersedes ${superseded.id}` : ''}`)
-  if (superseded) {
-    pending.delete(superseded.id) // the agent aborted that call; nobody is waiting on it
-    clearRenderRetries(superseded.id)
-    if (bridge) bridge.markSuperseded(store.get(superseded.id)).catch(() => {})
+  const { record, superseded_all } = store.open({ agent, ticket, kind, prompt, options, preview_url, recommended })
+  log(`escalation ${record.id} open (${kind}) agent=${agent} ticket=${ticket}${superseded_all.length ? ` supersedes ${superseded_all.map((r) => r.id).join(', ')}` : ''}`)
+  // Every corpse this agent left, not just the newest (#336): a card left
+  // rendered keeps asking a question nothing can receive an answer for.
+  for (const dead of superseded_all) {
+    pending.delete(dead.id) // the agent aborted that call; nobody is waiting on it
+    clearRenderRetries(dead.id)
+    if (bridge) bridge.markSuperseded(store.get(dead.id)).catch(() => {})
   }
   armRenderRetries(record)
   renderEscalation(record, files)
@@ -536,11 +538,14 @@ function notifyThread(ticket, message, opts = {}) {
 // button → gate.answer → dispatcher.onConfirmAnswered, and the record lapses
 // the moment its agent exits.
 function openConfirm({ ticket, prompt, action, originThreadId }) {
-  const { record, superseded } = store.open({
+  const { record, superseded_all } = store.open({
     agent: 'overseer', ticket, kind: CONFIRM_KIND, prompt, action, origin_thread_id: originThreadId ?? null,
   })
-  log(`confirm ${record.id} open (${action.verb}) ticket=${ticket}${superseded ? ` supersedes ${superseded.id}` : ''}`)
-  if (superseded && bridge) bridge.markSuperseded(store.get(superseded.id)).catch(() => {})
+  log(`confirm ${record.id} open (${action.verb}) ticket=${ticket}${superseded_all.length ? ` supersedes ${superseded_all.map((r) => r.id).join(', ')}` : ''}`)
+  for (const dead of superseded_all) {
+    clearRenderRetries(dead.id)
+    if (bridge) bridge.markSuperseded(store.get(dead.id)).catch(() => {})
+  }
   // A confirm has no reminder and no expiry, but it still has to be SEEN: a
   // confirm that never rendered carries buttons nobody can press, so it takes
   // the same bounded render retry every other escalation takes (#261).

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -7,9 +7,9 @@
 //
 // Semantics owned here:
 //   - first-valid-wins: answer/cancel close atomically; later attempts are rejected
-//   - supersede (#29): a re-issued ask_human (same agent + same payload while an
-//     older escalation is open) marks the old record superseded; answers posted
-//     to a dead id are routed along the successor chain to the live call
+//   - supersede (#29, #336): a re-issued ask_human — a second open record of one
+//     kind on one agent, whatever its wording — marks the old record superseded;
+//     answers posted to a dead id route along the successor chain to the live call
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -367,37 +367,54 @@ export class EscalationStore {
       .digest('hex').slice(0, 16)
   }
 
-  // Open a new escalation. If the same agent already has an OPEN escalation with
-  // the same payload, that record is a corpse from an aborted tool call (#29):
+  // Open a new escalation. If the same agent already has an OPEN escalation of
+  // this kind, that record is a corpse from an aborted tool call (#29):
   // supersede it and chain answers forward.
+  //
+  // The key is the agent and the KIND, not the wording (#336). It was the
+  // payload hash until a live re-send got past it: the standing orders tell an
+  // agent whose call failed to make the same call once more, the agent added
+  // "(Re-sent: the last call timed out with an error…)" to explain itself, and
+  // that note changed the hash. Two live cards for one question, and the
+  // original never closed. A re-send is the same call again, so the words are
+  // the one thing about it that can differ — and the promise the standing
+  // orders make, that curia routes the human to whichever call is live, is a
+  // promise about the call rather than about its wording.
+  //
+  // The kind stays in the key because one agent CAN hold two calls at once and
+  // mean both: a harness that backgrounds a pending `ask_human` leaves the
+  // question open while `request_review` opens the gate. Those are two
+  // questions to a human, and an approval routed into a free-text call would
+  // be read as an answer to it.
   //
   // A confirm (#94) supersedes on a different key: any open confirm sharing a
   // target INSTANCE — a newer confirm on the same agent replaces the older one
   // whatever its wording, so at most one set of live buttons ever points at a
-  // given agent.
+  // given agent. The two keys never cross: a confirm is an operator's record
+  // and belongs to no agent's call.
   open({ agent, ticket, kind, prompt, options, preview_url, recommended, action, origin_thread_id }) {
     const payload_hash = EscalationStore.payloadHash({ kind, prompt, options, preview_url })
     const id = `esc-${++this.seq}`
     const sharesInstance = (r) => (r.action?.targets ?? [])
       .some((t) => (action?.targets ?? []).some((u) => u.instance === t.instance))
-    let superseded = null
-    for (const r of this.escalations.values()) {
-      if (r.status !== 'open') continue
-      const match = kind === CONFIRM_KIND
+    // Oldest first, and ALL of them: one agent should never hold two open
+    // records of one kind, but a journal written before this rule can carry
+    // several, and a corpse this call walks past stays on the Needs-You list
+    // forever.
+    const superseded_all = [...this.escalations.values()].filter((r) => {
+      if (r.status !== 'open') return false
+      return kind === CONFIRM_KIND
         ? r.kind === CONFIRM_KIND && sharesInstance(r)
-        : r.agent === agent && r.payload_hash === payload_hash
-      if (match) {
-        superseded = r
-        break
-      }
-    }
-    // `recommended` (#285) stays OUT of the payload hash on purpose: the hash
-    // keys supersession on the question, and the flag is not the question. An
-    // agent that re-asks the same round with the flag flipped supersedes its
-    // own record, which is what a re-ask should do.
+        : r.kind === kind && r.agent === agent
+    })
+    // The hash keyed supersession until #336 took the question out of the key.
+    // It stays on the line as EVIDENCE: it is what tells a later reader whether
+    // a superseded record held the same question its successor asks. Nothing
+    // decides on it, so a round re-asked with `recommended` flipped (#285)
+    // supersedes its own record either way.
     this._append({ type: 'esc_open', id, agent, ticket, kind, prompt, options, preview_url, recommended, payload_hash, action, origin_thread_id })
-    if (superseded) this._append({ type: 'esc_supersede', id: superseded.id, successor: id })
-    return { record: this.escalations.get(id), superseded }
+    for (const r of superseded_all) this._append({ type: 'esc_supersede', id: r.id, successor: id })
+    return { record: this.escalations.get(id), superseded: superseded_all[0] ?? null, superseded_all }
   }
 
   attachRender(id, discord) {

--- a/daemon/test/cancel.test.mjs
+++ b/daemon/test/cancel.test.mjs
@@ -196,6 +196,10 @@ describe('the mark on a cancelled question (#200)', () => {
   test('it names the ending, and only a Discord user id becomes a mention', () => {
     assert.equal(DiscordBridge.cancelWords('cancel'), 'its agent was cancelled')
     assert.equal(DiscordBridge.cancelWords('agent-death'), 'its agent is gone')
+    // #336: the ending that closes a question its agent finished past. The
+    // card has to say WHY, or a question the operator answered elsewhere
+    // reads as one somebody decided against.
+    assert.equal(DiscordBridge.cancelWords('result'), 'its agent finished and reported a result')
     assert.equal(DiscordBridge.cancelWords('reconcile'), 'the daemon reconciled it away')
     assert.equal(DiscordBridge.cancelWords('rest'), 'it was cancelled over the REST seam')
     assert.equal(DiscordBridge.cancelWords('4207'), 'cancelled by <@4207>')

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -424,6 +424,169 @@ describe('a blocked agent is not a crashed one (#47)', () => {
   })
 })
 
+// #336: the other half of #47's evidence. An open escalation says "blocked"
+// only while someone could still read the answer. Once the agent has reported
+// its result, the record is a corpse: it held the ticket on the Needs-You list,
+// it made every later Stop hook mark a finished agent blocked, and through that
+// mark it kept the container up two days past a merge.
+describe('a question its own agent finished past (#336)', () => {
+  function writeJournal(lines) {
+    fs.writeFileSync(path.join(tmp, 'data', 'events.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')
+  }
+
+  // The gate double closes nothing by itself. index.mjs closes the record, so a
+  // test that asserts what the NEXT pass sees has to close it here too.
+  function closesRecords(d) {
+    d.cancelEscalation = (id, opts) => {
+      cancelled.push({ id, ...opts })
+      const r = escalations.find((x) => x.id === id)
+      if (r) r.status = 'cancelled'
+      return { ok: true }
+    }
+  }
+
+  const at = (iso) => new Date(iso).toISOString()
+
+  test('the result closes the question, and the Stop that follows ends the agent', async () => {
+    let killed = null
+    const d = makeDispatcher({ hasSession: async () => true, killSession: async (n) => { killed = n } })
+    closesRecords(d)
+    d.agents.set('curia-42', { repo: 'o/r', ticket: '42', session: 'curia-42', state: 'ready', resultReceived: false })
+    escalations = [{ id: 'esc-21', agent: 'curia-42', ticket: '42', status: 'open' }]
+
+    d.onResult('curia-42')
+
+    assert.deepEqual(cancelled, [{ id: 'esc-21', by: 'result' }])
+    assert.ok(typesOf().includes('escalation_stale_at_result'))
+
+    await d.onAgentDone('curia-42')
+
+    assert.ok(typesOf().includes('lifecycle_closed'))
+    assert.ok(!typesOf().includes('agent_blocked_on_human'), 'a finished agent is not blocked on anyone')
+    assert.equal(killed, 'curia-42', 'nothing holds the session any more')
+  })
+
+  test('the result speaks for its own agent only', async () => {
+    const d = makeDispatcher()
+    closesRecords(d)
+    d.agents.set('curia-42', { repo: 'o/r', ticket: '42', session: 'curia-42', state: 'ready' })
+    escalations = [
+      { id: 'esc-30', agent: 'overseer', ticket: '42', status: 'open' },
+      { id: 'esc-31', agent: 'curia-43', ticket: '43', status: 'open' },
+    ]
+
+    d.onResult('curia-42')
+
+    assert.deepEqual(cancelled, [], 'a confirm and another agent\'s question are not this result\'s to close')
+  })
+
+  test('reconcile closes a record whose result landed under an older daemon process', async () => {
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '313', agent: 'curia-313', ts: at('2026-08-11T17:00:00Z') },
+      { type: 'result', agent: 'curia-313', ticket: '313', ts: at('2026-08-12T21:33:00Z') },
+    ])
+    const d = makeDispatcher({ listSessions: async () => [] })
+    closesRecords(d)
+    escalations = [{ id: 'esc-267', agent: 'curia-313', ticket: '313', status: 'open', opened_at: at('2026-08-11T17:26:00Z') }]
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(cancelled, [{ id: 'esc-267', by: 'result' }])
+    assert.ok(events.some((e) => e.type === 'escalation_stale_at_result' && e.id === 'esc-267' && e.by === 'reconcile'))
+  })
+
+  test('a question asked after the result is not one of these', async () => {
+    // The rule is "the agent finished past this question", and the stamps are
+    // what say so. A record opened later belongs to a live exchange.
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', ts: at('2026-08-12T09:00:00Z') },
+      { type: 'result', agent: 'curia-42', ticket: '42', ts: at('2026-08-12T10:00:00Z') },
+    ])
+    const d = makeDispatcher({ listSessions: async () => [] })
+    closesRecords(d)
+    escalations = [{ id: 'esc-9', agent: 'curia-42', ticket: '42', status: 'open', opened_at: at('2026-08-12T11:00:00Z') }]
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(cancelled, [])
+  })
+
+  test('a re-dispatch does not inherit the last one\'s ending', async () => {
+    // Session names are reused. A result from the PREVIOUS agent of this
+    // ticket must not close the question the current one is asking.
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', ts: at('2026-08-10T09:00:00Z') },
+      { type: 'result', agent: 'curia-42', ticket: '42', ts: at('2026-08-10T10:00:00Z') },
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', ts: at('2026-08-12T09:00:00Z') },
+    ])
+    const d = makeDispatcher({ listSessions: async () => [] })
+    closesRecords(d)
+    escalations = [{ id: 'esc-9', agent: 'curia-42', ticket: '42', status: 'open', opened_at: at('2026-08-12T09:30:00Z') }]
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(cancelled, [])
+  })
+
+  test('an open question with no result is left asking — silence resolves nothing (#285)', async () => {
+    writeJournal([{ type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', ts: at('2026-08-12T09:00:00Z') }])
+    const d = makeDispatcher({ listSessions: async () => [] })
+    closesRecords(d)
+    escalations = [{ id: 'esc-9', agent: 'curia-42', ticket: '42', status: 'open', opened_at: at('2026-08-12T09:30:00Z') }]
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(cancelled, [])
+    assert.ok(!typesOf().includes('escalation_stale_at_result'))
+  })
+
+  test('the ending the Stop hook deferred to the corpse runs, and the container goes', async () => {
+    // The live ghost whole: a merged ticket, a result, a Stop hook that read
+    // the corpse as a live block, and a session nothing could ever end — the
+    // orphan sweep exempts exactly these agents.
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', ts: at('2026-08-12T09:00:00Z') },
+      { type: 'result', agent: 'curia-42', ticket: '42', ts: at('2026-08-12T21:33:00Z') },
+      { type: 'agent_blocked_on_human', agent: 'curia-42', ticket: '42', escalations: ['esc-21'], ts: at('2026-08-12T21:33:09Z') },
+    ])
+    let killed = null
+    const d = makeDispatcher({ listSessions: async () => ['curia-42'], killSession: async (n) => { killed = n } })
+    closesRecords(d)
+    fs.writeFileSync(path.join(tmp, 'data', 'results', 'curia-42.json'), '{"status":"resolved"}')
+    escalations = [{ id: 'esc-21', agent: 'curia-42', ticket: '42', status: 'open', opened_at: at('2026-08-12T17:26:00Z') }]
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(cancelled, [{ id: 'esc-21', by: 'result' }])
+    assert.ok(events.some((e) => e.type === 'orphan_sweep_skipped'), 'the sweep still keeps its hands off a finishing agent')
+    assert.ok(typesOf().includes('lifecycle_closed'))
+    assert.equal(killed, 'curia-42')
+  })
+
+  test('an indeterminate session list still closes the record, and ends nothing', async () => {
+    // The evidence rule of every sweep in this file: a tmux read that failed
+    // is not "no sessions". The journal alone is enough to close a question.
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', ts: at('2026-08-12T09:00:00Z') },
+      { type: 'result', agent: 'curia-42', ticket: '42', ts: at('2026-08-12T21:33:00Z') },
+      { type: 'agent_blocked_on_human', agent: 'curia-42', ticket: '42', escalations: ['esc-21'], ts: at('2026-08-12T21:33:09Z') },
+    ])
+    let killed = null
+    const d = makeDispatcher({
+      listSessions: async () => { throw new Error('tmux is wedged') },
+      killSession: async (n) => { killed = n },
+    })
+    closesRecords(d)
+    escalations = [{ id: 'esc-21', agent: 'curia-42', ticket: '42', status: 'open', opened_at: at('2026-08-12T17:26:00Z') }]
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(cancelled, [{ id: 'esc-21', by: 'result' }])
+    assert.equal(killed, null)
+    assert.ok(!typesOf().includes('lifecycle_closed'))
+  })
+})
+
 describe('reconcile epoch scoping (criterion 7)', () => {
   function writeJournal(lines) {
     fs.writeFileSync(path.join(tmp, 'data', 'events.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')

--- a/daemon/test/resend.test.mjs
+++ b/daemon/test/resend.test.mjs
@@ -1,0 +1,142 @@
+// A re-sent escalation, and the record its agent finished past (#336).
+//
+// Two ghosts on the live box, one rule broken twice. A question the operator
+// DID answer left its record open, and nothing ever closed it.
+//
+//   the re-send  — `curia-313` asked as `esc-267`, the call died with an
+//                  error, and the standing orders say to make the same call
+//                  once more. The agent added "(Re-sent: the last call timed
+//                  out with an error…)" to explain itself. That note changed
+//                  the payload hash, so the supersede key missed, and the
+//                  original asked on after the operator answered the copy.
+//   the result   — `curia-81` reported a result and merged its pull request.
+//                  Its record was still open 200 hours later, because nothing
+//                  read the result as an answer to "is anyone still asking".
+//
+// The keys settled here:
+//   - supersede keys on the AGENT, not on the wording. An agent blocks inside
+//     `ask_human`, so a second open record on one agent is always a corpse;
+//   - the agent's own `report_result` closes every record still open on it;
+//   - reconcile runs that same rule over the journal, so a result reported
+//     under a previous daemon process still closes its record — and the
+//     ending a Stop hook deferred to the corpse runs.
+//
+// Silence still resolves nothing (#285). Every close here needs a positive
+// act by the agent: a new question, or a result.
+
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { EscalationStore, CONFIRM_KIND } from '../src/store.mjs'
+import { REVIEW_KIND } from '../src/lifecycle.mjs'
+
+let dir
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-resend-test-')) })
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+const ask = (store, prompt, agent = 'curia-313') =>
+  store.open({ agent, ticket: '313', kind: 'free-text', prompt, recommended: true })
+
+const RE_SENT = '\n\n(Re-sent: the last call timed out with an error, not with your answer.)'
+
+describe('a re-send supersedes its original (#336)', () => {
+  test('the note the agent adds to explain itself no longer costs the supersede', () => {
+    const store = new EscalationStore(dir)
+    const { record: original } = ask(store, 'Q1 — mint the checklist?')
+    const { record: resent, superseded } = ask(store, `Q1 — mint the checklist?${RE_SENT}`)
+
+    assert.equal(superseded?.id, original.id, 'the original is the record the re-send replaces')
+    assert.equal(store.get(original.id).status, 'superseded')
+    assert.equal(store.get(original.id).successor, resent.id)
+    assert.deepEqual(store.openEscalations().map((r) => r.id), [resent.id], 'one live card, one question')
+  })
+
+  test('answering EITHER copy closes both — the answer routes to the live call', () => {
+    const store = new EscalationStore(dir)
+    const { record: original } = ask(store, 'which port?')
+    const { record: resent } = ask(store, `which port?${RE_SENT}`)
+
+    const r = store.answer(original.id, { answer: '9000', by: 'alp', via: 'thread' })
+
+    assert.equal(r.ok, true)
+    assert.equal(r.record.id, resent.id, 'the answer lands in the call that is still live')
+    assert.deepEqual(r.routed_from, [original.id])
+    assert.deepEqual(store.openEscalations(), [], 'neither record is left asking')
+  })
+
+  test('a wholly different question still closes the corpse it finds', () => {
+    // The re-send is the common case, not the rule. What makes the old record
+    // dead is that its call is gone, and the words never said otherwise.
+    const store = new EscalationStore(dir)
+    const { record: first } = ask(store, 'Q1 — which port?')
+    const { superseded } = ask(store, 'Q2 — which repo?')
+
+    assert.equal(superseded?.id, first.id)
+    assert.equal(store.get(first.id).status, 'superseded')
+  })
+
+  test('several corpses close together, not one per new question', () => {
+    // A journal written before this rule can hold more than one open record
+    // for an agent. A corpse the call walks past would stay on the Needs-You
+    // list for good.
+    const store = new EscalationStore(dir)
+    const a = ask(store, 'Q1').record
+    // written straight to the journal, the way the payload-hash key that
+    // shipped before #336 left them: two open records on one agent
+    for (const id of ['esc-old-1', 'esc-old-2']) {
+      store._append({ type: 'esc_open', id, agent: 'curia-313', ticket: '313', kind: 'free-text', prompt: `Q1 (${id})` })
+    }
+
+    const { record: live, superseded_all } = ask(store, 'Q1, once more')
+
+    assert.deepEqual(superseded_all.map((r) => r.id), [a.id, 'esc-old-1', 'esc-old-2'])
+    assert.deepEqual(store.openEscalations().map((r) => r.id), [live.id])
+    assert.equal(store.answer('esc-old-1', { answer: 'ok', by: 'alp', via: 'thread' }).record.id, live.id)
+  })
+
+  test('another agent keeps its own question — the key is the agent, not the ticket', () => {
+    const store = new EscalationStore(dir)
+    const mine = ask(store, 'Q1', 'curia-313').record
+    const theirs = ask(store, 'Q1', 'curia-330').record
+
+    assert.equal(store.get(mine.id).status, 'open')
+    assert.equal(store.get(theirs.id).status, 'open')
+  })
+
+  test('the review gate and a question are two calls, so neither closes the other', () => {
+    // One agent CAN hold two calls at once and mean both: a harness that
+    // backgrounds a pending `ask_human` leaves the question open while
+    // `request_review` opens the gate. An approval routed into the free-text
+    // call would be read there as an answer to the question.
+    const store = new EscalationStore(dir)
+    const question = ask(store, 'which port?').record
+    const gate = store.open({ agent: 'curia-313', ticket: '313', kind: REVIEW_KIND, prompt: 'is this done?' })
+
+    assert.equal(gate.superseded, null)
+    assert.deepEqual(store.openEscalations().map((r) => r.id), [question.id, gate.record.id])
+  })
+
+  test('a confirm belongs to the operator, so no agent question touches it', () => {
+    const store = new EscalationStore(dir)
+    const confirm = store.open({
+      agent: 'overseer', ticket: '313', kind: CONFIRM_KIND, prompt: 'Cancel?',
+      action: { verb: 'cancel', targets: [{ session: 'curia-313', instance: 'curia-313@1' }] },
+    }).record
+    const { superseded } = ask(store, 'Q1')
+
+    assert.equal(superseded, null)
+    assert.equal(store.get(confirm.id).status, 'open', 'the buttons the operator is looking at stay live')
+  })
+
+  test('the supersession survives a replay, chain and all', () => {
+    const store = new EscalationStore(dir)
+    const original = ask(store, 'Q1').record
+    const resent = ask(store, `Q1${RE_SENT}`).record
+
+    const replayed = new EscalationStore(dir)
+    assert.equal(replayed.get(original.id).status, 'superseded')
+    assert.equal(replayed.resolveLive(original.id).record.id, resent.id)
+  })
+})

--- a/docs/adr/0005-escalation-contract.md
+++ b/docs/adr/0005-escalation-contract.md
@@ -1,7 +1,7 @@
 # ADR-0005: The escalation contract
 
 **Status**: accepted (2026-07)
-**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200), [A cancel confirm lands in the ticket thread, not where the operator typed it (#218)](https://github.com/alp82/curia/issues/218), [The nudge dies; the render-retry stands alone (#261)](https://github.com/alp82/curia/issues/261), [The escalation contract meets round-by-round grilling (#285)](https://github.com/alp82/curia/issues/285)
+**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200), [A cancel confirm lands in the ticket thread, not where the operator typed it (#218)](https://github.com/alp82/curia/issues/218), [The nudge dies; the render-retry stands alone (#261)](https://github.com/alp82/curia/issues/261), [The escalation contract meets round-by-round grilling (#285)](https://github.com/alp82/curia/issues/285), [A re-sent escalation leaves its original open forever (#336)](https://github.com/alp82/curia/issues/336)
 
 ## Context
 
@@ -26,11 +26,22 @@ Agents need human answers from any device, with waits measured in hours, and the
 
   A question the operator does not answer is **not** taken as recommended. It returns in the next round. Only the ✅ button takes the recommendations, and only for the questions on the card it sits on. This is "never answer for the human" said in the one place a round could break it quietly. Silence taking the recommendation was considered and refused. It moves the small decisions out of the operator's sight, and a wrong answer to a small question is the one nobody checks. A round has no size limit: the frontier is the frontier.
 
+- **Amended by [#336](https://github.com/alp82/curia/issues/336)**: supersession keys on the **agent and the kind**, and a **result** closes the questions its own agent finished past.
+
+  Two records on the live box were asking questions that already had answers. `esc-267` was a re-send. The standing orders tell an agent whose call failed to make the same call once more. The agent added "(Re-sent: the last call timed out with an error, not with your answer.)" to explain itself. Supersession keyed on a hash of the exact words, so that note made the copy a second question. The operator answered the copy, and the original asked on. `esc-128` was the other shape. Its agent reported a result and merged its pull request. Nothing closed the record, and it stayed open for 200 hours.
+
+  The key is the agent and the kind now. A re-send is the same call again, so the wording is the one thing about it that can differ. The kind stays in the key because one agent can hold two calls at once and mean both. A harness that backgrounds a pending `ask_human` leaves that question open while `request_review` opens the gate. An approval routed into the free-text call would be read there as an answer to the question.
+
+  A result closes every record still open on the agent that reported it. `report_result` is the last call an agent makes. The call that opened the record is dead, and the agent that would have resumed it is at its end. Left open, the record holds the ticket on the Needs-You list. It also makes the next Stop hook mark a finished agent blocked, which is #47's evidence rule reading a corpse, and through that mark it holds the container up. Reconcile runs the same rule as a reduction over the journal. That reaches a result reported under an older daemon process. Where the journal also shows the Stop hook that deferred to such a record, reconcile runs the ending it deferred.
+
+  Silence still resolves nothing. Every close here needs a positive act by the agent: its next call, or its result. The typed answer stays the operator's escape hatch. It is no longer the only thing that can close these records.
+
 ## Consequences
 
 - The bridge renders and captures, and it never interprets. All routing keys on the escalation id, not on who or where.
 - A box reboot loses the in-flight turn. The ticket re-frontiers, per [ADR-0001](0001-github-is-the-only-durable-state-home.md).
 - An agent that dies without a Stop leaves its question asking until reconcile or `cancel <n>` cleans it up. Cancel also closes the orphaned question, and it renames the thread to ⚰️.
-- A round is one escalation record, so it holds one answer, one timestamp and one supersession key (#285). The `recommended` flag stays out of the payload hash, because the hash keys on the question and the flag is not the question. An agent that re-asks the same round with the flag flipped supersedes its own record, which is what a re-ask must do.
+- A record closes on three acts and no timer (#336): an answer, its agent asking that kind again, or its agent's own result. An agent that is merely quiet closes nothing.
+- A round is one escalation record, so it holds one answer, one timestamp and one supersession key (#285). That key is the agent and the kind (#336), and the question itself is no part of it. An agent that re-asks the same round supersedes its own record, whatever it changed in the words or in the `recommended` flag.
 - A round with no size limit can outrun one Discord message (#285). The existing paragraph-aware split (#119) carries it, and the buttons ride the last chunk, so the ✅ sits below every question it answers. The cost is real: a long round is a scroll before it is answerable, and the agent trades against that itself.
 - The review gate of [ADR-0008](0008-resolved-means-merged.md) is one more escalation kind and inherits all of this behavior. It is an agent escalation, so it stays in the ticket thread. The confirm is the one kind that moves.


### PR DESCRIPTION
Ticket: alp82/curia#336 — [A re-sent escalation leaves its original open forever](https://github.com/alp82/curia/issues/336)

#336: a re-sent escalation left its original open forever, and a record that outlived its agent's result held the container up.

Three changes in the daemon.

1. `store.open()` keys supersession on the agent and the KIND, not on a hash of the exact words. A re-send that adds "(Re-sent: …)" to explain itself is the same call, so it closes the original at birth and late answers route forward. The kind stays in the key because one agent can hold two calls at once and mean both: a backgrounded `ask_human` while `request_review` opens the gate. It also closes every corpse it finds, not only the newest.

2. `report_result` closes every escalation still open on the agent that reported it (`escalation_stale_at_result`). The card says why: "its agent finished and reported a result". The next Stop hook then runs the ending instead of marking a finished agent blocked.

3. Reconcile runs the same rule over the journal, which reaches a result reported under an older daemon process and the ghosts the box is holding now. Where the journal also shows the Stop hook that deferred to such a record, it runs the ending that was deferred, so the pane and its container go.

Silence still closes nothing. Every close needs a positive act by the agent: its next call, or its result. The typed-answer hatch is untouched.

ADR-0005 carries the amendment. CONTEXT.md gets "Stale question" and a corrected "Supersede".

Tests: 1758 pass, 0 fail. New: `daemon/test/resend.test.mjs` (8 store tests) and a `#336` block in `daemon/test/dispatch.test.mjs` (8 dispatcher and reconcile tests).

---

Dispatched by the curia daemon — session `curia-336`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `b196788` A re-sent escalation closes its original (#336)