### PR TITLE
Skills curia does not install (alp82/curia#348)

### DIFF
--- a/config/curia.yaml
+++ b/config/curia.yaml
@@ -180,9 +180,21 @@ skills:
     - tdd
     - code-review
     - diagnosing-bugs
+    # #348: an agent here edits agent-facing prose often — AGENTS.md,
+    # CONTEXT.md, docs/agents/, this vendored tree, the standing orders — and
+    # that is exactly what this skill triggers on. It rules STRUCTURE. voice.md
+    # is mandatory and stays the authority on words, so the two do not collide.
+    - writing-for-agents
   # Withheld on purpose: to-tickets, triage, to-spec, handoff — the
   # charting-and-PM side. to-tickets is mass ticket creation in the hands of an
   # agent that now carries charting authority (#49).
+  # Withheld too: wizard (#348). It writes an interactive bash script for a
+  # human at a terminal, and a `wayfinder:task` ticket hands its checklist over
+  # through `ask_human`, to a phone. The script writes `.env` and `gh secret`
+  # where it runs, which is the agent container and not the operator's box, and
+  # it reaches that box only after the merge that ends the ticket. A repeatable
+  # setup path under `scripts/` is the case that survives, and it earns its own
+  # ticket.
   # The vendored tree carries all 25 promoted skills, because a hand session
   # reads the same tree. This list, not the tree, is what an agent gets: the
   # seed builds <cfgDir>/skills from these names alone (#268).

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -966,6 +966,17 @@ export function plantedSkills(wtPath, harness, install) {
 // charting-and-PM side, and to-tickets is mass ticket creation in the hands of
 // an agent that now carries charting authority (#49).
 //
+// `wizard` is absent too (#348). It writes an interactive bash script for a
+// human at a terminal, and a `wayfinder:task` ticket hands its checklist over
+// through `ask_human`, to a phone. The script writes `.env` and `gh secret`
+// where it runs, which is the agent container rather than the operator's box,
+// and it reaches that box only after the merge that ends the ticket.
+//
+// `writing-for-agents` IS installed (#348): an agent here edits agent-facing
+// prose often — AGENTS.md, CONTEXT.md, docs/agents/, the vendored tree, these
+// standing orders — which is the skill's own trigger. It rules structure, and
+// voice.md stays the mandatory authority on words.
+//
 // `wayfinder` and `implement` carry `disable-model-invocation: true`, so they
 // are neither listed to the model nor reachable through its Skill tool — the
 // call comes back "cannot be used with Skill tool". Installing them is still
@@ -974,7 +985,7 @@ export function plantedSkills(wtPath, harness, install) {
 // constraint on the spawn prompt (#54), not on this list.
 export const DEFAULT_SKILLS = [
   'wayfinder', 'grilling', 'domain-modeling', 'research', 'prototype',
-  'implement', 'tdd', 'code-review', 'diagnosing-bugs',
+  'implement', 'tdd', 'code-review', 'diagnosing-bugs', 'writing-for-agents',
 ]
 
 // The FALLBACK skills root, for a config that names none. ~/.claude/skills is

--- a/daemon/test/workspace.test.mjs
+++ b/daemon/test/workspace.test.mjs
@@ -217,15 +217,34 @@ describe('the agent skill set (#57)', () => {
     )
   })
 
-  test('the default set is the nine of #49, and the charting-and-PM skills are withheld', () => {
+  test('the default set is the nine of #49 plus writing-for-agents, and the rest are withheld', () => {
     for (const name of ['wayfinder', 'grilling', 'domain-modeling', 'research', 'prototype',
       'implement', 'tdd', 'code-review', 'diagnosing-bugs']) {
       assert.ok(DEFAULT_SKILLS.includes(name), `${name} must be installed`)
     }
+    // #348: an agent here edits agent-facing prose often, which is this
+    // skill's own trigger.
+    assert.ok(DEFAULT_SKILLS.includes('writing-for-agents'), 'writing-for-agents joined the set (#348)')
     for (const name of ['to-tickets', 'triage', 'to-spec', 'handoff']) {
       assert.equal(DEFAULT_SKILLS.includes(name), false, `${name} is deliberately withheld (#49)`)
     }
+    // #348: wizard writes a terminal script, and a task ticket hands its
+    // checklist to a phone through `ask_human`.
+    assert.equal(DEFAULT_SKILLS.includes('wizard'), false, 'wizard is deliberately withheld (#348)')
     assert.equal(defaultSkillsRoot(), path.join(os.homedir(), '.claude', 'skills'))
+  })
+
+  // The vendored tree carries every promoted skill, so a name in the list that
+  // the tree does not carry is a boot refusal on the operator's own box — the
+  // one place the suite's seeded fixture root cannot catch it (#212).
+  test('every default skill is really in the vendored tree', () => {
+    const vendored = path.resolve(import.meta.dirname, '..', '..', 'skills')
+    for (const name of DEFAULT_SKILLS) {
+      assert.ok(
+        fs.existsSync(path.join(vendored, name, 'SKILL.md')),
+        `skills/${name}/SKILL.md must exist, or the daemon refuses to boot`,
+      )
+    }
   })
 })
 

--- a/docs/research/matt-pocock-skills.md
+++ b/docs/research/matt-pocock-skills.md
@@ -22,7 +22,7 @@ drift resolved with nothing lost.
 | **`grilling` is round-by-round.** It maps a design tree, asks the whole **frontier** in one numbered round, then recomputes. It also dispatches sub-agents for facts. | [ADR-0005](../adr/0005-escalation-contract.md) and the spawn prompt both said one question at a time. **Settled by [#285](https://github.com/alp82/curia/issues/285): the round wins.** A round needs no new kind — it is one `free-text` call whose prompt carries the numbered questions, and the new `recommended` flag adds a ✅ All as recommended button. An unanswered question returns in the next round. The rule applies to every HITL ticket, not only grilling. |
 | **`wayfinder` names the unit a decision ticket**, and the charting session now resolves research tickets with `/research` sub-agents on a `research/<name>` branch. Charting hand-resolves nothing else. | **Settled by [#286](https://github.com/alp82/curia/issues/286): curia takes both.** The operator ruled for compatibility with the skill over curia's earlier shape. A charting session burns down the research tickets it creates. Every subagent writes into the charting agent's own worktree on `curia/<map>` and never runs git, so one pull request carries the findings through the ordinary gate and [ADR-0008](../adr/0008-resolved-means-merged.md) holds unbent. The `research/<name>` branch is the one piece of the skill curia does not take. It exists to keep unreviewed findings off main, and the pull request already does that. **Decision ticket** joins [CONTEXT.md](../../CONTEXT.md) beside **Ticket**, as the subset it names. The skill file is untouched. |
 | **`prototype` produces one shareable HTML file**, captured on a throwaway `prototype/<name>` branch with a context pointer. | [ADR-0008](../adr/0008-resolved-means-merged.md) gives an agent one branch, `curia/<n>`, and one pull request. A second branch has no path through the gate. **Settled by [#287](https://github.com/alp82/curia/issues/287): one branch, and it is already the skill's throwaway one.** `curia/<n>` is cut from main and deleted at merge, the context pointer is the resolution comment plus the map line, and the verdict sits on the issue. One clause is deviated from: main keeps the prototype, under `prototypes/`, because the merge is curia's only durable home. curia took the skill's word too — the domain term is now **Prototype**, and `spikes/` is renamed. |
-| **`writing-great-skills` → `writing-for-agents`**, model-invoked, no alias. | Not in `skills.install`. The inventory table below is stale on this row. |
+| **`writing-great-skills` → `writing-for-agents`**, model-invoked, no alias. | **Settled by [#348](https://github.com/alp82/curia/issues/348): it joins `skills.install`.** An agent here edits agent-facing prose often — AGENTS.md, CONTEXT.md, `docs/agents/`, this vendored tree, the standing orders — which is the skill's own trigger. It rules structure, and `voice.md` stays the mandatory authority on words. The inventory table below is stale on this row. |
 | **`resolving-merge-conflicts` now ships** in the promoted set. | It was the one upstream/local gap this survey found. It is vendored now, still not installed. |
 | `code-review` drops Claude Code's tool and agent-type names. | Helps the codex harness ([#173](https://github.com/alp82/curia/issues/173)). No action. |
 | `diagnosing-bugs` gains a **Redact** section. | Agents paste command output into threads and pull requests. A gain, no action. |
@@ -39,8 +39,14 @@ drift resolved with nothing lost.
   tree copies it, so a codex agent reads it with no extra step.
 - **Three new promoted skills**: `wizard` (model-invoked, generates a bash script that walks
   a human through a manual procedure), `wait-what` (one word, re-pitches a message), and
-  `to-questionnaire`. None are installed. `wizard` is the interesting one for curia, because
-  a `wayfinder:task` ticket is exactly the HITL checklist it writes.
+  `to-questionnaire`. None are installed. `wizard` was the interesting one for curia, because
+  a `wayfinder:task` ticket is exactly the HITL checklist it writes. **Settled by
+  [#348](https://github.com/alp82/curia/issues/348): it stays out.** The checklist reaches the
+  operator through `ask_human`, on a phone, and a bash script is not answerable there. The
+  script also writes `.env` and `gh secret` where it runs, which is the agent container rather
+  than the operator's box, and it reaches that box only after the merge that ends the ticket.
+  A repeatable setup path under `scripts/` is the case that survives, and it earns its own
+  ticket.
 
 ---
 

--- a/skills/UPSTREAM.md
+++ b/skills/UPSTREAM.md
@@ -43,7 +43,11 @@ plus any reference pages the skill points at.
 
 `skills.install` is what bounds an agent, not this tree. The tree carries all 25 promoted
 skills so that a hand session reads the same copy. The four skills [#49](https://github.com/alp82/curia/issues/49)
-withholds stay withheld, because they are not in that list.
+withholds stay withheld, because they are not in that list. `wizard` is withheld with them
+([#348](https://github.com/alp82/curia/issues/348)): it writes an interactive bash script
+for a human at a terminal, and a `wayfinder:task` ticket hands its checklist to a phone
+through `ask_human`. `writing-for-agents` is in the list, because an agent here edits
+agent-facing prose often.
 
 ## How to bump the release
 


### PR DESCRIPTION
Ticket: alp82/curia#348 — [Skills curia does not install](https://github.com/alp82/curia/issues/348)

Ticket #348 settles the two vendored skills that were not in `skills.install`.

`writing-for-agents` joins the list. An agent here edits agent-facing prose often: AGENTS.md, CONTEXT.md, `docs/agents/`, the vendored tree, the standing orders. That is the skill's own trigger. It rules structure, and `voice.md` stays the mandatory authority on words.

`wizard` stays out. It writes an interactive bash script for a human at a terminal. A `wayfinder:task` ticket hands its checklist over through `ask_human`, to a phone. The script writes `.env` and `gh secret` where it runs, which is the agent container rather than the operator's box, and it reaches that box only after the merge that ends the ticket. A repeatable setup path under `scripts/` is the case that survives, and it earns its own ticket.

The list lives in two places, so both move: `config/curia.yaml` and `DEFAULT_SKILLS`. The withheld test records the reason for each name. A new test asserts every default skill is really in the vendored tree, because a name the tree lacks is a boot refusal the seeded fixture root cannot catch. `skills/UPSTREAM.md` and the skill-set survey lose the two rows #268 left stale.

The suite is green: 1851 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-348`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `48f704f` writing-for-agents joins the install list, wizard stays out (#348)