### PR TITLE
A tool channel that breaks mid-session (alp82/curia#341)

### DIFF
--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -571,8 +571,10 @@ const HARNESS = {
     // timer — the keepalive's logging branch never does (#104, the 314 s
     // death). The keepalive covers a client that offered a token; this floor
     // covers one that did not. One day, the same bound as
-    // CODEX_TOOL_TIMEOUT_S below; the 90 s transport-drop watchdog still
-    // aborts a call whose daemon actually died.
+    // CODEX_TOOL_TIMEOUT_S below; a call whose daemon actually died is aborted
+    // by the transport-drop watchdog instead, about 120 s after the death
+    // (#341, three runs at 119.5 s, 118.9 s and 119.2 s in
+    // docs/research/tool-channel-mid-session.md — this comment said 90 s).
     //
     // A CONTAINER cannot have that (#156): the host store lives in the host
     // HOME, which is the first thing the boundary denies. The variable is
@@ -1485,10 +1487,25 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     // read the transport error as permission to decide the question itself. A
     // failed call is the one case where "never answer for the human" has to be
     // said again, because the failure looks like an answer arriving empty.
+    //
+    // #341 measured the timing this rule runs against, and it beat the rule as
+    // written. The tool channel SURVIVES a daemon restart: the MCP server is
+    // stateless and the client opens a connection per call, so the first call
+    // after the outage lands with no handshake. What dies is the call in flight,
+    // and the transport reports it about 120 s late — by which time the daemon
+    // has usually been back for two minutes. A retry that fires seconds after
+    // the failure therefore falls inside the same outage. That is exactly what
+    // #56's own agent did: four calls inside two minutes, four failures, and it
+    // ended its turn on a channel that was already healthy. So the retry now
+    // carries WAITS, and the sleep is named because a harness that backgrounds
+    // one turns the wait into no wait at all.
     '- **A failed `curia` tool call is not an answer.** If a call returns an error instead of a human reply,',
-    '  make the same call once more: curia routes the human to whichever call is live. If it fails again,',
-    '  stop and end your turn — say what you were asking. Never treat an unanswered question as answered,',
-    '  and never decide it yourself because the tool broke.',
+    '  make the same call once more: curia routes the human to whichever call is live. A failure usually',
+    '  means the daemon is restarting, and the channel comes back by itself, so a retry that fails at once',
+    '  proves nothing. Wait two minutes with a foreground `sleep 120` and make the call again. If that',
+    '  fails too, wait five minutes the same way and make it one last time. Only then stop and end your',
+    '  turn — say what you were asking. Never treat an unanswered question as answered, and never decide',
+    '  it yourself because the tool broke.',
     // Written by the #56 live check, whose agent blocked for 7h53m and reported
     // that the rule above would never have fired: nothing broke. What pushed it
     // toward answering was silence plus a plausible story, and the low stakes of

--- a/daemon/test/prompt.test.mjs
+++ b/daemon/test/prompt.test.mjs
@@ -182,6 +182,18 @@ describe('bounds', () => {
     assert.match(body, /stand in for the reply/)
   })
 
+  // #341: the rule above had the right instinct and the wrong clock. The
+  // transport reports a dropped call about 120 s after the daemon died, and the
+  // daemon is back seconds after it left, so an immediate retry meets the same
+  // outage and the agent gives up on a channel that is already healthy.
+  test('the retry waits, and the wait is a foreground sleep (#341)', () => {
+    const body = write({ mapNumber: 1 })
+    assert.match(body, /the channel comes back by itself/, 'the agent needs the model of the world, not just the step')
+    assert.match(body, /Wait two minutes with a foreground `sleep 120`/)
+    assert.match(body, /wait five minutes the same way and make it one last time/)
+    assert.match(body, /Only then stop and end your/)
+  })
+
   // #172/#180 shut the namespaces both harnesses handed out unasked. This order
   // is the half no config key reaches: a skill that installs an MCP server, a
   // `codex plugin add`, a `claude mcp add`, a marketplace. Asserted on a

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -31,4 +31,5 @@ One note per investigation. Each line gives the topic and the outcome. The outco
 | [phone-attach.md](phone-attach.md) | tmux + ttyd + Tailscale browser terminal for phone attach | Adopted — this is ADR-0003's shipped worker host stack |
 | [pi.md](pi.md) | pi as a minimal embeddable worker runtime | Rejected — worker only; Claude Code in tmux shipped instead |
 | [pi-handson.md](pi-handson.md) | pi driven live via SDK, RPC, and pi-acp | Superseded — refines [pi.md](pi.md); the pi lane never shipped |
+| [tool-channel-mid-session.md](tool-channel-mid-session.md) | What a harness does when the daemon dies under it | Adopted — the channel survives a restart, so [#341](https://github.com/alp82/curia/issues/341) put the waits into the retry rule |
 | [worker-two-channels.md](worker-two-channels.md) | Side-channel driving plus human PTY attach | Adopted — the daemon never parses scrollback; underpins ADR-0005 |

--- a/docs/research/tool-channel-mid-session.md
+++ b/docs/research/tool-channel-mid-session.md
@@ -1,0 +1,83 @@
+# A tool channel that breaks mid-session
+
+Evidence for [wayfinder #341](https://github.com/alp82/curia/issues/341), on [map #244](https://github.com/alp82/curia/issues/244). Measured on 2026-08-15 inside an ordinary agent container, on the claude harness, CLI `2.1.220`. The harness is real. The daemon is a stand-in: [tool-channel-mid-session.probe.mjs](tool-channel-mid-session.probe.mjs), which serves curia's own `/mcp` route shape and nothing else.
+
+## The question
+
+[#194](https://github.com/alp82/curia/issues/194) closed the channel that never comes up. It ruled this case out of scope in its own words: after readiness, silence is what a healthy agent looks like, so the daemon cannot tell a mute agent from a busy one without a heartbeat, and a heartbeat is agent cooperation, which is the thing that fails here.
+
+The ticket carried the fault forward as a premise: the channel dies mid-session, the agent keeps working, and no wire reaches back. This file tests that premise instead of building on it.
+
+## What stands in for the daemon
+
+The probe serves `POST /mcp?agent=&ticket=` with a stateless `StreamableHTTPServerTransport` and the `x-curia-agent-token` header, the way `daemon/src/index.mjs:1558` does. The agent reaches it through the `.mcp.json` and the two settings files `daemon/src/workspace.mjs` writes, with `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` at the daemon's own one day. A supervisor respawns the stand-in after it exits, the way `restart: on-failure` respawns the daemon.
+
+Five deviations, all stated rather than hidden:
+
+1. The agent runs headless (`claude -p`), not in a tmux pane.
+2. The model is haiku. The transport is what is under test, and it carries no model.
+3. The stand-in sends no keepalive, writes no journal and has no Discord bridge.
+4. Client and server share one container, so the docker host gateway is not in the path.
+5. The codex harness is not measured at all. See [What this does not measure](#what-this-does-not-measure).
+
+## Run 1: the daemon dies under a blocking call
+
+The agent calls `ask_human`. The stand-in dies three seconds later, while it holds the call. The supervisor brings it back 5.5 seconds after that.
+
+| Time | What happened |
+| --- | --- |
+| 09:23:41.072 | `tools/call` `ask_human` arrives |
+| 09:23:44.078 | the daemon exits, holding the call |
+| 09:23:49.612 | a new daemon process listens on the same port |
+| 09:25:43.619 | the agent's NEXT call arrives, on the new process |
+
+The call failed. This is what the model was told, verbatim:
+
+> MCP server "curia" transport dropped mid-call; response for tool "ask_human" was lost
+
+**The wait is about two minutes.** The error reached the model 119.5 seconds after the daemon died, and the daemon had been back for 114 of them. Three runs of this case agree: 119.5 s, 118.9 s and 119.2 s from the death to the agent's next call. The comment at `daemon/src/workspace.mjs:575` called this a 90 second watchdog. The measurement says about 120, which is also where the harness moves a slow call to a background task.
+
+**Nothing else was lost.** The two calls after the failed one succeeded on the new process, with no new handshake and no `initialize`.
+
+## Run 2: the daemon is down when the call is made
+
+The stand-in dies with no call in flight and stays down. The agent was told to call `notify` again and again until it succeeds. This run used a 45 second outage, which is longer than the agent's patience. The `refused` case in the probe uses 20 seconds, so the agent outlives it.
+
+It made 25 attempts in about 40 seconds and gave up before the daemon returned. Every attempt failed the same way, in about 1.5 seconds:
+
+> Unable to connect. Is the computer able to access the url?
+
+So a call made into an outage fails fast and says so plainly. The client never stopped trying, and it never marked the server dead.
+
+## Run 3: the tools come back by themselves
+
+The same shape as run 2, with the outage cut to 20 seconds so the agent outlives it.
+
+| Time | What happened |
+| --- | --- |
+| 09:30:20.829 | the daemon exits |
+| 09:30:41.421 | a new daemon process listens |
+| 09:30:41.944 | attempt 16 of the agent's `notify` arrives and succeeds |
+
+**The channel needs no recovery.** The daemon's MCP server is stateless and the client opens a connection per call, so a restarted daemon is invisible to every call after the outage. Attempt 16 landed 0.5 seconds after the new process came up. It was an ordinary `tools/call`, not a handshake. A second run of this case took 16 attempts too, and landed 1.2 seconds after the new process.
+
+## What this means
+
+**The premise is wrong for a daemon that comes back.** Every deploy and every `POST /restart` restarts the daemon under live agents, and this measurement says the tool channel survives all of them. The channel only stays dead if the daemon does.
+
+**One thing dies: the call in flight.** It costs about two minutes of agent time, and it costs the answer, which is a bigger loss than the call. The retry the standing orders ask for then works.
+
+**[#56](https://github.com/alp82/curia/issues/56) recorded this from the agent's side** in [56-gateway-crash.md](../live-checks/56-gateway-crash.md), section 5, before anyone had measured it. That agent's `request_review` died with the same two sentences this probe produced. It then retried four times inside two minutes, met the same outage every time, and ended its turn. The rule was correct and the timing beat it.
+
+**So the fix is a wait, not a mechanism.** The retry sits in the standing orders, and it fires within seconds of the failure. A restart takes seconds to a minute, and the transport takes two minutes to report the drop. An agent that retries once and stops is a healthy agent that gave up during an ordinary restart.
+
+**The answer to a dead call is asked for twice.** The operator answers the card whose reader died. `settle` finds no resolver, so [#139](https://github.com/alp82/curia/issues/139) queues question and answer as an agent note and the thread says the agent gets it with its next tool result. The agent then re-asks. Supersede does not close the old record, because supersede only touches OPEN records (`daemon/src/store.mjs:405`) and this one is answered. So a second card carries the same question, the operator answers twice, and the queued answer only reaches the agent when the second answer returns the call. `drainNotes()` runs after the answer resolves (`daemon/src/index.mjs:1107`).
+
+**The daemon has no reading to show.** It stamps the FIRST `/mcp` call per agent (#194) and nothing after it, so no surface can say when an agent last reached curia. That reading is what turns a silent agent into a fact the operator can judge.
+
+## What this does not measure
+
+- **The codex harness.** An agent container carries no codex credential, so this probe cannot run there. Codex bounds one tool call at 24 hours (`CODEX_TOOL_TIMEOUT_S`), and nothing on record says its client survives a transport drop the way this one does. That reading needs a dev session or a codex-lane dispatch.
+- **A daemon that never comes back.** The agent's Stop hook rides curl to the same dead port, so its turn ends with nothing told to anyone. Section 5 of the #56 record is the only account of that state.
+- **The live daemon on the box.** The stand-in has no keepalive, so this says nothing about a call that is held for hours and answered.
+- **The pane.** A headless agent has no composer and no keystroke channel, so the note interrupt was not exercised.

--- a/docs/research/tool-channel-mid-session.probe.mjs
+++ b/docs/research/tool-channel-mid-session.probe.mjs
@@ -1,0 +1,255 @@
+// What a harness does when the daemon dies UNDER it (#341).
+//
+// #194 measured the channel that never comes up. This measures the channel that
+// breaks after readiness: the daemon exits while an agent works, and the
+// supervisor respawns it seconds later, which is what every deploy and every
+// `POST /restart` does to a live agent.
+//
+// The stand-in is faithful where it matters. It serves `POST /mcp?agent=&ticket=`
+// with a stateless `StreamableHTTPServerTransport` and the `x-curia-agent-token`
+// header, exactly as `daemon/src/index.mjs` does, and the agent reaches it with
+// the `.mcp.json` and the settings `daemon/src/workspace.mjs` writes. What it is
+// NOT is the live daemon on the box: no Discord, no journal, no keepalive.
+//
+// Two cases:
+//   drop     the daemon dies while it holds a blocking `ask_human`, and is back
+//            5 s later. Measures what the agent is told, and how long it waits.
+//   refused  the daemon dies with no call in flight and stays down 20 s while
+//            the agent retries. Measures whether the tools come back by
+//            themselves.
+//
+// Run:  node docs/research/tool-channel-mid-session.probe.mjs <drop|refused> [scratch-dir]
+// Needs the `claude` binary and a model credential in `CLAUDE_CODE_OAUTH_TOKEN`.
+// The numbers it prints are the timelines in tool-channel-mid-session.md.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import http from 'node:http'
+import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SELF = fileURLToPath(import.meta.url)
+
+// The MCP SDK is the daemon's dependency and this file lives outside its
+// package, so it is resolved from `daemon/package.json` rather than imported by
+// name. Run `npm ci` in `daemon/` first.
+const dep = createRequire(path.join(SELF, '../../../daemon/package.json'))
+const load = async (spec) => import(pathToFileURL(dep.resolve(spec)).href)
+const { McpServer } = await load('@modelcontextprotocol/sdk/server/mcp.js')
+const { StreamableHTTPServerTransport } = await load('@modelcontextprotocol/sdk/server/streamableHttp.js')
+const { z } = await load('zod')
+const PORT = Number(process.env.PROBE_PORT ?? 9010)
+const TOKEN = 'probe-token'
+const TOKEN_HEADER = 'x-curia-agent-token'
+const AGENT = 'curia-341'
+
+// ---- the stand-in daemon ---------------------------------------------------
+
+function log(dir, entry) {
+  fs.appendFileSync(path.join(dir, 'log.jsonl'), `${JSON.stringify({ ts: new Date().toISOString(), pid: process.pid, ...entry })}\n`)
+}
+
+// The daemon dies once, under the tool this case names, and the flag file is
+// what keeps the respawned process from dying again.
+function maybeDie(dir, tool, dieUnder, afterMs) {
+  const flag = path.join(dir, 'died')
+  if (tool !== dieUnder || fs.existsSync(flag)) return
+  fs.writeFileSync(flag, String(Date.now()))
+  setTimeout(() => {
+    log(dir, { ev: 'daemon_dies', while_holding: tool })
+    process.exit(1)
+  }, afterMs)
+}
+
+function buildMcpServer(dir, dieUnder, afterMs) {
+  const s = new McpServer({ name: 'curia', version: '0.0.1' })
+  s.tool('notify', 'Fire-and-forget status line.', { message: z.string() }, async ({ message }) => {
+    log(dir, { ev: 'tool', tool: 'notify', message })
+    maybeDie(dir, 'notify', dieUnder, afterMs)
+    return { content: [{ type: 'text', text: `noted: ${message}` }] }
+  })
+  s.tool('ask_human', 'Blocking question to a human.', { prompt: z.string() }, async ({ prompt }) => {
+    log(dir, { ev: 'tool', tool: 'ask_human', prompt })
+    maybeDie(dir, 'ask_human', dieUnder, afterMs)
+    // Blocks the way the real one does: an answer takes as long as a human takes.
+    await new Promise((r) => setTimeout(r, 300_000))
+    return { content: [{ type: 'text', text: 'the human said: go ahead' }] }
+  })
+  return s
+}
+
+async function readBody(req) {
+  const chunks = []
+  for await (const c of req) chunks.push(c)
+  try { return JSON.parse(Buffer.concat(chunks).toString()) } catch { return {} }
+}
+
+function serve(dir, dieUnder, afterMs) {
+  http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${PORT}`)
+    if (url.pathname !== '/mcp') { res.writeHead(404).end('{}'); return }
+    const body = await readBody(req)
+    log(dir, {
+      ev: 'request', method: req.method, rpc: body?.method ?? null, id: body?.id ?? null,
+      tool: body?.params?.name ?? null, token_ok: req.headers[TOKEN_HEADER] === TOKEN,
+    })
+    if (req.method !== 'POST') { res.writeHead(405).end('{}'); return }
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    res.on('close', () => { transport.close() })
+    const mcp = buildMcpServer(dir, dieUnder, afterMs)
+    await mcp.connect(transport)
+    await transport.handleRequest(req, res, body)
+  }).listen(PORT, '127.0.0.1', () => log(dir, { ev: 'listening', port: PORT }))
+}
+
+// ---- the agent's side ------------------------------------------------------
+
+// The files `daemon/src/workspace.mjs` writes for a claude agent, with this
+// probe's URL in them.
+function seed(dir) {
+  const ws = path.join(dir, 'ws')
+  const cfg = path.join(dir, 'cfg')
+  fs.mkdirSync(path.join(ws, '.claude'), { recursive: true })
+  fs.mkdirSync(cfg, { recursive: true })
+  fs.writeFileSync(path.join(ws, '.mcp.json'), JSON.stringify({
+    mcpServers: {
+      curia: {
+        type: 'http',
+        url: `http://127.0.0.1:${PORT}/mcp?agent=${AGENT}&ticket=341`,
+        headers: { [TOKEN_HEADER]: TOKEN },
+      },
+    },
+  }, null, 2))
+  fs.writeFileSync(path.join(ws, '.claude', 'settings.json'), JSON.stringify({
+    enableAllProjectMcpServers: true,
+    permissions: { defaultMode: 'bypassPermissions' },
+  }, null, 2))
+  fs.writeFileSync(path.join(cfg, 'settings.json'), JSON.stringify({
+    skipDangerousModePermissionPrompt: true,
+    disableClaudeAiConnectors: true,
+    allowedMcpServers: [{ serverName: 'curia' }],
+  }, null, 2))
+  fs.writeFileSync(path.join(cfg, '.claude.json'), JSON.stringify({
+    hasCompletedOnboarding: true, installMethod: 'native', autoUpdates: false, numStartups: 1,
+    projects: { [ws]: { hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true } },
+  }, null, 2))
+  return { ws, cfg }
+}
+
+const PROMPTS = {
+  drop: [
+    'You have the curia MCP tools. Follow these steps in order and do not stop early.',
+    '1. Call notify with message "one".',
+    '2. Call ask_human with prompt "blocking".',
+    '3. Whatever happened in step 2, including an error, call notify with message "two".',
+    '4. Call notify with message "three".',
+    'Then report, for each call, whether it succeeded or failed, and quote any error verbatim.',
+  ].join('\n'),
+  refused: [
+    'You have the curia MCP tools. Follow these steps in order and do not stop early.',
+    '1. Call notify with message "one".',
+    '2. Call notify with message "two". If that call fails, call it again at once with the',
+    '   same message. Keep calling it until it succeeds. Do not stop before it succeeds or',
+    '   before 25 attempts. Do not use the bash tool. Do not ask anybody anything.',
+    'Then report how many attempts step 2 took, and quote the first error verbatim.',
+  ].join('\n'),
+}
+
+const CASES = {
+  drop: { dieUnder: 'ask_human', dieAfterMs: 3000, downMs: 5000 },
+  refused: { dieUnder: 'notify', dieAfterMs: 1000, downMs: 20_000 },
+}
+
+async function main() {
+  const which = process.argv[2]
+  const kase = CASES[which]
+  if (!kase) {
+    console.error(`usage: node ${path.basename(SELF)} <${Object.keys(CASES).join('|')}> [scratch-dir]`)
+    process.exit(2)
+  }
+  if (!process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    console.error('no CLAUDE_CODE_OAUTH_TOKEN — this probe runs a real headless agent and needs a credential')
+    process.exit(2)
+  }
+  const dir = process.argv[3] || path.join(os.tmpdir(), `curia-channel-probe-${which}`)
+  fs.rmSync(dir, { recursive: true, force: true })
+  fs.mkdirSync(dir, { recursive: true })
+  const { ws, cfg } = seed(dir)
+
+  // The supervisor the box has: `restart: on-failure`, one respawn after the
+  // outage this case asks for.
+  let stop = false
+  let daemon = null
+  const supervise = async () => {
+    while (!stop) {
+      await new Promise((done) => {
+        daemon = spawn(process.execPath, [SELF], {
+          env: {
+            ...process.env,
+            PROBE_ROLE: 'server', PROBE_DIR: dir,
+            PROBE_DIE_UNDER: kase.dieUnder, PROBE_DIE_AFTER_MS: String(kase.dieAfterMs),
+          },
+          stdio: 'inherit',
+        })
+        daemon.on('exit', done)
+      })
+      if (stop) return
+      console.log(`[${new Date().toISOString()}] daemon down for ${kase.downMs / 1000}s`)
+      await new Promise((r) => setTimeout(r, kase.downMs))
+    }
+  }
+  supervise()
+  await new Promise((r) => setTimeout(r, 2000))
+
+  const started = Date.now()
+  const agent = spawn('claude', [
+    '-p', PROMPTS[which], '--model', 'haiku',
+    '--permission-mode', 'bypassPermissions', '--output-format', 'json',
+  ], {
+    cwd: ws,
+    // stdin is closed rather than inherited. `claude -p` waits three seconds for
+    // piped input, and an inherited terminal never closes it at all.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      HOME: process.env.HOME, PATH: process.env.PATH, TERM: 'xterm',
+      CLAUDE_CONFIG_DIR: cfg,
+      CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+      // What the daemon sets, so the client's own idle timer cannot be what
+      // ends the call (#34).
+      CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT: '86400000',
+    },
+  })
+  let out = ''
+  agent.stdout.on('data', (b) => { out += b })
+  agent.stderr.pipe(process.stderr)
+  await new Promise((done) => agent.on('exit', done))
+  // The stand-in outlives this process otherwise, and the next run of the probe
+  // then meets its own port held by the last one.
+  stop = true
+  daemon?.kill()
+
+  console.log(`\n=== ${which}: the timeline ===`)
+  const journal = path.join(dir, 'log.jsonl')
+  if (!fs.existsSync(journal)) {
+    console.log(`no requests reached the stand-in. Check that port ${PORT} was free.`)
+  }
+  for (const line of fs.existsSync(journal) ? fs.readFileSync(journal, 'utf8').trim().split('\n') : []) {
+    const e = JSON.parse(line)
+    console.log(`${e.ts}  pid ${e.pid}  ${e.ev}${e.rpc ? ` ${e.rpc}` : ''}${e.tool ? ` ${e.tool}` : ''}`)
+  }
+  console.log(`\n=== ${which}: what the agent reported (${Math.round((Date.now() - started) / 1000)}s) ===`)
+  try {
+    console.log(JSON.parse(out).result)
+  } catch {
+    console.log(out)
+  }
+  process.exit(0)
+}
+
+// One file, two roles: the supervisor respawns this same script as the daemon.
+if (process.env.PROBE_ROLE === 'server') {
+  serve(process.env.PROBE_DIR, process.env.PROBE_DIE_UNDER, Number(process.env.PROBE_DIE_AFTER_MS))
+} else {
+  await main()
+}


### PR DESCRIPTION
Ticket: alp82/curia#341 — [A tool channel that breaks mid-session](https://github.com/alp82/curia/issues/341)

#341 measured, and the retry rule fixed.

#194 closed the channel that never comes up and ruled this case out of scope. This ran it instead of reasoning about it: a stand-in daemon on curia's own `/mcp` shape, killed under a blocking call and respawned the way `restart: on-failure` respawns it. Claude harness, CLI 2.1.220, three drop runs and two outage runs.

**The channel survives a daemon restart.** The MCP server is stateless and the client opens a connection per call, so the first call after the outage lands with no handshake, 0.5 s after the new process comes up. One thing dies: the call in flight. The transport reports it about 120 s after the death (119.5 s, 118.9 s, 119.2 s), by which time the daemon has been back for two minutes. A call made into an outage fails in about 1.5 s with a plain message.

So the fix is a wait, not a mechanism. The standing order told an agent to retry at once, and #56's own agent burned four calls inside two minutes and ended its turn on a channel that was already healthy.

What is in the diff:
- `docs/research/tool-channel-mid-session.md` — the reading, the two failure texts verbatim, and what it does not measure.
- `docs/research/tool-channel-mid-session.probe.mjs` — the probe, so the reading can be taken again.
- `daemon/src/workspace.mjs` — the retry rule now waits two minutes, then five, and names a foreground `sleep 120`. The stale "90 s watchdog" comment carries the measurement.
- `daemon/test/prompt.test.mjs` — one test on the new order.

Suite green: 1823 tests, 0 failures.

---

Dispatched by the curia daemon — session `curia-341`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `c4bfa6a` Measure the channel that breaks mid-session, and give the retry rule its waits (#341)