### PR TITLE
A re-asked question is answered from the record (alp82/curia#369)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -323,7 +323,11 @@ The message curia queues at the builder the moment a reviewer spawns. It names t
 The answer rule. The first valid answer closes the escalation atomically. Any device may answer. Later answers get a refusal.
 
 **Supersede**:
-A re-asked question closes the older record and routes late answers to the live one. The key is the agent and the kind, never the wording (#336). A re-send that explains itself in its own words is the same call, so it closes the original at birth. A confirm keys on the target instance instead.
+A re-asked question closes the older record and routes late answers to the live one. The key is the agent and the kind, never the wording (#336). A re-send that explains itself in its own words is the same call, so it closes the original at birth. A confirm keys on the target instance instead. It reaches OPEN records only, so a question that is already answered is handled by the recorded answer (#369).
+
+**Recorded answer**:
+An answer a human gave to a question no live call could receive. `settle` finds no resolver, so the daemon parks question and answer on the agent's note queue (#139). A question re-asked word for word takes that answer back at once, while the note is still unread, and no second card opens (#369). The note leaves with the answer, so one fact is said once. The tool result names the record, the person and the moment, so the agent knows the answer is a recorded one. At the review gate the same rule needs the diff digest to match, or a fresh gate opens.
+_Avoid_: replay, cached answer.
 
 **Stale question**:
 An escalation still open when its own agent reports a result (#336). The result closes it, because nothing can read an answer to it any more. Reconcile runs the same rule over the journal, and it runs the ending a Stop hook deferred to such a record. Silence closes nothing: only the agent's own result or its next call does.

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1050,6 +1050,7 @@ const EVENTS = {
   esc_cancel: ["answer", "", (e) => `escalation ${esc(e.id)} cancelled by ${esc(e.by)}`],
   esc_lapse: ["answer", "", (e) => `escalation ${esc(e.id)} lapsed — ${esc(e.reason)}`],
   esc_supersede: ["escalation", "", (e) => `escalation ${esc(e.id)} superseded by ${esc(e.successor)}`],
+  esc_replayed: ["answer", "", (e) => `${who(e)} asked ${esc(e.id)} again and took the recorded answer — nobody was asked twice`],
   review_requested: ["gate", "warn", (e) => `review gate opened for ${tkt(e)} by ${who(e)}`],
   review_answered: ["gate", "", (e) => `${tkt(e)} ${e.approved ? "approved" : "rejected"} at the gate${e.outcome ? ` — ${esc(e.outcome)}` : ""}`],
   cross_check_requested: ["cross-check", "", (e) => `cross-check pressed on ${tkt(e)} — ${who(e)} parks`],

--- a/daemon/src/diffdigest.mjs
+++ b/daemon/src/diffdigest.mjs
@@ -299,6 +299,31 @@ export function biggestOf(digest) {
   return top
 }
 
+// Two digests of one change (#369). The review gate may hand back a recorded
+// approval only when the code is still the code the operator approved, and this
+// is that check.
+//
+// NULL NEVER MATCHES ITSELF. A gate curia could not count is not evidence of
+// anything, so two uncounted gates are not the same gate — they are two gates
+// nobody measured, and an approval must never ride on that.
+//
+// The totals alone would be weak evidence: two different changes can touch the
+// same file count and the same line counts. So the per-file list is compared
+// too, path by path, which is the same list the console draws.
+export function sameDigest(a, b) {
+  if (!a || !b) return false
+  for (const k of ['uncommitted', 'files', 'added', 'deleted', 'capped']) {
+    if (a[k] !== b[k]) return false
+  }
+  const one = a.list ?? []
+  const two = b.list ?? []
+  if (one.length !== two.length) return false
+  return one.every((f, i) => {
+    const g = two[i]
+    return f.path === g.path && f.status === g.status && f.added === g.added && f.deleted === g.deleted
+  })
+}
+
 const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`
 
 // The one line the Discord gate card gains under its links (#355).

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -2647,8 +2647,14 @@ export class Dispatcher {
       diff: digest, diff_error: digestError,
     })
     if (w) w.state = 'awaiting-review'
-    const { text: answer, status } = await this.askReview(agentName, ticket, text, { diff: digest, diffError: digestError })
+    // `recorded` is set only when the gate handed back an answer the operator
+    // had already given to this same summary over this same diff (#369). It is
+    // a LINE rather than a flag, and it stays out of `answer`: the answer is
+    // classified by a narrow set of words, and a preface in front of `approve`
+    // would read as a rejection.
+    const { text: answer, status, recorded } = await this.askReview(agentName, ticket, text, { diff: digest, diffError: digestError })
     if (w && w.state === 'awaiting-review') w.state = 'ready'
+    const said = (body) => (recorded && typeof body === 'string' ? `${recorded}\n\n${body}` : body)
 
     if (status !== 'answered') {
       this.store.logEvent('review_answered', { repo, ticket, agent: agentName, approved: false, status })
@@ -2658,12 +2664,16 @@ export class Dispatcher {
     this.store.logEvent('review_answered', {
       repo, ticket, agent: agentName, approved, via: 'gate',
       ...(crossCheck ? { outcome: 'cross-check' } : {}),
+      ...(recorded ? { recorded: true } : {}),
     })
     // #165, ADR-0010: the third button. The gate had two answers and now has
     // three, and this one answers NOTHING — nothing merges, nothing is rejected,
     // and the round ends where it started. What it does is put a second model on
     // the diff and hold the builder here until that model has read it.
-    if (crossCheck) return await this.#runCrossCheck(agentName, { repo, ticket, w })
+    if (crossCheck) {
+      const out = await this.#runCrossCheck(agentName, { repo, ticket, w })
+      return { ...out, text: said(out.text) }
+    }
     if (approved) {
       // #297: the ORDER is the answer to #48, and this is where it is said at
       // the moment it matters. A charting agent closes research tickets, never
@@ -2672,25 +2682,25 @@ export class Dispatcher {
       return {
         ok: true,
         approved: true,
-        text: mapDispatch
+        text: said(mapDispatch
           ? [
             `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`),`,
             'then resolve each research ticket you burned down — comment, close, map line — then report_result.',
             'Nothing closes before the merge, and the map itself never closes.',
           ].join('\n')
-          : `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`), then resolve the ticket, then report_result.`,
+          : `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`), then resolve the ticket, then report_result.`),
       }
     }
     return {
       ok: true,
       approved: false,
-      text: [
+      text: said([
         'NOT approved. The human said:',
         feedback || '(nothing beyond the rejection itself — ask them what to change with ask_human)',
         '',
         'Do not merge and do not resolve. Make the changes, commit, call open_pull_request again, then',
         'request_review again.',
-      ].join('\n'),
+      ].join('\n')),
     }
   }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -39,6 +39,7 @@ import { PROBE_MARK, PROBE_PATH, GUEST_DAEMON_HOST, dockerGateway, probeSideChan
 import { Cooling, providerOf } from './routing.mjs'
 import { Dispatcher } from './dispatch.mjs'
 import { REVIEW_KIND } from './lifecycle.mjs'
+import { sameDigest } from './diffdigest.mjs'
 import { CommandRouter } from './commands.mjs'
 import { SelfDeploy } from './deploy.mjs'
 import { OverseerHost } from './overseer.mjs'
@@ -398,6 +399,19 @@ function handOffAnswer(record) {
   log(`escalation ${record.id} answered with no live receiver — hand-off note queued for ${record.agent}`)
 }
 
+// #369: the one line that tells an agent its answer is a recorded one.
+//
+// The agent has to know. It re-asked because its own call died, and without
+// this line it reads the answer as a fresh reply to the exact wording it sent
+// this time — including the "(Re-sent: the last call timed out…)" note the
+// standing orders make it add. So the line names the record, the person and the
+// moment, which are the three facts that make it evidence rather than a claim.
+function recordedAnswerLine(record) {
+  const by = record.answered_by ? ` by ${record.answered_by}` : ''
+  return `[recorded answer — a human answered this exact question${by} at ${record.closed_at}, on ${record.id},`
+    + ' while no call of yours was live. Curia opened no second card and asked nobody again.]'
+}
+
 // handlers the bridge (and REST) call into — the single first-valid-wins gate
 const gate = {
   get: (id) => store.get(id),
@@ -617,6 +631,17 @@ function lapseEscalation(id, reason) {
 // the whole per-file list, which is what lets `GET /overview` hand the console
 // a gate card that costs no extra read.
 function askReview(agent, ticket, promptText, { diff = null, diffError = null } = {}) {
+  // #369 at the gate, where the wait costs most. The same rule as `ask_human`
+  // plus one guard: the code has to be the code the operator approved. The
+  // digest is already measured for this very call (#355), so the check is a
+  // comparison rather than a second read — and an unmeasured gate never
+  // replays, because `sameDigest` refuses two nulls.
+  const recorded = store.recordedAnswerFor({ agent, kind: REVIEW_KIND, prompt: promptText })
+  if (recorded && sameDigest(recorded.record.diff, diff)) {
+    store.takeRecordedAnswer(recorded.record, recorded.note)
+    log(`review gate ${recorded.record.id} replayed to ${agent} — the same summary over the same diff, answered already`)
+    return Promise.resolve({ text: recorded.record.answer, status: 'answered', recorded: recordedAnswerLine(recorded.record) })
+  }
   const { record, answered } = openEscalation({
     agent, ticket, kind: REVIEW_KIND, prompt: promptText, diff, diff_error: diffError,
   })
@@ -1173,6 +1198,32 @@ function buildMcpServer(agent, ticket) {
       // sit between the agent and the human it is asking.
       dispatcher.noteJudgement(agent, payload.prompt)
         .catch((e) => log(`judgement comment for ${agent} failed: ${e.message}`))
+      // #369: the answer this agent is about to wait for may already be sitting
+      // in its own note queue, unread. A daemon restart killed the call that
+      // asked, the operator answered the card anyway, and #139 parked the
+      // answer. Hand it back now rather than opening a second card and making
+      // the operator wait a second time for one question.
+      //
+      // This opens no record, so it supersedes nothing (#336). That is right:
+      // the record this answer belongs to is already closed, and a corpse of
+      // this kind on this agent would have been closed by the call that earned
+      // the answer in the first place.
+      const recorded = store.recordedAnswerFor({ agent, ...payload })
+      if (recorded) {
+        store.takeRecordedAnswer(recorded.record, recorded.note)
+        log(`escalation ${recorded.record.id} replayed to ${agent} — the same question, answered already, note ${recorded.note.id} taken`)
+        const lines = [recordedAnswerLine(recorded.record)]
+        // The card is what shows a picture, and no card opened. Said rather
+        // than swallowed: an agent that thinks the operator saw a screenshot
+        // reads the answer as being about it.
+        if (images?.length) lines.push(`(curia opened no card, so the ${images.length} image(s) you sent with this call were not shown.)`)
+        return {
+          content: [
+            { type: 'text', text: `${lines.join('\n')}\n\n${recorded.record.answer}` },
+            ...inboundContent(recorded.record.attachments ?? []),
+          ],
+        }
+      }
       const { files, refusals } = outboundImages(agent, images)
       const { record, answered } = openEscalation({ agent, ticket, ...payload, files })
       const stopKeepAlive = startKeepAlive(extra, record.id, promptTitle(payload.prompt))

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -10,6 +10,9 @@
 //   - supersede (#29, #336): a re-issued ask_human — a second open record of one
 //     kind on one agent, whatever its wording — marks the old record superseded;
 //     answers posted to a dead id route along the successor chain to the live call
+//   - the recorded answer (#369): a question re-asked word for word takes back
+//     the answer #139 parked for it, while that note is still unread — so the
+//     operator waits once for one question
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -144,6 +147,7 @@ export class EscalationStore {
     this.ticketRepos = new Map() // ticket -> repo of its last dispatch (#235)
     this.lastAgentEvents = new Map() // agent session -> last journal event about it (#236)
     this.notes = new Map() // note id -> every note ever queued, pending or not (#252)
+    this.handoffNotes = new Map() // escalation id -> the note its recorded answer rides on (#369)
     this.recent = [] // the last RECENT_EVENTS journal lines, oldest first (#262)
     this.outcomes = { cancelled: [], finished: [], died: [] } // the last RECENT_OUTCOMES of each (#289)
     this.pullRequests = new Map() // agent session -> the pull request its CURRENT dispatch pushed (#289)
@@ -340,14 +344,21 @@ export class EscalationStore {
         // can point at the words that receipt was about. Absent on every note
         // journalled before the two delivery modes existed, and a receipt with
         // no id carries no button.
+        // `handoff_for` names the escalation whose recorded answer this note
+        // carries (#369). Only the #139 hand-off sets it, and it is what lets a
+        // re-asked question find its own parked answer. Absent on every note
+        // journalled before this ticket, so an old hand-off is delivered by the
+        // drain alone, exactly as it always was.
         const note = {
           id: ev.id ?? null, agent: ev.agent, text: ev.text, after: ev.after ?? null,
           instance: ev.instance ?? null, label: ev.label ?? null, pending: true, at: ev.ts ?? null,
+          handoff_for: ev.handoff_for ?? null,
         }
         if (note.id) {
           const n = Number(String(note.id).split('-')[1])
           if (Number.isFinite(n) && n >= this.noteSeq) this.noteSeq = n
           this.notes.set(note.id, note)
+          if (note.handoff_for) this.handoffNotes.set(note.handoff_for, note.id)
         }
         arr.push(note)
         this.agentNotes.set(ev.agent, arr)
@@ -377,6 +388,19 @@ export class EscalationStore {
         const note = this.notes.get(ev.id)
         if (note) note.pending = false
         this.agentNotes.set(ev.agent, arr.filter((n) => n.id !== ev.id))
+        break
+      }
+      // #369: the re-asked question took its own recorded answer. ONE event for
+      // one act, because the answer and its note leave together — the call
+      // returns the answer, so the note carries nothing left to say and a drain
+      // that also delivered it would state one fact twice (ADR-0013).
+      case 'esc_replayed': {
+        const r = this.escalations.get(ev.id)
+        if (r) r.replayed_at = ev.ts
+        const note = this.notes.get(ev.note)
+        if (note) note.pending = false
+        const arr = this.agentNotes.get(ev.agent) ?? []
+        this.agentNotes.set(ev.agent, arr.filter((n) => n.id !== ev.note))
         break
       }
       case 'overseer_notes_drained': {
@@ -623,7 +647,11 @@ export class EscalationStore {
   // words are a human's. The cross-check verdict rides this same queue and must
   // not read as something the operator typed: it is a second model's reading,
   // and the builder judges it rather than obeying it.
-  queueAgentNote(agent, text, { by = null, instance = null, label = null, graceMs = 120_000, now = Date.now() } = {}) {
+  // `handoffFor` is the #139 hand-off's own mark (#369): the escalation whose
+  // recorded answer these words carry. Every other caller leaves it null,
+  // because only a recorded answer can be handed back to the call that re-asks
+  // for it.
+  queueAgentNote(agent, text, { by = null, instance = null, label = null, handoffFor = null, graceMs = 120_000, now = Date.now() } = {}) {
     const recent = [...this.escalations.values()]
       .filter((r) => r.agent === agent && r.status !== 'open' && r.closed_at)
       .sort((a, b) => String(a.closed_at).localeCompare(String(b.closed_at)))
@@ -631,7 +659,7 @@ export class EscalationStore {
     const closedMs = recent ? now - Date.parse(recent.closed_at) : Infinity
     const after = Number.isFinite(closedMs) && closedMs <= graceMs ? recent.id : null
     const id = `note-${++this.noteSeq}`
-    this._append({ type: 'agent_note', id, agent, text, after, by, instance, label })
+    this._append({ type: 'agent_note', id, agent, text, after, by, instance, label, handoff_for: handoffFor })
     return { id, after }
   }
 
@@ -668,7 +696,53 @@ export class EscalationStore {
       : ''
     const text = `a human answered ${record.id}, a question asked on this ticket that no live agent could receive.`
       + `\nquestion: ${record.prompt}\nanswer: ${record.answer}${att}`
-    return this.queueAgentNote(record.agent, text, { by: record.answered_by ?? null })
+    return this.queueAgentNote(record.agent, text, { by: record.answered_by ?? null, handoffFor: record.id })
+  }
+
+  // #369: the recorded answer a re-asked question may take back at once.
+  //
+  // The daemon restarts, the blocked call dies, the operator answers the card
+  // anyway, and #139 parks question and answer as a note. The agent then asks
+  // the same thing again. Supersede cannot help, because it only closes OPEN
+  // records and this one is answered — so a second card carried the same
+  // question and the operator paid the wait twice.
+  //
+  // TWO conditions, and both are narrow on purpose.
+  //
+  // The payload hash is EXACT here, where supersede deliberately dropped it
+  // (#336). Supersede asks "is this the same CALL", and a re-send may explain
+  // itself in new words. This asks "is this the same QUESTION", and only the
+  // question can decide that: an agent that asks something new of the same kind
+  // must never be handed the old answer instead of a human.
+  //
+  // The pending note is the WINDOW. A delivered answer parks no note, so this
+  // can only ever serve one nothing has read, and the moment the agent drains
+  // that note the answer has arrived and a later re-ask is a real second
+  // question. That needs no clock, and a clock would only guess at the same
+  // fact the queue already states.
+  //
+  // Only an ANSWERED record replays. A cancelled or lapsed one holds no answer,
+  // and a superseded one has a live successor to wait on.
+  recordedAnswerFor({ agent, kind, prompt, options, preview_url }) {
+    const payload_hash = EscalationStore.payloadHash({ kind, prompt, options, preview_url })
+    const matches = [...this.escalations.values()]
+      .filter((r) => r.agent === agent && r.kind === kind && r.status === 'answered' && r.payload_hash === payload_hash)
+      .sort((a, b) => String(a.closed_at).localeCompare(String(b.closed_at)))
+    // Newest first: if one question was somehow answered twice, the last answer
+    // is the operator's current mind.
+    for (const record of matches.reverse()) {
+      const note = this.notes.get(this.handoffNotes.get(record.id))
+      if (note?.pending) return { record, note }
+    }
+    return null
+  }
+
+  // The take, journalled as one act. The caller has already decided the record
+  // answers its question — this is where the answer stops being a queued note
+  // and becomes the return value of the call that asked.
+  takeRecordedAnswer(record, note) {
+    this._append({ type: 'esc_replayed', id: record.id, agent: record.agent, ticket: record.ticket, note: note.id })
+    return record
   }
 
   // The #208 rule, in one predicate: a note stamped with an instance belongs

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -3098,6 +3098,45 @@ describe('request_review: the one gate (#54 item 2)', () => {
     assert.ok(events.some((e) => e.type === 'review_answered' && e.approved === false))
   })
 
+  // #369: the gate handed back an answer the operator had already given, so no
+  // second card opened. The agent has to be told, and the answer has to keep
+  // its meaning — the line rides in front of the ORDER, never in front of the
+  // word `approve`, which is classified by a narrow set.
+  test('a recorded approval says so, and still orders the merge', async () => {
+    const d = makeDispatcher({}, {
+      askReview: async () => ({ text: 'approve', status: 'answered', recorded: '[recorded answer — a human answered this exact question by alp at T, on esc-12, while no call of yours was live.]' }),
+    })
+    liveAgent(d)
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+
+    assert.equal(r.approved, true)
+    assert.match(r.text, /recorded answer .* on esc-12/)
+    assert.match(r.text, /APPROVED by the human/)
+    assert.match(r.text, /gh pr merge/)
+    assert.ok(events.some((e) => e.type === 'review_answered' && e.approved === true && e.recorded === true))
+  })
+
+  test('a recorded rejection carries the same line in front of the human words', async () => {
+    const d = makeDispatcher({}, {
+      askReview: async () => ({ text: 'rename the flag', status: 'answered', recorded: '[recorded answer — on esc-12]' }),
+    })
+    liveAgent(d)
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+
+    assert.equal(r.approved, false)
+    assert.match(r.text, /recorded answer/)
+    assert.match(r.text, /NOT approved/)
+    assert.match(r.text, /rename the flag/)
+  })
+
+  test('an ordinary gate carries no such line', async () => {
+    const d = makeDispatcher({}, { askReview: async () => ({ text: 'approve', status: 'answered' }) })
+    liveAgent(d)
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+    assert.doesNotMatch(r.text, /recorded answer/)
+    assert.ok(events.some((e) => e.type === 'review_answered' && e.recorded === undefined))
+  })
+
   test('a cancelled gate is not a rejection: nothing is merged and nothing resolved', async () => {
     const d = makeDispatcher({}, { askReview: async () => ({ text: 'aborted: a human cancelled this escalation', status: 'cancelled' }) })
     liveAgent(d)

--- a/daemon/test/recordedanswer.test.mjs
+++ b/daemon/test/recordedanswer.test.mjs
@@ -1,0 +1,379 @@
+// A re-asked question is answered from the record (#369).
+//
+// The fault this closes, as it really ran: a daemon restart kills the call that
+// is asking, the card it opened stays live, the operator answers it, and #139
+// parks question and answer as an agent note. The agent then re-asks. Supersede
+// cannot help, because it only closes OPEN records and this one is answered. So
+// a second card carried the same question, the operator answered it twice, and
+// the first answer only arrived behind the second — `drainNotes()` runs after
+// the answer resolves.
+//
+// The cure has two conditions and no clock: the payload must match word for
+// word, and the parked note must still be unread. The note IS the window.
+//
+// Two levels here. The store half is a unit test, because the rule lives in the
+// reduction. The wire half boots the REAL daemon twice on one data dir and
+// drives it with a real MCP client, because nothing smaller exercises the path
+// that actually failed: the resolver has to die with a process for `settle` to
+// find none.
+
+import { test, describe, before, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { EscalationStore } from '../src/store.mjs'
+import { sameDigest } from '../src/diffdigest.mjs'
+import { REVIEW_KIND } from '../src/lifecycle.mjs'
+import { TOKEN_HEADER, mintAgentToken } from '../src/agenttoken.mjs'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
+import { sandboxYaml } from './fixtures/sandbox.mjs'
+
+const DIR = path.dirname(fileURLToPath(import.meta.url))
+const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
+
+function request(port, method, urlPath, { headers = {}, body = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method, path: urlPath, headers }, (res) => {
+      let data = ''
+      res.on('data', (c) => { data += c })
+      res.on('end', () => resolve({ status: res.statusCode, body: data }))
+    })
+    req.once('error', reject)
+    if (body !== null) req.write(body)
+    req.end()
+  })
+}
+
+// The whole fault in one helper: open, answer with nothing waiting, park the
+// answer. That is what a restart leaves behind.
+function parkedAnswer(store, { agent = 'curia-9', ticket = '9', kind = 'free-text', prompt, options, answer, attachments = [], by = 'alp', diff = null } = {}) {
+  const { record } = store.open({ agent, ticket, kind, prompt, options, diff })
+  store.answer(record.id, { answer, attachments, by, via: 'button' })
+  store.queueRecordedAnswer(store.get(record.id))
+  return store.get(record.id)
+}
+
+describe('the recorded answer a re-asked question takes back (#369, store)', () => {
+  let dir, store
+  const dirs = []
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-recorded-'))
+    dirs.push(dir)
+    store = new EscalationStore(dir)
+  })
+
+  after(() => { for (const d of dirs) fs.rmSync(d, { recursive: true, force: true }) })
+
+  test('the same question, asked again while the note is unread, finds its answer', () => {
+    const record = parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    const hit = store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' })
+    assert.equal(hit?.record.id, record.id)
+    assert.equal(hit.record.answer, '9012')
+    assert.equal(hit.note.handoff_for, record.id, 'the note names the record it carries')
+  })
+
+  test('taking it drops the note, so the answer is said once', () => {
+    const record = parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    const hit = store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' })
+    store.takeRecordedAnswer(hit.record, hit.note)
+    assert.deepEqual(store.takeAgentNotes('curia-9'), [], 'the drain has nothing left to deliver')
+    assert.equal(store.get(record.id).replayed_at != null, true, 'the record says the answer was served again')
+  })
+
+  test('and it cannot be taken twice', () => {
+    parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    const hit = store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' })
+    store.takeRecordedAnswer(hit.record, hit.note)
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' }), null)
+  })
+
+  test('an answer the agent has already drained is delivered, so nothing replays', () => {
+    parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    store.takeAgentNotes('curia-9')
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' }), null)
+  })
+
+  // The load-bearing refusal. Supersede keys on the agent and the kind (#336);
+  // this must not, or a genuinely new question is answered by an old answer
+  // instead of by a human.
+  test('a DIFFERENT question of the same kind never takes that answer', () => {
+    parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port, and which path?' }), null)
+  })
+
+  test('every part of the payload is part of the question', () => {
+    parkedAnswer(store, { kind: 'choice', prompt: 'which harness?', options: ['claude', 'codex'], answer: 'claude' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'choice', prompt: 'which harness?', options: ['claude', 'codex'] })?.record.answer, 'claude')
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'choice', prompt: 'which harness?', options: ['claude', 'codex', 'pi'] }), null)
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which harness?', options: ['claude', 'codex'] }), null)
+  })
+
+  test('another agent asking the same words gets nothing', () => {
+    parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-4', kind: 'free-text', prompt: 'which port?' }), null)
+  })
+
+  test('an answer that reached its own live call parks no note and never replays', () => {
+    const { record } = store.open({ agent: 'curia-9', ticket: '9', kind: 'free-text', prompt: 'which port?' })
+    store.answer(record.id, { answer: '9012', by: 'alp', via: 'button' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' }), null)
+  })
+
+  test('a cancelled question holds no answer to hand back', () => {
+    const { record } = store.open({ agent: 'curia-9', ticket: '9', kind: 'free-text', prompt: 'which port?' })
+    store.cancel(record.id, { by: 'alp' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' }), null)
+  })
+
+  test('the answer and its window survive a restart, because both are journalled', () => {
+    parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    const reborn = new EscalationStore(dir)
+    const hit = reborn.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' })
+    assert.equal(hit?.record.answer, '9012')
+    reborn.takeRecordedAnswer(hit.record, hit.note)
+    assert.equal(new EscalationStore(dir).recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' }), null)
+  })
+
+  // The journal is append-only, and every hand-off written before this ticket
+  // carries no `handoff_for`. Those notes keep the delivery they always had.
+  test('a hand-off note from before this ticket is delivered by the drain alone', () => {
+    const { record } = store.open({ agent: 'curia-9', ticket: '9', kind: 'free-text', prompt: 'which port?' })
+    store.answer(record.id, { answer: '9012', by: 'alp', via: 'button' })
+    store.queueAgentNote('curia-9', 'a human answered esc-1 ...', { by: 'alp' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' }), null)
+    assert.equal(store.takeAgentNotes('curia-9').length, 1)
+  })
+
+  test('the newest answer wins when one question was somehow answered twice', () => {
+    parkedAnswer(store, { prompt: 'which port?', answer: '9012' })
+    parkedAnswer(store, { prompt: 'which port?', answer: '9013' })
+    assert.equal(store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'which port?' })?.record.answer, '9013')
+  })
+
+  test('the attachments ride with the recorded answer', () => {
+    parkedAnswer(store, { prompt: 'does this look right?', answer: 'yes', attachments: ['/data/attachments/esc-1/shot.png'] })
+    const hit = store.recordedAnswerFor({ agent: 'curia-9', kind: 'free-text', prompt: 'does this look right?' })
+    assert.deepEqual(hit.record.attachments, ['/data/attachments/esc-1/shot.png'])
+  })
+})
+
+// The gate's extra guard (#369 question 4): a recorded approval is handed back
+// only when the code is still the code the operator approved.
+describe('the digest guard on a recorded approval (#369)', () => {
+  const digest = (over = {}) => ({
+    uncommitted: false, files: 2, added: 30, deleted: 4, capped: false,
+    list: [
+      { path: 'daemon/src/store.mjs', status: 'M', added: 25, deleted: 4 },
+      { path: 'daemon/test/store.test.mjs', status: 'A', added: 5, deleted: 0 },
+    ],
+    ...over,
+  })
+
+  test('the same measurement matches itself', () => {
+    assert.equal(sameDigest(digest(), digest()), true)
+  })
+
+  test('a changed total, a changed path, or a changed count is a different diff', () => {
+    assert.equal(sameDigest(digest(), digest({ added: 31 })), false)
+    assert.equal(sameDigest(digest(), digest({ files: 3 })), false)
+    assert.equal(sameDigest(digest(), digest({ list: [{ path: 'daemon/src/index.mjs', status: 'M', added: 25, deleted: 4 }, { path: 'daemon/test/store.test.mjs', status: 'A', added: 5, deleted: 0 }] })), false)
+  })
+
+  // Null is not empty (#355), and it is not evidence either.
+  test('a gate curia could not count never matches, not even another uncounted one', () => {
+    assert.equal(sameDigest(null, null), false)
+    assert.equal(sameDigest(digest(), null), false)
+  })
+
+  test('a recorded gate answer is found by the same rule as any other question', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-recorded-gate-'))
+    try {
+      const store = new EscalationStore(dir)
+      parkedAnswer(store, { kind: REVIEW_KIND, prompt: 'summary + charting', answer: 'approve', diff: digest() })
+      const hit = store.recordedAnswerFor({ agent: 'curia-9', kind: REVIEW_KIND, prompt: 'summary + charting' })
+      assert.equal(hit.record.answer, 'approve')
+      assert.equal(sameDigest(hit.record.diff, digest()), true, 'the stored digest is what the guard compares')
+      assert.equal(sameDigest(hit.record.diff, digest({ files: 5, added: 400 })), false, 'three more commits and the operator sees a fresh gate')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// The shipped path, twice booted. The resolver must die with a PROCESS — that
+// is the one thing no in-process test can stage, and it is the whole premise of
+// the fault.
+describe('the re-ask takes the recorded answer (#369, real boot pair + real MCP client)', () => {
+  let tmp
+  let child
+  let port
+  let watch
+
+  const armed = (agent) => {
+    const token = mintAgentToken(path.join(tmp, 'data'), agent)
+    return { requestInit: { headers: { [TOKEN_HEADER]: token } } }
+  }
+
+  const bootDaemon = async () => {
+    child = spawn(process.execPath, [DAEMON], {
+      env: {
+        ...process.env,
+        PORT: String(port),
+        CURIA_CONFIG_DIR: path.join(tmp, 'config'),
+        CURIA_DATA_DIR: path.join(tmp, 'data'),
+        PATH: `${path.join(tmp, 'shim')}:${process.env.PATH}`,
+        DISCORD_BOT_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    watch = watchDaemon(child)
+    await waitForBoot(watch, async () => {
+      try {
+        return (await request(port, 'GET', '/state')).status === 200
+      } catch { return false }
+    }, 'the /state route')
+  }
+
+  const killDaemon = () => new Promise((resolve) => {
+    if (!child || child.exitCode !== null) return resolve()
+    child.once('exit', resolve)
+    child.kill('SIGKILL')
+  })
+
+  const connect = async (agent, ticket) => {
+    const client = new Client({ name: 'curia-369-test', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp?agent=${agent}&ticket=${ticket}`), armed(agent))
+    await client.connect(transport)
+    return client
+  }
+
+  const call = async (agent, ticket, name, args) => {
+    const client = await connect(agent, ticket)
+    try {
+      return await client.callTool({ name, arguments: args }, undefined, { timeout: 30_000 })
+    } finally {
+      await client.close().catch(() => {})
+    }
+  }
+
+  before(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-369-test-'))
+    const cfgDir = path.join(tmp, 'config')
+    const shim = path.join(tmp, 'shim')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    fs.mkdirSync(shim, { recursive: true })
+    for (const bin of ['gh', 'tmux', 'tailscale']) {
+      const p = path.join(shim, bin)
+      fs.writeFileSync(p, '#!/bin/sh\nexit 1\n')
+      fs.chmodSync(p, 0o755)
+    }
+    const [daemonPort, ttydPort, servePort, proxyPort] = [await freePort(), await freePort(), await freePort(), await freePort()]
+    port = daemonPort
+    fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
+      'watch:',
+      '  - repo: example/fixture',
+      '    mode: ready-for-agent',
+      'dispatch:',
+      '  auto_dispatch: false',
+      '  max_concurrent: 1',
+      '  poll_interval_s: 60',
+      `  workspace_root: ${path.join(tmp, 'work')}`,
+      '  ready_timeout_s: 5',
+      '  confirm_ttl_h: 1',
+      'attach:',
+      `  ttyd_port: ${ttydPort}`,
+      `  serve_port: ${servePort}`,
+      'identity:',
+      '  allow: [tester@example.com]',
+      `  proxy_port: ${proxyPort}`,
+      ...skillsYaml(seedSkillsRoot(tmp)),
+      ...sandboxYaml(),
+      '',
+    ].join('\n'))
+    fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
+      'defaults:',
+      '  untyped: sonnet',
+      'models:',
+      '  sonnet: { provider: anthropic, harness: claude }',
+      'harnesses:',
+      '  claude:',
+      '    template: claude --model {model} "$(cat {prompt_file})"',
+      "    ready: '⏵⏵|bypass permissions'",
+      '    tool_channel_grace_s: 15',
+      '',
+    ].join('\n'))
+  })
+
+  after(async () => {
+    await killDaemon()
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  test('the operator waits once: the second ask returns at once and opens no card', async () => {
+    await bootDaemon()
+    // The agent asks. The card opens. The daemon then dies under the call, so
+    // its resolver dies with it — the #56 outage, exactly.
+    const asking = await connect('curia-369', '369')
+    asking
+      .callTool({ name: 'ask_human', arguments: { prompt: 'which port should the dev server bind?', kind: 'free-text' } }, undefined, { timeout: 60_000 })
+      .catch(() => { /* this call dies with the daemon, which IS the fault */ })
+    const open = await (async () => {
+      const deadline = Date.now() + 10_000
+      for (;;) {
+        const state = JSON.parse((await request(port, 'GET', '/state')).body)
+        if (state.open_escalations[0]) return state.open_escalations[0]
+        if (Date.now() > deadline) throw new Error('timed out waiting for the escalation to open')
+        await new Promise((r) => setTimeout(r, 50))
+      }
+    })()
+    await killDaemon()
+    await asking.close().catch(() => {})
+
+    // Daemon B recovers the record open, and the operator answers it. Nothing
+    // is waiting, so #139 parks the answer.
+    await bootDaemon()
+    const answered = await request(port, 'POST', '/answer', {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: open.id, answer: '9012' }),
+    })
+    assert.equal(JSON.parse(answered.body).ok, true)
+
+    // The agent re-asks, word for word, as its standing orders tell it to.
+    const second = await call('curia-369', '369', 'ask_human', { prompt: 'which port should the dev server bind?', kind: 'free-text' })
+    const text = second.content.map((c) => c.text ?? '').join('\n')
+    assert.match(text, /9012/, 'the answer came back on the call that asked')
+    assert.match(text, /recorded answer/, 'and the agent is told it is a recorded one')
+    assert.match(text, new RegExp(open.id), 'named by the record it came from')
+
+    assert.deepEqual(
+      JSON.parse((await request(port, 'GET', '/state')).body).open_escalations,
+      [],
+      'no second card: nobody was asked twice',
+    )
+
+    // One fact, one delivery: the parked note left with the answer, so the next
+    // tool result does not say it again. `notify` returns at once and drains the
+    // queue, which makes it the cheapest reader of what is left in it.
+    const after = await call('curia-369', '369', 'notify', { message: 'binding 9012' })
+    assert.doesNotMatch(
+      after.content.map((c) => c.text ?? '').join('\n'),
+      /operator note/,
+      'the note went with the answer rather than riding the next tool result',
+    )
+
+    const events = fs.readFileSync(path.join(tmp, 'data', 'events.jsonl'), 'utf8')
+      .split('\n').filter(Boolean).map((l) => JSON.parse(l))
+    const replay = events.find((e) => e.type === 'esc_replayed')
+    assert.ok(replay, 'the take is journalled, so a reader can see the operator was asked once')
+    assert.equal(replay.id, open.id)
+    assert.equal(replay.agent, 'curia-369')
+  })
+})

--- a/docs/adr/0005-escalation-contract.md
+++ b/docs/adr/0005-escalation-contract.md
@@ -1,7 +1,7 @@
 # ADR-0005: The escalation contract
 
 **Status**: accepted (2026-07)
-**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200), [A cancel confirm lands in the ticket thread, not where the operator typed it (#218)](https://github.com/alp82/curia/issues/218), [The nudge dies; the render-retry stands alone (#261)](https://github.com/alp82/curia/issues/261), [The escalation contract meets round-by-round grilling (#285)](https://github.com/alp82/curia/issues/285), [A re-sent escalation leaves its original open forever (#336)](https://github.com/alp82/curia/issues/336)
+**Provenance**: [Define the escalation contract (#11)](https://github.com/alp82/curia/issues/11), [Build the Discord bridge + durable escalation record (#31)](https://github.com/alp82/curia/issues/31), [Escalation live-checks (#34)](https://github.com/alp82/curia/issues/34), [A blocked agent must not read as a crashed one (#47)](https://github.com/alp82/curia/issues/47), [A cancelled question ends nothing, and the agent asks it again (#200)](https://github.com/alp82/curia/issues/200), [A cancel confirm lands in the ticket thread, not where the operator typed it (#218)](https://github.com/alp82/curia/issues/218), [The nudge dies; the render-retry stands alone (#261)](https://github.com/alp82/curia/issues/261), [The escalation contract meets round-by-round grilling (#285)](https://github.com/alp82/curia/issues/285), [A re-sent escalation leaves its original open forever (#336)](https://github.com/alp82/curia/issues/336), [A re-asked question is answered from the record (#369)](https://github.com/alp82/curia/issues/369)
 
 ## Context
 
@@ -36,6 +36,18 @@ Agents need human answers from any device, with waits measured in hours, and the
 
   Silence still resolves nothing. Every close here needs a positive act by the agent: its next call, or its result. The typed answer stays the operator's escape hatch. It is no longer the only thing that can close these records.
 
+- **Amended by [#369](https://github.com/alp82/curia/issues/369)**: a question re-asked word for word takes back the answer that is already recorded for it, and no second card opens.
+
+  Supersession cannot reach this case. It only closes OPEN records, and this one is answered. A daemon restart kills the call that is asking. The card stays live and the operator answers it. Nothing is waiting, so [#139](https://github.com/alp82/curia/issues/139) records the answer and parks question and answer as an agent note. The agent then re-asks. A second card carries the same question, the operator answers twice, and the first answer only arrives behind the second, because the note queue drains after the answer resolves. The operator pays the wait twice for one question.
+
+  So `ask_human` looks for a recorded answer before it opens anything. Two conditions must both hold, and both are narrow. The payload must match word for word, which is the exact opposite of the #336 supersession key and for the opposite reason: supersession asks whether this is the same call, and this asks whether it is the same question. An agent that asks something new of the same kind must reach a human. The parked note must still be unread, which is the whole window. A delivered answer parks no note, so this can only ever serve an answer nothing has read, and the moment the agent drains that note the answer has arrived. There is no clock, because a clock would only guess at what the queue already states.
+
+  The call takes the note with the answer. One fact, one delivery, per [ADR-0013](0013-one-voice-per-fact.md): the answer comes back as the answer, so a note that also said it would state the same fact twice on one tool result.
+
+  The agent is told. One line above the answer names the record, the person and the moment. Without it the agent reads a recorded answer as a fresh reply to the exact wording it just sent, which includes the re-send note the standing orders make it add.
+
+  The review gate takes the same rule plus one guard. The code must still be the code the operator approved, so the diff digest measured for this call must equal the digest on the recorded gate ([#355](https://github.com/alp82/curia/issues/355)). A digest curia could not count never matches, not even another uncounted one. A changed digest opens a fresh gate.
+
 ## Consequences
 
 - The bridge renders and captures, and it never interprets. All routing keys on the escalation id, not on who or where.
@@ -45,3 +57,4 @@ Agents need human answers from any device, with waits measured in hours, and the
 - A round is one escalation record, so it holds one answer, one timestamp and one supersession key (#285). That key is the agent and the kind (#336), and the question itself is no part of it. An agent that re-asks the same round supersedes its own record, whatever it changed in the words or in the `recommended` flag.
 - A round with no size limit can outrun one Discord message (#285). The existing paragraph-aware split (#119) carries it, and the buttons ride the last chunk, so the ✅ sits below every question it answers. The cost is real: a long round is a scroll before it is answerable, and the agent trades against that itself.
 - The review gate of [ADR-0008](0008-resolved-means-merged.md) is one more escalation kind and inherits all of this behavior. It is an agent escalation, so it stays in the ticket thread. The confirm is the one kind that moves.
+- An `ask_human` call can now return without asking anybody (#369). It returns only an answer a human really gave to that same question, and it says so in the tool result. Every other call still blocks until a human answers it.


### PR DESCRIPTION
Ticket: alp82/curia#369 — [A re-asked question is answered from the record](https://github.com/alp82/curia/issues/369)

A re-asked question takes back the answer curia already recorded for it (#369).

The fault: a daemon restart kills the call that is asking, the operator answers the live card, and #139 parks the answer as a note. The agent re-asks. Supersede only closes OPEN records, so a second card carried the same question and the operator answered twice.

`ask_human` now looks for a recorded answer first. Two conditions, both narrow: the payload matches word for word, and the parked note is still unread. A delivered answer parks no note, so this can only serve an answer nothing has read. No clock.

The call takes the note with the answer, so one fact is said once. The agent is told: one line names the record, the person and the moment.

The review gate takes the same rule plus a guard: the diff digest measured now must equal the digest on the recorded gate (#355), so a recorded approval covers the code the operator really approved.

ADR-0005 carries the amendment, CONTEXT.md gains the Recorded answer entry, and the console feed says when nobody was asked twice.

Tests: 18 new in `recordedanswer.test.mjs`, three at the gate in `dispatch.test.mjs`. The wire test boots the real daemon twice on one data dir and drives it with a real MCP client, because the resolver has to die with a process. Every new assertion was checked against a mutation of the shipped code. Suite: 2041 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-369`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `e3a449b` A re-asked question is answered from the record (alp82/curia#369)