### PR TITLE
The daemon becomes a GitHub App: one key, minted tokens (alp82/curia#352)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,7 +169,7 @@ _Avoid_: agent token (that one is per resource owner too, but it is read-write a
 [ADR-0018](docs/adr/0018-the-daemon-is-a-github-app.md) retires this PAT: the same read set becomes an installation token the daemon mints, and `.env.overseer` keeps only the model credential.
 
 **GitHub App**:
-Curia's one GitHub identity. The operator creates one app and installs it on each watched owner. The daemon holds its private key at `daemon/.curia-app.pem`, names it with `CURIA_GH_APP_ID` and `CURIA_GH_APP_KEY_FILE` in `daemon/.env.daemon`, and mints every GitHub token from it. The bot is `curia[bot]`. Decided at [ADR-0018](docs/adr/0018-the-daemon-is-a-github-app.md). The operator's own steps are [docs/github-app.md](docs/github-app.md). Partly built: the minting core ships, and each holder cuts over on its own ticket.
+Curia's one GitHub identity. The operator creates one app and installs it on each watched owner. The daemon holds its private key at `daemon/.curia-app.pem`, names it with `CURIA_GH_APP_ID` and `CURIA_GH_APP_KEY_FILE` in `daemon/.env.daemon`, and mints every GitHub token from it. The bot is `curia-sh[bot]`, and the app id is 4610603. Decided at [ADR-0018](docs/adr/0018-the-daemon-is-a-github-app.md). The operator's own steps are [docs/github-app.md](docs/github-app.md). Partly built: the minting core ships, and each holder cuts over on its own ticket.
 _Avoid_: OAuth app.
 
 **Installation token**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -166,6 +166,15 @@ What the overseer container runs at the start of every turn, before the model: c
 **Overseer token**:
 The read-only GitHub token the overseer container holds, one fine-grained PAT per resource owner. It is the control that replaces the seam: the container has a shell, and a shell cannot mint a token. It lives in `daemon/.env.overseer` as `CURIA_OVERSEER_GH_TOKEN_<OWNER>`, a second env file the overseer service loads whole and the daemon only reads. Each tool picks its owner differently, so the container installs two halves: git takes one `credential.https://github.com/<owner>.helper` line per owner, and `gh` takes a shim, because it reads a single `GH_TOKEN`. See [ADR-0014](docs/adr/0014-the-overseer-in-its-own-container.md) and the [live checks](docs/live-checks/313-overseer-github-token.md).
 _Avoid_: agent token (that one is per resource owner too, but it is read-write and it reaches an agent as `GH_TOKEN`).
+[ADR-0018](docs/adr/0018-the-daemon-is-a-github-app.md) retires this PAT: the same read set becomes an installation token the daemon mints, and `.env.overseer` keeps only the model credential.
+
+**GitHub App**:
+Curia's one GitHub identity. The operator creates one app and installs it on each watched owner. The daemon holds its private key at `daemon/.curia-app.pem`, names it with `CURIA_GH_APP_ID` and `CURIA_GH_APP_KEY_FILE` in `daemon/.env.daemon`, and mints every GitHub token from it. The bot is `curia[bot]`. Decided at [ADR-0018](docs/adr/0018-the-daemon-is-a-github-app.md). The operator's own steps are [docs/github-app.md](docs/github-app.md). Partly built: the minting core ships, and each holder cuts over on its own ticket.
+_Avoid_: OAuth app.
+
+**Installation token**:
+What the daemon mints from the app key, one per resource owner and per role. Two roles: read-write for agents, read-only for the overseer. A minted token scopes down from what the installation grants, which is what lets one key hold both. It lives one hour, so a holder reads a file the daemon rewrites and never an environment variable frozen at spawn.
+_Avoid_: app token (that name is the JWT the daemon signs, and a JWT mints installation tokens rather than reaching a repo).
 
 **The verbs**:
 `tickets`, `next`, `status`, `start`, `map`, `cancel`, `resume`, `attach`, `review`. The whole command surface, identical over Discord and REST. Each verb has one meaning. `start` works a thing, and `map` updates a map.
@@ -565,5 +574,6 @@ Everything else is a cache that reconcile can rebuild.
 - `docs/live-checks/`: first-person agent evidence.
 - `docs/agents/`: tracker, triage, and domain-doc conventions for agents.
 - `docs/full-loop.md`: the rehearsal record of the PoC map. History, not a live procedure.
+- `docs/github-app.md`: the operator's own checklist for the GitHub App. Nothing on it can be done by an agent.
 
 The tracker holds history. The docs hold what still constrains work.

--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -183,11 +183,11 @@ const FETCH_TIMEOUT_MS = 20_000
 // One place that builds a request and reads a failure, so every error the
 // operator sees names the same three things: what curia asked for, what GitHub
 // answered, and what to do about it.
-async function api(route, { jwt, token, method = 'GET', body = null, fetchImpl = globalThis.fetch } = {}) {
+async function api(route, { jwt, method = 'GET', body = null, fetchImpl = globalThis.fetch } = {}) {
   const res = await fetchImpl(`${API}${route}`, {
     method,
     headers: {
-      authorization: `Bearer ${jwt ?? token}`,
+      authorization: `Bearer ${jwt}`,
       accept: 'application/vnd.github+json',
       'x-github-api-version': API_VERSION,
       'user-agent': 'curia',
@@ -214,10 +214,13 @@ async function api(route, { jwt, token, method = 'GET', body = null, fetchImpl =
 // Every owner the app is installed on, as `{ id, owner }`. This is the ONE
 // lookup that says whether the operator finished the install step, so its
 // failure is worth a sentence rather than a status code.
+//
+// `per_page=100` rather than a pagination loop: GitHub's default page is 30,
+// and this app installs only on accounts the operator owns.
 export async function listInstallations({ jwt, fetchImpl = globalThis.fetch } = {}) {
   let payload
   try {
-    payload = await api('/app/installations', { jwt, fetchImpl })
+    payload = await api('/app/installations?per_page=100', { jwt, fetchImpl })
   } catch (e) {
     if (e.status === 401) throw new Error(`GitHub refused curia's app JWT (401) — ${APP_ID_KEY} and the key file must belong to the same app, and the box clock must be right`)
     throw e

--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -1,0 +1,349 @@
+// The daemon's own GitHub identity (#352, building the decision at #338).
+//
+// Curia's whole credential story used to be hand-minted fine-grained PATs: one
+// read-write pair for agents (#155), one read-only pair for the overseer
+// (#313), and the operator's own `gh` login for the daemon. Every one of them
+// is a secret an operator makes by hand, per resource owner, and re-makes when
+// it expires — `getalfredo` caps a fine-grained PAT at 366 days.
+//
+// #338 replaced all of it with ONE GitHub App. The operator creates the app
+// once and installs it on each watched owner. The daemon holds the app's
+// private key as its one durable secret and mints installation tokens itself.
+// This module is that minting, and nothing else: it turns a key into tokens.
+// Who holds which token is the business of the modules that ask.
+//
+// WHAT AN APP BUYS, in the order that decided it:
+//
+//   - The minting cost dies. One app, once, instead of a token pair per owner.
+//   - The boundary holds with no second secret. From the SAME key the daemon
+//     mints read-write tokens for agents and READ-ONLY tokens for the overseer,
+//     because a minted token may scope DOWN from what the installation grants.
+//     ADR-0014 stands: the overseer's shell still writes nowhere.
+//   - Gate integrity. An agent's pull request becomes `curia[bot]`-authored, so
+//     the operator's approval is a real GitHub approval by a different account.
+//   - Token life. An installation token lives one hour. The private key does
+//     not expire, so nothing is a calendar item any more.
+//
+// THE PRICE IS THE HOUR. A PAT was set once into a container environment and
+// stayed good for a year. An installation token dies inside a long ticket, so
+// whoever holds one must be REFRESHED rather than handed a value at start. That
+// is why `TokenMinter` caches with a margin and why the holders read a file the
+// daemon rewrites, instead of an environment variable frozen at spawn.
+//
+// NO DEPENDENCY. A GitHub App JWT is RS256 over two base64url JSON objects, and
+// `node:crypto` signs it. Adding a JWT library to sign one 100-byte string
+// would put a supply-chain surface in front of the daemon's only durable
+// secret.
+
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// ---- what the operator sets ------------------------------------------------
+//
+// Two keys in `daemon/.env.daemon`, beside the Discord token. The key ITSELF is
+// a file, named by the second one, and never a value in the env file: a PEM
+// carries newlines, and `writeEnvFile` already refuses a newline because docker
+// reads one as a second variable. A path also keeps the key out of every child
+// process environment the daemon spawns.
+
+export const APP_ID_KEY = 'CURIA_GH_APP_ID'
+export const APP_KEY_FILE_KEY = 'CURIA_GH_APP_KEY_FILE'
+
+// Where the operator is told to put the key. Relative paths resolve against the
+// daemon directory, so the deploy copies one more file beside the env file it
+// already copies.
+export const DEFAULT_KEY_FILE = '.curia-app.pem'
+
+// The app's configuration, or null when no app is set up yet.
+//
+// NULL IS LEGAL and stays legal until the last holder cuts over: #338 says a
+// working boundary does not come out ahead of its replacement, so a daemon with
+// no app keeps running on the PATs. What is NOT legal is half of it. An app id
+// with no key, or a key with no app id, is an operator typo, and it refuses the
+// boot rather than reaching a dispatch as a 401 nobody can place.
+export function appConfigFrom(env = process.env, daemonRoot = '.') {
+  const appId = String(env[APP_ID_KEY] ?? '').trim()
+  const keyFile = String(env[APP_KEY_FILE_KEY] ?? '').trim()
+  if (!appId && !keyFile) return null
+  if (!appId) throw new Error(`${APP_KEY_FILE_KEY} is set in daemon/.env.daemon and ${APP_ID_KEY} is not — an app needs both`)
+  if (!keyFile) throw new Error(`${APP_ID_KEY} is set in daemon/.env.daemon and ${APP_KEY_FILE_KEY} is not — an app needs both`)
+  if (!/^[0-9]+$/.test(appId)) {
+    throw new Error(`bad ${APP_ID_KEY} in daemon/.env.daemon: an app id is digits only — "${appId}" is the app SLUG or the client id, and GitHub states the id on the app's own settings page`)
+  }
+  return { appId, keyFile: path.resolve(daemonRoot, keyFile) }
+}
+
+// The private key, as a crypto key object rather than text: an unreadable or
+// wrong-shaped file must fail HERE, at boot, and not at the first mint.
+//
+// GitHub hands the operator one PKCS#1 file — `-----BEGIN RSA PRIVATE KEY-----`
+// — on a download that happens exactly once. The two mistakes worth naming back
+// are the ones that download makes easy: keeping the public half, and copying
+// the file with the wrong mode.
+export function readPrivateKey(file) {
+  let pem
+  try {
+    pem = fs.readFileSync(file, 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') throw new Error(`no GitHub App key at ${file} — ${APP_KEY_FILE_KEY} names a file that is not there`)
+    if (e.code === 'EACCES') throw new Error(`cannot read the GitHub App key at ${file}: permission denied — the daemon runs as the box user, and the key must be owned by it at mode 0600`)
+    throw e
+  }
+  if (/BEGIN[A-Z ]*PUBLIC KEY/.test(pem)) {
+    throw new Error(`${file} holds a PUBLIC key — GitHub downloads the PRIVATE half once, when the app's key is generated, and never again`)
+  }
+  try {
+    return crypto.createPrivateKey(pem)
+  } catch (e) {
+    throw new Error(`${file} is not a readable private key: ${e.message} — GitHub hands out a PKCS#1 PEM that starts "-----BEGIN RSA PRIVATE KEY-----"`)
+  }
+}
+
+// The key file's mode, checked rather than fixed. The daemon does not chmod a
+// file the operator placed: a key it silently repairs is a key nobody learns to
+// place correctly, and the next box repeats the mistake.
+export function keyFileIsPrivate(file) {
+  try {
+    return (fs.statSync(file).mode & 0o077) === 0
+  } catch {
+    return false // unreadable is a different failure, and readPrivateKey names it
+  }
+}
+
+// ---- the app JWT -----------------------------------------------------------
+//
+// GitHub accepts a JWT for at most ten minutes and REFUSES one whose `iat` is
+// in the future, so the claim is backdated against clock skew between this box
+// and GitHub. Nine minutes of life leaves the tenth as margin: a JWT is minted
+// per mint call and never cached, so a long-lived one buys nothing.
+
+export const JWT_LIFETIME_S = 540
+export const JWT_BACKDATE_S = 60
+
+function b64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function appJwt(appId, key, { now = Date.now } = {}) {
+  const iat = Math.floor(now() / 1000) - JWT_BACKDATE_S
+  const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+  const claims = b64url(JSON.stringify({ iat, exp: iat + JWT_LIFETIME_S, iss: appId }))
+  const signingInput = `${header}.${claims}`
+  const signature = b64url(crypto.createSign('RSA-SHA256').update(signingInput).sign(key))
+  return `${signingInput}.${signature}`
+}
+
+// ---- the permission sets ---------------------------------------------------
+//
+// An installation token may ask for a SUBSET of what the installation grants,
+// and asking for more is a 422. So the app is created with the write set, and
+// the read set is the same call with smaller words. These two constants are
+// what the operator checklist grants, and the checklist names them one for one.
+//
+// WORKFLOWS IS DELIBERATELY ABSENT. GitHub gates `.github/workflows/` behind
+// its own permission, and an app that holds it lets any agent rewrite CI — which
+// is a path from a ticket's text to whatever secrets the next workflow run
+// holds. The fine-grained PATs of #155 do not carry it either, so leaving it out
+// keeps today's reach exactly. The cost is stated rather than hidden: an agent
+// cannot push a change under `.github/workflows/`, and that push fails naming
+// the permission.
+export const WRITE_PERMISSIONS = Object.freeze({
+  contents: 'write',
+  issues: 'write',
+  pull_requests: 'write',
+  metadata: 'read',
+})
+
+// #313's set, unchanged: Contents, Issues, Pull requests, Commit statuses and
+// Metadata at READ, and nothing else. The overseer holds a shell, and this is
+// the control that replaces the `/command` seam.
+export const READ_PERMISSIONS = Object.freeze({
+  contents: 'read',
+  issues: 'read',
+  pull_requests: 'read',
+  statuses: 'read',
+  metadata: 'read',
+})
+
+export const ROLES = Object.freeze({ write: WRITE_PERMISSIONS, read: READ_PERMISSIONS })
+
+export function permissionsFor(role) {
+  const set = ROLES[role]
+  if (!set) throw new Error(`no such token role "${role}" — curia mints ${Object.keys(ROLES).join(' and ')}`)
+  return set
+}
+
+// ---- the API ---------------------------------------------------------------
+
+const API = 'https://api.github.com'
+const API_VERSION = '2022-11-28'
+const FETCH_TIMEOUT_MS = 20_000
+
+// One place that builds a request and reads a failure, so every error the
+// operator sees names the same three things: what curia asked for, what GitHub
+// answered, and what to do about it.
+async function api(route, { jwt, token, method = 'GET', body = null, fetchImpl = globalThis.fetch } = {}) {
+  const res = await fetchImpl(`${API}${route}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${jwt ?? token}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': API_VERSION,
+      'user-agent': 'curia',
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  const text = await res.text()
+  let payload = null
+  try {
+    payload = text ? JSON.parse(text) : null
+  } catch { /* a non-JSON body leaves the status as the whole answer */ }
+  if (!res.ok) {
+    const detail = payload?.message ? `: ${payload.message}` : ''
+    const err = new Error(`GitHub answered HTTP ${res.status} to ${method} ${route}${detail}`)
+    err.status = res.status
+    err.payload = payload
+    throw err
+  }
+  return payload
+}
+
+// Every owner the app is installed on, as `{ id, owner }`. This is the ONE
+// lookup that says whether the operator finished the install step, so its
+// failure is worth a sentence rather than a status code.
+export async function listInstallations({ jwt, fetchImpl = globalThis.fetch } = {}) {
+  let payload
+  try {
+    payload = await api('/app/installations', { jwt, fetchImpl })
+  } catch (e) {
+    if (e.status === 401) throw new Error(`GitHub refused curia's app JWT (401) — ${APP_ID_KEY} and the key file must belong to the same app, and the box clock must be right`)
+    throw e
+  }
+  return (payload ?? []).map((i) => ({ id: i.id, owner: i.account?.login ?? null }))
+}
+
+// One installation token. `permissions` scopes it DOWN from what the
+// installation grants; `repositories` narrows it to named repos of that owner.
+//
+// A 422 here is the operator's grant, not curia's code: the app was created
+// without a permission this role asks for. The message says so, because the
+// status alone sends nobody to the app settings page.
+export async function mintInstallationToken(installationId, {
+  jwt, permissions = null, repositories = null, fetchImpl = globalThis.fetch,
+} = {}) {
+  const body = {}
+  if (permissions) body.permissions = permissions
+  if (repositories) body.repositories = repositories
+  let payload
+  try {
+    payload = await api(`/app/installations/${installationId}/access_tokens`, {
+      jwt, method: 'POST', body: Object.keys(body).length ? body : null, fetchImpl,
+    })
+  } catch (e) {
+    if (e.status === 422) {
+      throw new Error(`${e.message} — curia asked for ${Object.entries(permissions ?? {}).map(([k, v]) => `${k}:${v}`).join(', ')}, and the app grants less; fix it on the app's Permissions page and accept the new grant on each installation`)
+    }
+    throw e
+  }
+  return {
+    token: payload.token,
+    expiresAt: Date.parse(payload.expires_at),
+    permissions: payload.permissions ?? {},
+  }
+}
+
+// ---- the minter ------------------------------------------------------------
+//
+// One per daemon. It caches a token per owner and role, and it hands back a
+// cached one until the refresh margin. The margin is what makes the hour safe
+// for a holder that reads a file: the daemon rewrites before the value in the
+// file could expire mid-use, so nothing downstream ever has to retry a 401.
+//
+// TEN MINUTES, and the number is a duty rather than a taste. The daemon
+// refreshes on its own poll interval (60 s), so a margin has only to be longer
+// than one poll plus the slowest `git push` a token is asked to carry.
+
+export const REFRESH_MARGIN_MS = 10 * 60 * 1000
+
+export class TokenMinter {
+  #installations = null
+
+  constructor({
+    appId, key, keyFile = null, fetchImpl = globalThis.fetch, now = Date.now, log = () => {},
+  } = {}) {
+    this.appId = appId
+    this.key = key
+    // Kept only so the boot line can name the file it read. Nothing mints with it.
+    this.keyFile = keyFile
+    this.fetchImpl = fetchImpl
+    this.now = now
+    this.log = log
+    this.cache = new Map() // `<owner>|<role>` → { token, expiresAt }
+  }
+
+  jwt() {
+    return appJwt(this.appId, this.key, { now: this.now })
+  }
+
+  // The installation list, read once and kept. An install is an operator act
+  // that happens between deploys, so a miss re-reads rather than a clock: the
+  // one case that matters is an owner added to the watch list and installed the
+  // same minute, and `refreshInstallations` is what a restart-free box calls.
+  async installations() {
+    if (!this.#installations) this.#installations = await listInstallations({ jwt: this.jwt(), fetchImpl: this.fetchImpl })
+    return this.#installations
+  }
+
+  async refreshInstallations() {
+    this.#installations = null
+    return this.installations()
+  }
+
+  async installationFor(owner) {
+    const wanted = String(owner ?? '').toLowerCase()
+    let hit = (await this.installations()).find((i) => String(i.owner ?? '').toLowerCase() === wanted)
+    if (!hit) hit = (await this.refreshInstallations()).find((i) => String(i.owner ?? '').toLowerCase() === wanted)
+    return hit ?? null
+  }
+
+  // A token for one owner in one role. Cached until the margin, then minted
+  // again. Throws when the app is not installed on that owner, because a null
+  // here would send an unauthenticated `git push` at a private repo and the
+  // failure would name the repo instead of the missing install.
+  async tokenFor(owner, role) {
+    const permissions = permissionsFor(role)
+    const cacheKey = `${owner}|${role}`
+    const hit = this.cache.get(cacheKey)
+    if (hit && hit.expiresAt - this.now() > REFRESH_MARGIN_MS) return hit.token
+    const install = await this.installationFor(owner)
+    if (!install) {
+      throw new Error(`curia's GitHub App is not installed on ${owner} — install it on that owner and grant it the watched repos`)
+    }
+    const minted = await mintInstallationToken(install.id, { jwt: this.jwt(), permissions, fetchImpl: this.fetchImpl })
+    this.cache.set(cacheKey, minted)
+    this.log(`minted a ${role} token for ${owner} (expires ${new Date(minted.expiresAt).toISOString()})`)
+    return minted.token
+  }
+
+  // Drop every cached token. Called when a holder has to be re-armed from
+  // scratch — a rotated key, or an install the operator has just repaired.
+  forget() {
+    this.cache.clear()
+    this.#installations = null
+  }
+}
+
+// The minter for this box, or null when no app is set up yet. One function so
+// that every caller reads the same two env keys and gets the same refusal text.
+export function minterFrom({ env = process.env, daemonRoot = '.', fetchImpl = globalThis.fetch, now = Date.now, log = () => {} } = {}) {
+  const cfg = appConfigFrom(env, daemonRoot)
+  if (!cfg) return null
+  const key = readPrivateKey(cfg.keyFile)
+  if (!keyFileIsPrivate(cfg.keyFile)) {
+    log(`WARNING: ${cfg.keyFile} is readable beyond its owner — this is curia's one durable secret; run \`chmod 600\` on it`)
+  }
+  return new TokenMinter({ appId: cfg.appId, key, keyFile: cfg.keyFile, fetchImpl, now, log })
+}

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -44,6 +44,7 @@ import { SelfDeploy } from './deploy.mjs'
 import { OverseerHost, CONSOLE_SESSION, CONSOLE_THREAD } from './overseer.mjs'
 import { hasSession } from './tmux.mjs'
 import { assertGhTokens, ghTokenKeyFor, agentGhToken } from './workspace.mjs'
+import { APP_ID_KEY, APP_KEY_FILE_KEY, minterFrom } from './githubapp.mjs'
 import {
   OVERSEER_ENV_FILE, overseerEnvPath, loadOverseerEnv, assertOverseerTokens,
   overseerGhToken, overseerTokenKeyFor, daemonOnlyKeys,
@@ -196,6 +197,32 @@ probeWatchedTokens({
   keyFor: overseerTokenKeyFor,
   refusal: 'the overseer cannot read it',
 })
+
+// #352, building ADR-0018: the GitHub App that replaces every token above. It
+// SWAPS NO HOLDER YET — each one cuts over on its own ticket, and no PAT comes
+// out ahead of its replacement. So what the boot does here is prove the
+// operator's checklist worked and say so out loud.
+//
+// A HALF-configured app refuses the boot inside minterFrom, because an app id
+// with no key is a typo, and a typo that boots reaches a dispatch as a 401
+// nobody can place. NO app is a different thing and stays legal: the tokens
+// above are still the live credential.
+const appMinter = minterFrom({ daemonRoot: ROOT, log })
+if (!appMinter) {
+  log(`no GitHub App configured — set ${APP_ID_KEY} and ${APP_KEY_FILE_KEY} in daemon/.env.daemon (docs/github-app.md)`)
+} else {
+  log(`GitHub App ${appMinter.appId}, key at ${appMinter.keyFile}`)
+  // Detached, for the same reason the token probes above are: this is a network
+  // round trip, and GitHub being slow must never hold up a boot whose other
+  // duties do not need it.
+  appMinter.installations().then((installs) => {
+    for (const { id, owner } of installs) log(`GitHub App installed on ${owner} (installation ${id})`)
+    const seen = new Set(installs.map((i) => String(i.owner ?? '').toLowerCase()))
+    for (const owner of WATCHED_OWNERS) {
+      if (!seen.has(owner.toLowerCase())) log(`WARNING: the GitHub App is not installed on ${owner} — install it there before that owner's holders cut over (docs/github-app.md)`)
+    }
+  }).catch((e) => log(`could not read the GitHub App's installations (${e.message}) — no holder mints yet, so nothing is broken by it`))
+}
 
 const store = new EscalationStore(DATA)
 

--- a/daemon/test/githubapp.test.mjs
+++ b/daemon/test/githubapp.test.mjs
@@ -185,7 +185,8 @@ describe('the API calls (#352)', () => {
       { id: 222, owner: 'getalfredo' },
     ])
     const { url, opts } = fetchImpl.calls[0]
-    assert.equal(url, 'https://api.github.com/app/installations')
+    // per_page, because GitHub's default page is 30 and nothing here paginates
+    assert.equal(url, 'https://api.github.com/app/installations?per_page=100')
     assert.equal(opts.headers.authorization, 'Bearer j')
     assert.equal(opts.headers['x-github-api-version'], '2022-11-28')
   })

--- a/daemon/test/githubapp.test.mjs
+++ b/daemon/test/githubapp.test.mjs
@@ -1,0 +1,316 @@
+// #352: the GitHub App minting core — the two env keys, the key file, the JWT,
+// the two permission sets, and the cache that makes the one-hour token safe.
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  APP_ID_KEY, APP_KEY_FILE_KEY, JWT_LIFETIME_S, JWT_BACKDATE_S, REFRESH_MARGIN_MS,
+  WRITE_PERMISSIONS, READ_PERMISSIONS,
+  appConfigFrom, readPrivateKey, keyFileIsPrivate, appJwt, permissionsFor,
+  listInstallations, mintInstallationToken, TokenMinter, minterFrom,
+} from '../src/githubapp.mjs'
+
+let dir
+let keyPair
+let keyFile
+
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-app-'))
+  keyPair = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+  keyFile = path.join(dir, 'app.pem')
+  fs.writeFileSync(keyFile, keyPair.privateKey.export({ type: 'pkcs1', format: 'pem' }), { mode: 0o600 })
+  fs.chmodSync(keyFile, 0o600)
+})
+
+after(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+describe('the two env keys (#352)', () => {
+  test('no app is the legal pre-cutover state, and reads as null', () => {
+    assert.equal(appConfigFrom({}, dir), null)
+    assert.equal(appConfigFrom({ [APP_ID_KEY]: '  ', [APP_KEY_FILE_KEY]: '' }, dir), null)
+  })
+
+  // Half an app is an operator typo, and it must refuse the boot rather than
+  // reach a dispatch as a 401 nobody can place.
+  test('half an app refuses, and the refusal names the missing key', () => {
+    assert.throws(() => appConfigFrom({ [APP_ID_KEY]: '123' }, dir), new RegExp(APP_KEY_FILE_KEY))
+    assert.throws(() => appConfigFrom({ [APP_KEY_FILE_KEY]: 'x.pem' }, dir), new RegExp(APP_ID_KEY))
+  })
+
+  // The app id, the app slug and the client id all sit on one settings page,
+  // and only one of them is digits.
+  test('an app id that is not digits refuses, and says which value was pasted', () => {
+    assert.throws(
+      () => appConfigFrom({ [APP_ID_KEY]: 'curia', [APP_KEY_FILE_KEY]: 'app.pem' }, dir),
+      /app SLUG or the client id/)
+  })
+
+  test('the key file resolves against the daemon directory, and an absolute path is kept', () => {
+    assert.equal(appConfigFrom({ [APP_ID_KEY]: '7', [APP_KEY_FILE_KEY]: '.curia-app.pem' }, dir).keyFile,
+      path.join(dir, '.curia-app.pem'))
+    assert.equal(appConfigFrom({ [APP_ID_KEY]: '7', [APP_KEY_FILE_KEY]: keyFile }, dir).keyFile, keyFile)
+  })
+})
+
+describe('the private key (#352)', () => {
+  test('a PKCS#1 PEM reads, which is the file GitHub hands out', () => {
+    assert.equal(readPrivateKey(keyFile).type, 'private')
+  })
+
+  test('the public half is named back, because that download is the easy mistake', () => {
+    const pub = path.join(dir, 'pub.pem')
+    fs.writeFileSync(pub, keyPair.publicKey.export({ type: 'spki', format: 'pem' }))
+    assert.throws(() => readPrivateKey(pub), /PUBLIC key/)
+  })
+
+  test('a missing file names the env key that pointed at it', () => {
+    assert.throws(() => readPrivateKey(path.join(dir, 'nope.pem')), new RegExp(APP_KEY_FILE_KEY))
+  })
+
+  test('junk is refused with what a real key looks like', () => {
+    const junk = path.join(dir, 'junk.pem')
+    fs.writeFileSync(junk, 'not a key\n')
+    assert.throws(() => readPrivateKey(junk), /BEGIN RSA PRIVATE KEY/)
+  })
+
+  // Checked, never fixed: a key curia silently chmods is a key nobody learns to
+  // place, and the next box repeats it.
+  test('the mode is read, and a group-readable key is not private', () => {
+    assert.equal(keyFileIsPrivate(keyFile), true)
+    const loose = path.join(dir, 'loose.pem')
+    fs.writeFileSync(loose, 'x')
+    fs.chmodSync(loose, 0o644)
+    assert.equal(keyFileIsPrivate(loose), false)
+    assert.equal(keyFileIsPrivate(path.join(dir, 'gone.pem')), false)
+  })
+})
+
+describe('the app JWT (#352)', () => {
+  const NOW = 1_800_000_000_000
+
+  function claimsOf(jwt) {
+    return JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString())
+  }
+
+  test('the claims are what GitHub asks for, and the issuer is the app id', () => {
+    const c = claimsOf(appJwt('12345', keyPair.privateKey, { now: () => NOW }))
+    assert.equal(c.iss, '12345')
+    // Backdated: GitHub refuses a JWT whose iat is in the future, and two clocks
+    // are never the same clock.
+    assert.equal(c.iat, Math.floor(NOW / 1000) - JWT_BACKDATE_S)
+    assert.equal(c.exp - c.iat, JWT_LIFETIME_S)
+    // GitHub's ceiling is ten minutes, and the tenth is left as margin.
+    assert.ok(JWT_LIFETIME_S < 600)
+  })
+
+  test('the header says RS256, and the signature verifies against the public half', () => {
+    const jwt = appJwt('12345', keyPair.privateKey, { now: () => NOW })
+    const [header, claims, signature] = jwt.split('.')
+    assert.deepEqual(JSON.parse(Buffer.from(header, 'base64url').toString()), { alg: 'RS256', typ: 'JWT' })
+    assert.ok(crypto.createVerify('RSA-SHA256')
+      .update(`${header}.${claims}`)
+      .verify(keyPair.publicKey, Buffer.from(signature, 'base64url')))
+  })
+
+  // base64url, not base64: a `+` or `/` in a JWT segment is a JWT GitHub reads
+  // as a different string, and the failure is a bare 401.
+  test('no segment carries a base64 character a URL would change', () => {
+    for (let i = 0; i < 20; i++) {
+      const jwt = appJwt(String(i), keyPair.privateKey, { now: () => NOW + i })
+      assert.doesNotMatch(jwt, /[+/=]/)
+    }
+  })
+})
+
+describe('the permission sets (#352)', () => {
+  // The write set is what an agent needs to resolve a ticket: comment, close,
+  // open a pull request, push a branch. Nothing wider.
+  test('the write set is the four an agent uses, and metadata stays read', () => {
+    assert.deepEqual({ ...WRITE_PERMISSIONS }, {
+      contents: 'write', issues: 'write', pull_requests: 'write', metadata: 'read',
+    })
+  })
+
+  // The path from a ticket's text to a CI secret. The PATs of #155 do not carry
+  // it either, so leaving it out keeps today's reach exactly.
+  test('no role can write a workflow file', () => {
+    assert.equal(WRITE_PERMISSIONS.workflows, undefined)
+    assert.equal(READ_PERMISSIONS.workflows, undefined)
+  })
+
+  // #313's set, unchanged. ADR-0014's boundary is this line.
+  test('the read set writes nothing at all', () => {
+    assert.deepEqual({ ...READ_PERMISSIONS }, {
+      contents: 'read', issues: 'read', pull_requests: 'read', statuses: 'read', metadata: 'read',
+    })
+    for (const level of Object.values(READ_PERMISSIONS)) assert.equal(level, 'read')
+  })
+
+  test('an unknown role refuses rather than minting something unnamed', () => {
+    assert.equal(permissionsFor('write'), WRITE_PERMISSIONS)
+    assert.equal(permissionsFor('read'), READ_PERMISSIONS)
+    assert.throws(() => permissionsFor('admin'), /no such token role/)
+  })
+})
+
+// A fetch stand-in: records every call and answers from a queue.
+function fakeFetch(answers) {
+  const calls = []
+  const impl = async (url, opts = {}) => {
+    calls.push({ url, opts, body: opts.body ? JSON.parse(opts.body) : null })
+    const next = answers.shift()
+    if (!next) throw new Error(`no canned answer for ${url}`)
+    return {
+      ok: next.status < 400,
+      status: next.status,
+      text: async () => (next.body === undefined ? '' : JSON.stringify(next.body)),
+    }
+  }
+  impl.calls = calls
+  return impl
+}
+
+describe('the API calls (#352)', () => {
+  test('the installation list is id and owner, and nothing else travels', async () => {
+    const fetchImpl = fakeFetch([{ status: 200, body: [
+      { id: 111, account: { login: 'alp82' } },
+      { id: 222, account: { login: 'getalfredo' } },
+    ] }])
+    assert.deepEqual(await listInstallations({ jwt: 'j', fetchImpl }), [
+      { id: 111, owner: 'alp82' },
+      { id: 222, owner: 'getalfredo' },
+    ])
+    const { url, opts } = fetchImpl.calls[0]
+    assert.equal(url, 'https://api.github.com/app/installations')
+    assert.equal(opts.headers.authorization, 'Bearer j')
+    assert.equal(opts.headers['x-github-api-version'], '2022-11-28')
+  })
+
+  // A 401 on the JWT has two causes and a status code names neither.
+  test('a refused JWT names the app id and the box clock', async () => {
+    const fetchImpl = fakeFetch([{ status: 401, body: { message: 'Bad credentials' } }])
+    await assert.rejects(listInstallations({ jwt: 'j', fetchImpl }), /box clock must be right/)
+  })
+
+  test('the mint posts the permission set and returns the token with its expiry', async () => {
+    const expires = '2026-08-15T12:00:00Z'
+    const fetchImpl = fakeFetch([{ status: 201, body: {
+      token: 'ghs_abc', expires_at: expires, permissions: { contents: 'write' },
+    } }])
+    const out = await mintInstallationToken(111, { jwt: 'j', permissions: WRITE_PERMISSIONS, fetchImpl })
+    assert.equal(out.token, 'ghs_abc')
+    assert.equal(out.expiresAt, Date.parse(expires))
+    const call = fetchImpl.calls[0]
+    assert.equal(call.url, 'https://api.github.com/app/installations/111/access_tokens')
+    assert.equal(call.opts.method, 'POST')
+    assert.deepEqual(call.body, { permissions: { ...WRITE_PERMISSIONS } })
+  })
+
+  // The 422 is the operator's grant, not curia's code, and the status alone
+  // sends nobody to the app settings page.
+  test('a 422 says what curia asked for and where to fix it', async () => {
+    const fetchImpl = fakeFetch([{ status: 422, body: { message: 'The permissions requested are not granted' } }])
+    await assert.rejects(
+      mintInstallationToken(111, { jwt: 'j', permissions: WRITE_PERMISSIONS, fetchImpl }),
+      /contents:write.*Permissions page/s)
+  })
+})
+
+describe('the minter (#352)', () => {
+  const NOW = 1_800_000_000_000
+  const HOUR = 3_600_000
+
+  function minter(answers, { now = () => NOW } = {}) {
+    const fetchImpl = fakeFetch(answers)
+    const m = new TokenMinter({ appId: '7', key: keyPair.privateKey, fetchImpl, now })
+    return { m, fetchImpl }
+  }
+
+  const installs = { status: 200, body: [{ id: 111, account: { login: 'alp82' } }] }
+  const mint = (token, at) => ({ status: 201, body: { token, expires_at: new Date(at).toISOString() } })
+
+  test('a token is minted once and served from cache while the margin holds', async () => {
+    const { m, fetchImpl } = minter([installs, mint('ghs_1', NOW + HOUR)])
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_1')
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_1')
+    assert.equal(fetchImpl.calls.length, 2) // the install list, then one mint
+  })
+
+  // The hour is the whole reason the holders read a file the daemon rewrites.
+  test('inside the refresh margin the token is minted again', async () => {
+    let now = NOW
+    const { m, fetchImpl } = minter(
+      [installs, mint('ghs_1', NOW + HOUR), mint('ghs_2', NOW + 2 * HOUR)],
+      { now: () => now })
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_1')
+    now = NOW + HOUR - REFRESH_MARGIN_MS - 1_000
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_1') // still outside the margin
+    now = NOW + HOUR - REFRESH_MARGIN_MS + 1_000
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_2')
+    assert.equal(fetchImpl.calls.length, 3)
+  })
+
+  // Same owner, two holders: the overseer's read-only token must never be the
+  // agents' write token served from a cache that forgot the difference.
+  test('the two roles cache apart, and each asks for its own permissions', async () => {
+    const { m, fetchImpl } = minter([installs, mint('ghs_w', NOW + HOUR), mint('ghs_r', NOW + HOUR)])
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_w')
+    assert.equal(await m.tokenFor('alp82', 'read'), 'ghs_r')
+    assert.deepEqual(fetchImpl.calls[1].body.permissions, { ...WRITE_PERMISSIONS })
+    assert.deepEqual(fetchImpl.calls[2].body.permissions, { ...READ_PERMISSIONS })
+  })
+
+  // An owner installed while the daemon runs must not need a restart.
+  test('an unknown owner re-reads the install list before it gives up', async () => {
+    const { m, fetchImpl } = minter([
+      { status: 200, body: [] },
+      { status: 200, body: [{ id: 222, account: { login: 'getalfredo' } }] },
+      mint('ghs_g', NOW + HOUR),
+    ])
+    assert.equal(await m.tokenFor('getalfredo', 'write'), 'ghs_g')
+    assert.equal(fetchImpl.calls.length, 3)
+  })
+
+  // Null would send an unauthenticated push at a private repo, and the failure
+  // would name the repo instead of the missing install.
+  test('an owner with no installation throws, naming the owner', async () => {
+    const { m } = minter([{ status: 200, body: [] }, { status: 200, body: [] }])
+    await assert.rejects(m.tokenFor('nobody', 'write'), /not installed on nobody/)
+  })
+
+  test('forget drops the tokens and the install list together', async () => {
+    const { m, fetchImpl } = minter([installs, mint('ghs_1', NOW + HOUR), installs, mint('ghs_2', NOW + HOUR)])
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_1')
+    m.forget()
+    assert.equal(await m.tokenFor('alp82', 'write'), 'ghs_2')
+    assert.equal(fetchImpl.calls.length, 4)
+  })
+})
+
+describe('the minter this box gets (#352)', () => {
+  test('no app configured is null, not a refusal', () => {
+    assert.equal(minterFrom({ env: {}, daemonRoot: dir }), null)
+  })
+
+  test('a configured app builds a minter carrying the app id', () => {
+    const m = minterFrom({ env: { [APP_ID_KEY]: '7', [APP_KEY_FILE_KEY]: keyFile }, daemonRoot: dir })
+    assert.equal(m.appId, '7')
+    assert.equal(m.key.type, 'private')
+  })
+
+  test('a key readable beyond its owner warns and still works', () => {
+    const loose = path.join(dir, 'loose-real.pem')
+    fs.writeFileSync(loose, keyPair.privateKey.export({ type: 'pkcs1', format: 'pem' }))
+    fs.chmodSync(loose, 0o644)
+    const said = []
+    const m = minterFrom({
+      env: { [APP_ID_KEY]: '7', [APP_KEY_FILE_KEY]: loose }, daemonRoot: dir, log: (s) => said.push(s),
+    })
+    assert.ok(m)
+    assert.match(said.join('\n'), /chmod 600/)
+  })
+})

--- a/docs/adr/0018-the-daemon-is-a-github-app.md
+++ b/docs/adr/0018-the-daemon-is-a-github-app.md
@@ -1,0 +1,55 @@
+# ADR-0018: The daemon is a GitHub App
+
+**Status**: accepted (2026-08). Partly built. The minting core ships with this ADR. Each holder cuts over on its own ticket.
+**Provenance**: [A GitHub App replaces the PAT (#338)](https://github.com/alp82/curia/issues/338), [The daemon becomes a GitHub App: one key, minted tokens (#352)](https://github.com/alp82/curia/issues/352)
+
+## Context
+
+Curia reaches GitHub four ways, and every one of them is a secret the operator makes by hand.
+
+- **Agents** carry a read-write fine-grained PAT, one per resource owner, as `GH_TOKEN` in the container environment ([#155](https://github.com/alp82/curia/issues/155)).
+- **The overseer** carries a read-only fine-grained PAT, one per resource owner, in a second env file ([#313](https://github.com/alp82/curia/issues/313)). That file is the boundary, because compose hands a container an env file whole.
+- **The daemon** uses the operator's own `gh` login for frontier reads, claims, pull-request creation and branch pushes.
+- **A dev session** uses the same host login again.
+
+Five costs come out of that shape.
+
+1. **The minting cost.** A fine-grained PAT has one resource-owner dropdown, so the count is holders times owners. Two holders and two owners is four tokens, made by hand and made again on expiry.
+2. **The expiry is a calendar item.** An organization can cap fine-grained PAT lifetime, and `getalfredo` caps it at 366 days. An expired token does not degrade. It answers every call with a 401.
+3. **The second env file is a boundary made of files.** `.env.overseer` exists because a container reads its env file whole, and `.env.daemon` carries the read-write tokens. The operator objected to the pair, and no narrower shape was available.
+4. **The gate is not a gate on GitHub.** An agent's pull request is authored by the operator's own token today. GitHub refuses a self-approval, so branch protection with one required review would block every curia pull request behind an approval nobody can post.
+5. **Attribution lies.** A push the daemon performs for an agent reads as the operator.
+
+## Decision
+
+- **One GitHub App replaces every PAT.** The operator creates one app under their own account and installs it on each watched owner (`alp82` and `getalfredo`). The app is per-operator. It is never a central shared app, and stranger distribution stays out of scope.
+
+- **The private key is curia's one durable secret.** It sits at `daemon/.curia-app.pem`, mode 0600, uncommitted, named by `CURIA_GH_APP_KEY_FILE` beside `CURIA_GH_APP_ID` in `daemon/.env.daemon`. The key is a FILE and never a value in the env file: a PEM carries newlines, docker reads a newline in an env file as a second variable, and a path keeps the key out of every child process environment the daemon spawns.
+
+- **The daemon mints, and nothing else does.** `daemon/src/githubapp.mjs` signs the app JWT with `node:crypto`, reads the installation list, and mints installation tokens. No container asks a daemon endpoint for a token: a shell that can mint is the capability [ADR-0014](0014-the-overseer-in-its-own-container.md) removed.
+
+- **One key, two permission sets.** A minted installation token may scope DOWN from what the installation grants, so agents get `contents:write, issues:write, pull_requests:write, metadata:read` and the overseer gets [#313](https://github.com/alp82/curia/issues/313)'s read set unchanged: `contents, issues, pull_requests, statuses, metadata`, all read. ADR-0014's boundary now holds with no second secret.
+
+- **Neither set carries `workflows`.** GitHub gates `.github/workflows/` behind its own permission, and an app that holds it lets any agent rewrite CI. That is a path from a ticket's text to whatever secret the next workflow run holds. The PATs of [#155](https://github.com/alp82/curia/issues/155) do not carry it either, so the reach stays exactly what it is today. The cost is stated rather than hidden: an agent cannot push a change under `.github/workflows/`.
+
+- **A holder reads a file the daemon rewrites.** An installation token lives one hour, and a ticket outlives it. So no holder is handed a value at spawn. The daemon refreshes a per-holder file, and the existing credential-helper path reads it. `GH_TOKEN` leaves the container environment.
+
+- **The claim assigns the operator, not the bot.** A claim is an issue assignee, and GitHub does not let an App be one. `gh api user` also answers nothing under an installation token, which is where `viewerLogin()` reads the name today. So the daemon calls as `curia[bot]` and assigns a login it reads from `dispatch.claim_login` in `config/curia.yaml`.
+
+- **The gate approval is the operator's own.** On the ✅ press the daemon submits a real GitHub approval with the host `gh` login. An app cannot approve for a human, and an app-minted approval on an app-authored pull request is a self-approval again. So the host login does not retreat whole. It keeps exactly one job on the daemon, beside dev sessions and the deploy sibling.
+
+- **The agent keeps `gh pr merge`.** The merge is the one write to the remote an agent owns, in the standing orders, in the Stop hook and in [ADR-0008](0008-resolved-means-merged.md). Branch protection is satisfied by the operator's approval, so the bot's merge goes through and nothing about the ending changes.
+
+- **Branch protection turns on with the gate cutover, and not before.** One required review on the watched repos, turned on in the same act that starts posting the approval. Turned on earlier it blocks every curia pull request behind an approval nobody posts.
+
+- **No PAT comes out ahead of its replacement.** The minting core ships first and swaps no holder. Each holder cuts over on its own ticket, provable live on the box, and its PAT retires only after that.
+
+## Consequences
+
+- **The hour is the price.** A PAT was set once and stayed good for a year. An installation token dies inside a long ticket, so every holder gains a refresh path, and the daemon gains a duty it did not have.
+- **The private key never expires**, so nothing here is a calendar item any more. The 366-day cap stops mattering.
+- **Attribution becomes honest.** A push the daemon performs for an agent reads as `curia[bot]`.
+- **The gate becomes a real GitHub approval**, which is what makes branch protection usable at all.
+- **`.env.overseer` retires as a token file** when the overseer cuts over. What is left in it is the model credential, which is the one host secret ADR-0014 lets into that container.
+- **One-click setup from the dashboard** rides GitHub's app manifest flow. It stays fog on [#244](https://github.com/alp82/curia/issues/244) until the app is real.
+- **[ADR-0007](0007-shared-credential-store.md) is untouched.** That one shares the MODEL credential, and nothing here reads it.

--- a/docs/adr/0018-the-daemon-is-a-github-app.md
+++ b/docs/adr/0018-the-daemon-is-a-github-app.md
@@ -34,7 +34,7 @@ Five costs come out of that shape.
 
 - **A holder reads a file the daemon rewrites.** An installation token lives one hour, and a ticket outlives it. So no holder is handed a value at spawn. The daemon refreshes a per-holder file, and the existing credential-helper path reads it. `GH_TOKEN` leaves the container environment.
 
-- **The claim assigns the operator, not the bot.** A claim is an issue assignee, and GitHub does not let an App be one. `gh api user` also answers nothing under an installation token, which is where `viewerLogin()` reads the name today. So the daemon calls as `curia[bot]` and assigns a login it reads from `dispatch.claim_login` in `config/curia.yaml`.
+- **The claim assigns the operator, not the bot.** A claim is an issue assignee, and GitHub does not let an App be one. `gh api user` also answers nothing under an installation token, which is where `viewerLogin()` reads the name today. So the daemon calls as `curia-sh[bot]` and assigns a login it reads from `dispatch.claim_login` in `config/curia.yaml`.
 
 - **The gate approval is the operator's own.** On the ✅ press the daemon submits a real GitHub approval with the host `gh` login. An app cannot approve for a human, and an app-minted approval on an app-authored pull request is a self-approval again. So the host login does not retreat whole. It keeps exactly one job on the daemon, beside dev sessions and the deploy sibling.
 
@@ -48,7 +48,7 @@ Five costs come out of that shape.
 
 - **The hour is the price.** A PAT was set once and stayed good for a year. An installation token dies inside a long ticket, so every holder gains a refresh path, and the daemon gains a duty it did not have.
 - **The private key never expires**, so nothing here is a calendar item any more. The 366-day cap stops mattering.
-- **Attribution becomes honest.** A push the daemon performs for an agent reads as `curia[bot]`.
+- **Attribution becomes honest.** A push the daemon performs for an agent reads as `curia-sh[bot]`.
 - **The gate becomes a real GitHub approval**, which is what makes branch protection usable at all.
 - **`.env.overseer` retires as a token file** when the overseer cuts over. What is left in it is the model credential, which is the one host secret ADR-0014 lets into that container.
 - **One-click setup from the dashboard** rides GitHub's app manifest flow. It stays fog on [#244](https://github.com/alp82/curia/issues/244) until the app is real.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,10 @@ One file per standing decision. A decision earns an ADR when it still constrains
 - [ADR-0006](0006-worker-containment-and-standing-orders.md): The agent resolves in the tracker's idiom, bounded by standing orders. The daemon verifies, repairs, and lands.
 - [ADR-0007](0007-shared-credential-store.md): Agents share the host credential store. Nothing is snapshotted, so nothing goes stale. The daemon reads that store for the account usage bars, and never writes it.
 
+## Credentials
+
+- [ADR-0018](0018-the-daemon-is-a-github-app.md): One GitHub App replaces every PAT. The daemon holds the private key and mints installation tokens — read-write for agents, read-only for the overseer. The gate approval is the operator's own, and the claim assigns a real user. Decided; the minting core is built and each holder cuts over on its own ticket.
+
 ## Human in the loop
 
 - [ADR-0005](0005-escalation-contract.md): Escalations are blocking MCP calls, rendered on Discord, first-valid-wins, durable in the journal.

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -8,14 +8,30 @@ Nothing on this page can be done by an agent. An app is created under a human ac
 
 The daemon runs fine with no app. Every PAT keeps working until its holder cuts over, so you can stop after any step here and nothing breaks.
 
+## What this box registered
+
+Run on 2026-08-16, as [#352](https://github.com/alp82/curia/issues/352). The cutover tickets read these facts from here.
+
+| Fact | Value |
+| --- | --- |
+| App name | `curia.sh` |
+| Settings page | <https://github.com/settings/apps/curia-sh> |
+| App ID | `4610603` |
+| Bot login | `curia-sh[bot]` |
+| Installed on | `alp82` and `getalfredo` |
+
+None of this is secret. The app id travels in every JWT the daemon signs. The private key is the secret, and it is never in this repo.
+
 ## 1. Create the app
 
 1. Open <https://github.com/settings/apps/new>.
-2. Set **GitHub App name** to `curia`. The bot then posts as `curia[bot]`, which is the name ADR-0018 uses. If GitHub says the name is taken, use `curia-daemon` and tell the daemon nothing: the name is cosmetic, and only the app id matters.
+2. Set **GitHub App name**. GitHub slugifies it, and the bot posts as `<slug>[bot]`, so the name is read as the author of every commit, pull request and gate approval. Nothing in the daemon reads it. The name must be free across the whole of GitHub, and `curia` is taken.
 3. Set **Homepage URL** to `https://github.com/alp82/curia`.
 4. Clear the **Webhook** → **Active** checkbox. Curia polls. It listens for no webhook.
-5. Set **Where can this GitHub App be installed?** to **Only on this account**.
+5. Set **Where can this GitHub App be installed?** to **Any account**.
 6. Press **Create GitHub App**.
+
+**Any account, and not "Only on this account".** The app is owned by the user `alp82`, and `getalfredo` is an organization. An organization is a different account, so "Only on this account" leaves it off the **Install App** page and there is no way to install there. "Any account" is what makes one app cover both owners, which is what [#338](https://github.com/alp82/curia/issues/338) decided. The app is not listed on the Marketplace, so it is reachable only through its own install URL, and a stranger who installed it would grant it their repos and reach none of curia's. The setting is on the **General** page and can be changed after the app exists.
 
 ## 2. Grant the permissions
 
@@ -58,7 +74,7 @@ The watch list lives in `config/curia.yaml`. A repo added there later must be ad
 Three facts resolve [#352](https://github.com/alp82/curia/issues/352) and the cutover tickets read them:
 
 - the **App ID**,
-- the **bot login** GitHub gave the app (`curia[bot]`, or whatever the name in step 1 produced),
+- the **bot login** GitHub gave the app: the slug in the settings URL, plus `[bot]`,
 - that **both installations** exist.
 
 ## 6. Put the key on the box (dev session)
@@ -87,6 +103,7 @@ The key never travels through an agent. This step happens in a dev session on th
 ## If something is wrong
 
 - **The boot says the JWT was refused (401).** The app id and the key file belong to different apps, or the box clock is wrong.
+- **The Install App page does not list `getalfredo`.** The app is set to **Only on this account**. An organization is a different account. Set **Where can this GitHub App be installed?** to **Any account** on the **General** page, then reload the Install App page.
 - **The boot lists no installation for a watched owner.** Step 4 was not run for that owner.
 - **A mint answers 422.** The app grants less than curia asked for. Fix the level on the app's **Permissions & events** page, then accept the new grant on EACH installation — GitHub holds a widened permission until the installation approves it.
 - **The key is lost.** Generate a second one on the **General** page and delete the old one. The app id does not change, and no installation has to be redone.

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -1,0 +1,92 @@
+# The curia GitHub App: the operator checklist
+
+Curia authenticates to GitHub as one GitHub App. [ADR-0018](adr/0018-the-daemon-is-a-github-app.md) says why. This file is what the operator does by hand, once.
+
+Nothing on this page can be done by an agent. An app is created under a human account, and its private key is downloaded exactly once.
+
+## Before you start
+
+The daemon runs fine with no app. Every PAT keeps working until its holder cuts over, so you can stop after any step here and nothing breaks.
+
+## 1. Create the app
+
+1. Open <https://github.com/settings/apps/new>.
+2. Set **GitHub App name** to `curia`. The bot then posts as `curia[bot]`, which is the name ADR-0018 uses. If GitHub says the name is taken, use `curia-daemon` and tell the daemon nothing: the name is cosmetic, and only the app id matters.
+3. Set **Homepage URL** to `https://github.com/alp82/curia`.
+4. Clear the **Webhook** → **Active** checkbox. Curia polls. It listens for no webhook.
+5. Set **Where can this GitHub App be installed?** to **Only on this account**.
+6. Press **Create GitHub App**.
+
+## 2. Grant the permissions
+
+On the app's **Permissions & events** page, under **Repository permissions**, set these five and nothing else.
+
+| Permission | Level | Who needs it |
+| --- | --- | --- |
+| Contents | Read and write | agents push branches, the overseer reads files |
+| Issues | Read and write | claims, resolution comments, map updates |
+| Pull requests | Read and write | pull-request creation, the gate approval, the merge |
+| Commit statuses | Read-only | the overseer reads check results |
+| Metadata | Read-only | mandatory, and GitHub sets it for you |
+
+Leave **Workflows** at **No access**. ADR-0018 says why: an app that can write `.github/workflows/` lets any agent rewrite CI, and today's PATs cannot do it either.
+
+Set no **Organization permissions** and no **Account permissions**. Subscribe to no events.
+
+Press **Save changes**.
+
+## 3. Generate the private key
+
+1. On the app's **General** page, scroll to **Private keys** and press **Generate a private key**.
+2. The browser downloads one `.pem` file. **GitHub never shows it again.** Keep it until step 6 puts it on the box.
+3. Note the **App ID** from the same page. It is digits. It is not the app slug and not the client id.
+
+## 4. Install it on both owners
+
+Do this twice, once per resource owner.
+
+1. Open the app's **Install App** page.
+2. Press **Install** beside `alp82`.
+3. Choose **Only select repositories** and pick every repo on the watch list for that owner: `alp82/curia`, `alp82/alperortac.com`, `alp82/aistack`.
+4. Press **Install**.
+5. Repeat for `getalfredo`, picking `getalfredo/landing-page`.
+
+The watch list lives in `config/curia.yaml`. A repo added there later must be added to its installation too, or every dispatch on it fails to authenticate.
+
+## 5. Report the facts back
+
+Three facts resolve [#352](https://github.com/alp82/curia/issues/352) and the cutover tickets read them:
+
+- the **App ID**,
+- the **bot login** GitHub gave the app (`curia[bot]`, or whatever the name in step 1 produced),
+- that **both installations** exist.
+
+## 6. Put the key on the box (dev session)
+
+The key never travels through an agent. This step happens in a dev session on the box.
+
+1. Copy the downloaded `.pem` to `daemon/.curia-app.pem`.
+2. `chmod 600 daemon/.curia-app.pem`, owned by the box user the daemon runs as.
+3. Add two lines to `daemon/.env.daemon`:
+
+   ```
+   CURIA_GH_APP_ID=<the digits from step 3>
+   CURIA_GH_APP_KEY_FILE=.curia-app.pem
+   ```
+
+4. Restart the daemon. Its boot log then states one line per installation it can see. An app it cannot read refuses the boot naming the file, rather than failing a dispatch hours later.
+
+`.curia-app.pem` is git-ignored. Never commit it.
+
+## What is NOT on this list yet
+
+**Branch protection stays off.** One required review on the watched repos is the gate cutover's own act, and it turns on in the same change that starts posting the approval. Turned on now it blocks every curia pull request behind an approval nobody posts.
+
+**No PAT comes out yet.** `CURIA_AGENT_GH_TOKEN_*` and `daemon/.env.overseer` keep working until each holder cuts over on its own ticket.
+
+## If something is wrong
+
+- **The boot says the JWT was refused (401).** The app id and the key file belong to different apps, or the box clock is wrong.
+- **The boot lists no installation for a watched owner.** Step 4 was not run for that owner.
+- **A mint answers 422.** The app grants less than curia asked for. Fix the level on the app's **Permissions & events** page, then accept the new grant on EACH installation — GitHub holds a widened permission until the installation approves it.
+- **The key is lost.** Generate a second one on the **General** page and delete the old one. The app id does not change, and no installation has to be redone.


### PR DESCRIPTION
Ticket: alp82/curia#352 — [The daemon becomes a GitHub App: one key, minted tokens](https://github.com/alp82/curia/issues/352)

Adds the GitHub App minting core, ADR-0018 and the operator checklist. No holder swaps: every PAT keeps working, and the four cutovers graduate as tickets.

The app is real. `curia.sh`, app id 4610603, bot `curia-sh[bot]`, installed on `alp82` and `getalfredo`. The key and the two env lines are on the box.

- `daemon/src/githubapp.mjs`: app JWT signed with `node:crypto` (no dependency), installation lookup, installation tokens per owner and per role. Two permission sets from one key — read-write for agents, #313's read set unchanged for the overseer. Neither carries `workflows`.
- `TokenMinter` caches per owner and role, and re-mints ten minutes before the hour. That margin is what lets a holder read a file the daemon rewrites instead of an env var frozen at spawn.
- Boot wiring in `index.mjs`: app id, key file, one line per installation, and a warning for a watched owner with no install. It proves the checklist worked and swaps nothing. A half-configured app refuses the boot; no app stays legal.
- `docs/adr/0018-the-daemon-is-a-github-app.md`. It settles the ticket's two open points: the claim assigns the operator (an App cannot be an assignee, and an installation token names no user), and the gate approval is the operator's own, so the agent keeps `gh pr merge`.
- `docs/github-app.md`: the checklist, plus a facts table the cutover tickets read. The live run found two errors in it, both fixed: the install scope had to be **Any account** for the `getalfredo` org, and the app name is the operator's to pick.
- CONTEXT.md gains **GitHub App** and **Installation token**; the ADR index gains a Credentials section.
- 29 new tests. Full suite green: 1893 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-352`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `84e2980` The app is real: curia.sh, 4610603, both owners (#352)
- `f099e45` Trim the mint call: one page of installations, one auth path (#352)
- `150040b` The daemon becomes a GitHub App: the key, the mint, the checklist (#352)