### PR TITLE
Where does the truth live (alp82/curia#319)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -481,7 +481,9 @@ How full an agent's context window is. The numerator is the last request's input
 ### State and evidence
 
 **Journal**:
-`daemon/data/events.jsonl`. Append-only, and the daemon's only durable artifact. In-memory state is a reduction over it. The file never rotates, so it only grows. The store reads it whole ONCE, at boot, and every append after that passes the same reducer. A surface that answers about the recent past reads the reduction and never the file again.
+`daemon/data/events.jsonl`. Append-only, and the daemon's only durable artifact. In-memory state is a reduction over it. The file never rotates, so it only grows. `EscalationStore` reads it whole ONCE, at boot, and every append after that passes the same reducer. A surface that answers about the recent past reads the reduction and never the file again.
+
+Decided and not built: the durable artifact becomes a `node:sqlite` store, and these JSON lines retire. A row keeps the written line verbatim, so the store is a superset of the file. The daemon is the only writer. See [ADR-0017](docs/adr/0017-the-journal-is-a-queryable-store.md), built on [the store map (#316)](https://github.com/alp82/curia/issues/316).
 
 **State home**:
 The one durable place a fact lives. GitHub holds ticket truth. The journal holds curia's events. Everything in memory is a disposable cache.
@@ -525,7 +527,7 @@ One box runs everything. Phones and PCs are pure clients on the tailnet.
 ## State homes
 
 - **GitHub**: ticket state, labels, claims, sub-issue parentage, map bodies, branches, pull requests. The source of truth.
-- **Journal** (`daemon/data/events.jsonl`): every durable curia event.
+- **Journal** (`daemon/data/events.jsonl`): every durable curia event. Decided and not built: a `node:sqlite` store replaces this file ([ADR-0017](docs/adr/0017-the-journal-is-a-queryable-store.md)).
 - **Verdicts** (`daemon/data/verdicts/`): one captured cross-check verdict per ticket, held for the return path.
 - **tmux**: the live agent sessions.
 - **tailscaled**: the Serve rules for attach, timeline, the dashboard, and previews.

--- a/docs/adr/0001-github-is-the-only-durable-state-home.md
+++ b/docs/adr/0001-github-is-the-only-durable-state-home.md
@@ -1,6 +1,6 @@
 # ADR-0001: GitHub is the only durable state home
 
-**Status**: accepted (2026-07)
+**Status**: accepted (2026-07), amended 2026-08 (#319)
 **Provenance**: [Decide dispatcher shape and state home (#9)](https://github.com/alp82/curia/issues/9), [Decide the overseer's awareness source (#10)](https://github.com/alp82/curia/issues/10)
 
 ## Context
@@ -14,11 +14,11 @@ Curia needs awareness of every watched repo, map, and ticket, and that awareness
 - The daemon is an always-on process, not a cron loop and not an agent. Dispatch is rules, not reasoning.
 - The watch list is checked-in configuration in `config/curia.yaml`, not evolving state. Each watched repo names its lane.
 - Read depth is a shallow poll. The daemon reads a ticket's full body only at dispatch.
-- The journal (`daemon/data/events.jsonl`) is curia's one durable artifact. It holds curia's own events, append-only. Everything in memory is a reduction over GitHub, tmux, and the journal. Reconcile re-derives it at boot and on demand.
+- ~~The journal (`daemon/data/events.jsonl`) is curia's one durable artifact.~~ **Amended by [#319](https://github.com/alp82/curia/issues/319)**: the durable artifact is a `node:sqlite` store, and the JSON lines retire. [ADR-0017](0017-the-journal-is-a-queryable-store.md) holds that record and its reasons. What stands here is unchanged: the journal holds curia's own events, append-only. Everything in memory is a reduction over GitHub, tmux, and the journal. Reconcile re-derives it at boot and on demand.
 
 ## Consequences
 
-- Restart recovery is a re-query, not a restore. There is no local brain to lose.
+- Restart recovery is a re-query, not a restore. There is no local brain to lose. **Amended by [#319](https://github.com/alp82/curia/issues/319)**: the store is a local brain. Ticket state still lives on the tracker, so recovery is still a re-query. A periodic `.dump` bounds what the store itself can lose ([ADR-0017](0017-the-journal-is-a-queryable-store.md)).
 - GitHub has no compare-and-swap on issue bodies. Concurrent map writes stay best-effort: detected, journaled verbatim, replayable, never prevented. See [ADR-0006](0006-worker-containment-and-standing-orders.md) for the agent-side convergence rule.
 - The flat lane has no native blocking or ordering. Label presence is its only gate. Dependency-aware frontiers need a map.
 - A whole-box reboot loses in-flight turns. The accepted recovery is re-dispatch, because the ticket is still on the tracker.

--- a/docs/adr/0017-the-journal-is-a-queryable-store.md
+++ b/docs/adr/0017-the-journal-is-a-queryable-store.md
@@ -1,0 +1,50 @@
+# ADR-0017: The journal is a queryable store
+
+**Status**: accepted (2026-08). Not built. The build is charted on [the store map (#316)](https://github.com/alp82/curia/issues/316).
+**Provenance**: [The journal becomes a queryable store (#303)](https://github.com/alp82/curia/issues/303), [Where does the truth live (#319)](https://github.com/alp82/curia/issues/319)
+
+## Context
+
+[ADR-0001](0001-github-is-the-only-durable-state-home.md) named `daemon/data/events.jsonl` curia's one durable artifact. It is append-only text, one JSON object per line, and it never rotates. The operator ruled at the [#303](https://github.com/alp82/curia/issues/303) escalation that the journal becomes a `node:sqlite` store. That ruling left one question open, and this record answers it: does the store hold the truth, or do the lines hold it while the store serves as a derived index?
+
+The evidence is measured. [What the journal scans cost](../research/journal-scan-cost.md) holds the full table.
+
+- Ten `#readJournal` call sites ask **fourteen** distinct questions. More than thirty callers sit above them.
+- All fourteen take one of three shapes. The last event of a type for a key. Whether a type occurred for a key after that key's epoch. One count. Not one is an ad-hoc query over history.
+- One whole read costs about **25 ms** today. The read dominates the question by about twenty to one.
+- The box held **4,282 events in 1.4 MB** on 2026-08-13, and it grows about **404 events per day**.
+- `#epochScan` runs at the end of every turn of every agent. It reaches a quarter of a second per turn in about five months.
+
+[What `node:sqlite` guarantees](../research/node-sqlite-guarantees.md) holds the durability facts. Node 24.19 marks the module Stability 1.2, which stays experimental. A Node patch update can change the API, the defaults, and the bundled SQLite engine.
+
+## Decision
+
+- **The store holds the truth.** The `node:sqlite` database is curia's durable artifact. `daemon/data/events.jsonl` retires.
+- **A row keeps the written line verbatim.** A `body` column holds the exact text curia serialized. The other columns are extracted copies, and they exist for indexing. So the store is a superset of the file, and a query regenerates that file byte for byte.
+- **The daemon owns the only write connection.** Every other process opens the store read-only. WAL permits one writer, and every process must sit on one host.
+- **The store runs WAL with `synchronous=FULL`.** The store now holds the record, so a commit lost to a power cut is a record lost. FULL costs about 1.230 ms per insert, against about 404 events per day.
+- **A periodic `.dump` backs up the store, and the Node patch version is pinned.** The record sits on an experimental module, and curia does not carry that risk bare. `sqlite3 events.db .dump` produces portable SQL text.
+- **The old spelling survives untouched.** [#184](https://github.com/alp82/curia/issues/184) renamed the worker to the agent, and the journal was never rewritten to match. Curia stores the line as written and translates on read, exactly as `normalizeEvent` does today.
+
+## Considered options
+
+**The lines stay the truth, and the store is a derived index rebuilt at boot.** This was the recommendation this ticket opened with, and the operator moved off it. It puts no record on an experimental module, and a bad Node upgrade costs only a rebuild. It keeps `grep` and `tail -f` free.
+
+It was refused for three reasons. It needs a dual write and a divergence window, because a process can die between the append and the insert. It keeps a boot cost proportional to the whole history. It leaves the text file growing forever, because the journal never rotates.
+
+Two arguments made for it did not survive. The smaller migration is a migration argument, and the operator accepts a migration. The cheaper write path is real as a ratio and not as a number, because 404 events per day at 1.230 ms costs about half a second per day.
+
+**One general index in the store, about 150 lines.** It answers all fourteen questions with no migration and no write-path change, and the journal stays a text file. It answers nothing outside the three shapes. The operator put it up at the #303 escalation and turned it down, which reads as buying the query engine rather than the ten scans.
+
+## Consequences
+
+- **ADR-0001's journal bullet moves here.** That record now points at this one.
+- **ADR-0001's "no local brain to lose" gains a caveat.** Restart recovery is still a re-query against GitHub, and the tracker still holds ticket state. The store is a local brain, and the `.dump` is what bounds the loss.
+- **The verbatim `body` column carries the debugging habit.** `sqlite3 -readonly events.db "SELECT body FROM events"` pipes into `grep`. [#320](https://github.com/alp82/curia/issues/320) decides the surface the operator actually types.
+- **Retention becomes possible and stays undecided.** The text file never rotated. A row deletes. Nothing here rules on what curia keeps.
+- **The schema is not decided here.** [#321](https://github.com/alp82/curia/issues/321) prototypes it against the fourteen queries. This record fixes only the verbatim `body` column and the truth.
+- **The boot replay changes.** `EscalationStore._replay` reads the whole file once per process today. [#322](https://github.com/alp82/curia/issues/322) decides what fills the [#289](https://github.com/alp82/curia/issues/289) reductions.
+- **The existing file migrates.** [#323](https://github.com/alp82/curia/issues/323) converts 4,282 rows and decides what remains of the file.
+- **The write path changes at 129 `logEvent` call sites**, and the crash guard must still journal while the process dies. `installCrashGuard` journals and then exits, and a synchronous insert completes before that exit.
+- **The test suite changes.** 37 places across 14 test files seed or read `events.jsonl` directly.
+- **The word "store" now names two things.** `EscalationStore` lives in `daemon/src/store.mjs` and holds the in-memory reductions. The durable artifact above is also a store. Curia writes one name for one thing, so the build picks a second name before it writes code.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,6 +5,7 @@ One file per standing decision. A decision earns an ADR when it still constrains
 ## State and awareness
 
 - [ADR-0001](0001-github-is-the-only-durable-state-home.md): GitHub is the only durable state home. The daemon holds no board, and the journal is its one artifact.
+- [ADR-0017](0017-the-journal-is-a-queryable-store.md): That artifact is a `node:sqlite` store, and the JSON lines retire. A row keeps the written line verbatim, and the daemon is the only writer. Decided, not built.
 
 ## Daemon and agent host
 


### PR DESCRIPTION
Ticket: alp82/curia#319 — [Where does the truth live](https://github.com/alp82/curia/issues/319)

Resolves #319, the truth ticket on the store map (#316).

The store holds curia's durable record. The JSON lines retire, and ADR-0001's journal bullet moves to the new ADR-0017.

**What the ADR fixes**

- The `node:sqlite` store is the durable artifact. `daemon/data/events.jsonl` retires.
- A row keeps the written line verbatim in a `body` column. The other columns are extracted copies for indexing. The store is a superset of the file, and a query regenerates that file byte for byte.
- The daemon owns the only write connection. Every other process opens the store read-only.
- WAL with `synchronous=FULL`, because a commit lost to a power cut is now a record lost.
- A periodic `.dump` backs the store up, and the Node patch version is pinned. The record sits on an experimental module, and curia does not carry that risk bare.
- The #184 old-spelling discipline survives. Curia stores the line as written and translates on read.

**What it does not decide**

The schema (#321), the greppable surface (#320), the boot replay (#322), and the migration (#323) stay open. Retention becomes possible and stays undecided.

**Files**

- `docs/adr/0017-the-journal-is-a-queryable-store.md`, new.
- `docs/adr/0001-github-is-the-only-durable-state-home.md`, the journal bullet and the "no local brain to lose" consequence both amended in the house strikethrough style.
- `docs/adr/README.md`, the index line.
- `CONTEXT.md`, the Journal term and the State homes list carry the decided-and-not-built note.

Docs only, no code path touched. The daemon suite is green: 1758 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-319`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `e04a70e` Where does the truth live (#319)