### PR TITLE
Scheduled tasks as tickets (alp82/curia#345)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -101,6 +101,11 @@ Merged. A ticket counts as resolved only when a human approved the work and the 
 **Dispatch**:
 The ordered act: claim, prepare, spawn. A failure before the spawn releases the claim.
 
+**Auto-dispatch**:
+The `dispatch.auto_dispatch` flag. The dispatch tick runs either way, because the liveness sweep rides it. While the flag is true, that same tick also starts takeable tickets, the map lane first, up to `max_concurrent`. It ships false, so the operator's press is the only door from a ticket to an agent.
+It is also the only door a clock could use. curia refuses scheduled tickets for that reason: a schedule that files one is auto-dispatch with a calendar in front of it. The demand behind the idea is a watch, not a clock. A watch states one event at its own instant, where the operator reads it. See [#345](https://github.com/alp82/curia/issues/345).
+_Avoid_: scheduler, cron.
+
 **Routing rule**:
 The label-based model choice. A `model:<x>` label wins, else the `wayfinder:<type>` default table. No intelligence sits in the dispatch path. `wayfinder:map` is a row in that table like any other type.
 


### PR DESCRIPTION
Ticket: alp82/curia#345 — [Scheduled tasks as tickets](https://github.com/alp82/curia/issues/345)

Refuses scheduled tickets (#345) and writes the rule where a future ticket reads it.

`CONTEXT.md` defined no entry for `dispatch.auto_dispatch`. The new **Auto-dispatch** entry states the flag, the tick behind it, and the rule the refusal rests on: the operator's press is the only door from a ticket to an agent, so it is also the only door a clock could use. A schedule that files a ticket is auto-dispatch with a calendar in front of it.

No daemon change, no `schedules:` block, no scheduled workflow, no console screen. `_Avoid_: scheduler, cron`.

---

Dispatched by the curia daemon — session `curia-345`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `7bc1ed7` Auto-dispatch is the only door, so curia refuses a clock (#345)