### PR TITLE
The daemon pins the live agent image and prunes the dead ones (alp82/curia#350)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -228,6 +228,9 @@ The boundary around an agent: one Docker container per agent, holding its own cl
 **Agent image**:
 The one image every agent container runs. It carries both harnesses at pinned versions and nothing per-ticket. Its tag is a content address over the Dockerfile and the pins, so a bump names an image the box does not have and the daemon rebuilds.
 
+**Image pin**:
+A container named `curia-agent-pin`, created against the live agent image and never started. The box's nightly docker cleanup deletes every image no container references, and no label protects one, so the reference is what keeps the image alive overnight. The daemon checks the pin on every dispatch. A new tag moves the pin and then removes every superseded tag of the same repository. See [#337](https://github.com/alp82/curia/issues/337) and [#350](https://github.com/alp82/curia/issues/350).
+
 **Cache volume**:
 A Docker volume shared by every agent for what is too heavy to bake into the image: the npm cache and the Playwright browsers. Cross-agent poisoning is an accepted risk.
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -1176,6 +1176,20 @@ export class Dispatcher {
       this.store.logEvent('agent_image_built', { agent: session, ticket, image: image.ref })
       this.log(`built the agent image ${image.ref} for ${session}`)
     }
+    // The pin and the prune (#350). Both are the image module's own work; what
+    // belongs here is saying what happened. A failed pin does not refuse the
+    // dispatch — the image is on the box — but it is the one warning that
+    // explains a four-minute rebuild after the next nightly docker cleanup.
+    if (image.pin?.error) {
+      this.log(`WARNING: could not pin the agent image ${image.ref}: ${image.pin.error} — the box's nightly docker cleanup deletes every image no container references`)
+    } else if (image.pin?.created) {
+      this.store.logEvent('agent_image_pinned', { agent: session, ticket, image: image.ref })
+      this.log(`pinned the agent image ${image.ref}`)
+    }
+    if (image.pruned?.length) {
+      this.store.logEvent('agent_image_pruned', { agent: session, ticket, tags: image.pruned })
+      this.log(`removed ${image.pruned.length} superseded agent image tag(s): ${image.pruned.join(', ')}`)
+    }
     // The side channel, before the agent rather than after it (#188). This is
     // the LAST thing checked and the first thing an agent needs: `ask_human`,
     // the Stop hook and every curia tool ride it, so a container started without

--- a/daemon/src/image.mjs
+++ b/daemon/src/image.mjs
@@ -1,6 +1,7 @@
 // The shared agent image (#154, from the sandbox decision at #148): its tag,
-// its build, and the "is it already there" check the dispatch path (#156) asks
-// before it runs a container.
+// its build, the "is it already there" check the dispatch path (#156) asks
+// before it runs a container, and the pin that keeps the box's nightly docker
+// cleanup from deleting it overnight (#337, built by #350).
 //
 // The tag is a CONTENT ADDRESS, not a name someone bumps by hand. It carries
 // the two CLI versions so a human reading `docker images` sees what an agent
@@ -100,9 +101,9 @@ export function agentImageRef(sandbox, dockerfile = DOCKERFILE) {
 
 // `docker image inspect` and nothing more: no pull, no registry. The image is
 // built on the box it runs on, so a miss means "build it", never "fetch it".
-export async function imageExists(ref) {
+export async function imageExists(ref, { exec = execFileP, docker = DOCKER_BIN } = {}) {
   try {
-    await execFileP(DOCKER_BIN, ['image', 'inspect', ref], { timeout: 15_000 })
+    await exec(docker, ['image', 'inspect', ref], { timeout: 15_000 })
     return true
   } catch (e) {
     // An absent image and an unreachable docker fail the same call, and they
@@ -171,19 +172,127 @@ export function buildAgentImage(ref, { onLine = () => {} } = {}) {
   })
 }
 
+// ---- the pin, and the tags it lets go ---------------------------------------------
+//
+// The box runs Coolify, and its forced nightly cleanup deletes every image no
+// container references (#337). The label gate meant to spare an image is broken
+// upstream — the inspect it runs exits 64 and the `|| docker rmi` branch always
+// runs — so no label protects an image on that box. A REFERENCE does, and it is
+// the only thing that survives both cleanup shapes and the next Coolify upgrade.
+//
+// So the daemon holds one: a container named `curia-agent-pin`, created against
+// the live tag and never started. It costs the bytes of a container record and
+// no process. It is checked on EVERY dispatch rather than after a build alone,
+// so a pin someone removed heals at the next dispatch instead of at the next
+// four-minute rebuild.
+export const PIN_CONTAINER = 'curia-agent-pin'
+
+// The image ref the pin container names, or null when there is no pin. Read
+// from `.Config.Image`, which is the ref as it was given to `docker create` —
+// the tag is a content address, so string equality is enough to tell "the pin
+// is on the live image" from "the pin is on a tag we are replacing".
+async function pinnedRef({ exec = execFileP, docker = DOCKER_BIN } = {}) {
+  try {
+    const { stdout } = await exec(docker, [
+      'inspect', PIN_CONTAINER, '--format', '{{.Config.Image}}',
+    ], { timeout: 15_000 })
+    return stdout.trim() || null
+  } catch (e) {
+    if (/No such object|No such container/i.test(`${e.stderr ?? ''}${e.message ?? ''}`)) return null
+    throw dockerError(e)
+  }
+}
+
+// Make the pin name `ref`. Returns whether it had to create one, which is the
+// only half worth a journal line.
+export async function pinAgentImage(ref, { exec = execFileP, docker = DOCKER_BIN } = {}) {
+  const seams = { exec, docker }
+  const current = await pinnedRef(seams)
+  if (current === ref) return { created: false }
+  // A pin on a superseded tag is what holds that tag on disk, so it goes first
+  // and the prune behind it can then remove the image itself.
+  if (current !== null) {
+    try {
+      await exec(docker, ['rm', '--force', PIN_CONTAINER], { timeout: 30_000 })
+    } catch (e) {
+      if (!/No such container/i.test(`${e.stderr ?? ''}${e.message ?? ''}`)) throw dockerError(e)
+    }
+  }
+  try {
+    await exec(docker, ['create', '--name', PIN_CONTAINER, ref], { timeout: 60_000 })
+  } catch (e) {
+    // Two dispatches can reach this line together. The loser is told the name
+    // is taken, and that is a success as long as the winner pinned the same
+    // ref — which it did, since both resolved the same content address.
+    const detail = `${e.stderr ?? ''}${e.message ?? ''}`
+    if (/already in use/i.test(detail) && await pinnedRef(seams) === ref) return { created: false }
+    throw dockerError(e)
+  }
+  return { created: true }
+}
+
+// Every other tag of the same repository, removed with plain `docker rmi`.
+//
+// Refusals are silenced by design: a tag a running agent still references
+// refuses safely, and the next build comes back for it. Nothing here is worth
+// failing a dispatch over — the agent has the image it asked for.
+export async function pruneOtherTags(ref, { exec = execFileP, docker = DOCKER_BIN } = {}) {
+  let stdout
+  try {
+    ({ stdout } = await exec(docker, [
+      'images', ref.repo, '--format', '{{.Repository}}:{{.Tag}}',
+    ], { timeout: 15_000 }))
+  } catch {
+    return []
+  }
+  const dead = [...new Set(stdout.split('\n').map((s) => s.trim()).filter(Boolean))]
+    .filter((tag) => tag !== ref.ref && !tag.endsWith(':<none>'))
+  const removed = []
+  for (const tag of dead) {
+    try {
+      await exec(docker, ['rmi', tag], { timeout: 60_000 })
+      removed.push(tag)
+    } catch { /* still referenced, or already gone: both are fine here */ }
+  }
+  return removed
+}
+
 // One build at a time per tag. Two dispatches landing together would otherwise
 // each run a four-minute build of the same image, and the second would win a
 // race it did not need to enter.
 const inflight = new Map()
 
-export async function ensureAgentImage(sandbox, { onLine } = {}) {
+export async function ensureAgentImage(sandbox, {
+  onLine, exec = execFileP, docker = DOCKER_BIN, build = buildAgentImage,
+} = {}) {
+  const seams = { exec, docker }
   const ref = agentImageRef(sandbox)
-  if (await imageExists(ref.ref)) return { ...ref, built: false }
+  const built = !(await imageExists(ref.ref, seams))
 
-  if (!inflight.has(ref.ref)) {
-    const p = buildAgentImage(ref, { onLine }).finally(() => inflight.delete(ref.ref))
-    inflight.set(ref.ref, p)
+  if (built) {
+    if (!inflight.has(ref.ref)) {
+      const p = build(ref, { onLine }).finally(() => inflight.delete(ref.ref))
+      inflight.set(ref.ref, p)
+    }
+    await inflight.get(ref.ref)
   }
-  await inflight.get(ref.ref)
-  return { ...ref, built: true }
+
+  // The pin moves BEFORE the prune, so the tag it used to hold is free to go.
+  // A pin that cannot be made is reported, never thrown: the image is on the
+  // box and the agent can run: what the failure costs is one rebuild after the
+  // next nightly cleanup, and a refused dispatch costs more than that.
+  let pin
+  try {
+    pin = await pinAgentImage(ref.ref, seams)
+  } catch (e) {
+    pin = { created: false, error: e.message }
+  }
+  // The sweep runs when the live tag CHANGED, which the pin states better than
+  // the build does: `npm run build-agent-image` ahead of a bump is the way to
+  // keep the dispatch path warm, and it leaves the next dispatch nothing to
+  // build and a superseded tag to remove. A dispatch that finds its pin already
+  // on the live image changed nothing, and sweeps nothing.
+  const pruned = built || pin.created ? await pruneOtherTags(ref, seams) : []
+
+  return { ...ref, built, pin, pruned }
 }

--- a/daemon/test/image.test.mjs
+++ b/daemon/test/image.test.mjs
@@ -15,8 +15,8 @@ import { parse } from 'yaml'
 
 import { loadCuriaConfig } from '../src/config.mjs'
 import {
-  BUILD_CONTEXT, DEFAULT_IMAGE, DOCKERFILE, SANDBOX_KEYS,
-  buildArgs, imageDigest, agentImageRef,
+  BUILD_CONTEXT, DEFAULT_IMAGE, DOCKERFILE, PIN_CONTAINER, SANDBOX_KEYS,
+  buildArgs, imageDigest, agentImageRef, ensureAgentImage,
 } from '../src/image.mjs'
 import { withSeededHome } from './fixtures/skills.mjs'
 
@@ -106,6 +106,148 @@ describe('the image tag (#154)', () => {
   test('the Dockerfile stays on the classic builder — the box runs docker 20.10', () => {
     assert.doesNotMatch(instructions(), /RUN\s+--mount/)
     assert.doesNotMatch(instructions(), /<<[A-Z]/)
+  })
+})
+
+// A fake docker: one box's images and one pin container, driven through the
+// same `exec` seam the daemon uses. It answers the four verbs this path runs
+// and records every argv, because the ORDER matters as much as the calls — the
+// pin has to move off a superseded tag before the rmi of that tag can work.
+function fakeDocker({ images = [], pin = null, refuse = [] } = {}) {
+  const calls = []
+  const box = { images: [...images], pin, calls }
+  const fail = (stderr) => { const e = new Error(stderr); e.stderr = stderr; throw e }
+  box.exec = async (bin, argv) => {
+    calls.push(argv.join(' '))
+    const [cmd, ...rest] = argv
+    if (cmd === 'image' && rest[0] === 'inspect') {
+      if (!box.images.includes(rest[1])) fail(`Error: No such image: ${rest[1]}`)
+      return { stdout: '[]', stderr: '' }
+    }
+    if (cmd === 'inspect') {
+      if (box.pin === null) fail(`Error: No such object: ${rest[0]}`)
+      return { stdout: `${box.pin}\n`, stderr: '' }
+    }
+    if (cmd === 'rm') { box.pin = null; return { stdout: '', stderr: '' } }
+    if (cmd === 'create') {
+      if (box.pin !== null) fail(`docker: Error response from daemon: Conflict. The container name "/${rest[1]}" is already in use.`)
+      box.pin = rest[2]
+      return { stdout: 'deadbeef\n', stderr: '' }
+    }
+    if (cmd === 'images') {
+      const repo = rest[0]
+      return { stdout: `${box.images.filter((i) => i.startsWith(`${repo}:`)).join('\n')}\n`, stderr: '' }
+    }
+    if (cmd === 'rmi') {
+      if (refuse.includes(rest[0])) fail(`Error response from daemon: conflict: unable to remove repository reference "${rest[0]}"`)
+      box.images = box.images.filter((i) => i !== rest[0])
+      return { stdout: '', stderr: '' }
+    }
+    throw new Error(`the fake docker was asked for \`${argv.join(' ')}\``)
+  }
+  // The build seam: a build puts the tag on the box and nothing else.
+  box.build = async (ref) => { box.images.push(ref.ref); return ref }
+  return box
+}
+
+const LIVE = agentImageRef(PINS).ref
+const OLD = 'curia-agent:2.1.219-0.146.0-aaaaaaaa'
+
+describe('the image pin (#337, built by #350)', () => {
+  test('a dispatch that builds nothing still pins the live image', async () => {
+    const box = fakeDocker({ images: [LIVE] })
+    const out = await ensureAgentImage(PINS, box)
+    assert.equal(out.built, false)
+    assert.equal(out.pin.created, true)
+    assert.equal(box.pin, LIVE)
+    assert.ok(box.calls.includes(`create --name ${PIN_CONTAINER} ${LIVE}`))
+  })
+
+  test('a pin already on the live image is left where it is', async () => {
+    const box = fakeDocker({ images: [LIVE], pin: LIVE })
+    const out = await ensureAgentImage(PINS, box)
+    assert.equal(out.pin.created, false)
+    assert.ok(!box.calls.some((c) => c.startsWith('create ')), 'it created a second pin')
+    assert.ok(!box.calls.some((c) => c.startsWith('rm ')), 'it removed the pin it should have kept')
+  })
+
+  test('a pin someone removed heals on the next dispatch, with no rebuild', async () => {
+    const box = fakeDocker({ images: [LIVE], pin: null })
+    const out = await ensureAgentImage(PINS, box)
+    assert.equal(out.built, false)
+    assert.equal(box.pin, LIVE)
+  })
+
+  // `npm run build-agent-image` ahead of a bump is how the dispatch path is
+  // kept warm, and it leaves the dispatch nothing to build. The old tag is
+  // still dead, so the moving pin is what says "sweep", not the build.
+  test('a tag built by hand before the dispatch still prunes the tag it supersedes', async () => {
+    const box = fakeDocker({ images: [OLD, LIVE], pin: OLD })
+    const out = await ensureAgentImage(PINS, box)
+    assert.equal(out.built, false)
+    assert.deepEqual(out.pruned, [OLD])
+    assert.deepEqual(box.images, [LIVE])
+  })
+
+  test('a new tag moves the pin, then the superseded tags go', async () => {
+    const box = fakeDocker({ images: [OLD], pin: OLD })
+    const out = await ensureAgentImage(PINS, box)
+    assert.equal(out.built, true)
+    assert.equal(box.pin, LIVE)
+    assert.deepEqual(out.pruned, [OLD])
+    assert.deepEqual(box.images, [LIVE])
+    // The pin has to leave the old tag before that tag can be removed.
+    assert.ok(box.calls.indexOf(`create --name ${PIN_CONTAINER} ${LIVE}`) < box.calls.indexOf(`rmi ${OLD}`))
+  })
+
+  test('every other tag of the repo goes, and no tag of another repo', async () => {
+    const other = 'curia-agent:2.1.218-0.145.0-bbbbbbbb'
+    const foreign = 'coolify/somethingelse:latest'
+    const box = fakeDocker({ images: [OLD, other, foreign] })
+    const out = await ensureAgentImage(PINS, box)
+    assert.deepEqual(out.pruned.sort(), [other, OLD].sort())
+    assert.deepEqual(box.images, [foreign, LIVE])
+  })
+
+  test('a tag a running agent still holds refuses safely, and the rest still go', async () => {
+    const other = 'curia-agent:2.1.218-0.145.0-bbbbbbbb'
+    const box = fakeDocker({ images: [OLD, other], refuse: [OLD] })
+    const out = await ensureAgentImage(PINS, box)
+    assert.deepEqual(out.pruned, [other])
+    assert.ok(box.images.includes(OLD), 'the refused tag was counted as removed')
+  })
+
+  test('an untagged image is never handed to rmi', async () => {
+    const box = fakeDocker({ images: [OLD, 'curia-agent:<none>'] })
+    await ensureAgentImage(PINS, box)
+    assert.ok(!box.calls.some((c) => c.includes('<none>')), 'it tried to remove a `<none>` tag by name')
+  })
+
+  test('a dispatch that builds nothing prunes nothing — the box has not changed', async () => {
+    const box = fakeDocker({ images: [LIVE, OLD], pin: LIVE })
+    const out = await ensureAgentImage(PINS, box)
+    assert.deepEqual(out.pruned, [])
+    assert.ok(!box.calls.some((c) => c.startsWith('images ')), 'it swept the tags with nothing built')
+  })
+
+  test('a pin curia cannot make is reported, not thrown — the agent has its image', async () => {
+    const box = fakeDocker({ images: [LIVE] })
+    const exec = box.exec
+    box.exec = async (bin, argv) => {
+      if (argv[0] === 'create') { const e = new Error('permission denied'); e.stderr = 'permission denied'; throw e }
+      return exec(bin, argv)
+    }
+    const out = await ensureAgentImage(PINS, box)
+    assert.equal(out.built, false)
+    assert.equal(out.pin.created, false)
+    assert.match(out.pin.error, /permission denied/)
+  })
+
+  test('two dispatches racing for the pin: the loser takes the winner\'s pin', async () => {
+    const box = fakeDocker({ images: [LIVE] })
+    const [a, b] = await Promise.all([ensureAgentImage(PINS, box), ensureAgentImage(PINS, box)])
+    assert.equal(box.pin, LIVE)
+    for (const out of [a, b]) assert.equal(out.pin.error, undefined)
   })
 })
 

--- a/daemon/test/sandbox.test.mjs
+++ b/daemon/test/sandbox.test.mjs
@@ -558,6 +558,32 @@ describe('a sandboxed dispatch (#156)', () => {
   // channel, because it had no container — went with the bare pane (#195).
   // Every dispatch checks it now, which the case above asserts.
 
+  // #350: the pin and the prune are the image module's work. What the dispatch
+  // owes them is a record, because both are silent otherwise — and the pin is
+  // the one thing standing between the live image and the nightly cleanup.
+  test('a new pin and a prune are journalled', async () => {
+    const { d, events } = makeDispatcher({
+      ensureAgentImage: async () => ({
+        ref: 'curia-agent:test', built: true, pin: { created: true }, pruned: ['curia-agent:old'],
+      }),
+    })
+    await d.start('42', { repo: 'o/r' })
+    assert.equal(events.find((e) => e.type === 'agent_image_pinned')?.image, 'curia-agent:test')
+    assert.deepEqual(events.find((e) => e.type === 'agent_image_pruned')?.tags, ['curia-agent:old'])
+  })
+
+  test('a pin curia could not make warns, and the dispatch still runs', async () => {
+    const log = []
+    const { d, spawns } = makeDispatcher({
+      ensureAgentImage: async () => ({
+        ref: 'curia-agent:test', built: false, pin: { created: false, error: 'docker refused the daemon user' }, pruned: [],
+      }),
+    }, { log })
+    await d.start('42', { repo: 'o/r' })
+    assert.equal(spawns.length, 1, 'the dispatch was refused over a pin')
+    assert.ok(log.some((l) => /could not pin the agent image/.test(l) && /docker refused the daemon user/.test(l)))
+  })
+
   test('the pane runs docker, with the image, the mounts and the ports', async () => {
     const { d, spawns } = makeDispatcher()
     await d.start('42', { repo: 'o/r' })


### PR DESCRIPTION
Ticket: alp82/curia#350 — [The daemon pins the live agent image and prunes the dead ones](https://github.com/alp82/curia/issues/350)

Builds the #337 ruling in `daemon/src/image.mjs`.

**The pin.** `ensureAgentImage` now makes sure a container named `curia-agent-pin` exists against the tag it resolves — `docker create`, never started. It is checked on every dispatch, not only after a build, so a lost pin heals at the next dispatch. The box's forced nightly cleanup deletes every image no container references, and its label gate is broken upstream, so only a reference protects the live image.

**The prune.** When the live tag changes, the pin moves first, then every other tag of the `sandbox.image` repository goes through plain `docker rmi`. Refusals are silenced: a tag a running agent still holds refuses safely, and the next move retries it. The sweep keys off the pin moving rather than off the build, so a tag built by hand with `npm run build-agent-image` still prunes what it supersedes.

**Failure posture.** A pin curia cannot make is reported and warned about, never thrown — the image is on the box and the agent can run. A failed pin costs one rebuild after the next cleanup. A refused dispatch costs more.

The dispatch path journals `agent_image_pinned` and `agent_image_pruned`, and logs a warning for a failed pin.

Tests: 11 new cases in `daemon/test/image.test.mjs` drive a fake docker through the `exec` seam (pin created, pin left alone, pin healed, pin moved before the rmi, foreign repos untouched, `<none>` never named, refusal silenced, no sweep with nothing changed, failure reported, two dispatches racing). Two cases in `daemon/test/sandbox.test.mjs` cover the journal lines and the warning. `npm test` in `daemon/`: 1864 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-350`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `42c5f8c` The daemon pins the live agent image and prunes the dead ones (#350)