### PR TITLE
Limit-reset auto-resume (alp82/curia#346)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,7 +121,10 @@ A temporary hold on a model or provider after a usage-limit signal, until the st
 The instant a cooling ends. Two surfaces state it, and curia reads both: the anthropic pane text carries an epoch beside the reached-text, and the codex transcript carries `resets_at` beside the rate-limit window that is spent. A cap is account-level, so any live agent on that provider states it for the harness. With neither surface stating one, cooling holds for one hour.
 
 **Exhaustion**:
-The state where every candidate model is cooling. The frontier stays the queue, and a wake timer fires at the earliest reset.
+The state where every candidate model is cooling. The frontier stays the queue, and a wake timer fires at the earliest reset. Exhaustion that stops a LIVE agent also arms a limit resume.
+
+**Limit resume**:
+The dispatch curia owes a ticket its own cooling stopped. Exhaustion kills the agent and releases the claim, and the worktree stands, so the resume is `resume` and never `start`: `start` recreates the worktree from origin and takes every uncommitted file with it. It is not gated on `auto_dispatch`, because that setting decides whether curia takes NEW work off the frontier and this puts back work the operator already ordered. A reviewer gets none, because the builder has already been told the reviewer ended. One arm buys one attempt, and a resume that walks back into the cap arms again from the fresh reset. The arm is journalled, so a daemon restart inside the window does not lose it. The thread carries the promise with the exhaustion and the outcome at the reset, and it says so when the resume cannot be made.
 
 **Overseer**:
 The command brain of curia. The standing design is one brain with three skins (Discord, text, voice). The shipped daemon uses a deterministic router instead.

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -163,6 +163,30 @@ const sleep = (ms) => sleepFor(ms, undefined, { ref: false })
 // pressed the button reads it as an interrupt rather than a queue.
 const INTERRUPT_GRACE_MS = 5_000
 
+// The limit resume (#346). A window rolls at an instant the PROVIDER states, on
+// the provider's own clock, and the box's clock is its own. A resume that lands
+// one second early walks straight back into the cap and cools again, so the arm
+// sits a minute behind the stated reset. A minute costs nothing against a
+// window measured in hours.
+const RESUME_GRACE_MS = 60_000
+
+// The floor under every wake. It keeps a reset already in the past — the one a
+// daemon that was down through the window re-arms at boot — from firing inside
+// the same tick that armed it. A field on the dispatcher rather than a constant
+// at the call site, so a test can drive the path without waiting out a real one
+// (the same reason `interruptGraceMs` is one).
+const WAKE_FLOOR_MS = 5_000
+
+// An instant a phone can read. Discord renders `<t:…>` in the reader's own
+// timezone, so the operator reads a local clock time instead of an ISO string
+// in UTC, and `:R` beside it answers the question they actually have — how long
+// until then. Every surface these messages reach is Discord (`notify` goes to
+// the bridge and nowhere else), so nothing here renders the markup raw.
+export function discordTime(date) {
+  const s = Math.floor(date.getTime() / 1000)
+  return `<t:${s}:t> (<t:${s}:R>)`
+}
+
 const DEFAULT_DEPS = {
   viewerLogin, repoMaps, mapFrontier, flatFrontier, fetchIssue, claim, unclaim, blockedByOf,
   hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey,
@@ -364,6 +388,15 @@ export class Dispatcher {
     this.reviewWaits = new Map()
     this.mapLocks = new Map() // "repo#map" -> tail of that map's write chain (#41)
     this.exhaustionNotified = false
+    // The limit resumes curia owes (#346), ticket -> { repo, at: Date }. The
+    // journal is the durable half (`limit_resume_armed`, re-read at boot); this
+    // is the live index the wake timer reads.
+    this.limitResumes = new Map()
+    // Fields rather than constants at the call site, so a test can drive the
+    // whole path — cap, cooling, arm, wake, resume — without waiting out a real
+    // reset (the same reason `interruptGraceMs` above is one).
+    this.resumeGraceMs = RESUME_GRACE_MS
+    this.wakeFloorMs = WAKE_FLOOR_MS
     // The dashboard's frontier and the instant reconcile computed it (#262).
     // Null until the first pass lands, which is how `GET /overview` says "no
     // frontier has been read yet" rather than "the frontier is empty".
@@ -879,7 +912,14 @@ export class Dispatcher {
       // Returns null when #exhausted's latched notify fired (so a confirm
       // continuation cannot echo it) and the reply sentinel when the latch
       // suppressed it (so the continuation is never silent).
-      return this.#exhausted(n, repo)
+      //
+      // #346: a LIMIT RESUME that lands here re-arms rather than giving up. The
+      // wake fires at the earliest reset, and a second lane with a later one is
+      // still cooling then — dropping the arm there would strand exactly the
+      // ticket this path exists to bring back. Nothing else re-arms: an
+      // operator whose `start` is refused reads the refusal in their own reply
+      // and types it again, so curia holds no order they did not repeat.
+      return this.#exhausted(n, repo, { armFor: by === 'limit-reset' ? { ticket: n, repo } : null })
     }
 
     // The harness belongs to the model actually being SPAWNED, not the one that
@@ -1256,26 +1296,145 @@ export class Dispatcher {
   // live agent died, exhaustion landed inside a latched window, and nothing
   // was ever said in the thread. The direct /start reply path builds its own
   // reply string (see #exhaustedReply); a reply is not a notify.
-  #exhausted(ticket, repo) {
+  //
+  // `armFor` is #346: pass `{ ticket, repo }` and this exhaustion also ARMS a
+  // limit resume for that ticket. The promise rides the one message rather than
+  // a second one, because the latch is per WINDOW and the promise is per
+  // TICKET: with the promise on its own line, the second ticket to exhaust in
+  // one window would be armed and never told (ADR-0013 — one fact, one voice,
+  // and the two facts land in two different threads).
+  #exhausted(ticket, repo, { armFor = null } = {}) {
     const reset = this.cooling.earliestReset()
     const when = reset ? reset.toISOString() : 'unknown'
     this.store.logEvent('dispatch_exhausted', { repo, ticket, earliest_reset: when })
-    if (this.exhaustionNotified) return this.#exhaustedReply()
+    const resumeAt = armFor ? this.#armLimitResume(armFor.ticket, armFor.repo) : null
+    this.#armWake(reset ?? new Date(Date.now() + 3600_000))
+    if (this.exhaustionNotified) return this.#exhaustedReply(resumeAt)
     this.exhaustionNotified = true
-    this.notify(ticket, `⚠️ every routing lane is cooling — no claim made. Earliest reset: ${when}`)
-    const ms = Math.max(5_000, (reset?.getTime() ?? Date.now() + 3600_000) - Date.now())
-    clearTimeout(this.wakeTimer)
-    this.wakeTimer = setTimeout(() => {
-      this.exhaustionNotified = false
-      this.#autoTick().catch((e) => this.log('post-cooldown auto tick failed:', e.message))
-    }, ms)
-    this.wakeTimer.unref()
+    this.notify(ticket, resumeAt
+      ? `⚠️ every routing lane is cooling. The claim is released and the worktree stands. curia resumes this ticket at ${discordTime(resumeAt)}`
+      : `⚠️ every routing lane is cooling — no claim made. Earliest reset: ${reset ? discordTime(reset) : 'unknown'}`)
     return null
   }
 
-  #exhaustedReply() {
+  #exhaustedReply(resumeAt = null) {
     const reset = this.cooling.earliestReset()
-    return `⚠️ all routing lanes are cooling (earliest reset ${reset ? reset.toISOString() : 'unknown'}) — nothing claimed`
+    if (resumeAt) {
+      return `⏳ every routing lane is cooling. The worktree stands, and curia resumes this ticket at ${discordTime(resumeAt)}`
+    }
+    return `⚠️ all routing lanes are cooling (earliest reset ${reset ? discordTime(reset) : 'unknown'}) — nothing claimed`
+  }
+
+  // ---- the limit resume (#346) ---------------------------------------------------
+  //
+  // A cap does not park an agent: #handleLimit kills it and falls down the
+  // chain, and only true exhaustion releases the claim and drops the ticket
+  // back on the frontier. What stayed parked was the TICKET. The wake timer
+  // fired `#autoTick`, `#autoTick` returns at once while `auto_dispatch` is
+  // false, and `auto_dispatch` ships false — so the work stopped until a human
+  // noticed and typed `resume` themselves.
+  //
+  // Three rules decide the shape, and each keeps a wrong answer out:
+  //
+  //   1. It resumes, it does not start. `resume` inherits the surviving
+  //      worktree and the last model; `start` calls createPrivateClone, which
+  //      DELETES that worktree first and takes every uncommitted file with it.
+  //   2. It is not gated on `auto_dispatch`. That flag decides whether curia
+  //      takes NEW work off the frontier by itself. This puts back work the
+  //      operator already ordered and curia itself stopped.
+  //   3. One arm buys ONE attempt. The cooling is its own throttle: a resume
+  //      that walks back into the cap re-cools with a fresh reset and arms
+  //      again from there, so a wrong reset instant costs one spawn per window
+  //      rather than a loop.
+
+  // Arm the resume, and answer with the instant it will run at. Null when
+  // nothing is cooling any more — there is then no reset to wait for, and the
+  // ordinary dispatch path is already open.
+  #armLimitResume(ticket, repo) {
+    const reset = this.cooling.earliestReset()
+    if (!reset) return null
+    const at = new Date(reset.getTime() + this.resumeGraceMs)
+    this.limitResumes.set(String(ticket), { repo: repo ?? null, at })
+    this.store.logEvent('limit_resume_armed', {
+      repo, ticket, resume_at: at.toISOString(), cooling_until: reset.toISOString(),
+    })
+    return at
+  }
+
+  // ONE timer for both wake reasons, set to whichever comes first: the earliest
+  // cooling reset (the exhaustion latch clears there, and the auto loop gets a
+  // tick) and the earliest armed resume. `floor` is the instant the exhaustion
+  // path insists on even with nothing cooling, so the latch can never stick.
+  #armWake(floor = null) {
+    const times = []
+    const reset = this.cooling.earliestReset()
+    if (reset) times.push(reset.getTime())
+    for (const e of this.limitResumes.values()) times.push(e.at.getTime())
+    if (floor) times.push(floor.getTime())
+    clearTimeout(this.wakeTimer)
+    this.wakeTimer = null
+    if (!times.length) return
+    const ms = Math.max(this.wakeFloorMs, Math.min(...times) - Date.now())
+    this.wakeTimer = setTimeout(() => {
+      this.#wake().catch((e) => this.log('post-cooldown wake failed:', e.message))
+    }, ms)
+    this.wakeTimer.unref()
+  }
+
+  // The resumes run BEFORE the auto tick, so an auto-dispatch that is on cannot
+  // `start` a ticket this pass is about to `resume` — the session is live by
+  // then and #autoTick skips it.
+  async #wake() {
+    this.wakeTimer = null
+    this.exhaustionNotified = false
+    const now = Date.now()
+    for (const [ticket, entry] of [...this.limitResumes]) {
+      if (entry.at.getTime() > now) continue
+      this.limitResumes.delete(ticket)
+      await this.#runLimitResume(ticket, entry)
+    }
+    this.#armWake()
+    await this.#autoTick()
+  }
+
+  // One attempt, and it always says what happened. Silence after a cap is the
+  // fault this whole path exists to end, so a resume that curia cannot make —
+  // the ticket closed, somebody else claimed it, the dispatch threw — lands in
+  // the same thread as the promise did.
+  async #runLimitResume(ticket, entry) {
+    let reply
+    try {
+      reply = await this.resume(ticket, { repo: entry.repo ?? undefined, by: 'limit-reset' })
+    } catch (e) {
+      this.store.logEvent('limit_resume', { repo: entry.repo, ticket, outcome: 'failed', error: e.message })
+      this.notify(ticket, `⚠️ the usage limit reset and curia could not resume this ticket: ${e.message}. \`resume ${ticket}\` starts a fresh agent on the surviving worktree`)
+      return
+    }
+    this.store.logEvent('limit_resume', { repo: entry.repo, ticket, outcome: 'ran' })
+    // A lane that is STILL cooling re-armed this ticket inside the dispatch —
+    // and #exhausted has already stated the new instant in this thread. Adding
+    // the reply on top would say the same window twice.
+    if (this.limitResumes.has(String(ticket))) return
+    this.notify(ticket, `⏰ the usage limit reset. ${reply}`)
+  }
+
+  // Boot repair (#346): the arms this process did not make. Cooling holds for
+  // hours and a deploy takes minutes, so most arms outlive the daemon that
+  // wrote them. An arm whose instant already passed is due at once, which is
+  // exactly the daemon that was down through the whole window.
+  #reArmLimitResumes() {
+    if (typeof this.store.armedLimitResumes !== 'function') return
+    for (const { ticket, repo, at } of this.store.armedLimitResumes()) {
+      const when = new Date(at)
+      if (!Number.isFinite(when.getTime())) continue
+      const session = `curia-${ticket}`
+      // Adoption has already run this pass, so a live agent here is an agent
+      // that came back some other way and needs no resume.
+      if (this.agents.has(session) || this.inFlight.has(session)) continue
+      this.limitResumes.set(String(ticket), { repo: repo ?? null, at: when })
+      this.log(`reconcile: re-armed the limit resume of ${repo ?? '?'}#${ticket} for ${when.toISOString()}`)
+    }
+    this.#armWake()
   }
 
   // ---- the cross-check (#164, ADR-0010) -----------------------------------------
