### PR TITLE
Codex cases for the remaining gap-13 test files (alp82/curia#342)

### DIFF
--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -436,6 +436,13 @@ describe('attach refusal withdraws the serve rule (index.mjs, real boot)', () =>
 // fakes only `docker network inspect` — the gateway it reports is 127.0.0.2,
 // another loopback address this box can bind and dial. So the container-facing
 // listener here is the shipped one, reached the way a container reaches it.
+//
+// #342 (gap 13 of the codex-lane inventory) makes this boot a TWO-harness box,
+// the shape `config/routing.yaml` actually ships. This file used to name the
+// claude harness alone, so everything below it was measured on a box that has
+// only ever had one lane — and the two things that read the harness table on
+// this surface (the side channel's list, and the Stop-hook body codex validates)
+// could both have regressed with the suite still green.
 describe('the per-agent token on the agent routes (#159, real boot, both listeners)', () => {
   let tmp
   let child
@@ -501,11 +508,16 @@ describe('the per-agent token on the agent routes (#159, real boot, both listene
       '  untyped: sonnet',
       'models:',
       '  sonnet: { provider: anthropic, harness: claude }',
+      '  gpt: { provider: openai, harness: codex, id: gpt-5.6-sol }',
       'harnesses:',
       '  claude:',
       '    template: claude --model {model} "$(cat {prompt_file})"',
     "    ready: '⏵⏵|bypass permissions'",
     "    tool_channel_grace_s: 15",
+      '  codex:',
+      '    template: codex --model {model} "$(cat {prompt_file})"',
+      "    ready: '·\\s[~/]'",
+      '    tool_channel_grace_s: 20',
       '',
     ].join('\n'))
 
@@ -533,6 +545,16 @@ describe('the per-agent token on the agent routes (#159, real boot, both listene
   after(() => {
     if (child && child.exitCode === null) child.kill('SIGKILL')
     fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  // #342, gap 13. The side channel is bound once and serves every containerized
+  // harness, and the list it names is `Object.keys(routingConfig.harnesses)` —
+  // not a constant, and not the dispatch lane. A daemon that named one harness
+  // on a two-harness box would be the #185 fault told backwards: the operator
+  // reads a line saying the codex containers have no side channel while they
+  // are in fact served, or the reverse.
+  test('the side channel names every configured harness, not the one that happened to be first', async () => {
+    assert.match(watch.log(), /the side channel for claude, codex containers/)
   })
 
   test('an agent route with no token is refused on loopback', async () => {
@@ -566,6 +588,33 @@ describe('the per-agent token on the agent routes (#159, real boot, both listene
     const journal = fs.readFileSync(path.join(tmp, 'data', 'events.jsonl'), 'utf8')
     assert.ok(journal.includes('"type":"agent_token_refused"'), 'a refusal is journalled, or nobody ever learns it happened')
     assert.ok(journal.includes('"type":"agent_done"'), 'and the accepted call reached the route')
+  })
+
+  // #342, gap 13. The one place index.mjs speaks a codex dialect, and until now
+  // the only thing holding it was a comment beside the `return`.
+  //
+  // Both CLIs read "no decision" as allow, so `{ok:true}` looks harmless and is
+  // harmless on the claude lane. Codex validates this body against a CLOSED
+  // schema and rejects the extra key outright — `Stop hook (failed): hook
+  // returned invalid stop hook JSON output`, printed in the agent's own pane on
+  // every clean ending (observed, #152). It fails OPEN, so nothing is trapped
+  // and no test of the decision itself would notice; what it costs is the
+  // signal, because a genuinely broken hook looks exactly the same.
+  //
+  // So the assertion is on the KEYS, not on the decision: an allow answer must
+  // carry nothing at all.
+  test('the Stop hook\'s allow answer is an EMPTY object — codex refuses any extra key', async () => {
+    const token = mint('curia-46')
+    const res = await request(port, 'POST', '/agent_done?agent=curia-46', {
+      headers: { 'content-type': 'application/json', [TOKEN_HEADER]: token },
+      body: JSON.stringify({ hook_event_name: 'Stop', session_id: 'fixture' }),
+    })
+    assert.equal(res.status, 200)
+    assert.deepEqual(
+      Object.keys(JSON.parse(res.body)),
+      [],
+      'an allow answer says nothing — a key here is a failed Stop hook on the codex lane and a silent pass on the claude one',
+    )
   })
 
   test('the container-facing listener carries the agent surface and nothing else', async () => {

--- a/daemon/test/keepalive.test.mjs
+++ b/daemon/test/keepalive.test.mjs
@@ -200,11 +200,17 @@ describe('a blocked ask_human keeps its stream alive (index.mjs, real boot + rea
     await client.close()
   })
 
-  // The other branch. An agent harness that offers no progressToken still has to
-  // get bytes, or it dies at its own idle timeout exactly like Claude Code did
-  // — and this is the branch a silent regression would leave uncovered, since
-  // Claude Code itself never takes it. (What a *given* client does with a
-  // logging notification is its business; the daemon's job is to keep sending.)
+  // The other branch, and the codex lane's own (#342, gap 13). An agent harness
+  // that offers no progressToken still has to get bytes, or it dies at its own
+  // idle timeout exactly like Claude Code did — and this is the branch a silent
+  // regression would leave uncovered, since Claude Code itself never takes it.
+  // (What a *given* client does with a logging notification is its business;
+  // the daemon's job is to keep sending.)
+  //
+  // The envelope is asserted alongside the text since #342. A logging
+  // notification is routed by `level` and `logger` before anything reads its
+  // data, so a keepalive that arrived unlabelled would be filtered out by a
+  // conforming client and the lane would go silent with this test still green.
   test('a client that offers no progressToken still gets keepalive traffic', async () => {
     const client = new Client({ name: 'curia-keepalive-test-notoken', version: '0.0.0' })
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp?agent=curia-lab2&ticket=78`), armed('curia-lab2'))
@@ -231,12 +237,97 @@ describe('a blocked ask_human keeps its stream alive (index.mjs, real boot + rea
       `expected repeated logging notifications on the tokenless path, got ${logs.length}`,
     )
     assert.match(String(logs.at(-1).params.data ?? ''), new RegExp(open.id))
+    assert.equal(logs.at(-1).params.level, 'info', 'an unlabelled notification is one a conforming client drops')
+    assert.equal(logs.at(-1).params.logger, 'curia', 'and the logger is how it tells curia from the harness\'s own noise')
 
     await request(port, 'POST', '/answer', {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ id: open.id, answer: 'released' }),
     })
     await call
+    await client.close()
+  })
+
+  // #342, gap 13. The inbound half of #34, end to end on a real client — and
+  // the reason it is a CODEX case rather than a claude one.
+  //
+  // Gap 8 of the codex-lane inventory (#152) asked whether an MCP `image` block
+  // reaches a codex agent at all, because `inboundContent` predates that lane.
+  // #176 settled it live: a stdio MCP server returned a 120x80 solid red PNG and
+  // the codex agent answered with the colour and the dimensions, both of which
+  // come only from the pixels. So the lane reads the block, and what is left to
+  // hold is that the daemon still PRODUCES it — which no test asserted past
+  // `inboundContent` itself. A refactor that let the answer's attachments stop
+  // at the route would turn every screenshot answer into a silent drop on both
+  // lanes, and the unit test of the pure function would stay green.
+  test('a screenshot answer comes back as a real image block, not a path the agent must go and read', async () => {
+    // A real PNG, because the block carries the bytes: 1x1, the smallest file
+    // the format has.
+    const workRoot = path.join(tmp, 'work')
+    fs.mkdirSync(workRoot, { recursive: true })
+    const shot = path.join(workRoot, 'shot.png')
+    fs.writeFileSync(shot, Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      'base64',
+    ))
+
+    const client = new Client({ name: 'curia-image-test', version: '0.0.0' })
+    await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp?agent=curia-70&ticket=70`), armed('curia-70')))
+    const call = client.callTool(
+      { name: 'ask_human', arguments: { prompt: 'does this look right?', kind: 'free-text' } },
+      undefined,
+      { timeout: 30_000 },
+    )
+
+    const open = await until(
+      async () => JSON.parse((await request(port, 'GET', '/state')).body).open_escalations.find((e) => e.ticket === '70'),
+      'the image escalation to open',
+    )
+    const answered = await request(port, 'POST', '/answer', {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: open.id, answer: 'no — look at the header', attachments: [shot] }),
+    })
+    assert.equal(answered.status, 200)
+
+    const { content } = await call
+    const image = content.find((c) => c.type === 'image')
+    assert.ok(image, `the answer's attachment must ride back as an image block — got ${JSON.stringify(content.map((c) => c.type))}`)
+    assert.equal(image.mimeType, 'image/png')
+    assert.equal(image.data, fs.readFileSync(shot).toString('base64'), 'the bytes are the picture, not a path to it')
+    // Text stays the floor (#34): the words the human typed are never traded
+    // for the picture.
+    assert.match(content.filter((c) => c.type === 'text').map((c) => c.text).join('\n'), /look at the header/)
+    await client.close()
+  })
+
+  // #342, gap 13. #152 measured the `choice` kind working on a live codex agent
+  // and filed it under "measured parity, so do not re-open it" — measured on a
+  // transcript, and held by nothing since. It is the one kind whose payload the
+  // agent supplies beyond the prompt, so it is the one that can rot: options
+  // dropped from the record leave a human a text box where the agent asked for
+  // a pick, and neither side can tell that anything was lost.
+  test('the choice kind carries its options to the human and the pick back to the agent', async () => {
+    const client = new Client({ name: 'curia-choice-test', version: '0.0.0' })
+    await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp?agent=curia-71&ticket=71`), armed('curia-71')))
+    const call = client.callTool(
+      { name: 'ask_human', arguments: { prompt: 'which harness runs this?', kind: 'choice', options: ['claude', 'codex'] } },
+      undefined,
+      { timeout: 30_000 },
+    )
+
+    const open = await until(
+      async () => JSON.parse((await request(port, 'GET', '/state')).body).open_escalations.find((e) => e.ticket === '71'),
+      'the choice escalation to open',
+    )
+    assert.equal(open.kind, 'choice')
+    assert.deepEqual(open.options, ['claude', 'codex'], 'the options reach the surface that has to draw the buttons')
+
+    await request(port, 'POST', '/answer', {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: open.id, answer: 'codex' }),
+    })
+    const result = await call
+    assert.match(result.content.map((c) => c.text ?? '').join('\n'), /codex/, 'the pick reaches the agent as its tool result')
     await client.close()
   })
 


### PR DESCRIPTION
Ticket: alp82/curia#342 — [Codex cases for the remaining gap-13 test files](https://github.com/alp82/curia/issues/342)

Gap 13 of the codex-lane inventory (#152) named four test files with no codex case. `prompt.test.mjs` got one with #173 and `statusline.test.mjs` with #179. This closes the other two.

**index.test.mjs**

- The #159 boot now names two harnesses, the shape `config/routing.yaml` ships. It named the claude harness alone, so every test under it measured a box with one lane.
- The side channel must name every configured harness. The list comes from the harness table, not from a constant.
- The Stop hook's allow answer must be an EMPTY object. Codex validates this body against a closed schema and refuses an extra key. It fails open, so only the signal is lost, and a comment beside the `return` was the whole guard.

**keepalive.test.mjs**

- An answer that carries a screenshot comes back as a real MCP image block. #176 measured a live codex agent reading such a block off the pixels. Nothing held that the daemon still makes one past the unit test of `inboundContent`.
- The `choice` kind carries its options to the human and the pick back to the agent. #152 filed this as measured parity on codex and nothing has held it since.
- The tokenless keepalive notification states its `level` and its `logger`. A conforming client routes on both before it reads the data. That branch is the codex lane's, because Claude Code never takes it.

Test files only. `docs/research/codex-lane-gaps.md` is not touched: it is the dated inventory, and no fix ticket has amended it.

Each new assertion was checked against a mutation of the shipped code, and each one failed alone. The suite is green: 1834 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-342`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `973ce04` Codex cases for the last two gap-13 test files (#342)