### PR TITLE
The read-only MCP history server (alp82/curia#344)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -196,7 +196,7 @@ One of the three loopback ports an agent's container publishes, the same number 
 The agent's private config home for its harness. It holds the prompt, the skills, the harness settings, and on the claude path nothing else. It holds no credentials.
 
 **Tool namespace**:
-The MCP servers an agent can reach: curia's own, and nothing else. Two settings keys in the config dir hold that line. One stops the fetch of the operator's account-level claude.ai connectors, which follow the shared credential rather than the config dir. The other admits curia's server alone.
+The MCP servers an agent can reach: curia's own, and nothing else. Two settings keys in the config dir hold that line. One stops the fetch of the operator's account-level claude.ai connectors, which follow the shared credential rather than the config dir. The other admits curia's server alone. The line is closed by decision as well as by settings: a read-only MCP history server was proposed and refused (#344). History that ever reaches an agent arrives as tools on curia's own server, or it does not ship.
 
 **Skills**:
 The skill set curia symlinks into every agent's config dir, so an agent resolves in the same idiom as a hand session.

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -633,6 +633,11 @@ const HARNESS = {
       // not strings — `['curia']` fails schema validation, and an invalid
       // allowlist enforces an EMPTY one, which takes curia's own server down
       // with it. That trap was measured, not reasoned about.
+      //
+      // #344 made the one-server line a DECISION and not only a setting: a
+      // read-only MCP history server was proposed here and refused. History
+      // that ever reaches an agent arrives as tools on the server below, so
+      // this list stays at one entry.
       fs.writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify({
         skipDangerousModePermissionPrompt: true,
         disableClaudeAiConnectors: true,


### PR DESCRIPTION
Ticket: alp82/curia#344 — [The read-only MCP history server](https://github.com/alp82/curia/issues/344)

#344 decides that curia does not want a read-only MCP history server.

Two small records, no build:
- `CONTEXT.md` — the **Tool namespace** entry now says the one-server line is closed by decision as well as by settings, and names the refusal.
- `daemon/src/workspace.mjs` — a comment beside `allowedMcpServers`, so the decision sits next to the code that enforces it.

Daemon suite: 1830 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-344`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `248e7d7` The tool namespace is closed by decision (#344)