@@ -1926,8 +2085,16 @@ export class Dispatcher {
     // which is the opposite of the truth when the unclaim failed — the ticket
     // stays assigned, filterTakeable drops it from every frontier, and only
     // reconcile's unclaim_failed retry will recover it.
+    //
+    // #346 arms the resume here, and here ONLY: this is the one exhaustion
+    // where curia stopped an agent it had already spawned, so the worktree it
+    // was writing in survives and the operator's order still stands. A REVIEWER
+    // is excluded. #releaseClaim has already unparked the builder with "the
+    // reviewer ended", so a resumed reviewer would read the same diff a second
+    // time and land its verdict on a builder that stopped waiting for one.
     const released = await this.#releaseClaim(agent, 'exhausted: all candidates cooling')
-    const suppressed = this.#exhausted(agent.ticket, agent.repo)
+    const armFor = agent.reviewer ? null : { ticket: agent.ticket, repo: agent.repo }
+    const suppressed = this.#exhausted(agent.ticket, agent.repo, { armFor })
     if (suppressed) this.notify(agent.ticket, suppressed)
     if (!released) this.notify(agent.ticket, `⚠️ \`${agent.session}\`: claim release FAILED: the issue is still assigned; reconcile will retry`)
     // the binding stays (#140): exhaustion re-frontiers the ticket, it does not end it
@@ -4560,6 +4727,10 @@ export class Dispatcher {
     await this.#reconcileStaleQuestions(ctx)
 
     if (boot) this.#voidBootConfirms()
+    // #346, after adoption: the limit resumes a previous process armed. Journal
+    // evidence only, so a failed identity read or an indeterminate tmux costs
+    // it nothing — and the arm is worth nothing if the resume is not made.
+    if (boot) this.#reArmLimitResumes()
     await this.#assertAttachSurface()
     // The timeline surface (#74) rides the same posture: asserted every
     // reconcile, never fatally, withdrawn when it cannot be verified. The
@@ -5231,6 +5402,11 @@ export class Dispatcher {
       if (liveCount() >= max) break
       const session = `curia-${num}`
       if (this.agents.has(session) || this.inFlight.has(session)) continue
+      // #346: curia owes this ticket a resume, and a resume is not what this
+      // loop does. `start` recreates the worktree from origin, so an auto
+      // dispatch landing here first would delete the very files the armed
+      // resume exists to hand back.
+      if (this.limitResumes.has(String(num))) continue
       if (await this.deps.hasSession(session)) continue // collision or leftover: skip, never churn
       const msg = await this.start(num, { repo, by: 'auto' })
       this.log(`[auto] ${msg}`)

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -144,6 +144,7 @@ export class EscalationStore {
     this.recent = [] // the last RECENT_EVENTS journal lines, oldest first (#262)
     this.outcomes = { cancelled: [], finished: [], died: [] } // the last RECENT_OUTCOMES of each (#289)
     this.pullRequests = new Map() // agent session -> the pull request its CURRENT dispatch pushed (#289)
+    this.limitResumes = new Map() // ticket -> the limit resume curia still owes it (#346)
     this.seq = 0
     this.noteSeq = 0
     this._replay()
@@ -202,6 +203,23 @@ export class EscalationStore {
     // the last one pushed. The order inside one journal is the order here.
     if (ev.agent && ev.type === 'agent_spawned') this.pullRequests.delete(ev.agent)
     if (ev.agent && ev.url && PR_EVENTS.has(ev.type)) this.pullRequests.set(ev.agent, ev.url)
+
+    // The limit resume curia owes a ticket (#346). A reduction for the reason
+    // the pull-request map above is one: the arm has to outlive the process
+    // that made it. Cooling holds for hours and a deploy takes minutes, so an
+    // arm kept only in the dispatcher would mostly never fire — and the boot
+    // replay is what hands it back.
+    //
+    // TWO events clear it, and both mean the same thing. `limit_resume` is the
+    // attempt itself, whatever it ended as: one arm buys one attempt, and a
+    // fresh cap arms a fresh one. `agent_spawned` is an agent on that ticket by
+    // any other route, which is what the resume was for.
+    if (ev.ticket != null && ev.type === 'limit_resume_armed') {
+      this.limitResumes.set(String(ev.ticket), { repo: ev.repo ?? null, at: ev.resume_at })
+    }
+    if (ev.ticket != null && (ev.type === 'limit_resume' || ev.type === 'agent_spawned')) {
+      this.limitResumes.delete(String(ev.ticket))
+    }
 
     switch (ev.type) {
       case 'esc_open': {
@@ -730,5 +748,13 @@ export class EscalationStore {
   // the review gate card carries it too.
   pullRequestFor(agent) {
     return this.pullRequests.get(agent) ?? null
+  }
+
+  // Every limit resume curia still owes, as `{ ticket, repo, at }` (#346). The
+  // dispatcher re-arms its own timers from this at boot. `at` is the ISO
+  // instant the arm was written with, so a resume whose window rolled while the
+  // daemon was down is due the moment this is read.
+  armedLimitResumes() {
+    return [...this.limitResumes.entries()].map(([ticket, v]) => ({ ticket, repo: v.repo, at: v.at }))
   }
 }

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -14,10 +14,10 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { Dispatcher, paneTail, textCarriesLimitPhrase, parseTicketRef, newExitMarker, parseExitMarker, paneExcerpt } from '../src/dispatch.mjs'
+import { Dispatcher, discordTime, paneTail, textCarriesLimitPhrase, parseTicketRef, newExitMarker, parseExitMarker, paneExcerpt } from '../src/dispatch.mjs'
 import { EscalationStore } from '../src/store.mjs'
 import { parseUsageLimit } from '../src/routing.mjs'
-import { TEST_PINS, containerDeps, seedConfigDirStub, withTestCredential } from './fixtures/sandbox.mjs'
+import { TEST_PINS, containerDeps, fakePrivateClone, seedConfigDirStub, withTestCredential } from './fixtures/sandbox.mjs'
 import { ENV_FILE, GUEST_CFG } from '../src/sandbox.mjs'
 
 const ROUTING = {
@@ -129,6 +129,8 @@ function makeDispatcher(deps = {}, {
     },
     recentOutcomes: () => journal.recentOutcomes(),
     pullRequestFor: (agent) => journal.pullRequestFor(agent),
+    // #346: the arm outlives the process, so the reduction is the real one.
+    armedLimitResumes: () => journal.armedLimitResumes(),
     openEscalations: () => escalations.filter((r) => r.status === 'open'),
     cancel: () => ({ ok: true }),
     // #208, the real EscalationStore predicate: a note stamped with an
@@ -1416,6 +1418,216 @@ describe('exactly one notify per exhaustion window (B7/R5)', () => {
     assert.match(reply, /start never dispatches over an anomaly/)
     assert.deepEqual(confirms, [])
     assert.equal(notifies.filter((n) => /cooling/.test(n.message)).length, 0, 'a refusal never reaches #dispatch, so the latch never fires')
+  })
+})
+
+// The limit resume (#346). True exhaustion killed the agent, released the claim
+// and left the worktree standing, and then nothing moved: the wake timer fired
+// #autoTick, which returns at once while `auto_dispatch` is false, and that
+// flag ships false. The work waited for a human to notice.
+describe('the limit resume: the window rolls and curia puts the agent back (#346)', () => {
+  function writeJournal(lines) {
+    fs.writeFileSync(path.join(tmp, 'data', 'events.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')
+  }
+
+  // An epoch the pane can state, seconds out, so the whole real path runs
+  // inside a test: cap, cooling, exhaustion, arm, wake, resume.
+  const soon = (s) => Math.floor(Date.now() / 1000) + s
+  const iso = (s) => new Date(s).toISOString()
+  const MAP = [{ number: 1, state: 'open', labels: [{ name: 'wayfinder:map' }] }]
+  const child = (n) => ({
+    number: n, state: 'open', assignees: [], labels: [{ name: 'wayfinder:task' }],
+    issue_dependencies_summary: { blocked_by: 0 },
+  })
+
+  test('an instant goes out as epoch SECONDS in Discord markup, so a phone renders its own clock', () => {
+    // Seconds, not milliseconds: Discord reads the number as epoch seconds and
+    // a millisecond value lands the operator tens of thousands of years out.
+    assert.equal(discordTime(new Date('2026-08-15T10:00:00.000Z')), '<t:1786788000:t> (<t:1786788000:R>)')
+    assert.equal(discordTime(new Date('2026-08-15T10:00:00.999Z')), '<t:1786788000:t> (<t:1786788000:R>)')
+  })
+
+  test('true exhaustion arms the resume, and the thread states the instant in local time', async () => {
+    const at = soon(3600)
+    const d = makeDispatcher({ capturePane: async () => `Claude usage limit reached | ${at}` })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+
+    await waitFor(() => events.some((e) => e.type === 'limit_resume_armed'))
+    const armed = events.find((e) => e.type === 'limit_resume_armed')
+    assert.equal(String(armed.ticket), '42')
+    assert.equal(armed.repo, 'o/r')
+    assert.equal(Date.parse(armed.resume_at), at * 1000 + 60_000, 'a minute behind the stated reset, for the clock skew')
+    assert.ok(d.limitResumes.has('42'))
+
+    // ONE message, not two: the promise is per ticket and the window sentence
+    // is per window, and folding them keeps the count where #13 put it.
+    const line = notifies.find((n) => /every routing lane is cooling/.test(n.message))
+    assert.match(line.message, /curia resumes this ticket/)
+    assert.match(line.message, new RegExp(`<t:${at + 60}:t>`), 'a phone reads its own clock, never an ISO string in UTC')
+    assert.equal(notifies.filter((n) => /cooling/.test(n.message)).length, 1)
+  })
+
+  test('the SECOND ticket to exhaust in one window is armed AND told', async () => {
+    // The latch is per window and the promise is per ticket, and the two land
+    // in two different threads. A promise on its own line would be swallowed
+    // by the latch here, and #43 would be resumed with nobody told it would be.
+    let capped = false
+    const at = soon(3600)
+    const d = makeDispatcher({
+      fetchIssue: async (repo, n) => ({ ...OPEN_ISSUE, number: Number(n) }),
+      capturePane: async () => (capped ? `Claude usage limit reached | ${at}` : ''),
+    })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await d.start('43', { repo: 'o/r', by: 'test' })
+    capped = true
+
+    await waitFor(() => events.filter((e) => e.type === 'limit_resume_armed').length === 2, 15_000)
+    assert.deepEqual(
+      events.filter((e) => e.type === 'limit_resume_armed').map((e) => String(e.ticket)).sort(),
+      ['42', '43'],
+    )
+    for (const ticket of ['42', '43']) {
+      const said = notifies.filter((n) => String(n.ticket) === ticket && /curia resumes this ticket/.test(n.message))
+      assert.equal(said.length, 1, `#${ticket} is told once that curia will resume it`)
+      assert.match(said[0].message, new RegExp(`<t:${at + 60}:t>`))
+    }
+  })
+
+  test('the wake RESUMES: the surviving worktree is handed back, never recreated from origin', async () => {
+    let clones = 0
+    let wt = null
+    let capped = true
+    const d = makeDispatcher({
+      capturePane: async () => (capped ? `Claude usage limit reached | ${soon(2)}` : '⏵⏵ bypass permissions'),
+      // The cap is a one-shot: the kill is what ends this agent's, so the
+      // resumed one comes up on a healthy pane.
+      killSession: async () => { capped = false },
+      createPrivateClone: async (r, repo, n) => { clones += 1; wt = fakePrivateClone(r, repo, n); return wt },
+    })
+    d.resumeGraceMs = 0
+    d.wakeFloorMs = 5
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => events.some((e) => e.type === 'limit_resume_armed'))
+    // What an agent had written and not committed when the cap landed.
+    fs.writeFileSync(path.join(wt, 'work-in-progress.txt'), 'half a day of it')
+
+    await waitFor(() => notifies.some((n) => /the usage limit reset/.test(n.message)), 15_000)
+
+    assert.equal(clones, 1, 'createPrivateClone deletes the worktree first, so a resume must never reach it')
+    assert.equal(fs.readFileSync(path.join(wt, 'work-in-progress.txt'), 'utf8'), 'half a day of it')
+    assert.ok(notifies.some((n) => /the usage limit reset\. ⚙️ dispatched o\/r#42/.test(n.message)),
+      'the reason curia started it rides in front of the ordinary dispatch line')
+    assert.ok(events.some((e) => e.type === 'limit_resume' && e.outcome === 'ran'))
+    assert.equal(d.limitResumes.size, 0, 'one arm buys one attempt')
+  })
+
+  test('a lane still cooling at the wake re-arms instead of stranding the ticket', async () => {
+    const d = makeDispatcher({ capturePane: async () => `Claude usage limit reached | ${soon(2)}` })
+    d.resumeGraceMs = 0
+    d.wakeFloorMs = 5
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => events.some((e) => e.type === 'limit_resume_armed'))
+    // A second cap the first one hid: the provider rolls, the model does not.
+    const later = new Date(Date.now() + 3600_000)
+    d.cooling.coolModel('sonnet', later)
+
+    await waitFor(() => events.filter((e) => e.type === 'limit_resume_armed').length === 2, 15_000)
+
+    const arms = events.filter((e) => e.type === 'limit_resume_armed')
+    assert.equal(Date.parse(arms[1].resume_at), later.getTime(), 'the arm follows the lane that is still cooling')
+    assert.ok(d.limitResumes.has('42'))
+    assert.equal(events.filter((e) => e.type === 'limit_resume').length, 1, 'the attempt happened, and it was one')
+    assert.equal(notifies.filter((n) => /the usage limit reset/.test(n.message)).length, 0,
+      'the exhaustion already stated the new instant — saying it twice is two voices on one fact')
+  })
+
+  test('a resume curia cannot make says so in the same thread the promise landed in', async () => {
+    // tmux goes indeterminate between the cap and the wake, which is the shape
+    // every dispatch refuses on rather than guessing at.
+    let wedged = false
+    const d = makeDispatcher({
+      capturePane: async () => `Claude usage limit reached | ${soon(2)}`,
+      killSession: async () => { wedged = true },
+      hasSession: async () => {
+        if (wedged) throw new Error('tmux session presence is indeterminate: timeout')
+        return false
+      },
+    })
+    d.resumeGraceMs = 0
+    d.wakeFloorMs = 5
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await waitFor(() => events.some((e) => e.type === 'limit_resume_armed'))
+
+    await waitFor(() => events.some((e) => e.type === 'limit_resume' && e.outcome === 'failed'), 15_000)
+    const said = notifies.find((n) => /curia could not resume this ticket/.test(n.message))
+    assert.ok(said, 'silence after a cap is the fault this path exists to end')
+    assert.match(said.message, /`resume 42`/, 'the operator is told how to do it by hand')
+    assert.equal(d.limitResumes.size, 0)
+  })
+
+  test('the arm outlives the daemon: reconcile re-arms it at boot from the journal', async () => {
+    const at = new Date(Date.now() + 3600_000)
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', model: 'sonnet', ts: iso('2026-08-15T09:00:00Z') },
+      { type: 'limit_resume_armed', repo: 'o/r', ticket: '42', resume_at: at.toISOString(), ts: iso('2026-08-15T10:00:00Z') },
+    ])
+    const d = makeDispatcher({ listSessions: async () => [] })
+
+    await d.reconcile({ boot: true })
+
+    assert.deepEqual([...d.limitResumes.keys()], ['42'])
+    assert.equal(d.limitResumes.get('42').at.getTime(), at.getTime())
+    assert.equal(d.limitResumes.get('42').repo, 'o/r')
+  })
+
+  test('a reset that passed while the daemon was down is due at once, not lost', async () => {
+    writeJournal([
+      { type: 'agent_spawned', repo: 'o/r', ticket: '42', agent: 'curia-42', model: 'sonnet', ts: iso('2026-08-15T09:00:00Z') },
+      { type: 'limit_resume_armed', repo: 'o/r', ticket: '42', resume_at: iso('2026-08-15T10:00:00Z'), ts: iso('2026-08-15T09:30:00Z') },
+    ])
+    const d = makeDispatcher()
+    d.wakeFloorMs = 5
+
+    await d.reconcile({ boot: true })
+
+    await waitFor(() => events.some((e) => e.type === 'limit_resume'), 15_000)
+    assert.ok(notifies.some((n) => /the usage limit reset/.test(n.message)))
+  })
+
+  test('an agent that came back some other way is not resumed on top of itself', async () => {
+    writeJournal([
+      { type: 'limit_resume_armed', repo: 'o/r', ticket: '42', resume_at: new Date(Date.now() + 3600_000).toISOString(), ts: iso('2026-08-15T10:00:00Z') },
+    ])
+    const d = makeDispatcher({ listSessions: async () => [] })
+    d.agents.set('curia-42', { session: 'curia-42', ticket: '42', repo: 'o/r' })
+
+    await d.reconcile({ boot: true })
+
+    assert.equal(d.limitResumes.size, 0)
+  })
+
+  test('auto-dispatch steps over a ticket curia owes a resume, because start would delete its worktree', async () => {
+    const started = []
+    const d = makeDispatcher({
+      repoMaps: async () => MAP,
+      mapFrontier: async () => [child(42), child(43)],
+      createPrivateClone: async (r, repo, n) => { started.push(String(n)); return fakePrivateClone(r, repo, n) },
+    })
+    d.config.dispatch.auto_dispatch = true
+    d.config.dispatch.poll_interval_s = 0.05
+    d.limitResumes.set('42', { repo: 'o/r', at: new Date(Date.now() + 3600_000) })
+
+    d.startAutoLoop()
+    await waitFor(() => started.includes('43'))
+    await new Promise((r) => setTimeout(r, 150))
+    clearInterval(d.autoTimer)
+
+    assert.ok(!started.includes('42'), 'the armed ticket is the resume\'s, and a start would recreate its worktree')
   })
 })
 

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -413,6 +413,57 @@ describe('the recent past, answered without the file (#289)', () => {
   })
 })
 
+// The arm has to outlive the process that made it (#346). Cooling holds for
+// hours and a deploy takes minutes, so an arm kept only in the dispatcher would
+// mostly never fire. It is a reduction for the reason the pull request above is
+// one: the boot replay is what hands it back.
+describe('the limit resume curia still owes (#346)', () => {
+  let dir
+  const store = () => new EscalationStore(dir)
+
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-346-')) })
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('an arm is answered per ticket, with the repo and the instant it was written with', () => {
+    const s = store()
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 42, resume_at: '2026-08-15T12:00:00.000Z' })
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 43, resume_at: '2026-08-15T13:00:00.000Z' })
+    assert.deepEqual(s.armedLimitResumes(), [
+      { ticket: '42', repo: 'o/r', at: '2026-08-15T12:00:00.000Z' },
+      { ticket: '43', repo: 'o/r', at: '2026-08-15T13:00:00.000Z' },
+    ])
+  })
+
+  test('a restart replays it, which is the whole point of the reduction', () => {
+    const s = store()
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 42, resume_at: '2026-08-15T12:00:00.000Z' })
+    assert.deepEqual(store().armedLimitResumes(), s.armedLimitResumes())
+  })
+
+  test('the attempt clears it, so one arm buys one attempt and never a loop', () => {
+    const s = store()
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 42, resume_at: '2026-08-15T12:00:00.000Z' })
+    s.logEvent('limit_resume', { repo: 'o/r', ticket: 42, outcome: 'ran' })
+    assert.deepEqual(s.armedLimitResumes(), [])
+  })
+
+  test('an agent on that ticket by any other route clears it too', () => {
+    const s = store()
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 42, resume_at: '2026-08-15T12:00:00.000Z' })
+    s.logEvent('agent_spawned', { repo: 'o/r', ticket: 42, agent: 'curia-42' })
+    assert.deepEqual(s.armedLimitResumes(), [], 'the operator resumed it by hand, so curia owes nothing')
+  })
+
+  test('a fresh cap after an attempt arms again', () => {
+    const s = store()
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 42, resume_at: '2026-08-15T12:00:00.000Z' })
+    s.logEvent('limit_resume', { repo: 'o/r', ticket: 42, outcome: 'ran' })
+    s.logEvent('agent_spawned', { repo: 'o/r', ticket: 42, agent: 'curia-42' })
+    s.logEvent('limit_resume_armed', { repo: 'o/r', ticket: 42, resume_at: '2026-08-15T17:00:00.000Z' })
+    assert.deepEqual(s.armedLimitResumes(), [{ ticket: '42', repo: 'o/r', at: '2026-08-15T17:00:00.000Z' }])
+  })
+})
+
 describe('the two-level frontier, and reconcile\'s stamp (#262)', () => {
   let tmp
   const dispatchers = []

--- a/daemon/test/reviewer.test.mjs
+++ b/daemon/test/reviewer.test.mjs
@@ -598,6 +598,25 @@ describe('a reviewer never touches the builder\'s claim (#164)', () => {
     assert.ok(!typesOf().includes('unclaim_failed'))
   })
 
+  // #346 arms a limit resume on true exhaustion, and a reviewer is the one
+  // agent it must not arm one for: #releaseClaim has already unparked the
+  // builder with "the reviewer ended", so a resumed reviewer would read the
+  // same diff twice and land a verdict on a builder that stopped waiting.
+  test('a reviewer that exhausts every lane arms no limit resume', async () => {
+    const d = makeDispatcher({ capturePane: async () => "You've hit your usage limit." })
+    withBuilder(d)
+    // The builder's own provider is already cooling, so the reviewer's chain
+    // has nowhere left to fall when its cap lands.
+    d.cooling.coolProvider('anthropic', new Date(Date.now() + 3600_000))
+    await d.crossCheck('42')
+
+    await waitFor(() => events.some((e) => e.type === 'reviewer_ended'))
+
+    assert.ok(!typesOf().includes('limit_resume_armed'), 'nothing may resume a reviewer')
+    assert.equal(d.limitResumes.size, 0)
+    assert.ok(typesOf().includes('dispatch_exhausted'), 'the exhaustion itself is still journalled and said')
+  })
+
   test('a dead reviewer says so and leaves the builder working', async () => {
     const d = makeDispatcher({
       listSessions: async () => ['curia-42'],


### PR DESCRIPTION
Ticket: alp82/curia#346 — [Limit-reset auto-resume](https://github.com/alp82/curia/issues/346)

Resolves #346. Exhaustion that stops a live agent now arms a limit resume at the earliest reset, a minute behind it for the clock skew.

The gap: only true exhaustion parks a ticket, and its wake timer fired `#autoTick`, which returns at once while `auto_dispatch` is false. That flag ships false, so the work waited for a human.

Five rules:
- It resumes, it does not start. `start` calls `createPrivateClone`, which deletes the surviving worktree first. The auto loop steps over an armed ticket for the same reason.
- It is not gated on `auto_dispatch`. That flag decides whether curia takes NEW work off the frontier. This puts back work the operator ordered.
- A reviewer is never armed: the builder has already been unparked, and a second read of one diff is refused everywhere else.
- One arm buys one attempt. A resume that walks back into the cap re-arms from the fresh reset.
- The arm is a store reduction, so a restart inside the window does not lose it. Reconcile re-arms at boot.

The thread carries the promise inside the exhaustion sentence, because the latch is per window and the promise is per ticket. The reset goes out as a Discord timestamp. A resume curia cannot make says so.

`CONTEXT.md` gains **Limit resume** beside **Exhaustion**. 1850 tests pass, 16 new, each checked against a mutation of the shipped code.

---

Dispatched by the curia daemon — session `curia-346`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `3f24305` The limit reset puts the agent back (#346)