### PR TITLE
The schema and the fourteen queries (alp82/curia#321)

### DIFF
--- a/prototypes/journal-schema/README.md
+++ b/prototypes/journal-schema/README.md
@@ -1,0 +1,42 @@
+# The schema and the fourteen queries
+
+The prototype for [alp82/curia#321](https://github.com/alp82/curia/issues/321), on
+[the store map #316](https://github.com/alp82/curia/issues/316). Throwaway code under `prototypes/`
+(ADR-0008). It answers one question: does one table carry 96 event types and all fourteen questions,
+and what does it cost?
+
+```sh
+node prototypes/journal-schema/run.mjs    # build, check, measure — writes results.json
+node prototypes/journal-schema/demo.mjs   # write demo.html from results.json
+```
+
+`run.mjs` needs Node 24 for `node:sqlite`. It writes its fixtures to a temp directory and touches
+nothing in `daemon/data`.
+
+## What is here
+
+| file | what it holds |
+|---|---|
+| `schema.sql` | The proposal: one table, four indexes, one trigger. |
+| `schema-no-epoch.sql` | The same table without the `epoch` column, so the stamp costs a number. |
+| `journal.mjs` | The write path: one journal line in, one row out, through `normalizeEvent`. |
+| `synth.mjs` | A synthetic journal of the measured shape, dispatches interleaved, oldest fifth in the pre-#184 spelling. |
+| `oracle.mjs` | The fourteen questions as the daemon answers them today, ported out of `dispatch.mjs`. |
+| `queries.mjs` | The fourteen as SQL, plus the five the operator types from the daemon README. |
+| `run.mjs` | Builds, checks every query against the oracle, times both, measures the write and the disk. |
+| `demo.mjs` | Turns `results.json` into `demo.html`. Every number on the page comes from the run. |
+| `results.json` | The last run's numbers, committed so the verdict can be read without running anything. |
+
+## The check
+
+`run.mjs` does not assert that the SQL looks right. It runs every query and the daemon's own loop over
+the same journal and compares the answers, for every ticket and every agent the journal holds, at four
+sizes. A query that disagrees with the loop is wrong by definition — including where the daemon's rule
+is surprising.
+
+## What it does not do
+
+It does not touch `daemon/src`, and it is not the build. The migration
+([#323](https://github.com/alp82/curia/issues/323)), the boot replay
+([#322](https://github.com/alp82/curia/issues/322)) and the write path behind 129 `logEvent` call sites
+are their own tickets.

--- a/prototypes/journal-schema/demo.html
+++ b/prototypes/journal-schema/demo.html
@@ -47,18 +47,18 @@
   fourteen questions exactly as the daemon's loop answers them: <b>17,307 checks</b>
   over four journal sizes, <b>0 mismatches</b>.</p>
   <ul>
-    <li><b>The thirteen keyed questions cost 0.192 ms together</b>, and the number does not
-    move with history: 0.284 ms at 250,000 events. Today one of them costs a
-    29.58 ms whole read.</li>
+    <li><b>The thirteen keyed questions cost 0.224 ms together</b>, and the number does not
+    move with history: 0.328 ms at 250,000 events. Today one of them costs a
+    28.49 ms whole read.</li>
     <li><b>The Stop hook is the win.</b> It pays one whole read per turn of every agent today. It pays
     three indexed seeks after this.</li>
     <li><b>One question stays proportional to history.</b> Question 12 asks about every ticket at once, and
-    reconcile runs it once a pass: 1.4241 ms today, 186.5719 ms at 250,000 — against the
-    2044.9 ms read it replaces.</li>
-    <li><b>A committed write costs 1.185 ms</b> with WAL and <code>synchronous=full</code>, against
-    1.005 ms without the epoch trigger. At 404 events a day that difference is a tenth of a second a day.</li>
+    reconcile runs it once a pass: 1.0535 ms today, 233.8908 ms at 250,000 — against the
+    2473.92 ms read it replaces.</li>
+    <li><b>A committed write costs 1.152 ms</b> with WAL and <code>synchronous=full</code>, against
+    0.874 ms without the epoch trigger. At 404 events a day that difference is a tenth of a second a day.</li>
     <li><b>The journal costs about 1.9× the text file</b>:
-    2.23 MB against 1.19 MB today. The verbatim <code>body</code> is the record,
+    2.29 MB against 1.19 MB today. The verbatim <code>body</code> is the record,
     and the columns and indexes are what make it answer.</li>
     <li><b>The five queries in the daemon README all run</b>, on a journal whose oldest fifth carries the
     pre-#184 spelling.</li>
@@ -73,34 +73,34 @@
   <tr>
     <td>4,282 <span class="tag">today</span></td>
     <td>1.19 MB</td>
-    <td>2.23 MB</td>
-    <td>29.58 ms</td>
-    <td>0.192 ms</td>
-    <td>1.4241 ms</td>
+    <td>2.29 MB</td>
+    <td>28.49 ms</td>
+    <td>0.224 ms</td>
+    <td>1.0535 ms</td>
   </tr>
   <tr>
     <td>30,000</td>
     <td>8.35 MB</td>
-    <td>15.45 MB</td>
-    <td>194.01 ms</td>
-    <td>0.221 ms</td>
-    <td>23.563 ms</td>
+    <td>15.89 MB</td>
+    <td>195.49 ms</td>
+    <td>0.250 ms</td>
+    <td>19.1553 ms</td>
   </tr>
   <tr>
     <td>60,000</td>
     <td>16.76 MB</td>
-    <td>31.30 MB</td>
-    <td>384.97 ms</td>
-    <td>0.234 ms</td>
-    <td>50.4635 ms</td>
+    <td>32.15 MB</td>
+    <td>421.98 ms</td>
+    <td>0.254 ms</td>
+    <td>54.3737 ms</td>
   </tr>
   <tr>
     <td>250,000</td>
     <td>69.99 MB</td>
-    <td>131.83 MB</td>
-    <td>2044.9 ms</td>
-    <td>0.284 ms</td>
-    <td>186.5719 ms</td>
+    <td>135.52 MB</td>
+    <td>2473.92 ms</td>
+    <td>0.328 ms</td>
+    <td>233.8908 ms</td>
   </tr>
 </table>
 </div>
@@ -143,6 +143,12 @@ create table events (
   -- The agent session, in today's spelling. A pre-#184 line carries
   -- `"worker": "curia-170"` in `body` and `curia-170` here.
   agent  text,
+
+  -- The repo the event is about, or null. A column because the operator types
+  -- it, which is the rule that made `agent` one. It gets NO index of its own:
+  -- curia runs one or two repos, so `where repo='alp82/curia'` selects nearly
+  -- every row and SQLite scans whatever we build.
+  repo   text,
 
   -- The dispatch this row belongs to: the id of the `dispatch_claimed` or
   -- `agent_spawned` row that opened the ticket's latest epoch at the moment
@@ -195,7 +201,7 @@ end;
 <div class="scroll">
 <table>
   <tr><th>on disk today (4,282 events)</th><th></th></tr>
-  <tr><td>events</td><td>1.56 MB</td></tr><tr><td>events_agent_type</td><td>0.18 MB</td></tr><tr><td>events_ticket_type</td><td>0.15 MB</td></tr><tr><td>events_epoch_type</td><td>0.13 MB</td></tr><tr><td>events_type</td><td>0.13 MB</td></tr><tr><td>events_ticket_epoch</td><td>0.07 MB</td></tr>
+  <tr><td>events</td><td>1.63 MB</td></tr><tr><td>events_agent_type</td><td>0.18 MB</td></tr><tr><td>events_ticket_type</td><td>0.15 MB</td></tr><tr><td>events_epoch_type</td><td>0.13 MB</td></tr><tr><td>events_type</td><td>0.13 MB</td></tr><tr><td>events_ticket_epoch</td><td>0.07 MB</td></tr>
 </table>
 </div>
 
@@ -206,7 +212,7 @@ is surprising.</p>
 
   <article class="q">
     <h3><span class="n">1</span> Did this dispatch push a pull request?</h3>
-    <p class="meta">shape B · #epochScan · <b>0.0321 ms</b> today, <b>0.0274 ms</b> at 250,000 · the loop it replaces: 0.4397 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape B · #epochScan · <b>0.0266 ms</b> today, <b>0.05 ms</b> at 250,000 · the loop it replaces: 0.4481 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))
      or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer</pre>
@@ -222,7 +228,7 @@ SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details
   </article>
   <article class="q">
     <h3><span class="n">2</span> Did a human approve this dispatch at the gate?</h3>
-    <p class="meta">shape B · #epochScan · <b>0.0156 ms</b> today, <b>0.0222 ms</b> at 250,000 · the loop it replaces: 0.327 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape B · #epochScan · <b>0.0159 ms</b> today, <b>0.0299 ms</b> at 250,000 · the loop it replaces: 0.2941 ms <i>plus</i> a 28.49 ms read</p>
     <p class="note">Predicate-narrowed: only a review_answered whose `approved` is true counts.</p>
     <pre>select (exists(select 1 from events where ticket = :t and type = 'review_answered'
                 and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)
@@ -240,7 +246,7 @@ SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details
   </article>
   <article class="q">
     <h3><span class="n">3</span> How many times has the Stop hook held this agent?</h3>
-    <p class="meta">shape C · #epochScan · <b>0.0125 ms</b> today, <b>0.0403 ms</b> at 250,000 · the loop it replaces: 0.3734 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape C · #epochScan · <b>0.0133 ms</b> today, <b>0.0183 ms</b> at 250,000 · the loop it replaces: 0.4824 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select count(*) as answer from events
  where id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t)
@@ -252,7 +258,7 @@ SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details
   </article>
   <article class="q">
     <h3><span class="n">4</span> Did the merge outrun the reviewer?</h3>
-    <p class="meta">shape A · #verdictIsLate · <b>0.0102 ms</b> today, <b>0.0144 ms</b> at 250,000 · the loop it replaces: 0.2104 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #verdictIsLate · <b>0.012 ms</b> today, <b>0.0128 ms</b> at 250,000 · the loop it replaces: 0.2702 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select coalesce(
   (select max(id) from events where ticket = :t and type = 'ticket_resolved')
@@ -265,7 +271,7 @@ SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)</pre
   </article>
   <article class="q">
     <h3><span class="n">5</span> When was this ticket last claimed?</h3>
-    <p class="meta">shape A · #liveUnjudgedVerdict · <b>0.0111 ms</b> today, <b>0.0118 ms</b> at 250,000 · the loop it replaces: 0.1333 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #liveUnjudgedVerdict · <b>0.0116 ms</b> today, <b>0.0185 ms</b> at 250,000 · the loop it replaces: 0.1199 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select ts from events
  where ticket = :t and type = 'dispatch_claimed'
@@ -274,19 +280,19 @@ SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)</pre
   </article>
   <article class="q">
     <h3><span class="n">6</span> Which repo was this ticket last dispatched against?</h3>
-    <p class="meta">shape A · #epochRepo · <b>0.0192 ms</b> today, <b>0.0379 ms</b> at 250,000 · the loop it replaces: 0.1687 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #epochRepo · <b>0.0174 ms</b> today, <b>0.032 ms</b> at 250,000 · the loop it replaces: 0.2645 ms <i>plus</i> a 28.49 ms read</p>
     <p class="note">Predicate-narrowed: the last dispatch event that CARRIES a repo.</p>
-    <pre>select json_extract(body, '$.repo') as repo from events
+    <pre>select repo from events
  where ticket = :t
    and type in ('dispatch_claimed', 'agent_spawned')
-   and json_extract(body, '$.repo') &lt;&gt; ''
+   and repo &lt;&gt; ''
  order by id desc limit 1</pre>
     <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)
 USE TEMP B-TREE FOR ORDER BY</pre></details>
   </article>
   <article class="q">
     <h3><span class="n">7</span> Was the last dispatch a charting one, and what rode it?</h3>
-    <p class="meta">shape A · #epochCharting · <b>0.0114 ms</b> today, <b>0.0158 ms</b> at 250,000 · the loop it replaces: 0.1056 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #epochCharting · <b>0.0195 ms</b> today, <b>0.0218 ms</b> at 250,000 · the loop it replaces: 0.1213 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select json_extract(body, '$.kind') = 'charting' as charting,
        json_extract(body, '$.instruction') as instruction,
@@ -298,7 +304,7 @@ USE TEMP B-TREE FOR ORDER BY</pre></details>
   </article>
   <article class="q">
     <h3><span class="n">8</span> Which model and harness was this session last spawned on?</h3>
-    <p class="meta">shape A · #epochSpawn · <b>0.0137 ms</b> today, <b>0.0224 ms</b> at 250,000 · the loop it replaces: 0.1026 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #epochSpawn · <b>0.0156 ms</b> today, <b>0.0222 ms</b> at 250,000 · the loop it replaces: 0.1449 ms <i>plus</i> a 28.49 ms read</p>
     <p class="note">The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.</p>
     <pre>select json_extract(body, '$.model') as model,
        coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness
@@ -309,7 +315,7 @@ USE TEMP B-TREE FOR ORDER BY</pre></details>
   </article>
   <article class="q">
     <h3><span class="n">9</span> Which map did this session report?</h3>
-    <p class="meta">shape A · #epochAdoptedMap · <b>0.0092 ms</b> today, <b>0.0098 ms</b> at 250,000 · the loop it replaces: 0.1842 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #epochAdoptedMap · <b>0.0125 ms</b> today, <b>0.0112 ms</b> at 250,000 · the loop it replaces: 0.1949 ms <i>plus</i> a 28.49 ms read</p>
     <p class="note">Keyed by agent, and reset at that session`s last spawn line.</p>
     <pre>select json_extract(body, '$.map') as map from events
  where agent = :a and type = 'map_adopted'
@@ -322,7 +328,7 @@ SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)</pre><
   </article>
   <article class="q">
     <h3><span class="n">10</span> What did the ending say?</h3>
-    <p class="meta">shape A · #endingClause · <b>0.0198 ms</b> today, <b>0.0355 ms</b> at 250,000 · the loop it replaces: 0.2233 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #endingClause · <b>0.0286 ms</b> today, <b>0.0441 ms</b> at 250,000 · the loop it replaces: 0.1699 ms <i>plus</i> a 28.49 ms read</p>
     <p class="note">Predicate-narrowed: the last ending carrier that CARRIES a summary.</p>
     <pre>select json_extract(body, '$.summary') as summary from events
  where agent = :a
@@ -337,10 +343,10 @@ USE TEMP B-TREE FOR ORDER BY</pre></details>
   </article>
   <article class="q">
     <h3><span class="n">11</span> Which ticket and repo does this reviewer belong to?</h3>
-    <p class="meta">shape A · #captureVerdict · <b>0.0109 ms</b> today, <b>0.0073 ms</b> at 250,000 · the loop it replaces: 0.1434 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #captureVerdict · <b>0.0084 ms</b> today, <b>0.0122 ms</b> at 250,000 · the loop it replaces: 0.1992 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select ticket,
-       json_extract(body, '$.repo') as repo,
+       repo,
        json_extract(body, '$.model') as model,
        json_extract(body, '$.builder_model') as builder_model,
        json_extract(body, '$.same_provider') as same_provider,
@@ -352,9 +358,9 @@ USE TEMP B-TREE FOR ORDER BY</pre></details>
   </article>
   <article class="q">
     <h3><span class="n">12</span> What is every ticket`s latest dispatch epoch?</h3>
-    <p class="meta">shape A · #reconcileContext · <b>1.4241 ms</b> today, <b>186.5719 ms</b> at 250,000 · the loop it replaces: 0.4301 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape A · #reconcileContext · <b>1.0535 ms</b> today, <b>233.8908 ms</b> at 250,000 · the loop it replaces: 0.4626 ms <i>plus</i> a 28.49 ms read</p>
     <p class="note">The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.</p>
-    <pre>select e.ticket, e.id, json_extract(e.body, '$.repo') as repo
+    <pre>select e.ticket, e.id, e.repo
   from events e
   join (select ticket, max(id) as id from events
          where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null
@@ -369,7 +375,7 @@ USE TEMP B-TREE FOR ORDER BY</pre></details>
   </article>
   <article class="q">
     <h3><span class="n">13</span> Did this session report a result after its dispatch?</h3>
-    <p class="meta">shape B · reconcile, the orphan guard · <b>0.0121 ms</b> today, <b>0.0237 ms</b> at 250,000 · the loop it replaces: 0.2464 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape B · reconcile, the orphan guard · <b>0.0204 ms</b> today, <b>0.0308 ms</b> at 250,000 · the loop it replaces: 0.3181 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))
      or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer</pre>
@@ -385,7 +391,7 @@ SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details
   </article>
   <article class="q">
     <h3><span class="n">14</span> Did anything close this epoch?</h3>
-    <p class="meta">shape B · reconcile, the dead-claim guard · <b>0.0141 ms</b> today, <b>0.0158 ms</b> at 250,000 · the loop it replaces: 0.265 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="meta">shape B · reconcile, the dead-claim guard · <b>0.0218 ms</b> today, <b>0.0239 ms</b> at 250,000 · the loop it replaces: 0.2912 ms <i>plus</i> a 28.49 ms read</p>
     
     <pre>select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))
      or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer</pre>
@@ -408,7 +414,7 @@ say <code>"worker"</code> and the column still finds them.</p>
   <article class="q">
     <h3>what happened to one ticket</h3>
     <pre>select ts, type, ticket, agent from events where ticket=100 order by id</pre>
-    <p class="meta">37 rows in 0.217 ms</p>
+    <p class="meta">37 rows in 0.266 ms</p>
     <p class="note">A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.</p>
     <pre class="out">{
  "ts": "2026-05-01T08:00:00.000Z",
@@ -420,7 +426,7 @@ say <code>"worker"</code> and the column still finds them.</p>
   <article class="q">
     <h3>the last thirty events</h3>
     <pre>select ts, type, ticket, agent from events order by id desc limit 30</pre>
-    <p class="meta">30 rows in 0.129 ms</p>
+    <p class="meta">30 rows in 0.125 ms</p>
     
     <pre class="out">{
  "ts": "2026-05-02T08:58:21.000Z",
@@ -432,7 +438,7 @@ say <code>"worker"</code> and the column still finds them.</p>
   <article class="q">
     <h3>one whole line, exactly as curia wrote it</h3>
     <pre>select body from events where id=2141</pre>
-    <p class="meta">1 row in 0.035 ms</p>
+    <p class="meta">1 row in 0.037 ms</p>
     
     <pre class="out">{
  "body": "{\"ts\":\"2026-05-01T20:29:00.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/curia-site\",\"ticket\":184,\"agent\":\"curia-184\",\"reason\":\"result\"}"
@@ -441,7 +447,7 @@ say <code>"worker"</code> and the column still finds them.</p>
   <article class="q">
     <h3>the census, by type</h3>
     <pre>select type, count(*) from events group by type order by 2 desc</pre>
-    <p class="meta">109 rows in 1.157 ms</p>
+    <p class="meta">109 rows in 0.662 ms</p>
     
     <pre class="out">{
  "type": "stop_blocked",
@@ -451,7 +457,7 @@ say <code>"worker"</code> and the column still finds them.</p>
   <article class="q">
     <h3>how one agent ended</h3>
     <pre>select ts, type, body from events where agent='curia-100' order by id desc limit 10</pre>
-    <p class="meta">10 rows in 0.204 ms</p>
+    <p class="meta">10 rows in 0.128 ms</p>
     <p class="note">The #184 test: this agent was named `"worker"` on the lines it wrote, and the normalized column still finds them.</p>
     <pre class="out">{
  "ts": "2026-05-01T08:23:06.000Z",
@@ -493,17 +499,43 @@ say <code>"worker"</code> and the column still finds them.</p>
   wrong in <code>dispatch.mjs</code>, and it is not this ticket's to change.</p>
 </article>
 
-<h2>What the operator is asked</h2>
+<article class="q">
+  <h3>5 · The cut is an id, and it cannot be a stamp</h3>
+  <p>The operator asked what <code>epoch</code> buys over <code>ts</code>. Two things, and the second one
+  is not a preference.</p>
+  <p><b>It says WHICH dispatch, not "later than".</b> <code>where epoch=X</code> reads one dispatch whole.
+  A stamp can only give a range, and the upper end of that range is the next dispatch, which is a second
+  lookup.</p>
+  <p><b>Stamps tie, and the answer then flips.</b> <code>_append</code> writes
+  <code>new Date().toISOString()</code>, which is milliseconds, and nothing makes it unique.
+  2,000 events through the daemon's own writer carried
+  <b>58 distinct stamps</b>, up to 53 events on one. A claim
+  and the pull request it earns landed on one stamp
+  on the first try. Asked
+  "did this dispatch push a pull request", the id cut answers
+  <b>true</b> and the stamp cut answers
+  <b>false</b>. The stamp cut is wrong. The ten scans this schema replaces
+  compare POSITION in the file, so an id reproduces their rule and a stamp does not.</p>
+  <p>A clock is the third reason. NTP can step <code>ts</code> backwards. It cannot step a rowid.</p>
+</article>
+
+<h2>What the operator ruled</h2>
 <ol class="ask">
-  <li><b>The <code>epoch</code> column: keep it?</b> #320 asked for it, and this prototype reads it as the
-  dispatch epoch rather than a unix stamp. It buys the operator
-  <code>select * from events where epoch=(select max(epoch) from events where ticket=321)</code> — one
-  dispatch, whole. It does not buy speed: a query that probes the epoch itself runs the same. It costs
-  0.180 ms a write and one index.
-  <i>Recommended: keep it.</i></li>
-  <li><b>A sixth column, <code>repo</code>?</b> Three of the fourteen read it out of the body, and it is a
-  plausible thing to type by hand. It costs about twelve bytes a row and nothing at write time.
-  <i>Recommended: add it.</i></li>
+  <li><b><code>repo</code> is a column.</b> Three of the fourteen read it, and the operator types it by
+  hand. It carries no index of its own: curia runs one or two repos, so
+  <code>where repo='alp82/curia'</code> selects nearly every row and SQLite scans whatever we build.</li>
+</ol>
+
+<h2>What is still open</h2>
+<ol class="ask">
+  <li><b>The <code>epoch</code> column: keep it?</b> Finding 5 is the answer to "why not <code>ts</code>",
+  and it settles the CUT: the cut is an id either way. What is left is whether the id is stored on the row
+  or probed by each query. Stored, it costs
+  0.278 ms a write and one index — about a tenth of a second
+  a day at 404 events a day — and it gives the operator
+  <code>where epoch=(select max(epoch) from events where ticket=321)</code>. Probed, it costs nothing and
+  runs at the same speed, and every "since the epoch" query carries the subquery instead. The prototype
+  runs both, in <code>schema.sql</code> and <code>schema-no-epoch.sql</code>.</li>
 </ol>
 
 <h2>Run it</h2>

--- a/prototypes/journal-schema/demo.html
+++ b/prototypes/journal-schema/demo.html
@@ -524,18 +524,13 @@ say <code>"worker"</code> and the column still finds them.</p>
   <li><b><code>repo</code> is a column.</b> Three of the fourteen read it, and the operator types it by
   hand. It carries no index of its own: curia runs one or two repos, so
   <code>where repo='alp82/curia'</code> selects nearly every row and SQLite scans whatever we build.</li>
-</ol>
-
-<h2>What is still open</h2>
-<ol class="ask">
-  <li><b>The <code>epoch</code> column: keep it?</b> Finding 5 is the answer to "why not <code>ts</code>",
-  and it settles the CUT: the cut is an id either way. What is left is whether the id is stored on the row
-  or probed by each query. Stored, it costs
-  0.278 ms a write and one index — about a tenth of a second
-  a day at 404 events a day — and it gives the operator
-  <code>where epoch=(select max(epoch) from events where ticket=321)</code>. Probed, it costs nothing and
-  runs at the same speed, and every "since the epoch" query carries the subquery instead. The prototype
-  runs both, in <code>schema.sql</code> and <code>schema-no-epoch.sql</code>.</li>
+  <li><b>The <code>epoch</code> id is STORED on the row</b>, rather than probed by each query. Finding 5
+  settled the cut itself: it is an id either way. Storing it costs
+  0.278 ms a write and one index, which is about a tenth of a
+  second a day at 404 events a day, and it buys
+  <code>where epoch=(select max(epoch) from events where ticket=321)</code> — one dispatch, whole. A trigger
+  does the stamping, so the 129 <code>logEvent</code> call sites stay ignorant of it.
+  <code>schema-no-epoch.sql</code> stays in the prototype as the measured alternative.</li>
 </ol>
 
 <h2>Run it</h2>

--- a/prototypes/journal-schema/demo.html
+++ b/prototypes/journal-schema/demo.html
@@ -1,0 +1,514 @@
+<title>The schema and the fourteen queries — curia#321</title>
+<style>
+  :root { color-scheme: light dark; --fg: #16181d; --dim: #5c6470; --bg: #fbfbfa; --card: #fff; --line: #e3e2dd; --accent: #7a4a1e; --ok: #1f6b3a; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #e8e6e1; --dim: #9aa1ac; --bg: #16181c; --card: #1e2126; --line: #2e323a; --accent: #e0a166; --ok: #6fd39a; }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 1rem 1rem 5rem; background: var(--bg); color: var(--fg);
+         font: 16px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+         max-width: 52rem; margin-inline: auto; overflow-wrap: break-word; }
+  h1 { font-size: 1.45rem; line-height: 1.25; margin: .4rem 0 .2rem; }
+  h2 { font-size: 1.1rem; margin: 2.2rem 0 .6rem; padding-top: .8rem; border-top: 1px solid var(--line); }
+  h3 { font-size: 1rem; margin: 0 0 .3rem; font-weight: 620; }
+  .sub { color: var(--dim); margin: 0 0 1rem; font-size: .92rem; }
+  .verdict { background: var(--card); border: 1px solid var(--line); border-left: 3px solid var(--ok);
+             border-radius: 8px; padding: .9rem 1rem; }
+  .verdict p:first-child { margin-top: 0; }
+  .verdict ul { margin: .5rem 0 0; padding-left: 1.1rem; }
+  .verdict li { margin: .35rem 0; }
+  article.q { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+              padding: .8rem .9rem; margin: .7rem 0; }
+  .n { display: inline-block; min-width: 1.5rem; color: var(--accent); font-variant-numeric: tabular-nums; }
+  .meta { color: var(--dim); font-size: .84rem; margin: .2rem 0 .5rem; }
+  .note { font-size: .88rem; margin: .3rem 0 .5rem; }
+  pre { background: color-mix(in srgb, var(--fg) 5%, transparent); border-radius: 6px;
+        padding: .6rem .7rem; overflow-x: auto; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        margin: .4rem 0; }
+  pre.plan, pre.out { font-size: 11.5px; color: var(--dim); }
+  details summary { cursor: pointer; color: var(--dim); font-size: .82rem; }
+  .scroll { overflow-x: auto; }
+  table { border-collapse: collapse; width: 100%; font-size: .88rem; min-width: 34rem; }
+  th, td { text-align: left; padding: .4rem .55rem; border-bottom: 1px solid var(--line); white-space: nowrap; }
+  th { color: var(--dim); font-weight: 600; font-size: .8rem; }
+  .tag { background: var(--accent); color: var(--bg); border-radius: 4px; padding: 0 .3rem; font-size: .7rem; vertical-align: 2px; }
+  ol.ask { padding-left: 1.2rem; }
+  ol.ask li { margin: .6rem 0; }
+  code { font: 12.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+         background: color-mix(in srgb, var(--fg) 7%, transparent); border-radius: 4px; padding: .05rem .25rem; }
+  footer { color: var(--dim); font-size: .8rem; margin-top: 2.5rem; }
+</style>
+
+<h1>The schema and the fourteen queries</h1>
+<p class="sub">alp82/curia#321, on the store map #316 · prototype · Node v24.19.0, SQLite 3.53.3</p>
+
+<div class="verdict">
+  <p><b>The schema holds.</b> One table, seven columns, four indexes, one trigger. It answers all
+  fourteen questions exactly as the daemon's loop answers them: <b>17,307 checks</b>
+  over four journal sizes, <b>0 mismatches</b>.</p>
+  <ul>
+    <li><b>The thirteen keyed questions cost 0.192 ms together</b>, and the number does not
+    move with history: 0.284 ms at 250,000 events. Today one of them costs a
+    29.58 ms whole read.</li>
+    <li><b>The Stop hook is the win.</b> It pays one whole read per turn of every agent today. It pays
+    three indexed seeks after this.</li>
+    <li><b>One question stays proportional to history.</b> Question 12 asks about every ticket at once, and
+    reconcile runs it once a pass: 1.4241 ms today, 186.5719 ms at 250,000 — against the
+    2044.9 ms read it replaces.</li>
+    <li><b>A committed write costs 1.185 ms</b> with WAL and <code>synchronous=full</code>, against
+    1.005 ms without the epoch trigger. At 404 events a day that difference is a tenth of a second a day.</li>
+    <li><b>The journal costs about 1.9× the text file</b>:
+    2.23 MB against 1.19 MB today. The verbatim <code>body</code> is the record,
+    and the columns and indexes are what make it answer.</li>
+    <li><b>The five queries in the daemon README all run</b>, on a journal whose oldest fifth carries the
+    pre-#184 spelling.</li>
+  </ul>
+</div>
+
+<h2>What one journal costs</h2>
+<div class="scroll">
+<table>
+  <tr><th>events</th><th>text file</th><th>journal</th><th>one whole read (today)</th><th>the 13 keyed queries</th><th>question 12</th></tr>
+  
+  <tr>
+    <td>4,282 <span class="tag">today</span></td>
+    <td>1.19 MB</td>
+    <td>2.23 MB</td>
+    <td>29.58 ms</td>
+    <td>0.192 ms</td>
+    <td>1.4241 ms</td>
+  </tr>
+  <tr>
+    <td>30,000</td>
+    <td>8.35 MB</td>
+    <td>15.45 MB</td>
+    <td>194.01 ms</td>
+    <td>0.221 ms</td>
+    <td>23.563 ms</td>
+  </tr>
+  <tr>
+    <td>60,000</td>
+    <td>16.76 MB</td>
+    <td>31.30 MB</td>
+    <td>384.97 ms</td>
+    <td>0.234 ms</td>
+    <td>50.4635 ms</td>
+  </tr>
+  <tr>
+    <td>250,000</td>
+    <td>69.99 MB</td>
+    <td>131.83 MB</td>
+    <td>2044.9 ms</td>
+    <td>0.284 ms</td>
+    <td>186.5719 ms</td>
+  </tr>
+</table>
+</div>
+<p class="sub">The read column is what the daemon pays now, once per question that misses its in-memory
+short circuit. The two query columns are what it pays after. Every row is one synthetic journal of the
+measured shape: about 277 bytes a line, 109 distinct types,
+dispatches interleaved, the oldest fifth in the old spelling.</p>
+
+<h2>The schema</h2>
+<pre>-- The journal schema, prototyped for alp82/curia#321.
+--
+-- One table. 96 event types share it, because the boot replay reads every
+-- event in write order and the fourteen questions all key by ticket, by agent
+-- or by type. Ninety-six tables would make the operator's "last thirty events"
+-- a ninety-six-way union.
+--
+-- STRICT is permitted: #320 ruled the operator's sqlite3 comes out of the
+-- daemon image, which carries SQLite 3.53. The host's 3.31 does not read this
+-- file and does not constrain it.
+
+create table events (
+  -- The write order. `id` IS the position the ten scans used when they said
+  -- "after the epoch", so every ordering below is `order by id`, never by ts.
+  -- Two events inside one millisecond keep their order.
+  id     integer primary key,
+
+  -- ISO-8601 UTC, exactly as `_append` stamps it.
+  ts     text    not null,
+
+  -- The event type, in TODAY's spelling. A line written before #184 says
+  -- `worker_spawned` in `body` and `agent_spawned` here.
+  type   text    not null,
+
+  -- The ticket, as text. Null when the event names none (image builds, bridge
+  -- health, deploys). Text and not integer, so `where ticket='320'` works —
+  -- and `where ticket=320` works too, because SQLite applies the column's TEXT
+  -- affinity to a bare numeric literal.
+  ticket text,
+
+  -- The agent session, in today's spelling. A pre-#184 line carries
+  -- `"worker": "curia-170"` in `body` and `curia-170` here.
+  agent  text,
+
+  -- The dispatch this row belongs to: the id of the `dispatch_claimed` or
+  -- `agent_spawned` row that opened the ticket's latest epoch at the moment
+  -- this row was written. An epoch-opening row carries its own id. 0 for a row
+  -- with no ticket, or one written before its ticket was ever dispatched.
+  --
+  -- This is the "after the epoch" of the three shapes, precomputed. Four of the
+  -- fourteen questions become an equality on it, and the operator gets
+  -- `where epoch=(select max(epoch) from events where ticket=321)` — one
+  -- dispatch, whole, at 2 a.m.
+  epoch  integer not null default 0,
+
+  -- The line curia wrote, byte for byte, old spelling and all (ADR-0017).
+  -- `select body from events order by id` regenerates events.jsonl.
+  body   text    not null
+) strict;
+
+-- Shape A ("the last event of type T for key K") and the type-narrowed halves
+-- of B and C. Both directions, because six of the fourteen key by agent.
+create index events_ticket_type on events (ticket, type, id);
+create index events_agent_type  on events (agent, type, id);
+
+-- The current epoch of a ticket, as one index probe: the rightmost entry for
+-- the ticket. Without it, `max(epoch)` reads every row the ticket ever wrote.
+create index events_ticket_epoch on events (ticket, epoch);
+
+-- Shapes B and C ("since the epoch"), and the operator's "this dispatch, whole".
+create index events_epoch_type  on events (epoch, type);
+
+-- The census, `group by type`. Also the type-only reads the reduction does at
+-- boot for the recent-outcome rings.
+create index events_type on events (type, id);
+
+-- The epoch stamp is a property of the TABLE, not of the write path. 129
+-- `logEvent` call sites stay ignorant of it, and a migrated row gets the same
+-- stamp as a live one because both arrive through this trigger.
+create trigger events_stamp_epoch after insert on events
+when new.ticket is not null
+begin
+  update events set epoch = coalesce((
+    select e.id from events e
+     where e.ticket = new.ticket
+       and e.type in ('dispatch_claimed', 'agent_spawned')
+       and e.id &lt;= new.id
+     order by e.id desc limit 1
+  ), 0)
+  where id = new.id;
+end;
+</pre>
+<div class="scroll">
+<table>
+  <tr><th>on disk today (4,282 events)</th><th></th></tr>
+  <tr><td>events</td><td>1.56 MB</td></tr><tr><td>events_agent_type</td><td>0.18 MB</td></tr><tr><td>events_ticket_type</td><td>0.15 MB</td></tr><tr><td>events_epoch_type</td><td>0.13 MB</td></tr><tr><td>events_type</td><td>0.13 MB</td></tr><tr><td>events_ticket_epoch</td><td>0.07 MB</td></tr>
+</table>
+</div>
+
+<h2>The fourteen questions</h2>
+<p class="sub">Every one is checked against the daemon's own loop, ported line for line into
+<code>oracle.mjs</code>. Where the two disagree the query is wrong — including where the daemon's rule
+is surprising.</p>
+
+  <article class="q">
+    <h3><span class="n">1</span> Did this dispatch push a pull request?</h3>
+    <p class="meta">shape B · #epochScan · <b>0.0321 ms</b> today, <b>0.0274 ms</b> at 250,000 · the loop it replaces: 0.4397 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))
+     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer</pre>
+    <details><summary>query plan</summary><pre class="plan">SCAN CONSTANT ROW
+SCALAR SUBQUERY 2
+SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)
+SCALAR SUBQUERY 4
+SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 3
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">2</span> Did a human approve this dispatch at the gate?</h3>
+    <p class="meta">shape B · #epochScan · <b>0.0156 ms</b> today, <b>0.0222 ms</b> at 250,000 · the loop it replaces: 0.327 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="note">Predicate-narrowed: only a review_answered whose `approved` is true counts.</p>
+    <pre>select (exists(select 1 from events where ticket = :t and type = 'review_answered'
+                and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)
+     or exists(select 1 from events where agent = :a and type = 'review_answered'
+                and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer</pre>
+    <details><summary>query plan</summary><pre class="plan">SCAN CONSTANT ROW
+SCALAR SUBQUERY 2
+SEARCH events USING INDEX events_ticket_type (ticket=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)
+SCALAR SUBQUERY 4
+SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 3
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">3</span> How many times has the Stop hook held this agent?</h3>
+    <p class="meta">shape C · #epochScan · <b>0.0125 ms</b> today, <b>0.0403 ms</b> at 250,000 · the loop it replaces: 0.3734 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select count(*) as answer from events
+ where id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t)
+   and type = 'stop_blocked'
+   and agent = :a</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">4</span> Did the merge outrun the reviewer?</h3>
+    <p class="meta">shape A · #verdictIsLate · <b>0.0102 ms</b> today, <b>0.0144 ms</b> at 250,000 · the loop it replaces: 0.2104 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select coalesce(
+  (select max(id) from events where ticket = :t and type = 'ticket_resolved')
+  &gt; (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer</pre>
+    <details><summary>query plan</summary><pre class="plan">SCAN CONSTANT ROW
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)
+SCALAR SUBQUERY 2
+SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">5</span> When was this ticket last claimed?</h3>
+    <p class="meta">shape A · #liveUnjudgedVerdict · <b>0.0111 ms</b> today, <b>0.0118 ms</b> at 250,000 · the loop it replaces: 0.1333 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select ts from events
+ where ticket = :t and type = 'dispatch_claimed'
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">6</span> Which repo was this ticket last dispatched against?</h3>
+    <p class="meta">shape A · #epochRepo · <b>0.0192 ms</b> today, <b>0.0379 ms</b> at 250,000 · the loop it replaces: 0.1687 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="note">Predicate-narrowed: the last dispatch event that CARRIES a repo.</p>
+    <pre>select json_extract(body, '$.repo') as repo from events
+ where ticket = :t
+   and type in ('dispatch_claimed', 'agent_spawned')
+   and json_extract(body, '$.repo') &lt;&gt; ''
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)
+USE TEMP B-TREE FOR ORDER BY</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">7</span> Was the last dispatch a charting one, and what rode it?</h3>
+    <p class="meta">shape A · #epochCharting · <b>0.0114 ms</b> today, <b>0.0158 ms</b> at 250,000 · the loop it replaces: 0.1056 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select json_extract(body, '$.kind') = 'charting' as charting,
+       json_extract(body, '$.instruction') as instruction,
+       coalesce(json_extract(body, '$.newMap'), 0) as newMap
+  from events
+ where ticket = :t and type = 'agent_spawned'
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">8</span> Which model and harness was this session last spawned on?</h3>
+    <p class="meta">shape A · #epochSpawn · <b>0.0137 ms</b> today, <b>0.0224 ms</b> at 250,000 · the loop it replaces: 0.1026 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="note">The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.</p>
+    <pre>select json_extract(body, '$.model') as model,
+       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness
+  from events
+ where agent = :a and type = 'agent_spawned'
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_agent_type (agent=? AND type=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">9</span> Which map did this session report?</h3>
+    <p class="meta">shape A · #epochAdoptedMap · <b>0.0092 ms</b> today, <b>0.0098 ms</b> at 250,000 · the loop it replaces: 0.1842 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="note">Keyed by agent, and reset at that session`s last spawn line.</p>
+    <pre>select json_extract(body, '$.map') as map from events
+ where agent = :a and type = 'map_adopted'
+   and id &gt; coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)
+   and json_extract(body, '$.map') &lt;&gt; ''
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">10</span> What did the ending say?</h3>
+    <p class="meta">shape A · #endingClause · <b>0.0198 ms</b> today, <b>0.0355 ms</b> at 250,000 · the loop it replaces: 0.2233 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="note">Predicate-narrowed: the last ending carrier that CARRIES a summary.</p>
+    <pre>select json_extract(body, '$.summary') as summary from events
+ where agent = :a
+   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')
+   and id &gt; coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)
+   and json_extract(body, '$.summary') &lt;&gt; ''
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)
+USE TEMP B-TREE FOR ORDER BY</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">11</span> Which ticket and repo does this reviewer belong to?</h3>
+    <p class="meta">shape A · #captureVerdict · <b>0.0109 ms</b> today, <b>0.0073 ms</b> at 250,000 · the loop it replaces: 0.1434 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select ticket,
+       json_extract(body, '$.repo') as repo,
+       json_extract(body, '$.model') as model,
+       json_extract(body, '$.builder_model') as builder_model,
+       json_extract(body, '$.same_provider') as same_provider,
+       json_extract(body, '$.sha') as sha
+  from events
+ where agent = :a and type = 'reviewer_spawned'
+ order by id desc limit 1</pre>
+    <details><summary>query plan</summary><pre class="plan">SEARCH events USING INDEX events_agent_type (agent=? AND type=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">12</span> What is every ticket`s latest dispatch epoch?</h3>
+    <p class="meta">shape A · #reconcileContext · <b>1.4241 ms</b> today, <b>186.5719 ms</b> at 250,000 · the loop it replaces: 0.4301 ms <i>plus</i> a 29.58 ms read</p>
+    <p class="note">The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.</p>
+    <pre>select e.ticket, e.id, json_extract(e.body, '$.repo') as repo
+  from events e
+  join (select ticket, max(id) as id from events
+         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null
+         group by ticket) latest on latest.id = e.id
+ order by e.ticket</pre>
+    <details><summary>query plan</summary><pre class="plan">CO-ROUTINE latest
+SEARCH events USING INDEX events_type (type=?)
+USE TEMP B-TREE FOR GROUP BY
+SCAN latest
+SEARCH e USING INTEGER PRIMARY KEY (rowid=?)
+USE TEMP B-TREE FOR ORDER BY</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">13</span> Did this session report a result after its dispatch?</h3>
+    <p class="meta">shape B · reconcile, the orphan guard · <b>0.0121 ms</b> today, <b>0.0237 ms</b> at 250,000 · the loop it replaces: 0.2464 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))
+     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer</pre>
+    <details><summary>query plan</summary><pre class="plan">SCAN CONSTANT ROW
+SCALAR SUBQUERY 2
+SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)
+SCALAR SUBQUERY 4
+SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 3
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details>
+  </article>
+  <article class="q">
+    <h3><span class="n">14</span> Did anything close this epoch?</h3>
+    <p class="meta">shape B · reconcile, the dead-claim guard · <b>0.0141 ms</b> today, <b>0.0158 ms</b> at 250,000 · the loop it replaces: 0.265 ms <i>plus</i> a 29.58 ms read</p>
+    
+    <pre>select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))
+     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id &gt; (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer</pre>
+    <details><summary>query plan</summary><pre class="plan">SCAN CONSTANT ROW
+SCALAR SUBQUERY 2
+SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 1
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)
+SCALAR SUBQUERY 4
+SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id&gt;?)
+SCALAR SUBQUERY 3
+SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)</pre></details>
+  </article>
+
+<h2>The five the operator types</h2>
+<p class="sub">From <a href="https://github.com/alp82/curia/blob/main/daemon/README.md#reading-the-journal">the daemon README</a>,
+run as written against the synthetic journal. The ticket below was dispatched before #184, so its lines
+say <code>"worker"</code> and the column still finds them.</p>
+
+  <article class="q">
+    <h3>what happened to one ticket</h3>
+    <pre>select ts, type, ticket, agent from events where ticket=100 order by id</pre>
+    <p class="meta">37 rows in 0.217 ms</p>
+    <p class="note">A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.</p>
+    <pre class="out">{
+ "ts": "2026-05-01T08:00:00.000Z",
+ "type": "dispatch_claimed",
+ "ticket": "100",
+ "agent": "curia-100"
+}</pre>
+  </article>
+  <article class="q">
+    <h3>the last thirty events</h3>
+    <pre>select ts, type, ticket, agent from events order by id desc limit 30</pre>
+    <p class="meta">30 rows in 0.129 ms</p>
+    
+    <pre class="out">{
+ "ts": "2026-05-02T08:58:21.000Z",
+ "type": "result",
+ "ticket": "269",
+ "agent": "curia-269"
+}</pre>
+  </article>
+  <article class="q">
+    <h3>one whole line, exactly as curia wrote it</h3>
+    <pre>select body from events where id=2141</pre>
+    <p class="meta">1 row in 0.035 ms</p>
+    
+    <pre class="out">{
+ "body": "{\"ts\":\"2026-05-01T20:29:00.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/curia-site\",\"ticket\":184,\"agent\":\"curia-184\",\"reason\":\"result\"}"
+}</pre>
+  </article>
+  <article class="q">
+    <h3>the census, by type</h3>
+    <pre>select type, count(*) from events group by type order by 2 desc</pre>
+    <p class="meta">109 rows in 1.157 ms</p>
+    
+    <pre class="out">{
+ "type": "stop_blocked",
+ "count(*)": 311
+}</pre>
+  </article>
+  <article class="q">
+    <h3>how one agent ended</h3>
+    <pre>select ts, type, body from events where agent='curia-100' order by id desc limit 10</pre>
+    <p class="meta">10 rows in 0.204 ms</p>
+    <p class="note">The #184 test: this agent was named `"worker"` on the lines it wrote, and the normalized column still finds them.</p>
+    <pre class="out">{
+ "ts": "2026-05-01T08:23:06.000Z",
+ "type": "lifecycle_closed",
+ "body": "{\"ts\":\"2026-05-01T08:23:06.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"reason\":\"result\"}"
+}</pre>
+  </article>
+
+<h2>What the prototype found</h2>
+<article class="q">
+  <h3>1 · Split the disjunction, or lose the index</h3>
+  <p>The daemon's test is <code>ev.agent === agent || ticket matches</code>. Written as one
+  <code>where … and (ticket = :t or agent = :a)</code>, SQLite drops both keyed indexes and walks the type
+  index instead: <b>3.75 ms</b> at 60,000 events, against <b>0.02 ms</b> for two <code>exists</code> —
+  185 times the work for the same answer. Shapes B and C are written as two <code>exists</code> above.</p>
+</article>
+<article class="q">
+  <h3>2 · Stringify the ticket at the write edge</h3>
+  <p><code>node:sqlite</code> binds a JavaScript number as a REAL, so a ticket handed straight off the event
+  lands in the TEXT column as <code>"321.0"</code> — and every
+  <code>where ticket=321</code> then misses it. Stringified, it stores
+  <code>"321"</code> and a bare integer literal finds it:
+  <code>where ticket=100</code> and <code>where ticket='100'</code>
+  both return 37 rows.</p>
+</article>
+<article class="q">
+  <h3>3 · <code>body</code> is verbatim, so one JSON field still says <code>backend</code></h3>
+  <p>The columns carry today's spelling. <code>body</code> carries the line as written, which is what
+  ADR-0017 fixes. #184 renamed two fields, and one of them is not a column: a pre-rename line says
+  <code>"backend"</code> where today's says <code>"harness"</code>. Question 8 reads
+  <code>coalesce(json_extract(body,'$.harness'), json_extract(body,'$.backend'))</code> for it. That is the
+  only field with the problem — <code>worker</code> is the <code>agent</code> column.</p>
+</article>
+<article class="q">
+  <h3>4 · The epoch is keyed by ticket, and a reviewer moves it</h3>
+  <p>A cross-check writes <code>agent_spawned</code> under the BUILDER's ticket, so spawning a reviewer
+  opens a new epoch for the builder. The daemon does that today. The schema reproduces it rather than
+  fixing it, because the check is "does the query answer what the loop answers". If it is wrong it is
+  wrong in <code>dispatch.mjs</code>, and it is not this ticket's to change.</p>
+</article>
+
+<h2>What the operator is asked</h2>
+<ol class="ask">
+  <li><b>The <code>epoch</code> column: keep it?</b> #320 asked for it, and this prototype reads it as the
+  dispatch epoch rather than a unix stamp. It buys the operator
+  <code>select * from events where epoch=(select max(epoch) from events where ticket=321)</code> — one
+  dispatch, whole. It does not buy speed: a query that probes the epoch itself runs the same. It costs
+  0.180 ms a write and one index.
+  <i>Recommended: keep it.</i></li>
+  <li><b>A sixth column, <code>repo</code>?</b> Three of the fourteen read it out of the body, and it is a
+  plausible thing to type by hand. It costs about twelve bytes a row and nothing at write time.
+  <i>Recommended: add it.</i></li>
+</ol>
+
+<h2>Run it</h2>
+<pre>node prototypes/journal-schema/run.mjs   # builds, checks, measures, writes results.json
+node prototypes/journal-schema/demo.mjs  # writes this page</pre>
+
+<footer>Generated from results.json. Throwaway code under <code>prototypes/</code> (ADR-0008), kept on main
+because a merge is the only durable home curia has.</footer>

--- a/prototypes/journal-schema/demo.mjs
+++ b/prototypes/journal-schema/demo.mjs
@@ -212,18 +212,13 @@ ${operatorCards}
   <li><b><code>repo</code> is a column.</b> Three of the fourteen read it, and the operator types it by
   hand. It carries no index of its own: curia runs one or two repos, so
   <code>where repo='alp82/curia'</code> selects nearly every row and SQLite scans whatever we build.</li>
-</ol>
-
-<h2>What is still open</h2>
-<ol class="ask">
-  <li><b>The <code>epoch</code> column: keep it?</b> Finding 5 is the answer to "why not <code>ts</code>",
-  and it settles the CUT: the cut is an id either way. What is left is whether the id is stored on the row
-  or probed by each query. Stored, it costs
-  ${(live.write.stamped - live.write.plain).toFixed(3)} ms a write and one index — about a tenth of a second
-  a day at 404 events a day — and it gives the operator
-  <code>where epoch=(select max(epoch) from events where ticket=321)</code>. Probed, it costs nothing and
-  runs at the same speed, and every "since the epoch" query carries the subquery instead. The prototype
-  runs both, in <code>schema.sql</code> and <code>schema-no-epoch.sql</code>.</li>
+  <li><b>The <code>epoch</code> id is STORED on the row</b>, rather than probed by each query. Finding 5
+  settled the cut itself: it is an id either way. Storing it costs
+  ${(live.write.stamped - live.write.plain).toFixed(3)} ms a write and one index, which is about a tenth of a
+  second a day at 404 events a day, and it buys
+  <code>where epoch=(select max(epoch) from events where ticket=321)</code> — one dispatch, whole. A trigger
+  does the stamping, so the 129 <code>logEvent</code> call sites stay ignorant of it.
+  <code>schema-no-epoch.sql</code> stays in the prototype as the measured alternative.</li>
 </ol>
 
 <h2>Run it</h2>

--- a/prototypes/journal-schema/demo.mjs
+++ b/prototypes/journal-schema/demo.mjs
@@ -187,17 +187,43 @@ ${operatorCards}
   wrong in <code>dispatch.mjs</code>, and it is not this ticket's to change.</p>
 </article>
 
-<h2>What the operator is asked</h2>
+<article class="q">
+  <h3>5 · The cut is an id, and it cannot be a stamp</h3>
+  <p>The operator asked what <code>epoch</code> buys over <code>ts</code>. Two things, and the second one
+  is not a preference.</p>
+  <p><b>It says WHICH dispatch, not "later than".</b> <code>where epoch=X</code> reads one dispatch whole.
+  A stamp can only give a range, and the upper end of that range is the next dispatch, which is a second
+  lookup.</p>
+  <p><b>Stamps tie, and the answer then flips.</b> <code>_append</code> writes
+  <code>new Date().toISOString()</code>, which is milliseconds, and nothing makes it unique.
+  ${r.stamps.events.toLocaleString('en-US')} events through the daemon's own writer carried
+  <b>${r.stamps.distinctStamps} distinct stamps</b>, up to ${r.stamps.mostOnOneStamp} events on one. A claim
+  and the pull request it earns landed on one stamp
+  ${r.stamps.boundary.pairs === 1 ? 'on the first try' : `after ${r.stamps.boundary.pairs} tries`}. Asked
+  "did this dispatch push a pull request", the id cut answers
+  <b>${String(r.stamps.boundary.byId)}</b> and the stamp cut answers
+  <b>${String(r.stamps.boundary.byTs)}</b>. The stamp cut is wrong. The ten scans this schema replaces
+  compare POSITION in the file, so an id reproduces their rule and a stamp does not.</p>
+  <p>A clock is the third reason. NTP can step <code>ts</code> backwards. It cannot step a rowid.</p>
+</article>
+
+<h2>What the operator ruled</h2>
 <ol class="ask">
-  <li><b>The <code>epoch</code> column: keep it?</b> #320 asked for it, and this prototype reads it as the
-  dispatch epoch rather than a unix stamp. It buys the operator
-  <code>select * from events where epoch=(select max(epoch) from events where ticket=321)</code> — one
-  dispatch, whole. It does not buy speed: a query that probes the epoch itself runs the same. It costs
-  ${(live.write.stamped - live.write.plain).toFixed(3)} ms a write and one index.
-  <i>Recommended: keep it.</i></li>
-  <li><b>A sixth column, <code>repo</code>?</b> Three of the fourteen read it out of the body, and it is a
-  plausible thing to type by hand. It costs about twelve bytes a row and nothing at write time.
-  <i>Recommended: add it.</i></li>
+  <li><b><code>repo</code> is a column.</b> Three of the fourteen read it, and the operator types it by
+  hand. It carries no index of its own: curia runs one or two repos, so
+  <code>where repo='alp82/curia'</code> selects nearly every row and SQLite scans whatever we build.</li>
+</ol>
+
+<h2>What is still open</h2>
+<ol class="ask">
+  <li><b>The <code>epoch</code> column: keep it?</b> Finding 5 is the answer to "why not <code>ts</code>",
+  and it settles the CUT: the cut is an id either way. What is left is whether the id is stored on the row
+  or probed by each query. Stored, it costs
+  ${(live.write.stamped - live.write.plain).toFixed(3)} ms a write and one index — about a tenth of a second
+  a day at 404 events a day — and it gives the operator
+  <code>where epoch=(select max(epoch) from events where ticket=321)</code>. Probed, it costs nothing and
+  runs at the same speed, and every "since the epoch" query carries the subquery instead. The prototype
+  runs both, in <code>schema.sql</code> and <code>schema-no-epoch.sql</code>.</li>
 </ol>
 
 <h2>Run it</h2>

--- a/prototypes/journal-schema/demo.mjs
+++ b/prototypes/journal-schema/demo.mjs
@@ -1,0 +1,212 @@
+// Turns `results.json` into the one self-contained page (#321).
+//
+//   node prototypes/journal-schema/run.mjs && node prototypes/journal-schema/demo.mjs
+//
+// Every number on the page comes out of the run. Nothing here is typed by hand.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const r = JSON.parse(fs.readFileSync(path.join(here, 'results.json'), 'utf8'))
+const schema = fs.readFileSync(path.join(here, 'schema.sql'), 'utf8')
+
+const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+const mb = (b) => `${(b / 1e6).toFixed(2)} MB`
+const live = r.sizes.find((s) => s.live)
+const top = r.sizes[r.sizes.length - 1]
+const keyedTotal = (s) => s.queries.filter((q) => q.n !== 12).reduce((a, b) => a + b.sqlMs, 0)
+const q12 = (s) => s.queries.find((q) => q.n === 12)
+const checks = r.sizes.reduce((a, s) => a + s.equivalence.checks, 0)
+const mismatches = r.sizes.reduce((a, s) => a + s.equivalence.mismatches.length, 0)
+
+const costRows = r.sizes.map((s) => `
+  <tr>
+    <td>${s.size.toLocaleString('en-US')}${s.live ? ' <span class="tag">today</span>' : ''}</td>
+    <td>${mb(s.sizes.journalFileBytes)}</td>
+    <td>${mb(s.sizes.dbBytes)}</td>
+    <td>${s.wholeReadMs} ms</td>
+    <td>${keyedTotal(s).toFixed(3)} ms</td>
+    <td>${q12(s).sqlMs} ms</td>
+  </tr>`).join('')
+
+const queryCards = live.queries.map((q) => {
+  const atTop = top.queries.find((x) => x.n === q.n)
+  return `
+  <article class="q">
+    <h3><span class="n">${q.n}</span> ${esc(q.question)}</h3>
+    <p class="meta">shape ${q.shape} · ${esc(q.where)} · <b>${q.sqlMs} ms</b> today, <b>${atTop.sqlMs} ms</b> at 250,000 · the loop it replaces: ${q.scanMs} ms <i>plus</i> a ${live.wholeReadMs} ms read</p>
+    ${q.note ? `<p class="note">${esc(q.note)}</p>` : ''}
+    <pre>${esc(q.sql)}</pre>
+    <details><summary>query plan</summary><pre class="plan">${esc(q.plan.join('\n'))}</pre></details>
+  </article>`
+}).join('')
+
+const operatorCards = live.operator.map((o) => `
+  <article class="q">
+    <h3>${esc(o.title)}</h3>
+    <pre>${esc(o.sql)}</pre>
+    <p class="meta">${o.count} row${o.count === 1 ? '' : 's'} in ${o.ms} ms</p>
+    ${o.note ? `<p class="note">${esc(o.note)}</p>` : ''}
+    <pre class="out">${esc(JSON.stringify(o.sample[0] ?? null, null, 1))}</pre>
+  </article>`).join('')
+
+const indexRows = live.sizes.perIndex.map((i) => `<tr><td>${esc(i.name)}</td><td>${mb(i.bytes)}</td></tr>`).join('')
+
+const html = `<title>The schema and the fourteen queries — curia#321</title>
+<style>
+  :root { color-scheme: light dark; --fg: #16181d; --dim: #5c6470; --bg: #fbfbfa; --card: #fff; --line: #e3e2dd; --accent: #7a4a1e; --ok: #1f6b3a; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #e8e6e1; --dim: #9aa1ac; --bg: #16181c; --card: #1e2126; --line: #2e323a; --accent: #e0a166; --ok: #6fd39a; }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 1rem 1rem 5rem; background: var(--bg); color: var(--fg);
+         font: 16px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+         max-width: 52rem; margin-inline: auto; overflow-wrap: break-word; }
+  h1 { font-size: 1.45rem; line-height: 1.25; margin: .4rem 0 .2rem; }
+  h2 { font-size: 1.1rem; margin: 2.2rem 0 .6rem; padding-top: .8rem; border-top: 1px solid var(--line); }
+  h3 { font-size: 1rem; margin: 0 0 .3rem; font-weight: 620; }
+  .sub { color: var(--dim); margin: 0 0 1rem; font-size: .92rem; }
+  .verdict { background: var(--card); border: 1px solid var(--line); border-left: 3px solid var(--ok);
+             border-radius: 8px; padding: .9rem 1rem; }
+  .verdict p:first-child { margin-top: 0; }
+  .verdict ul { margin: .5rem 0 0; padding-left: 1.1rem; }
+  .verdict li { margin: .35rem 0; }
+  article.q { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+              padding: .8rem .9rem; margin: .7rem 0; }
+  .n { display: inline-block; min-width: 1.5rem; color: var(--accent); font-variant-numeric: tabular-nums; }
+  .meta { color: var(--dim); font-size: .84rem; margin: .2rem 0 .5rem; }
+  .note { font-size: .88rem; margin: .3rem 0 .5rem; }
+  pre { background: color-mix(in srgb, var(--fg) 5%, transparent); border-radius: 6px;
+        padding: .6rem .7rem; overflow-x: auto; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        margin: .4rem 0; }
+  pre.plan, pre.out { font-size: 11.5px; color: var(--dim); }
+  details summary { cursor: pointer; color: var(--dim); font-size: .82rem; }
+  .scroll { overflow-x: auto; }
+  table { border-collapse: collapse; width: 100%; font-size: .88rem; min-width: 34rem; }
+  th, td { text-align: left; padding: .4rem .55rem; border-bottom: 1px solid var(--line); white-space: nowrap; }
+  th { color: var(--dim); font-weight: 600; font-size: .8rem; }
+  .tag { background: var(--accent); color: var(--bg); border-radius: 4px; padding: 0 .3rem; font-size: .7rem; vertical-align: 2px; }
+  ol.ask { padding-left: 1.2rem; }
+  ol.ask li { margin: .6rem 0; }
+  code { font: 12.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+         background: color-mix(in srgb, var(--fg) 7%, transparent); border-radius: 4px; padding: .05rem .25rem; }
+  footer { color: var(--dim); font-size: .8rem; margin-top: 2.5rem; }
+</style>
+
+<h1>The schema and the fourteen queries</h1>
+<p class="sub">alp82/curia#321, on the store map #316 · prototype · Node ${r.node}, SQLite ${r.sqlite}</p>
+
+<div class="verdict">
+  <p><b>The schema holds.</b> One table, seven columns, four indexes, one trigger. It answers all
+  fourteen questions exactly as the daemon's loop answers them: <b>${checks.toLocaleString('en-US')} checks</b>
+  over four journal sizes, <b>${mismatches} mismatches</b>.</p>
+  <ul>
+    <li><b>The thirteen keyed questions cost ${keyedTotal(live).toFixed(3)} ms together</b>, and the number does not
+    move with history: ${keyedTotal(top).toFixed(3)} ms at 250,000 events. Today one of them costs a
+    ${live.wholeReadMs} ms whole read.</li>
+    <li><b>The Stop hook is the win.</b> It pays one whole read per turn of every agent today. It pays
+    three indexed seeks after this.</li>
+    <li><b>One question stays proportional to history.</b> Question 12 asks about every ticket at once, and
+    reconcile runs it once a pass: ${q12(live).sqlMs} ms today, ${q12(top).sqlMs} ms at 250,000 — against the
+    ${top.wholeReadMs} ms read it replaces.</li>
+    <li><b>A committed write costs ${live.write.stamped} ms</b> with WAL and <code>synchronous=full</code>, against
+    ${live.write.plain} ms without the epoch trigger. At 404 events a day that difference is a tenth of a second a day.</li>
+    <li><b>The journal costs about ${(live.sizes.dbBytes / live.sizes.journalFileBytes).toFixed(1)}× the text file</b>:
+    ${mb(live.sizes.dbBytes)} against ${mb(live.sizes.journalFileBytes)} today. The verbatim <code>body</code> is the record,
+    and the columns and indexes are what make it answer.</li>
+    <li><b>The five queries in the daemon README all run</b>, on a journal whose oldest fifth carries the
+    pre-#184 spelling.</li>
+  </ul>
+</div>
+
+<h2>What one journal costs</h2>
+<div class="scroll">
+<table>
+  <tr><th>events</th><th>text file</th><th>journal</th><th>one whole read (today)</th><th>the 13 keyed queries</th><th>question 12</th></tr>
+  ${costRows}
+</table>
+</div>
+<p class="sub">The read column is what the daemon pays now, once per question that misses its in-memory
+short circuit. The two query columns are what it pays after. Every row is one synthetic journal of the
+measured shape: about ${live.fidelity.bytesPerLine} bytes a line, ${live.fidelity.types} distinct types,
+dispatches interleaved, the oldest fifth in the old spelling.</p>
+
+<h2>The schema</h2>
+<pre>${esc(schema)}</pre>
+<div class="scroll">
+<table>
+  <tr><th>on disk today (${live.size.toLocaleString('en-US')} events)</th><th></th></tr>
+  ${indexRows}
+</table>
+</div>
+
+<h2>The fourteen questions</h2>
+<p class="sub">Every one is checked against the daemon's own loop, ported line for line into
+<code>oracle.mjs</code>. Where the two disagree the query is wrong — including where the daemon's rule
+is surprising.</p>
+${queryCards}
+
+<h2>The five the operator types</h2>
+<p class="sub">From <a href="https://github.com/alp82/curia/blob/main/daemon/README.md#reading-the-journal">the daemon README</a>,
+run as written against the synthetic journal. The ticket below was dispatched before #184, so its lines
+say <code>"worker"</code> and the column still finds them.</p>
+${operatorCards}
+
+<h2>What the prototype found</h2>
+<article class="q">
+  <h3>1 · Split the disjunction, or lose the index</h3>
+  <p>The daemon's test is <code>ev.agent === agent || ticket matches</code>. Written as one
+  <code>where … and (ticket = :t or agent = :a)</code>, SQLite drops both keyed indexes and walks the type
+  index instead: <b>3.75 ms</b> at 60,000 events, against <b>0.02 ms</b> for two <code>exists</code> —
+  185 times the work for the same answer. Shapes B and C are written as two <code>exists</code> above.</p>
+</article>
+<article class="q">
+  <h3>2 · Stringify the ticket at the write edge</h3>
+  <p><code>node:sqlite</code> binds a JavaScript number as a REAL, so a ticket handed straight off the event
+  lands in the TEXT column as <code>"${live.fidelity.numbers.bound_number.stored}"</code> — and every
+  <code>where ticket=321</code> then misses it. Stringified, it stores
+  <code>"${live.fidelity.numbers.bound_string.stored}"</code> and a bare integer literal finds it:
+  <code>where ticket=${live.fidelity.affinity.ticket}</code> and <code>where ticket='${live.fidelity.affinity.ticket}'</code>
+  both return ${live.fidelity.affinity.asNumber} rows.</p>
+</article>
+<article class="q">
+  <h3>3 · <code>body</code> is verbatim, so one JSON field still says <code>backend</code></h3>
+  <p>The columns carry today's spelling. <code>body</code> carries the line as written, which is what
+  ADR-0017 fixes. #184 renamed two fields, and one of them is not a column: a pre-rename line says
+  <code>"backend"</code> where today's says <code>"harness"</code>. Question 8 reads
+  <code>coalesce(json_extract(body,'$.harness'), json_extract(body,'$.backend'))</code> for it. That is the
+  only field with the problem — <code>worker</code> is the <code>agent</code> column.</p>
+</article>
+<article class="q">
+  <h3>4 · The epoch is keyed by ticket, and a reviewer moves it</h3>
+  <p>A cross-check writes <code>agent_spawned</code> under the BUILDER's ticket, so spawning a reviewer
+  opens a new epoch for the builder. The daemon does that today. The schema reproduces it rather than
+  fixing it, because the check is "does the query answer what the loop answers". If it is wrong it is
+  wrong in <code>dispatch.mjs</code>, and it is not this ticket's to change.</p>
+</article>
+
+<h2>What the operator is asked</h2>
+<ol class="ask">
+  <li><b>The <code>epoch</code> column: keep it?</b> #320 asked for it, and this prototype reads it as the
+  dispatch epoch rather than a unix stamp. It buys the operator
+  <code>select * from events where epoch=(select max(epoch) from events where ticket=321)</code> — one
+  dispatch, whole. It does not buy speed: a query that probes the epoch itself runs the same. It costs
+  ${(live.write.stamped - live.write.plain).toFixed(3)} ms a write and one index.
+  <i>Recommended: keep it.</i></li>
+  <li><b>A sixth column, <code>repo</code>?</b> Three of the fourteen read it out of the body, and it is a
+  plausible thing to type by hand. It costs about twelve bytes a row and nothing at write time.
+  <i>Recommended: add it.</i></li>
+</ol>
+
+<h2>Run it</h2>
+<pre>node prototypes/journal-schema/run.mjs   # builds, checks, measures, writes results.json
+node prototypes/journal-schema/demo.mjs  # writes this page</pre>
+
+<footer>Generated from results.json. Throwaway code under <code>prototypes/</code> (ADR-0008), kept on main
+because a merge is the only durable home curia has.</footer>
+`
+
+fs.writeFileSync(path.join(here, 'demo.html'), html)
+console.log(`demo.html written (${(html.length / 1024).toFixed(1)} kB)`)

--- a/prototypes/journal-schema/journal.mjs
+++ b/prototypes/journal-schema/journal.mjs
@@ -20,8 +20,12 @@ export function columnsFor(line) {
   return {
     ts: String(ev.ts ?? ''),
     type: String(ev.type ?? ''),
+    // Stringified, always. `node:sqlite` binds a JavaScript number as a REAL,
+    // so a ticket handed over as a number lands in the TEXT column as "321.0"
+    // and every `where ticket=321` misses it.
     ticket: ev.ticket == null ? null : String(ev.ticket),
     agent: ev.agent == null ? null : String(ev.agent),
+    repo: ev.repo == null ? null : String(ev.repo),
     body: line,
   }
 }
@@ -37,13 +41,13 @@ export function openJournal(file, { epochColumn = true, wal = true } = {}) {
   }
   const schema = epochColumn ? 'schema.sql' : 'schema-no-epoch.sql'
   db.exec(fs.readFileSync(path.join(here, schema), 'utf8'))
-  const insert = db.prepare('insert into events (ts, type, ticket, agent, body) values (?, ?, ?, ?, ?)')
+  const insert = db.prepare('insert into events (ts, type, ticket, agent, repo, body) values (?, ?, ?, ?, ?, ?)')
   return {
     db,
     epochColumn,
     append(line) {
       const c = columnsFor(line)
-      insert.run(c.ts, c.type, c.ticket, c.agent, c.body)
+      insert.run(c.ts, c.type, c.ticket, c.agent, c.repo, c.body)
     },
     // One transaction for a migration or a synthetic fill. The daemon commits
     // per event, and `bench.mjs` measures that separately.

--- a/prototypes/journal-schema/journal.mjs
+++ b/prototypes/journal-schema/journal.mjs
@@ -1,0 +1,57 @@
+// The write path, prototyped for #321: one journal line in, one row out.
+//
+// The daemon's `_append` builds `{ ts, ...event }`, serializes it, and appends
+// the text. Here the same text becomes `body`, and the five columns #320 asks
+// for are extracted beside it — through `normalizeEvent`, the daemon's own
+// #184 translation, so `where agent='curia-170'` finds a line that says
+// `"worker"`.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
+import { normalizeEvent } from '../../daemon/src/store.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+// What a line becomes in the columns. The line itself is untouched.
+export function columnsFor(line) {
+  const ev = normalizeEvent(JSON.parse(line))
+  return {
+    ts: String(ev.ts ?? ''),
+    type: String(ev.type ?? ''),
+    ticket: ev.ticket == null ? null : String(ev.ticket),
+    agent: ev.agent == null ? null : String(ev.agent),
+    body: line,
+  }
+}
+
+export function openJournal(file, { epochColumn = true, wal = true } = {}) {
+  fs.rmSync(file, { force: true })
+  fs.rmSync(`${file}-wal`, { force: true })
+  fs.rmSync(`${file}-shm`, { force: true })
+  const db = new DatabaseSync(file)
+  if (wal) {
+    db.exec('pragma journal_mode = wal')
+    db.exec('pragma synchronous = full') // ADR-0017: the record is here now
+  }
+  const schema = epochColumn ? 'schema.sql' : 'schema-no-epoch.sql'
+  db.exec(fs.readFileSync(path.join(here, schema), 'utf8'))
+  const insert = db.prepare('insert into events (ts, type, ticket, agent, body) values (?, ?, ?, ?, ?)')
+  return {
+    db,
+    epochColumn,
+    append(line) {
+      const c = columnsFor(line)
+      insert.run(c.ts, c.type, c.ticket, c.agent, c.body)
+    },
+    // One transaction for a migration or a synthetic fill. The daemon commits
+    // per event, and `bench.mjs` measures that separately.
+    appendAll(lines) {
+      this.db.exec('begin')
+      for (const line of lines) this.append(line)
+      this.db.exec('commit')
+    },
+    close() { db.close() },
+  }
+}

--- a/prototypes/journal-schema/oracle.mjs
+++ b/prototypes/journal-schema/oracle.mjs
@@ -1,0 +1,149 @@
+// The fourteen questions as the daemon answers them TODAY: a whole read of
+// `events.jsonl`, then a loop.
+//
+// Ported line for line out of `daemon/src/dispatch.mjs` (#epochScan,
+// #verdictIsLate, #liveUnjudgedVerdict, #epochRepo, #epochCharting,
+// #epochSpawn, #epochAdoptedMap, #endingClause, #captureVerdict,
+// #reconcileContext). This is the oracle the SQL is checked against, so a
+// query that disagrees with it is wrong by definition — including where the
+// daemon's own rule is surprising. One example the checker exercises: a
+// reviewer's `agent_spawned` carries the BUILDER's ticket, so spawning a
+// cross-check moves the builder's epoch. The queries reproduce that.
+
+const PR_EVENTS = ['pr_opened', 'pr_reused', 'land_repaired']
+const EPOCH_EVENTS = ['dispatch_claimed', 'agent_spawned']
+const ENDING_CARRIERS = ['ticket_resolved', 'nonclean_noted', 'charting_finished']
+
+const sameTicket = (ev, t) => String(ev.ticket ?? '') === String(t)
+
+// The index of the row that opened this ticket's latest dispatch, or -1.
+export function epochIndex(journal, ticket) {
+  let idx = -1
+  journal.forEach((ev, i) => { if (EPOCH_EVENTS.includes(ev.type) && sameTicket(ev, ticket)) idx = i })
+  return idx
+}
+
+export const oracle = {
+  // 1, 2, 3 — #epochScan, one pass for three answers.
+  prOpened(journal, { ticket, agent }) {
+    const e = epochIndex(journal, ticket)
+    return journal.some((ev, i) => i > e && PR_EVENTS.includes(ev.type) && (ev.agent === agent || sameTicket(ev, ticket)))
+  },
+  reviewApproved(journal, { ticket, agent }) {
+    const e = epochIndex(journal, ticket)
+    return journal.some((ev, i) => i > e && ev.type === 'review_answered' && ev.approved === true
+      && (ev.agent === agent || sameTicket(ev, ticket)))
+  },
+  blocks(journal, { ticket, agent }) {
+    const e = epochIndex(journal, ticket)
+    return journal.filter((ev, i) => i > e && ev.type === 'stop_blocked' && ev.agent === agent).length
+  },
+
+  // 4 — #verdictIsLate: did the merge outrun the reviewer?
+  verdictIsLate(journal, { ticket }) {
+    let spawned = -1
+    let resolved = -1
+    journal.forEach((ev, i) => {
+      if (!sameTicket(ev, ticket)) return
+      if (ev.type === 'reviewer_spawned') spawned = i
+      if (ev.type === 'ticket_resolved') resolved = i
+    })
+    return spawned >= 0 && resolved > spawned
+  },
+
+  // 5 — #liveUnjudgedVerdict: when was this ticket last claimed?
+  lastClaim(journal, { ticket }) {
+    let ts = null
+    for (const ev of journal) if (ev.type === 'dispatch_claimed' && sameTicket(ev, ticket) && ev.ts) ts = ev.ts
+    return ts
+  },
+
+  // 6 — #epochRepo. Predicate-narrowed: the last dispatch event that CARRIES a repo.
+  epochRepo(journal, { ticket }) {
+    let repo = null
+    for (const ev of journal) if (EPOCH_EVENTS.includes(ev.type) && sameTicket(ev, ticket) && ev.repo) repo = ev.repo
+    return repo ?? null
+  },
+
+  // 7 — #epochCharting: was the latest dispatch a charting one, and what rode it?
+  epochCharting(journal, { ticket }) {
+    let out = { charting: false, instruction: null, newMap: false }
+    for (const ev of journal) {
+      if (ev.type !== 'agent_spawned' || !sameTicket(ev, ticket)) continue
+      out = { charting: ev.kind === 'charting', instruction: ev.instruction ?? null, newMap: Boolean(ev.newMap) }
+    }
+    return out
+  },
+
+  // 8 — #epochSpawn: which model and harness is this session actually on?
+  epochSpawn(journal, { agent }) {
+    let out = null
+    for (const ev of journal) {
+      if (ev.type !== 'agent_spawned' || ev.agent !== agent) continue
+      out = { model: ev.model ?? null, harness: ev.harness ?? null }
+    }
+    return out
+  },
+
+  // 9 — #epochAdoptedMap. Keyed by AGENT, and reset at every spawn of it.
+  adoptedMap(journal, { agent }) {
+    let out = null
+    for (const ev of journal) {
+      if (ev.agent !== agent) continue
+      if (ev.type === 'agent_spawned') out = null
+      else if (ev.type === 'map_adopted' && ev.map) out = String(ev.map)
+    }
+    return out
+  },
+
+  // 10 — #endingClause. Keyed by agent, reset at spawn, predicate-narrowed:
+  // the last ending carrier that CARRIES a summary.
+  endingClause(journal, { agent }) {
+    let out = null
+    for (const ev of journal) {
+      if (ev.agent !== agent) continue
+      if (ev.type === 'agent_spawned') out = null
+      else if (ENDING_CARRIERS.includes(ev.type) && ev.summary) out = ev.summary
+    }
+    return out
+  },
+
+  // 11 — #captureVerdict: which ticket and repo does this reviewer belong to?
+  reviewerSpawn(journal, { agent }) {
+    let spawn = null
+    for (const ev of journal) if (ev.type === 'reviewer_spawned' && ev.agent === agent) spawn = ev
+    if (!spawn) return null
+    return {
+      ticket: String(spawn.ticket ?? ''),
+      repo: spawn.repo ?? null,
+      model: spawn.model ?? null,
+      builder_model: spawn.builder_model ?? null,
+      same_provider: Boolean(spawn.same_provider),
+      sha: spawn.sha ?? null,
+    }
+  },
+
+  // 12 — #reconcileContext: every ticket's latest dispatch epoch, in one pass.
+  epochs(journal) {
+    const out = new Map()
+    journal.forEach((ev, idx) => {
+      if (EPOCH_EVENTS.includes(ev.type) && ev.ticket != null) out.set(String(ev.ticket), { idx, repo: ev.repo ?? null })
+    })
+    return out
+  },
+
+  // 13 — reconcile's orphan guard: did this session report after its dispatch?
+  reportedAfterEpoch(journal, { ticket, agent }) {
+    const e = epochIndex(journal, ticket)
+    return journal.some((ev, i) => i > e && (ev.type === 'result' || ev.type === 'ticket_resolved')
+      && (ev.agent === agent || sameTicket(ev, ticket)))
+  },
+
+  // 14 — reconcile's dead-claim guard: did anything close this epoch?
+  closedAfterEpoch(journal, { ticket, agent }) {
+    const e = epochIndex(journal, ticket)
+    return journal.some((ev, i) => i > e
+      && (ev.type === 'result' || ev.type === 'lifecycle_closed' || ev.type === 'dispatch_unclaimed')
+      && (ev.agent === agent || sameTicket(ev, ticket)))
+  },
+}

--- a/prototypes/journal-schema/queries.mjs
+++ b/prototypes/journal-schema/queries.mjs
@@ -1,0 +1,296 @@
+// The fourteen questions as SQL, for #321.
+//
+// Each entry carries the SQL for the proposed schema (`sql`) and, where the
+// two differ, the SQL the same question needs on a table with NO epoch column
+// (`plain`). The difference is exactly one subquery, and it is the whole case
+// for the column.
+//
+// `read` turns the rows into the value `oracle.mjs` returns for the same
+// question, so the two can be compared with deepStrictEqual.
+
+// The epoch of a ticket, two ways.
+//   stamped — one probe of (ticket, epoch), rightmost entry.
+//   probed  — one probe each of (ticket, 'dispatch_claimed') and
+//             (ticket, 'agent_spawned') on (ticket, type, id).
+const EPOCH_STAMPED = "(select coalesce(max(epoch), 0) from events where ticket = :t)"
+const EPOCH_PROBED = "(select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))"
+
+// Shape B, split in two on purpose.
+//
+// The daemon's test is `ev.agent === agentName || ticket matches`, and written
+// as one `where ... and (ticket = :t or agent = :a)` that disjunction defeats
+// both indexes: SQLite falls back to the type index and walks every event of
+// that type since the epoch. Measured at 60,000 events, that costs 3.75 ms
+// against 0.02 ms for the form below — 185 times the work, for the same answer.
+// So each key gets its own `exists`, and each one is a covering-index seek.
+const since = (types) => (epoch) => {
+  const list = types.map((t) => `'${t}'`).join(', ')
+  return `
+select (exists(select 1 from events where ticket = :t and type in (${list}) and id > ${epoch})
+     or exists(select 1 from events where agent = :a and type in (${list}) and id > ${epoch})) as answer`.trim()
+}
+
+const prSince = since(['pr_opened', 'pr_reused', 'land_repaired'])
+const reportedSince = since(['result', 'ticket_resolved'])
+const closedSince = since(['result', 'lifecycle_closed', 'dispatch_unclaimed'])
+
+const approvedSince = (epoch) => `
+select (exists(select 1 from events where ticket = :t and type = 'review_answered'
+                and id > ${epoch} and json_extract(body, '$.approved') = 1)
+     or exists(select 1 from events where agent = :a and type = 'review_answered'
+                and id > ${epoch} and json_extract(body, '$.approved') = 1)) as answer`.trim()
+
+const blocksSince = (epoch) => `
+select count(*) as answer from events
+ where id > ${epoch}
+   and type = 'stop_blocked'
+   and agent = :a`.trim()
+
+// The reset an agent-keyed question runs on: everything after this session's
+// last spawn line.
+const LAST_SPAWN = "coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)"
+
+export const QUERIES = [
+  {
+    n: 1,
+    shape: 'B',
+    where: '#epochScan',
+    question: 'Did this dispatch push a pull request?',
+    sql: prSince(EPOCH_STAMPED),
+    plain: prSince(EPOCH_PROBED),
+    args: ({ ticket, agent }) => ({ t: String(ticket), a: agent }),
+    read: (rows) => Boolean(rows[0]?.answer),
+    oracle: 'prOpened',
+  },
+  {
+    n: 2,
+    shape: 'B',
+    where: '#epochScan',
+    question: 'Did a human approve this dispatch at the gate?',
+    note: 'Predicate-narrowed: only a review_answered whose `approved` is true counts.',
+    sql: approvedSince(EPOCH_STAMPED),
+    plain: approvedSince(EPOCH_PROBED),
+    args: ({ ticket, agent }) => ({ t: String(ticket), a: agent }),
+    read: (rows) => Boolean(rows[0]?.answer),
+    oracle: 'reviewApproved',
+  },
+  {
+    n: 3,
+    shape: 'C',
+    where: '#epochScan',
+    question: 'How many times has the Stop hook held this agent?',
+    sql: blocksSince(EPOCH_STAMPED),
+    plain: blocksSince(EPOCH_PROBED),
+    args: ({ ticket, agent }) => ({ t: String(ticket), a: agent }),
+    read: (rows) => Number(rows[0].answer),
+    oracle: 'blocks',
+  },
+  {
+    n: 4,
+    shape: 'A',
+    where: '#verdictIsLate',
+    question: 'Did the merge outrun the reviewer?',
+    sql: `
+select coalesce(
+  (select max(id) from events where ticket = :t and type = 'ticket_resolved')
+  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer`.trim(),
+    args: ({ ticket }) => ({ t: String(ticket) }),
+    read: (rows) => Boolean(rows[0].answer),
+    oracle: 'verdictIsLate',
+  },
+  {
+    n: 5,
+    shape: 'A',
+    where: '#liveUnjudgedVerdict',
+    question: 'When was this ticket last claimed?',
+    sql: `
+select ts from events
+ where ticket = :t and type = 'dispatch_claimed'
+ order by id desc limit 1`.trim(),
+    args: ({ ticket }) => ({ t: String(ticket) }),
+    read: (rows) => rows[0]?.ts ?? null,
+    oracle: 'lastClaim',
+  },
+  {
+    n: 6,
+    shape: 'A',
+    where: '#epochRepo',
+    question: 'Which repo was this ticket last dispatched against?',
+    note: 'Predicate-narrowed: the last dispatch event that CARRIES a repo.',
+    sql: `
+select json_extract(body, '$.repo') as repo from events
+ where ticket = :t
+   and type in ('dispatch_claimed', 'agent_spawned')
+   and json_extract(body, '$.repo') <> ''
+ order by id desc limit 1`.trim(),
+    args: ({ ticket }) => ({ t: String(ticket) }),
+    read: (rows) => rows[0]?.repo ?? null,
+    oracle: 'epochRepo',
+  },
+  {
+    n: 7,
+    shape: 'A',
+    where: '#epochCharting',
+    question: 'Was the last dispatch a charting one, and what rode it?',
+    sql: `
+select json_extract(body, '$.kind') = 'charting' as charting,
+       json_extract(body, '$.instruction') as instruction,
+       coalesce(json_extract(body, '$.newMap'), 0) as newMap
+  from events
+ where ticket = :t and type = 'agent_spawned'
+ order by id desc limit 1`.trim(),
+    args: ({ ticket }) => ({ t: String(ticket) }),
+    read: (rows) => (rows.length
+      ? { charting: Boolean(rows[0].charting), instruction: rows[0].instruction ?? null, newMap: Boolean(rows[0].newMap) }
+      : { charting: false, instruction: null, newMap: false }),
+    oracle: 'epochCharting',
+  },
+  {
+    n: 8,
+    shape: 'A',
+    where: '#epochSpawn',
+    question: 'Which model and harness was this session last spawned on?',
+    note: 'The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.',
+    sql: `
+select json_extract(body, '$.model') as model,
+       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness
+  from events
+ where agent = :a and type = 'agent_spawned'
+ order by id desc limit 1`.trim(),
+    args: ({ agent }) => ({ a: agent }),
+    read: (rows) => (rows.length ? { model: rows[0].model ?? null, harness: rows[0].harness ?? null } : null),
+    oracle: 'epochSpawn',
+  },
+  {
+    n: 9,
+    shape: 'A',
+    where: '#epochAdoptedMap',
+    question: 'Which map did this session report?',
+    note: 'Keyed by agent, and reset at that session`s last spawn line.',
+    sql: `
+select json_extract(body, '$.map') as map from events
+ where agent = :a and type = 'map_adopted'
+   and id > ${LAST_SPAWN}
+   and json_extract(body, '$.map') <> ''
+ order by id desc limit 1`.trim(),
+    args: ({ agent }) => ({ a: agent }),
+    read: (rows) => (rows[0]?.map == null ? null : String(rows[0].map)),
+    oracle: 'adoptedMap',
+  },
+  {
+    n: 10,
+    shape: 'A',
+    where: '#endingClause',
+    question: 'What did the ending say?',
+    note: 'Predicate-narrowed: the last ending carrier that CARRIES a summary.',
+    sql: `
+select json_extract(body, '$.summary') as summary from events
+ where agent = :a
+   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')
+   and id > ${LAST_SPAWN}
+   and json_extract(body, '$.summary') <> ''
+ order by id desc limit 1`.trim(),
+    args: ({ agent }) => ({ a: agent }),
+    read: (rows) => rows[0]?.summary ?? null,
+    oracle: 'endingClause',
+  },
+  {
+    n: 11,
+    shape: 'A',
+    where: '#captureVerdict',
+    question: 'Which ticket and repo does this reviewer belong to?',
+    sql: `
+select ticket,
+       json_extract(body, '$.repo') as repo,
+       json_extract(body, '$.model') as model,
+       json_extract(body, '$.builder_model') as builder_model,
+       json_extract(body, '$.same_provider') as same_provider,
+       json_extract(body, '$.sha') as sha
+  from events
+ where agent = :a and type = 'reviewer_spawned'
+ order by id desc limit 1`.trim(),
+    args: ({ agent }) => ({ a: agent }),
+    read: (rows) => (rows.length
+      ? {
+        ticket: String(rows[0].ticket ?? ''),
+        repo: rows[0].repo ?? null,
+        model: rows[0].model ?? null,
+        builder_model: rows[0].builder_model ?? null,
+        same_provider: Boolean(rows[0].same_provider),
+        sha: rows[0].sha ?? null,
+      }
+      : null),
+    oracle: 'reviewerSpawn',
+  },
+  {
+    n: 12,
+    shape: 'A',
+    where: '#reconcileContext',
+    question: 'What is every ticket`s latest dispatch epoch?',
+    note: 'The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.',
+    sql: `
+select e.ticket, e.id, json_extract(e.body, '$.repo') as repo
+  from events e
+  join (select ticket, max(id) as id from events
+         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null
+         group by ticket) latest on latest.id = e.id
+ order by e.ticket`.trim(),
+    args: () => ({}),
+    read: (rows) => new Map(rows.map((r) => [String(r.ticket), { idx: r.id - 1, repo: r.repo ?? null }])),
+    oracle: 'epochs',
+    whole: true,
+  },
+  {
+    n: 13,
+    shape: 'B',
+    where: 'reconcile, the orphan guard',
+    question: 'Did this session report a result after its dispatch?',
+    sql: reportedSince(EPOCH_STAMPED),
+    plain: reportedSince(EPOCH_PROBED),
+    args: ({ ticket, agent }) => ({ t: String(ticket), a: agent }),
+    read: (rows) => Boolean(rows[0]?.answer),
+    oracle: 'reportedAfterEpoch',
+  },
+  {
+    n: 14,
+    shape: 'B',
+    where: 'reconcile, the dead-claim guard',
+    question: 'Did anything close this epoch?',
+    sql: closedSince(EPOCH_STAMPED),
+    plain: closedSince(EPOCH_PROBED),
+    args: ({ ticket, agent }) => ({ t: String(ticket), a: agent }),
+    read: (rows) => Boolean(rows[0]?.answer),
+    oracle: 'closedAfterEpoch',
+  },
+]
+
+// The five the operator types by hand, from the daemon README. They are here
+// to be RUN, not quoted: #320 made this schema the whole debugging surface.
+//
+// Each one is built as literal SQL text, because that is what a human types
+// into `sqlite3`. A bound parameter would prove something else — see the
+// `numbers` note in `run.mjs`.
+export const OPERATOR_QUERIES = [
+  {
+    title: 'what happened to one ticket',
+    sql: ({ ticket }) => `select ts, type, ticket, agent from events where ticket=${ticket} order by id`,
+    note: 'A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.',
+  },
+  {
+    title: 'the last thirty events',
+    sql: () => 'select ts, type, ticket, agent from events order by id desc limit 30',
+  },
+  {
+    title: 'one whole line, exactly as curia wrote it',
+    sql: ({ id }) => `select body from events where id=${id}`,
+  },
+  {
+    title: 'the census, by type',
+    sql: () => 'select type, count(*) from events group by type order by 2 desc',
+  },
+  {
+    title: 'how one agent ended',
+    sql: ({ agent }) => `select ts, type, body from events where agent='${agent}' order by id desc limit 10`,
+    note: 'The #184 test: this agent was named `"worker"` on the lines it wrote, and the normalized column still finds them.',
+  },
+]

--- a/prototypes/journal-schema/queries.mjs
+++ b/prototypes/journal-schema/queries.mjs
@@ -118,10 +118,10 @@ select ts from events
     question: 'Which repo was this ticket last dispatched against?',
     note: 'Predicate-narrowed: the last dispatch event that CARRIES a repo.',
     sql: `
-select json_extract(body, '$.repo') as repo from events
+select repo from events
  where ticket = :t
    and type in ('dispatch_claimed', 'agent_spawned')
-   and json_extract(body, '$.repo') <> ''
+   and repo <> ''
  order by id desc limit 1`.trim(),
     args: ({ ticket }) => ({ t: String(ticket) }),
     read: (rows) => rows[0]?.repo ?? null,
@@ -201,7 +201,7 @@ select json_extract(body, '$.summary') as summary from events
     question: 'Which ticket and repo does this reviewer belong to?',
     sql: `
 select ticket,
-       json_extract(body, '$.repo') as repo,
+       repo,
        json_extract(body, '$.model') as model,
        json_extract(body, '$.builder_model') as builder_model,
        json_extract(body, '$.same_provider') as same_provider,
@@ -229,7 +229,7 @@ select ticket,
     question: 'What is every ticket`s latest dispatch epoch?',
     note: 'The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.',
     sql: `
-select e.ticket, e.id, json_extract(e.body, '$.repo') as repo
+select e.ticket, e.id, e.repo
   from events e
   join (select ticket, max(id) as id from events
          where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null

--- a/prototypes/journal-schema/results.json
+++ b/prototypes/journal-schema/results.json
@@ -1,21 +1,33 @@
 {
   "node": "v24.19.0",
   "sqlite": "3.53.3",
+  "stamps": {
+    "events": 2000,
+    "distinctStamps": 58,
+    "mostOnOneStamp": 53,
+    "boundary": {
+      "ticket": "901",
+      "ts": "2026-08-16T11:19:51.710Z",
+      "pairs": 1,
+      "byId": true,
+      "byTs": false
+    }
+  },
   "sizes": [
     {
       "size": 4282,
       "live": true,
       "tickets": 171,
-      "loadMs": 247.005,
-      "wholeReadMs": 29.58,
+      "loadMs": 297.643,
+      "wholeReadMs": 28.49,
       "sizes": {
         "journalFileBytes": 1187203,
-        "dbBytes": 2228224,
+        "dbBytes": 2289664,
         "plainDbBytes": 4096,
         "perIndex": [
           {
             "name": "events",
-            "bytes": 1564672
+            "bytes": 1626112
           },
           {
             "name": "events_agent_type",
@@ -54,9 +66,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0321,
-          "plainMs": 0.0362,
-          "scanMs": 0.4397,
+          "sqlMs": 0.0266,
+          "plainMs": 0.0349,
+          "scanMs": 0.4481,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -77,9 +89,9 @@
           "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
           "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
-          "sqlMs": 0.0156,
-          "plainMs": 0.0229,
-          "scanMs": 0.327,
+          "sqlMs": 0.0159,
+          "plainMs": 0.0265,
+          "scanMs": 0.2941,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -100,9 +112,9 @@
           "note": null,
           "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
           "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
-          "sqlMs": 0.0125,
-          "plainMs": 0.0156,
-          "scanMs": 0.3734,
+          "sqlMs": 0.0133,
+          "plainMs": 0.0181,
+          "scanMs": 0.4824,
           "plan": [
             "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -117,9 +129,9 @@
           "note": null,
           "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
           "plain": null,
-          "sqlMs": 0.0102,
-          "plainMs": 0.0091,
-          "scanMs": 0.2104,
+          "sqlMs": 0.012,
+          "plainMs": 0.0136,
+          "scanMs": 0.2702,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 1",
@@ -136,9 +148,9 @@
           "note": null,
           "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0111,
-          "plainMs": 0.0103,
-          "scanMs": 0.1333,
+          "sqlMs": 0.0116,
+          "plainMs": 0.0129,
+          "scanMs": 0.1199,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -149,11 +161,11 @@
           "where": "#epochRepo",
           "question": "Which repo was this ticket last dispatched against?",
           "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
-          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "sql": "select repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and repo <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0192,
-          "plainMs": 0.0229,
-          "scanMs": 0.1687,
+          "sqlMs": 0.0174,
+          "plainMs": 0.0269,
+          "scanMs": 0.2645,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
             "USE TEMP B-TREE FOR ORDER BY"
@@ -167,9 +179,9 @@
           "note": null,
           "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0114,
-          "plainMs": 0.0145,
-          "scanMs": 0.1056,
+          "sqlMs": 0.0195,
+          "plainMs": 0.0184,
+          "scanMs": 0.1213,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -182,9 +194,9 @@
           "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
           "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0137,
-          "plainMs": 0.0147,
-          "scanMs": 0.1026,
+          "sqlMs": 0.0156,
+          "plainMs": 0.012,
+          "scanMs": 0.1449,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -197,9 +209,9 @@
           "note": "Keyed by agent, and reset at that session`s last spawn line.",
           "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0092,
-          "plainMs": 0.0103,
-          "scanMs": 0.1842,
+          "sqlMs": 0.0125,
+          "plainMs": 0.0118,
+          "scanMs": 0.1949,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -214,9 +226,9 @@
           "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
           "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0198,
-          "plainMs": 0.02,
-          "scanMs": 0.2233,
+          "sqlMs": 0.0286,
+          "plainMs": 0.0337,
+          "scanMs": 0.1699,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -230,11 +242,11 @@
           "where": "#captureVerdict",
           "question": "Which ticket and repo does this reviewer belong to?",
           "note": null,
-          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "sql": "select ticket,\n       repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0109,
-          "plainMs": 0.0108,
-          "scanMs": 0.1434,
+          "sqlMs": 0.0084,
+          "plainMs": 0.0063,
+          "scanMs": 0.1992,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -245,11 +257,11 @@
           "where": "#reconcileContext",
           "question": "What is every ticket`s latest dispatch epoch?",
           "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
-          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "sql": "select e.ticket, e.id, e.repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
           "plain": null,
-          "sqlMs": 1.4241,
-          "plainMs": 0.9991,
-          "scanMs": 0.4301,
+          "sqlMs": 1.0535,
+          "plainMs": 1.0534,
+          "scanMs": 0.4626,
           "plan": [
             "CO-ROUTINE latest",
             "SEARCH events USING INDEX events_type (type=?)",
@@ -267,9 +279,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0121,
-          "plainMs": 0.0152,
-          "scanMs": 0.2464,
+          "sqlMs": 0.0204,
+          "plainMs": 0.0259,
+          "scanMs": 0.3181,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -290,9 +302,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0141,
-          "plainMs": 0.0156,
-          "scanMs": 0.265,
+          "sqlMs": 0.0218,
+          "plainMs": 0.0281,
+          "scanMs": 0.2912,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -311,7 +323,7 @@
           "title": "what happened to one ticket",
           "sql": "select ts, type, ticket, agent from events where ticket=100 order by id",
           "note": "A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.",
-          "ms": 0.217,
+          "ms": 0.266,
           "count": 37,
           "sample": [
             {
@@ -344,7 +356,7 @@
           "title": "the last thirty events",
           "sql": "select ts, type, ticket, agent from events order by id desc limit 30",
           "note": null,
-          "ms": 0.129,
+          "ms": 0.125,
           "count": 30,
           "sample": [
             {
@@ -377,7 +389,7 @@
           "title": "one whole line, exactly as curia wrote it",
           "sql": "select body from events where id=2141",
           "note": null,
-          "ms": 0.035,
+          "ms": 0.037,
           "count": 1,
           "sample": [
             {
@@ -389,7 +401,7 @@
           "title": "the census, by type",
           "sql": "select type, count(*) from events group by type order by 2 desc",
           "note": null,
-          "ms": 1.157,
+          "ms": 0.662,
           "count": 109,
           "sample": [
             {
@@ -414,7 +426,7 @@
           "title": "how one agent ended",
           "sql": "select ts, type, body from events where agent='curia-100' order by id desc limit 10",
           "note": "The #184 test: this agent was named `\"worker\"` on the lines it wrote, and the normalized column still finds them.",
-          "ms": 0.204,
+          "ms": 0.128,
           "count": 10,
           "sample": [
             {
@@ -475,24 +487,24 @@
         "bytesPerLine": 277
       },
       "write": {
-        "stamped": 1.185,
-        "plain": 1.005
+        "stamped": 1.152,
+        "plain": 0.874
       }
     },
     {
       "size": 30000,
       "live": false,
       "tickets": 1186,
-      "loadMs": 2823.361,
-      "wholeReadMs": 194.01,
+      "loadMs": 3677.919,
+      "wholeReadMs": 195.49,
       "sizes": {
         "journalFileBytes": 8346451,
-        "dbBytes": 15454208,
-        "plainDbBytes": 13991936,
+        "dbBytes": 15888384,
+        "plainDbBytes": 14430208,
         "perIndex": [
           {
             "name": "events",
-            "bytes": 11010048
+            "bytes": 11444224
           },
           {
             "name": "events_agent_type",
@@ -531,9 +543,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0174,
-          "plainMs": 0.023,
-          "scanMs": 6.0171,
+          "sqlMs": 0.0221,
+          "plainMs": 0.0296,
+          "scanMs": 6.2175,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -554,9 +566,9 @@
           "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
           "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
-          "sqlMs": 0.0173,
-          "plainMs": 0.0204,
-          "scanMs": 5.6245,
+          "sqlMs": 0.0207,
+          "plainMs": 0.0251,
+          "scanMs": 6.9777,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -577,9 +589,9 @@
           "note": null,
           "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
           "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
-          "sqlMs": 0.0092,
-          "plainMs": 0.0134,
-          "scanMs": 11.6228,
+          "sqlMs": 0.013,
+          "plainMs": 0.0154,
+          "scanMs": 8.7042,
           "plan": [
             "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -594,9 +606,9 @@
           "note": null,
           "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
           "plain": null,
-          "sqlMs": 0.0125,
-          "plainMs": 0.0098,
-          "scanMs": 1.839,
+          "sqlMs": 0.013,
+          "plainMs": 0.0125,
+          "scanMs": 1.5585,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 1",
@@ -613,9 +625,9 @@
           "note": null,
           "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0138,
-          "plainMs": 0.0148,
-          "scanMs": 4.3195,
+          "sqlMs": 0.0134,
+          "plainMs": 0.0123,
+          "scanMs": 3.5227,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -626,11 +638,11 @@
           "where": "#epochRepo",
           "question": "Which repo was this ticket last dispatched against?",
           "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
-          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "sql": "select repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and repo <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0277,
-          "plainMs": 0.0301,
-          "scanMs": 4.625,
+          "sqlMs": 0.0254,
+          "plainMs": 0.0222,
+          "scanMs": 4.4509,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
             "USE TEMP B-TREE FOR ORDER BY"
@@ -645,8 +657,8 @@
           "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
           "sqlMs": 0.0172,
-          "plainMs": 0.0113,
-          "scanMs": 3.1268,
+          "plainMs": 0.017,
+          "scanMs": 3.2597,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -659,9 +671,9 @@
           "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
           "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0145,
-          "plainMs": 0.0106,
-          "scanMs": 2.9286,
+          "sqlMs": 0.02,
+          "plainMs": 0.0191,
+          "scanMs": 3.0842,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -674,9 +686,9 @@
           "note": "Keyed by agent, and reset at that session`s last spawn line.",
           "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0141,
-          "plainMs": 0.0136,
-          "scanMs": 4.4622,
+          "sqlMs": 0.0139,
+          "plainMs": 0.0135,
+          "scanMs": 3.8834,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -691,9 +703,9 @@
           "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
           "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0338,
-          "plainMs": 0.0389,
-          "scanMs": 3.8664,
+          "sqlMs": 0.0371,
+          "plainMs": 0.0311,
+          "scanMs": 2.9529,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -707,11 +719,11 @@
           "where": "#captureVerdict",
           "question": "Which ticket and repo does this reviewer belong to?",
           "note": null,
-          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "sql": "select ticket,\n       repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0097,
-          "plainMs": 0.0091,
-          "scanMs": 2.8688,
+          "sqlMs": 0.0086,
+          "plainMs": 0.0111,
+          "scanMs": 2.983,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -722,11 +734,11 @@
           "where": "#reconcileContext",
           "question": "What is every ticket`s latest dispatch epoch?",
           "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
-          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "sql": "select e.ticket, e.id, e.repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
           "plain": null,
-          "sqlMs": 23.563,
-          "plainMs": 23.2442,
-          "scanMs": 8.7506,
+          "sqlMs": 19.1553,
+          "plainMs": 23.9932,
+          "scanMs": 7.1658,
           "plan": [
             "CO-ROUTINE latest",
             "SEARCH events USING INDEX events_type (type=?)",
@@ -744,9 +756,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0205,
-          "plainMs": 0.0241,
-          "scanMs": 4.3737,
+          "sqlMs": 0.0223,
+          "plainMs": 0.0289,
+          "scanMs": 6.2146,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -767,9 +779,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0135,
-          "plainMs": 0.0188,
-          "scanMs": 6.357,
+          "sqlMs": 0.0232,
+          "plainMs": 0.0304,
+          "scanMs": 5.3812,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -788,16 +800,16 @@
       "size": 60000,
       "live": false,
       "tickets": 2393,
-      "loadMs": 6805.193,
-      "wholeReadMs": 384.97,
+      "loadMs": 7772.914,
+      "wholeReadMs": 421.98,
       "sizes": {
         "journalFileBytes": 16755914,
-        "dbBytes": 31301632,
-        "plainDbBytes": 28241920,
+        "dbBytes": 32149504,
+        "plainDbBytes": 29122560,
         "perIndex": [
           {
             "name": "events",
-            "bytes": 22167552
+            "bytes": 23015424
           },
           {
             "name": "events_agent_type",
@@ -836,9 +848,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.029,
-          "plainMs": 0.0258,
-          "scanMs": 14.0344,
+          "sqlMs": 0.0318,
+          "plainMs": 0.0353,
+          "scanMs": 16.6212,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -859,9 +871,9 @@
           "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
           "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
-          "sqlMs": 0.0123,
-          "plainMs": 0.0165,
-          "scanMs": 13.8516,
+          "sqlMs": 0.0169,
+          "plainMs": 0.0226,
+          "scanMs": 14.7173,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -882,9 +894,9 @@
           "note": null,
           "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
           "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
-          "sqlMs": 0.0157,
-          "plainMs": 0.0189,
-          "scanMs": 22.7631,
+          "sqlMs": 0.0129,
+          "plainMs": 0.0195,
+          "scanMs": 25.6194,
           "plan": [
             "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -899,9 +911,9 @@
           "note": null,
           "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
           "plain": null,
-          "sqlMs": 0.0125,
-          "plainMs": 0.0123,
-          "scanMs": 4.2695,
+          "sqlMs": 0.0124,
+          "plainMs": 0.0124,
+          "scanMs": 4.9805,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 1",
@@ -918,9 +930,9 @@
           "note": null,
           "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0133,
-          "plainMs": 0.0129,
-          "scanMs": 7.8271,
+          "sqlMs": 0.0136,
+          "plainMs": 0.0139,
+          "scanMs": 8.2656,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -931,11 +943,11 @@
           "where": "#epochRepo",
           "question": "Which repo was this ticket last dispatched against?",
           "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
-          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "sql": "select repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and repo <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.034,
-          "plainMs": 0.0252,
-          "scanMs": 10.4597,
+          "sqlMs": 0.0284,
+          "plainMs": 0.0265,
+          "scanMs": 16.1218,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
             "USE TEMP B-TREE FOR ORDER BY"
@@ -949,9 +961,9 @@
           "note": null,
           "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0172,
-          "plainMs": 0.0165,
-          "scanMs": 7.2932,
+          "sqlMs": 0.0186,
+          "plainMs": 0.0186,
+          "scanMs": 11.4079,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -964,9 +976,9 @@
           "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
           "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0121,
-          "plainMs": 0.0186,
-          "scanMs": 6.8724,
+          "sqlMs": 0.0239,
+          "plainMs": 0.0207,
+          "scanMs": 8.7752,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -979,9 +991,9 @@
           "note": "Keyed by agent, and reset at that session`s last spawn line.",
           "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0133,
-          "plainMs": 0.0127,
-          "scanMs": 6.6507,
+          "sqlMs": 0.016,
+          "plainMs": 0.0147,
+          "scanMs": 8.322,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -996,9 +1008,9 @@
           "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
           "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.035,
-          "plainMs": 0.025,
-          "scanMs": 7.2847,
+          "sqlMs": 0.0352,
+          "plainMs": 0.0373,
+          "scanMs": 8.1975,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -1012,11 +1024,11 @@
           "where": "#captureVerdict",
           "question": "Which ticket and repo does this reviewer belong to?",
           "note": null,
-          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "sql": "select ticket,\n       repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.01,
-          "plainMs": 0.007,
-          "scanMs": 6.6494,
+          "sqlMs": 0.0108,
+          "plainMs": 0.0109,
+          "scanMs": 8.199,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -1027,11 +1039,11 @@
           "where": "#reconcileContext",
           "question": "What is every ticket`s latest dispatch epoch?",
           "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
-          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "sql": "select e.ticket, e.id, e.repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
           "plain": null,
-          "sqlMs": 50.4635,
-          "plainMs": 51.3098,
-          "scanMs": 13.5906,
+          "sqlMs": 54.3737,
+          "plainMs": 53.0124,
+          "scanMs": 15.8127,
           "plan": [
             "CO-ROUTINE latest",
             "SEARCH events USING INDEX events_type (type=?)",
@@ -1049,9 +1061,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0156,
-          "plainMs": 0.0306,
-          "scanMs": 10.2286,
+          "sqlMs": 0.0175,
+          "plainMs": 0.0253,
+          "scanMs": 11.9201,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -1072,9 +1084,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0137,
-          "plainMs": 0.0169,
-          "scanMs": 10.0148,
+          "sqlMs": 0.0163,
+          "plainMs": 0.0186,
+          "scanMs": 12.0416,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -1093,7 +1105,7 @@
           "title": "what happened to one ticket",
           "sql": "select ts, type, ticket, agent from events where ticket=100 order by id",
           "note": "A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.",
-          "ms": 0.28,
+          "ms": 0.402,
           "count": 37,
           "sample": [
             {
@@ -1126,7 +1138,7 @@
           "title": "the last thirty events",
           "sql": "select ts, type, ticket, agent from events order by id desc limit 30",
           "note": null,
-          "ms": 0.138,
+          "ms": 0.19,
           "count": 30,
           "sample": [
             {
@@ -1159,7 +1171,7 @@
           "title": "one whole line, exactly as curia wrote it",
           "sql": "select body from events where id=30000",
           "note": null,
-          "ms": 0.038,
+          "ms": 0.047,
           "count": 1,
           "sample": [
             {
@@ -1171,7 +1183,7 @@
           "title": "the census, by type",
           "sql": "select type, count(*) from events group by type order by 2 desc",
           "note": null,
-          "ms": 10.158,
+          "ms": 11.218,
           "count": 109,
           "sample": [
             {
@@ -1196,7 +1208,7 @@
           "title": "how one agent ended",
           "sql": "select ts, type, body from events where agent='curia-100' order by id desc limit 10",
           "note": "The #184 test: this agent was named `\"worker\"` on the lines it wrote, and the normalized column still finds them.",
-          "ms": 0.242,
+          "ms": 0.345,
           "count": 10,
           "sample": [
             {
@@ -1257,24 +1269,24 @@
         "bytesPerLine": 279
       },
       "write": {
-        "stamped": 1.285,
-        "plain": 1.022
+        "stamped": 1.217,
+        "plain": 0.944
       }
     },
     {
       "size": 250000,
       "live": false,
       "tickets": 9997,
-      "loadMs": 30390.514,
-      "wholeReadMs": 2044.9,
+      "loadMs": 35332.283,
+      "wholeReadMs": 2473.92,
       "sizes": {
         "journalFileBytes": 69992760,
-        "dbBytes": 131833856,
-        "plainDbBytes": 118636544,
+        "dbBytes": 135520256,
+        "plainDbBytes": 122249216,
         "perIndex": [
           {
             "name": "events",
-            "bytes": 92827648
+            "bytes": 96514048
           },
           {
             "name": "events_agent_type",
@@ -1313,9 +1325,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0274,
-          "plainMs": 0.0327,
-          "scanMs": 43.2421,
+          "sqlMs": 0.05,
+          "plainMs": 0.0559,
+          "scanMs": 48.9107,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -1336,9 +1348,9 @@
           "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
           "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
-          "sqlMs": 0.0222,
-          "plainMs": 0.0309,
-          "scanMs": 45.1881,
+          "sqlMs": 0.0299,
+          "plainMs": 0.0385,
+          "scanMs": 52.2065,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -1359,9 +1371,9 @@
           "note": null,
           "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
           "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
-          "sqlMs": 0.0403,
-          "plainMs": 0.0548,
-          "scanMs": 74.399,
+          "sqlMs": 0.0183,
+          "plainMs": 0.0214,
+          "scanMs": 97.3437,
           "plan": [
             "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -1376,9 +1388,9 @@
           "note": null,
           "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
           "plain": null,
-          "sqlMs": 0.0144,
-          "plainMs": 0.0146,
-          "scanMs": 12.2307,
+          "sqlMs": 0.0128,
+          "plainMs": 0.0107,
+          "scanMs": 15.8863,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 1",
@@ -1395,9 +1407,9 @@
           "note": null,
           "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0118,
-          "plainMs": 0.0144,
-          "scanMs": 32.7485,
+          "sqlMs": 0.0185,
+          "plainMs": 0.0222,
+          "scanMs": 34.5823,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -1408,11 +1420,11 @@
           "where": "#epochRepo",
           "question": "Which repo was this ticket last dispatched against?",
           "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
-          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "sql": "select repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and repo <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0379,
-          "plainMs": 0.0376,
-          "scanMs": 35.8827,
+          "sqlMs": 0.032,
+          "plainMs": 0.0352,
+          "scanMs": 42.969,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
             "USE TEMP B-TREE FOR ORDER BY"
@@ -1426,9 +1438,9 @@
           "note": null,
           "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0158,
-          "plainMs": 0.0118,
-          "scanMs": 27.8271,
+          "sqlMs": 0.0218,
+          "plainMs": 0.0206,
+          "scanMs": 36.6813,
           "plan": [
             "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
           ]
@@ -1441,9 +1453,9 @@
           "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
           "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0224,
-          "plainMs": 0.0192,
-          "scanMs": 25.8342,
+          "sqlMs": 0.0222,
+          "plainMs": 0.0207,
+          "scanMs": 29.2846,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -1456,9 +1468,9 @@
           "note": "Keyed by agent, and reset at that session`s last spawn line.",
           "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0098,
-          "plainMs": 0.0087,
-          "scanMs": 25.3705,
+          "sqlMs": 0.0112,
+          "plainMs": 0.0092,
+          "scanMs": 29.6367,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -1473,9 +1485,9 @@
           "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
           "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0355,
-          "plainMs": 0.0228,
-          "scanMs": 23.2186,
+          "sqlMs": 0.0441,
+          "plainMs": 0.0448,
+          "scanMs": 27.8249,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
             "SCALAR SUBQUERY 1",
@@ -1489,11 +1501,11 @@
           "where": "#captureVerdict",
           "question": "Which ticket and repo does this reviewer belong to?",
           "note": null,
-          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "sql": "select ticket,\n       repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
           "plain": null,
-          "sqlMs": 0.0073,
-          "plainMs": 0.0102,
-          "scanMs": 23.5,
+          "sqlMs": 0.0122,
+          "plainMs": 0.0103,
+          "scanMs": 29.4852,
           "plan": [
             "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
           ]
@@ -1504,11 +1516,11 @@
           "where": "#reconcileContext",
           "question": "What is every ticket`s latest dispatch epoch?",
           "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
-          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "sql": "select e.ticket, e.id, e.repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
           "plain": null,
-          "sqlMs": 186.5719,
-          "plainMs": 183.0662,
-          "scanMs": 58.9981,
+          "sqlMs": 233.8908,
+          "plainMs": 178.2148,
+          "scanMs": 58.4841,
           "plan": [
             "CO-ROUTINE latest",
             "SEARCH events USING INDEX events_type (type=?)",
@@ -1526,9 +1538,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0237,
-          "plainMs": 0.0227,
-          "scanMs": 38.9094,
+          "sqlMs": 0.0308,
+          "plainMs": 0.0378,
+          "scanMs": 37.5813,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",
@@ -1549,9 +1561,9 @@
           "note": null,
           "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
           "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
-          "sqlMs": 0.0158,
-          "plainMs": 0.0167,
-          "scanMs": 49.379,
+          "sqlMs": 0.0239,
+          "plainMs": 0.0299,
+          "scanMs": 38.7071,
           "plan": [
             "SCAN CONSTANT ROW",
             "SCALAR SUBQUERY 2",

--- a/prototypes/journal-schema/results.json
+++ b/prototypes/journal-schema/results.json
@@ -1,0 +1,1570 @@
+{
+  "node": "v24.19.0",
+  "sqlite": "3.53.3",
+  "sizes": [
+    {
+      "size": 4282,
+      "live": true,
+      "tickets": 171,
+      "loadMs": 247.005,
+      "wholeReadMs": 29.58,
+      "sizes": {
+        "journalFileBytes": 1187203,
+        "dbBytes": 2228224,
+        "plainDbBytes": 4096,
+        "perIndex": [
+          {
+            "name": "events",
+            "bytes": 1564672
+          },
+          {
+            "name": "events_agent_type",
+            "bytes": 176128
+          },
+          {
+            "name": "events_ticket_type",
+            "bytes": 151552
+          },
+          {
+            "name": "events_epoch_type",
+            "bytes": 131072
+          },
+          {
+            "name": "events_type",
+            "bytes": 126976
+          },
+          {
+            "name": "events_ticket_epoch",
+            "bytes": 73728
+          }
+        ]
+      },
+      "equivalence": {
+        "checks": 2705,
+        "mismatches": [],
+        "keys": 208,
+        "capped": false
+      },
+      "queries": [
+        {
+          "n": 1,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did this dispatch push a pull request?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0321,
+          "plainMs": 0.0362,
+          "scanMs": 0.4397,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 2,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did a human approve this dispatch at the gate?",
+          "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
+          "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
+          "sqlMs": 0.0156,
+          "plainMs": 0.0229,
+          "scanMs": 0.327,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 3,
+          "shape": "C",
+          "where": "#epochScan",
+          "question": "How many times has the Stop hook held this agent?",
+          "note": null,
+          "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
+          "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
+          "sqlMs": 0.0125,
+          "plainMs": 0.0156,
+          "scanMs": 0.3734,
+          "plan": [
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 4,
+          "shape": "A",
+          "where": "#verdictIsLate",
+          "question": "Did the merge outrun the reviewer?",
+          "note": null,
+          "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
+          "plain": null,
+          "sqlMs": 0.0102,
+          "plainMs": 0.0091,
+          "scanMs": 0.2104,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 5,
+          "shape": "A",
+          "where": "#liveUnjudgedVerdict",
+          "question": "When was this ticket last claimed?",
+          "note": null,
+          "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0111,
+          "plainMs": 0.0103,
+          "scanMs": 0.1333,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 6,
+          "shape": "A",
+          "where": "#epochRepo",
+          "question": "Which repo was this ticket last dispatched against?",
+          "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
+          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0192,
+          "plainMs": 0.0229,
+          "scanMs": 0.1687,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 7,
+          "shape": "A",
+          "where": "#epochCharting",
+          "question": "Was the last dispatch a charting one, and what rode it?",
+          "note": null,
+          "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0114,
+          "plainMs": 0.0145,
+          "scanMs": 0.1056,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 8,
+          "shape": "A",
+          "where": "#epochSpawn",
+          "question": "Which model and harness was this session last spawned on?",
+          "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
+          "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0137,
+          "plainMs": 0.0147,
+          "scanMs": 0.1026,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 9,
+          "shape": "A",
+          "where": "#epochAdoptedMap",
+          "question": "Which map did this session report?",
+          "note": "Keyed by agent, and reset at that session`s last spawn line.",
+          "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0092,
+          "plainMs": 0.0103,
+          "scanMs": 0.1842,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 10,
+          "shape": "A",
+          "where": "#endingClause",
+          "question": "What did the ending say?",
+          "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
+          "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0198,
+          "plainMs": 0.02,
+          "scanMs": 0.2233,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 11,
+          "shape": "A",
+          "where": "#captureVerdict",
+          "question": "Which ticket and repo does this reviewer belong to?",
+          "note": null,
+          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0109,
+          "plainMs": 0.0108,
+          "scanMs": 0.1434,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 12,
+          "shape": "A",
+          "where": "#reconcileContext",
+          "question": "What is every ticket`s latest dispatch epoch?",
+          "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
+          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "plain": null,
+          "sqlMs": 1.4241,
+          "plainMs": 0.9991,
+          "scanMs": 0.4301,
+          "plan": [
+            "CO-ROUTINE latest",
+            "SEARCH events USING INDEX events_type (type=?)",
+            "USE TEMP B-TREE FOR GROUP BY",
+            "SCAN latest",
+            "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 13,
+          "shape": "B",
+          "where": "reconcile, the orphan guard",
+          "question": "Did this session report a result after its dispatch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0121,
+          "plainMs": 0.0152,
+          "scanMs": 0.2464,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 14,
+          "shape": "B",
+          "where": "reconcile, the dead-claim guard",
+          "question": "Did anything close this epoch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0141,
+          "plainMs": 0.0156,
+          "scanMs": 0.265,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        }
+      ],
+      "operator": [
+        {
+          "title": "what happened to one ticket",
+          "sql": "select ts, type, ticket, agent from events where ticket=100 order by id",
+          "note": "A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.",
+          "ms": 0.217,
+          "count": 37,
+          "sample": [
+            {
+              "ts": "2026-05-01T08:00:00.000Z",
+              "type": "dispatch_claimed",
+              "ticket": "100",
+              "agent": "curia-100"
+            },
+            {
+              "ts": "2026-05-01T08:01:03.000Z",
+              "type": "agent_spawned",
+              "ticket": "100",
+              "agent": "curia-100"
+            },
+            {
+              "ts": "2026-05-01T08:01:24.000Z",
+              "type": "dispatch_claimed",
+              "ticket": "100",
+              "agent": "curia-100"
+            },
+            {
+              "ts": "2026-05-01T08:01:45.000Z",
+              "type": "agent_spawned",
+              "ticket": "100",
+              "agent": "curia-100"
+            }
+          ]
+        },
+        {
+          "title": "the last thirty events",
+          "sql": "select ts, type, ticket, agent from events order by id desc limit 30",
+          "note": null,
+          "ms": 0.129,
+          "count": 30,
+          "sample": [
+            {
+              "ts": "2026-05-02T08:58:21.000Z",
+              "type": "result",
+              "ticket": "269",
+              "agent": "curia-269"
+            },
+            {
+              "ts": "2026-05-02T08:58:00.000Z",
+              "type": "result",
+              "ticket": "268",
+              "agent": "curia-268"
+            },
+            {
+              "ts": "2026-05-02T08:57:39.000Z",
+              "type": "command",
+              "ticket": "270",
+              "agent": "curia-270"
+            },
+            {
+              "ts": "2026-05-02T08:57:18.000Z",
+              "type": "agent_ready",
+              "ticket": "270",
+              "agent": "curia-270"
+            }
+          ]
+        },
+        {
+          "title": "one whole line, exactly as curia wrote it",
+          "sql": "select body from events where id=2141",
+          "note": null,
+          "ms": 0.035,
+          "count": 1,
+          "sample": [
+            {
+              "body": "{\"ts\":\"2026-05-01T20:29:00.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/curia-site\",\"ticket\":184,\"agent\":\"curia-184\",\"reason\":\"result\"}"
+            }
+          ]
+        },
+        {
+          "title": "the census, by type",
+          "sql": "select type, count(*) from events group by type order by 2 desc",
+          "note": null,
+          "ms": 1.157,
+          "count": 109,
+          "sample": [
+            {
+              "type": "stop_blocked",
+              "count(*)": 311
+            },
+            {
+              "type": "review_answered",
+              "count(*)": 269
+            },
+            {
+              "type": "agent_spawned",
+              "count(*)": 265
+            },
+            {
+              "type": "result",
+              "count(*)": 263
+            }
+          ]
+        },
+        {
+          "title": "how one agent ended",
+          "sql": "select ts, type, body from events where agent='curia-100' order by id desc limit 10",
+          "note": "The #184 test: this agent was named `\"worker\"` on the lines it wrote, and the normalized column still finds them.",
+          "ms": 0.204,
+          "count": 10,
+          "sample": [
+            {
+              "ts": "2026-05-01T08:23:06.000Z",
+              "type": "lifecycle_closed",
+              "body": "{\"ts\":\"2026-05-01T08:23:06.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"reason\":\"result\"}"
+            },
+            {
+              "ts": "2026-05-01T08:22:03.000Z",
+              "type": "result",
+              "body": "{\"ts\":\"2026-05-01T08:22:03.000Z\",\"type\":\"result\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"status\":\"resolved\",\"summary\":\"own one finding event own its so own the so and line stands its s…"
+            },
+            {
+              "ts": "2026-05-01T08:21:00.000Z",
+              "type": "ticket_resolved",
+              "body": "{\"ts\":\"2026-05-01T08:21:00.000Z\",\"type\":\"ticket_resolved\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"comment\":\"posted\",\"close\":\"closed\",\"map\":\"appended\",\"land\":\"merged\",\"pr\":\"https://gith…"
+            },
+            {
+              "ts": "2026-05-01T08:19:57.000Z",
+              "type": "lifecycle_closed",
+              "body": "{\"ts\":\"2026-05-01T08:19:57.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/scratch\",\"ticket\":100,\"worker\":\"curia-100\",\"reason\":\"result\"}"
+            }
+          ]
+        }
+      ],
+      "fidelity": {
+        "byteForByte": true,
+        "lines": 4282,
+        "legacy": {
+          "id": 1,
+          "agent": "curia-100",
+          "type": "dispatch_claimed",
+          "body": "{\"ts\":\"2026-05-01T08:00:00.000Z\",\"type\":\"dispatch_claimed\",\"repo\":\"alp82/scratch\",\"ticket\":100,\"worker\":\"curia-100\",\"by\":\"auto\",\"kind\":\"ticket\"}",
+          "foundByAgent": 37,
+          "legacyTypeNormalized": 58
+        },
+        "affinity": {
+          "ticket": "100",
+          "asNumber": 37,
+          "asText": 37,
+          "equal": true
+        },
+        "numbers": {
+          "bound_number": {
+            "stored": "321.0",
+            "typeof": "text"
+          },
+          "bound_string": {
+            "stored": "321",
+            "typeof": "text"
+          }
+        },
+        "strict": {
+          "blobIntoText": "refused",
+          "message": "cannot store BLOB value in TEXT column events.ts"
+        },
+        "types": 109,
+        "bytesPerLine": 277
+      },
+      "write": {
+        "stamped": 1.185,
+        "plain": 1.005
+      }
+    },
+    {
+      "size": 30000,
+      "live": false,
+      "tickets": 1186,
+      "loadMs": 2823.361,
+      "wholeReadMs": 194.01,
+      "sizes": {
+        "journalFileBytes": 8346451,
+        "dbBytes": 15454208,
+        "plainDbBytes": 13991936,
+        "perIndex": [
+          {
+            "name": "events",
+            "bytes": 11010048
+          },
+          {
+            "name": "events_agent_type",
+            "bytes": 1187840
+          },
+          {
+            "name": "events_ticket_type",
+            "bytes": 1003520
+          },
+          {
+            "name": "events_type",
+            "bytes": 892928
+          },
+          {
+            "name": "events_epoch_type",
+            "bytes": 876544
+          },
+          {
+            "name": "events_ticket_epoch",
+            "bytes": 479232
+          }
+        ]
+      },
+      "equivalence": {
+        "checks": 4746,
+        "mismatches": [],
+        "keys": 365,
+        "capped": true
+      },
+      "queries": [
+        {
+          "n": 1,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did this dispatch push a pull request?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0174,
+          "plainMs": 0.023,
+          "scanMs": 6.0171,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 2,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did a human approve this dispatch at the gate?",
+          "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
+          "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
+          "sqlMs": 0.0173,
+          "plainMs": 0.0204,
+          "scanMs": 5.6245,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 3,
+          "shape": "C",
+          "where": "#epochScan",
+          "question": "How many times has the Stop hook held this agent?",
+          "note": null,
+          "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
+          "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
+          "sqlMs": 0.0092,
+          "plainMs": 0.0134,
+          "scanMs": 11.6228,
+          "plan": [
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 4,
+          "shape": "A",
+          "where": "#verdictIsLate",
+          "question": "Did the merge outrun the reviewer?",
+          "note": null,
+          "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
+          "plain": null,
+          "sqlMs": 0.0125,
+          "plainMs": 0.0098,
+          "scanMs": 1.839,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 5,
+          "shape": "A",
+          "where": "#liveUnjudgedVerdict",
+          "question": "When was this ticket last claimed?",
+          "note": null,
+          "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0138,
+          "plainMs": 0.0148,
+          "scanMs": 4.3195,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 6,
+          "shape": "A",
+          "where": "#epochRepo",
+          "question": "Which repo was this ticket last dispatched against?",
+          "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
+          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0277,
+          "plainMs": 0.0301,
+          "scanMs": 4.625,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 7,
+          "shape": "A",
+          "where": "#epochCharting",
+          "question": "Was the last dispatch a charting one, and what rode it?",
+          "note": null,
+          "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0172,
+          "plainMs": 0.0113,
+          "scanMs": 3.1268,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 8,
+          "shape": "A",
+          "where": "#epochSpawn",
+          "question": "Which model and harness was this session last spawned on?",
+          "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
+          "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0145,
+          "plainMs": 0.0106,
+          "scanMs": 2.9286,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 9,
+          "shape": "A",
+          "where": "#epochAdoptedMap",
+          "question": "Which map did this session report?",
+          "note": "Keyed by agent, and reset at that session`s last spawn line.",
+          "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0141,
+          "plainMs": 0.0136,
+          "scanMs": 4.4622,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 10,
+          "shape": "A",
+          "where": "#endingClause",
+          "question": "What did the ending say?",
+          "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
+          "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0338,
+          "plainMs": 0.0389,
+          "scanMs": 3.8664,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 11,
+          "shape": "A",
+          "where": "#captureVerdict",
+          "question": "Which ticket and repo does this reviewer belong to?",
+          "note": null,
+          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0097,
+          "plainMs": 0.0091,
+          "scanMs": 2.8688,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 12,
+          "shape": "A",
+          "where": "#reconcileContext",
+          "question": "What is every ticket`s latest dispatch epoch?",
+          "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
+          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "plain": null,
+          "sqlMs": 23.563,
+          "plainMs": 23.2442,
+          "scanMs": 8.7506,
+          "plan": [
+            "CO-ROUTINE latest",
+            "SEARCH events USING INDEX events_type (type=?)",
+            "USE TEMP B-TREE FOR GROUP BY",
+            "SCAN latest",
+            "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 13,
+          "shape": "B",
+          "where": "reconcile, the orphan guard",
+          "question": "Did this session report a result after its dispatch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0205,
+          "plainMs": 0.0241,
+          "scanMs": 4.3737,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 14,
+          "shape": "B",
+          "where": "reconcile, the dead-claim guard",
+          "question": "Did anything close this epoch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0135,
+          "plainMs": 0.0188,
+          "scanMs": 6.357,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        }
+      ]
+    },
+    {
+      "size": 60000,
+      "live": false,
+      "tickets": 2393,
+      "loadMs": 6805.193,
+      "wholeReadMs": 384.97,
+      "sizes": {
+        "journalFileBytes": 16755914,
+        "dbBytes": 31301632,
+        "plainDbBytes": 28241920,
+        "perIndex": [
+          {
+            "name": "events",
+            "bytes": 22167552
+          },
+          {
+            "name": "events_agent_type",
+            "bytes": 2445312
+          },
+          {
+            "name": "events_ticket_type",
+            "bytes": 2064384
+          },
+          {
+            "name": "events_epoch_type",
+            "bytes": 1798144
+          },
+          {
+            "name": "events_type",
+            "bytes": 1794048
+          },
+          {
+            "name": "events_ticket_epoch",
+            "bytes": 1028096
+          }
+        ]
+      },
+      "equivalence": {
+        "checks": 4759,
+        "mismatches": [],
+        "keys": 366,
+        "capped": true
+      },
+      "queries": [
+        {
+          "n": 1,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did this dispatch push a pull request?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.029,
+          "plainMs": 0.0258,
+          "scanMs": 14.0344,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 2,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did a human approve this dispatch at the gate?",
+          "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
+          "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
+          "sqlMs": 0.0123,
+          "plainMs": 0.0165,
+          "scanMs": 13.8516,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 3,
+          "shape": "C",
+          "where": "#epochScan",
+          "question": "How many times has the Stop hook held this agent?",
+          "note": null,
+          "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
+          "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
+          "sqlMs": 0.0157,
+          "plainMs": 0.0189,
+          "scanMs": 22.7631,
+          "plan": [
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 4,
+          "shape": "A",
+          "where": "#verdictIsLate",
+          "question": "Did the merge outrun the reviewer?",
+          "note": null,
+          "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
+          "plain": null,
+          "sqlMs": 0.0125,
+          "plainMs": 0.0123,
+          "scanMs": 4.2695,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 5,
+          "shape": "A",
+          "where": "#liveUnjudgedVerdict",
+          "question": "When was this ticket last claimed?",
+          "note": null,
+          "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0133,
+          "plainMs": 0.0129,
+          "scanMs": 7.8271,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 6,
+          "shape": "A",
+          "where": "#epochRepo",
+          "question": "Which repo was this ticket last dispatched against?",
+          "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
+          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.034,
+          "plainMs": 0.0252,
+          "scanMs": 10.4597,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 7,
+          "shape": "A",
+          "where": "#epochCharting",
+          "question": "Was the last dispatch a charting one, and what rode it?",
+          "note": null,
+          "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0172,
+          "plainMs": 0.0165,
+          "scanMs": 7.2932,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 8,
+          "shape": "A",
+          "where": "#epochSpawn",
+          "question": "Which model and harness was this session last spawned on?",
+          "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
+          "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0121,
+          "plainMs": 0.0186,
+          "scanMs": 6.8724,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 9,
+          "shape": "A",
+          "where": "#epochAdoptedMap",
+          "question": "Which map did this session report?",
+          "note": "Keyed by agent, and reset at that session`s last spawn line.",
+          "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0133,
+          "plainMs": 0.0127,
+          "scanMs": 6.6507,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 10,
+          "shape": "A",
+          "where": "#endingClause",
+          "question": "What did the ending say?",
+          "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
+          "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.035,
+          "plainMs": 0.025,
+          "scanMs": 7.2847,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 11,
+          "shape": "A",
+          "where": "#captureVerdict",
+          "question": "Which ticket and repo does this reviewer belong to?",
+          "note": null,
+          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.01,
+          "plainMs": 0.007,
+          "scanMs": 6.6494,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 12,
+          "shape": "A",
+          "where": "#reconcileContext",
+          "question": "What is every ticket`s latest dispatch epoch?",
+          "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
+          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "plain": null,
+          "sqlMs": 50.4635,
+          "plainMs": 51.3098,
+          "scanMs": 13.5906,
+          "plan": [
+            "CO-ROUTINE latest",
+            "SEARCH events USING INDEX events_type (type=?)",
+            "USE TEMP B-TREE FOR GROUP BY",
+            "SCAN latest",
+            "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 13,
+          "shape": "B",
+          "where": "reconcile, the orphan guard",
+          "question": "Did this session report a result after its dispatch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0156,
+          "plainMs": 0.0306,
+          "scanMs": 10.2286,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 14,
+          "shape": "B",
+          "where": "reconcile, the dead-claim guard",
+          "question": "Did anything close this epoch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0137,
+          "plainMs": 0.0169,
+          "scanMs": 10.0148,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        }
+      ],
+      "operator": [
+        {
+          "title": "what happened to one ticket",
+          "sql": "select ts, type, ticket, agent from events where ticket=100 order by id",
+          "note": "A bare number against a TEXT column. SQLite applies the column`s TEXT affinity to the integer literal, so `ticket=320` finds the rows stored as `320`.",
+          "ms": 0.28,
+          "count": 37,
+          "sample": [
+            {
+              "ts": "2026-05-01T08:00:00.000Z",
+              "type": "dispatch_claimed",
+              "ticket": "100",
+              "agent": "curia-100"
+            },
+            {
+              "ts": "2026-05-01T08:01:03.000Z",
+              "type": "agent_spawned",
+              "ticket": "100",
+              "agent": "curia-100"
+            },
+            {
+              "ts": "2026-05-01T08:01:24.000Z",
+              "type": "dispatch_claimed",
+              "ticket": "100",
+              "agent": "curia-100"
+            },
+            {
+              "ts": "2026-05-01T08:01:45.000Z",
+              "type": "agent_spawned",
+              "ticket": "100",
+              "agent": "curia-100"
+            }
+          ]
+        },
+        {
+          "title": "the last thirty events",
+          "sql": "select ts, type, ticket, agent from events order by id desc limit 30",
+          "note": null,
+          "ms": 0.138,
+          "count": 30,
+          "sample": [
+            {
+              "ts": "2026-05-15T21:59:39.000Z",
+              "type": "lifecycle_closed",
+              "ticket": "2489",
+              "agent": "curia-2489"
+            },
+            {
+              "ts": "2026-05-15T21:59:18.000Z",
+              "type": "review_requested",
+              "ticket": "2490",
+              "agent": "curia-2490"
+            },
+            {
+              "ts": "2026-05-15T21:58:57.000Z",
+              "type": "result",
+              "ticket": "2489",
+              "agent": "curia-2489"
+            },
+            {
+              "ts": "2026-05-15T21:58:36.000Z",
+              "type": "charting_unreviewed",
+              "ticket": "2492",
+              "agent": "curia-2492"
+            }
+          ]
+        },
+        {
+          "title": "one whole line, exactly as curia wrote it",
+          "sql": "select body from events where id=30000",
+          "note": null,
+          "ms": 0.038,
+          "count": 1,
+          "sample": [
+            {
+              "body": "{\"ts\":\"2026-05-08T14:59:39.000Z\",\"type\":\"stop_blocked\",\"repo\":\"alp82/curia-site\",\"ticket\":1283,\"agent\":\"curia-1283\",\"attempt\":1,\"outstanding\":[\"no pull request\",\"no approved review\"],\"stop_hook_active…"
+            }
+          ]
+        },
+        {
+          "title": "the census, by type",
+          "sql": "select type, count(*) from events group by type order by 2 desc",
+          "note": null,
+          "ms": 10.158,
+          "count": 109,
+          "sample": [
+            {
+              "type": "stop_blocked",
+              "count(*)": 4773
+            },
+            {
+              "type": "agent_spawned",
+              "count(*)": 3748
+            },
+            {
+              "type": "result",
+              "count(*)": 3745
+            },
+            {
+              "type": "review_answered",
+              "count(*)": 3723
+            }
+          ]
+        },
+        {
+          "title": "how one agent ended",
+          "sql": "select ts, type, body from events where agent='curia-100' order by id desc limit 10",
+          "note": "The #184 test: this agent was named `\"worker\"` on the lines it wrote, and the normalized column still finds them.",
+          "ms": 0.242,
+          "count": 10,
+          "sample": [
+            {
+              "ts": "2026-05-01T08:23:06.000Z",
+              "type": "lifecycle_closed",
+              "body": "{\"ts\":\"2026-05-01T08:23:06.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"reason\":\"result\"}"
+            },
+            {
+              "ts": "2026-05-01T08:22:03.000Z",
+              "type": "result",
+              "body": "{\"ts\":\"2026-05-01T08:22:03.000Z\",\"type\":\"result\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"status\":\"resolved\",\"summary\":\"own one finding event own its so own the so and line stands its s…"
+            },
+            {
+              "ts": "2026-05-01T08:21:00.000Z",
+              "type": "ticket_resolved",
+              "body": "{\"ts\":\"2026-05-01T08:21:00.000Z\",\"type\":\"ticket_resolved\",\"repo\":\"alp82/curia\",\"ticket\":100,\"worker\":\"curia-100\",\"comment\":\"posted\",\"close\":\"closed\",\"map\":\"appended\",\"land\":\"merged\",\"pr\":\"https://gith…"
+            },
+            {
+              "ts": "2026-05-01T08:19:57.000Z",
+              "type": "lifecycle_closed",
+              "body": "{\"ts\":\"2026-05-01T08:19:57.000Z\",\"type\":\"lifecycle_closed\",\"repo\":\"alp82/scratch\",\"ticket\":100,\"worker\":\"curia-100\",\"reason\":\"result\"}"
+            }
+          ]
+        }
+      ],
+      "fidelity": {
+        "byteForByte": true,
+        "lines": 60000,
+        "legacy": {
+          "id": 1,
+          "agent": "curia-100",
+          "type": "dispatch_claimed",
+          "body": "{\"ts\":\"2026-05-01T08:00:00.000Z\",\"type\":\"dispatch_claimed\",\"repo\":\"alp82/scratch\",\"ticket\":100,\"worker\":\"curia-100\",\"by\":\"auto\",\"kind\":\"ticket\"}",
+          "foundByAgent": 37,
+          "legacyTypeNormalized": 745
+        },
+        "affinity": {
+          "ticket": "100",
+          "asNumber": 37,
+          "asText": 37,
+          "equal": true
+        },
+        "numbers": {
+          "bound_number": {
+            "stored": "321.0",
+            "typeof": "text"
+          },
+          "bound_string": {
+            "stored": "321",
+            "typeof": "text"
+          }
+        },
+        "strict": {
+          "blobIntoText": "refused",
+          "message": "cannot store BLOB value in TEXT column events.ts"
+        },
+        "types": 109,
+        "bytesPerLine": 279
+      },
+      "write": {
+        "stamped": 1.285,
+        "plain": 1.022
+      }
+    },
+    {
+      "size": 250000,
+      "live": false,
+      "tickets": 9997,
+      "loadMs": 30390.514,
+      "wholeReadMs": 2044.9,
+      "sizes": {
+        "journalFileBytes": 69992760,
+        "dbBytes": 131833856,
+        "plainDbBytes": 118636544,
+        "perIndex": [
+          {
+            "name": "events",
+            "bytes": 92827648
+          },
+          {
+            "name": "events_agent_type",
+            "bytes": 10379264
+          },
+          {
+            "name": "events_ticket_type",
+            "bytes": 8769536
+          },
+          {
+            "name": "events_epoch_type",
+            "bytes": 7692288
+          },
+          {
+            "name": "events_type",
+            "bytes": 7655424
+          },
+          {
+            "name": "events_ticket_epoch",
+            "bytes": 4505600
+          }
+        ]
+      },
+      "equivalence": {
+        "checks": 5097,
+        "mismatches": [],
+        "keys": 392,
+        "capped": true
+      },
+      "queries": [
+        {
+          "n": 1,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did this dispatch push a pull request?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('pr_opened', 'pr_reused', 'land_repaired') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0274,
+          "plainMs": 0.0327,
+          "scanMs": 43.2421,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 2,
+          "shape": "B",
+          "where": "#epochScan",
+          "question": "Did a human approve this dispatch at the gate?",
+          "note": "Predicate-narrowed: only a review_answered whose `approved` is true counts.",
+          "sql": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(epoch), 0) from events where ticket = :t) and json_extract(body, '$.approved') = 1)) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)\n     or exists(select 1 from events where agent = :a and type = 'review_answered'\n                and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')) and json_extract(body, '$.approved') = 1)) as answer",
+          "sqlMs": 0.0222,
+          "plainMs": 0.0309,
+          "scanMs": 45.1881,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 3,
+          "shape": "C",
+          "where": "#epochScan",
+          "question": "How many times has the Stop hook held this agent?",
+          "note": null,
+          "sql": "select count(*) as answer from events\n where id > (select coalesce(max(epoch), 0) from events where ticket = :t)\n   and type = 'stop_blocked'\n   and agent = :a",
+          "plain": "select count(*) as answer from events\n where id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned'))\n   and type = 'stop_blocked'\n   and agent = :a",
+          "sqlMs": 0.0403,
+          "plainMs": 0.0548,
+          "scanMs": 74.399,
+          "plan": [
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 4,
+          "shape": "A",
+          "where": "#verdictIsLate",
+          "question": "Did the merge outrun the reviewer?",
+          "note": null,
+          "sql": "select coalesce(\n  (select max(id) from events where ticket = :t and type = 'ticket_resolved')\n  > (select max(id) from events where ticket = :t and type = 'reviewer_spawned'), 0) as answer",
+          "plain": null,
+          "sqlMs": 0.0144,
+          "plainMs": 0.0146,
+          "scanMs": 12.2307,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 5,
+          "shape": "A",
+          "where": "#liveUnjudgedVerdict",
+          "question": "When was this ticket last claimed?",
+          "note": null,
+          "sql": "select ts from events\n where ticket = :t and type = 'dispatch_claimed'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0118,
+          "plainMs": 0.0144,
+          "scanMs": 32.7485,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 6,
+          "shape": "A",
+          "where": "#epochRepo",
+          "question": "Which repo was this ticket last dispatched against?",
+          "note": "Predicate-narrowed: the last dispatch event that CARRIES a repo.",
+          "sql": "select json_extract(body, '$.repo') as repo from events\n where ticket = :t\n   and type in ('dispatch_claimed', 'agent_spawned')\n   and json_extract(body, '$.repo') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0379,
+          "plainMs": 0.0376,
+          "scanMs": 35.8827,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 7,
+          "shape": "A",
+          "where": "#epochCharting",
+          "question": "Was the last dispatch a charting one, and what rode it?",
+          "note": null,
+          "sql": "select json_extract(body, '$.kind') = 'charting' as charting,\n       json_extract(body, '$.instruction') as instruction,\n       coalesce(json_extract(body, '$.newMap'), 0) as newMap\n  from events\n where ticket = :t and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0158,
+          "plainMs": 0.0118,
+          "scanMs": 27.8271,
+          "plan": [
+            "SEARCH events USING INDEX events_ticket_type (ticket=? AND type=?)"
+          ]
+        },
+        {
+          "n": 8,
+          "shape": "A",
+          "where": "#epochSpawn",
+          "question": "Which model and harness was this session last spawned on?",
+          "note": "The one query that reaches for a field #184 renamed. `body` is verbatim, so a pre-rename line says `backend`. The columns are normalized; a JSON field is not.",
+          "sql": "select json_extract(body, '$.model') as model,\n       coalesce(json_extract(body, '$.harness'), json_extract(body, '$.backend')) as harness\n  from events\n where agent = :a and type = 'agent_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0224,
+          "plainMs": 0.0192,
+          "scanMs": 25.8342,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 9,
+          "shape": "A",
+          "where": "#epochAdoptedMap",
+          "question": "Which map did this session report?",
+          "note": "Keyed by agent, and reset at that session`s last spawn line.",
+          "sql": "select json_extract(body, '$.map') as map from events\n where agent = :a and type = 'map_adopted'\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.map') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0098,
+          "plainMs": 0.0087,
+          "scanMs": 25.3705,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 10,
+          "shape": "A",
+          "where": "#endingClause",
+          "question": "What did the ending say?",
+          "note": "Predicate-narrowed: the last ending carrier that CARRIES a summary.",
+          "sql": "select json_extract(body, '$.summary') as summary from events\n where agent = :a\n   and type in ('ticket_resolved', 'nonclean_noted', 'charting_finished')\n   and id > coalesce((select max(id) from events where agent = :a and type = 'agent_spawned'), 0)\n   and json_extract(body, '$.summary') <> ''\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0355,
+          "plainMs": 0.0228,
+          "scanMs": 23.2186,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 11,
+          "shape": "A",
+          "where": "#captureVerdict",
+          "question": "Which ticket and repo does this reviewer belong to?",
+          "note": null,
+          "sql": "select ticket,\n       json_extract(body, '$.repo') as repo,\n       json_extract(body, '$.model') as model,\n       json_extract(body, '$.builder_model') as builder_model,\n       json_extract(body, '$.same_provider') as same_provider,\n       json_extract(body, '$.sha') as sha\n  from events\n where agent = :a and type = 'reviewer_spawned'\n order by id desc limit 1",
+          "plain": null,
+          "sqlMs": 0.0073,
+          "plainMs": 0.0102,
+          "scanMs": 23.5,
+          "plan": [
+            "SEARCH events USING INDEX events_agent_type (agent=? AND type=?)"
+          ]
+        },
+        {
+          "n": 12,
+          "shape": "A",
+          "where": "#reconcileContext",
+          "question": "What is every ticket`s latest dispatch epoch?",
+          "note": "The one question that is not keyed: it answers for every ticket at once, and reconcile runs it once a pass.",
+          "sql": "select e.ticket, e.id, json_extract(e.body, '$.repo') as repo\n  from events e\n  join (select ticket, max(id) as id from events\n         where type in ('dispatch_claimed', 'agent_spawned') and ticket is not null\n         group by ticket) latest on latest.id = e.id\n order by e.ticket",
+          "plain": null,
+          "sqlMs": 186.5719,
+          "plainMs": 183.0662,
+          "scanMs": 58.9981,
+          "plan": [
+            "CO-ROUTINE latest",
+            "SEARCH events USING INDEX events_type (type=?)",
+            "USE TEMP B-TREE FOR GROUP BY",
+            "SCAN latest",
+            "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+            "USE TEMP B-TREE FOR ORDER BY"
+          ]
+        },
+        {
+          "n": 13,
+          "shape": "B",
+          "where": "reconcile, the orphan guard",
+          "question": "Did this session report a result after its dispatch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'ticket_resolved') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0237,
+          "plainMs": 0.0227,
+          "scanMs": 38.9094,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        },
+        {
+          "n": 14,
+          "shape": "B",
+          "where": "reconcile, the dead-claim guard",
+          "question": "Did anything close this epoch?",
+          "note": null,
+          "sql": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(epoch), 0) from events where ticket = :t))) as answer",
+          "plain": "select (exists(select 1 from events where ticket = :t and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))\n     or exists(select 1 from events where agent = :a and type in ('result', 'lifecycle_closed', 'dispatch_unclaimed') and id > (select coalesce(max(id), 0) from events where ticket = :t and type in ('dispatch_claimed', 'agent_spawned')))) as answer",
+          "sqlMs": 0.0158,
+          "plainMs": 0.0167,
+          "scanMs": 49.379,
+          "plan": [
+            "SCAN CONSTANT ROW",
+            "SCALAR SUBQUERY 2",
+            "SEARCH events USING COVERING INDEX events_ticket_type (ticket=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 1",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)",
+            "SCALAR SUBQUERY 4",
+            "SEARCH events USING COVERING INDEX events_agent_type (agent=? AND type=? AND id>?)",
+            "SCALAR SUBQUERY 3",
+            "SEARCH events USING COVERING INDEX events_ticket_epoch (ticket=?)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/prototypes/journal-schema/run.mjs
+++ b/prototypes/journal-schema/run.mjs
@@ -13,7 +13,7 @@ import os from 'node:os'
 import assert from 'node:assert'
 import { fileURLToPath } from 'node:url'
 import { DatabaseSync } from 'node:sqlite'
-import { normalizeEvent } from '../../daemon/src/store.mjs'
+import { normalizeEvent, EscalationStore } from '../../daemon/src/store.mjs'
 import { synthesize } from './synth.mjs'
 import { oracle } from './oracle.mjs'
 import { QUERIES, OPERATOR_QUERIES } from './queries.mjs'
@@ -241,8 +241,8 @@ function fidelity(fixture, journal) {
   // extraction stringifies for exactly this reason.
   const numbers = (() => {
     const probe = (value) => {
-      db.prepare('insert into events (ts, type, ticket, agent, body) values (?, ?, ?, ?, ?)')
-        .run('2026-08-16T00:00:00.000Z', 'probe', value, null, '{"probe":true}')
+      db.prepare('insert into events (ts, type, ticket, agent, repo, body) values (?, ?, ?, ?, ?, ?)')
+        .run('2026-08-16T00:00:00.000Z', 'probe', value, null, null, '{"probe":true}')
       const row = db.prepare("select ticket, typeof(ticket) as t from events where type='probe'").get()
       db.exec("delete from events where type='probe'")
       return { stored: row.ticket, typeof: row.t }
@@ -253,7 +253,7 @@ function fidelity(fixture, journal) {
   // STRICT is the point of #320's ruling that the shell comes out of the image.
   const strict = (() => {
     try {
-      db.exec("insert into events (ts, type, ticket, agent, body) values (x'00', 'probe', null, null, '{}')")
+      db.exec("insert into events (ts, type, ticket, agent, repo, body) values (x'00', 'probe', null, null, null, '{}')")
       db.exec("delete from events where type='probe'")
       return { blobIntoText: 'accepted' }
     } catch (e) {
@@ -275,9 +275,72 @@ function fidelity(fixture, journal) {
   }
 }
 
+// ------------------------------------------------- why the cut is an id, not a ts
+//
+// The operator asked what `epoch` buys over `ts`. This measures it against the
+// daemon's OWN writer rather than the synthetic journal, whose stamps are
+// spaced by construction.
+//
+// `_append` stamps `new Date().toISOString()`, which is milliseconds, and
+// nothing makes it unique. Two events in one millisecond tie, and a `ts >`
+// comparison at the epoch boundary then answers the wrong question: `>` drops
+// every row that shares the opener's stamp, and `>=` takes rows written before
+// it. The ten scans this schema replaces compare POSITION in the file, so an
+// id reproduces their rule exactly and a stamp does not.
+function stampEvidence() {
+  const dir = fs.mkdtempSync(path.join(tmp, 'stamps-'))
+  const store = new EscalationStore(dir)
+  for (let i = 0; i < 2000; i++) store.logEvent('probe', { ticket: 900, agent: 'curia-900', i })
+  const lines = fs.readFileSync(path.join(dir, 'events.jsonl'), 'utf8').trim().split('\n')
+  const stamps = lines.map((l) => JSON.parse(l).ts)
+  const counts = new Map()
+  for (const s of stamps) counts.set(s, (counts.get(s) ?? 0) + 1)
+
+  // The boundary itself. A dispatch is claimed and the pull request lands in
+  // the SAME millisecond, which is what happens whenever two `logEvent` calls
+  // sit in one tick. Pairs are written until one ties, and the count says how
+  // hard that was to provoke through the daemon's own writer.
+  const dir2 = fs.mkdtempSync(path.join(tmp, 'boundary-'))
+  const store2 = new EscalationStore(dir2)
+  let pairs = 0
+  let tie = null
+  while (!tie && pairs < 500) {
+    const ticket = 901 + pairs
+    pairs++
+    const a = store2.logEvent('dispatch_claimed', { repo: 'alp82/curia', ticket, agent: `curia-${ticket}`, by: 'auto' })
+    const b = store2.logEvent('pr_opened', { repo: 'alp82/curia', ticket, agent: `curia-${ticket}`, url: 'https://example.invalid/1' })
+    if (a.ts === b.ts) tie = { ticket: String(ticket), ts: a.ts }
+  }
+
+  const probe = openJournal(path.join(tmp, 'boundary.db'), { epochColumn: true })
+  probe.appendAll(fs.readFileSync(path.join(dir2, 'events.jsonl'), 'utf8').trim().split('\n'))
+  const ask = (sql) => Boolean(probe.db.prepare(sql).get({ t: tie?.ticket ?? '0' }).answer)
+  // "Did this dispatch push a pull request?", cut by the id and cut by the stamp.
+  const byId = ask(`
+    select exists(select 1 from events where ticket = :t and type = 'pr_opened'
+      and id > (select coalesce(max(epoch), 0) from events where ticket = :t)) as answer`)
+  const byTs = ask(`
+    select exists(select 1 from events where ticket = :t and type = 'pr_opened'
+      and ts > (select ts from events where ticket = :t and type = 'dispatch_claimed'
+                 order by id desc limit 1)) as answer`)
+  probe.close()
+
+  return {
+    events: stamps.length,
+    distinctStamps: counts.size,
+    mostOnOneStamp: Math.max(...counts.values()),
+    boundary: tie ? { ...tie, pairs, byId, byTs } : { tied: false, pairs },
+  }
+}
+
 // ----------------------------------------------------------------------- main
 
-const results = { node: process.version, sqlite: new DatabaseSync(':memory:').prepare('select sqlite_version() as v').get().v, sizes: [] }
+const results = {
+  node: process.version,
+  sqlite: new DatabaseSync(':memory:').prepare('select sqlite_version() as v').get().v,
+  stamps: stampEvidence(),
+  sizes: [],
+}
 
 for (const size of SIZES) {
   process.stdout.write(`building ${size}…`)
@@ -331,4 +394,7 @@ for (const s of results.sizes) {
   for (const m of s.equivalence.mismatches) console.log(`    q${m.n} ${m.key}: ${m.why}`)
   if (s.write) console.log(`  one committed insert: ${s.write.stamped} ms stamped, ${s.write.plain} ms without the epoch column`)
 }
+const st = results.stamps
+console.log(`\nthe stamp: ${st.events} events through the daemon's own writer carried ${st.distinctStamps} distinct stamps, up to ${st.mostOnOneStamp} on one`)
+console.log(`  a claim and its pull request tied on one stamp after ${st.boundary.pairs} pair(s): by id ${st.boundary.byId}, by ts ${st.boundary.byTs}`)
 console.log(`\nresults.json written. Temp fixtures in ${tmp}`)

--- a/prototypes/journal-schema/run.mjs
+++ b/prototypes/journal-schema/run.mjs
@@ -1,0 +1,334 @@
+// The prototype's one entry point (#321).
+//
+//   node prototypes/journal-schema/run.mjs
+//
+// It builds a synthetic journal, loads it into the schema, checks all fourteen
+// queries against the daemon's own loop, times both, measures the write path
+// and the file on disk, runs the operator's five README queries, and writes
+// `results.json` beside itself. `demo.mjs` turns that into the one HTML page.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
+import { normalizeEvent } from '../../daemon/src/store.mjs'
+import { synthesize } from './synth.mjs'
+import { oracle } from './oracle.mjs'
+import { QUERIES, OPERATOR_QUERIES } from './queries.mjs'
+import { openJournal } from './journal.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'journal-schema-'))
+
+// The sizes from the cost table in docs/research/journal-scan-cost.md, plus
+// the live one the operator measured on the box: 4,282 events on 2026-08-13.
+const SIZES = [4282, 30000, 60000, 250000]
+const LIVE = 4282
+
+const ms = (t) => Number((Number(t) / 1e6).toFixed(3))
+const now = () => process.hrtime.bigint()
+
+function timed(fn, iterations) {
+  fn() // warm
+  const t0 = now()
+  for (let i = 0; i < iterations; i++) fn()
+  return Number(now() - t0) / 1e6 / iterations
+}
+
+// ---------------------------------------------------------------- the fixture
+
+function buildFixture(size) {
+  const { lines, tickets } = synthesize(size)
+  const file = path.join(tmp, `events-${size}.jsonl`)
+  fs.writeFileSync(file, lines.map((l) => `${l}\n`).join(''))
+  const dbFile = path.join(tmp, `events-${size}.db`)
+  const j = openJournal(dbFile, { epochColumn: true })
+  const t0 = now()
+  j.appendAll(lines)
+  const loadMs = ms(now() - t0)
+  const plainFile = path.join(tmp, `plain-${size}.db`)
+  const plain = openJournal(plainFile, { epochColumn: false })
+  plain.appendAll(lines)
+  return { lines, tickets, file, dbFile, plainFile, j, plain, loadMs }
+}
+
+// What the daemon does today: read the whole file, split, parse, normalize.
+function wholeRead(file) {
+  const raw = fs.readFileSync(file, 'utf8')
+  const events = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    events.push(normalizeEvent(JSON.parse(line)))
+  }
+  return events
+}
+
+// ------------------------------------------------------------------- checking
+
+// Every key the checker asks about: real tickets, their builders, their
+// reviewers, and keys nothing ever wrote.
+function keysFor(journal, tickets) {
+  const reviewers = [...new Set(journal.filter((e) => /^curia-review-/.test(e.agent ?? '')).map((e) => e.agent))]
+  const keys = []
+  for (const t of tickets) keys.push({ ticket: t, agent: `curia-${t}` })
+  for (const a of reviewers) keys.push({ ticket: a.match(/(\d+)$/)[1], agent: a })
+  keys.push({ ticket: '999999', agent: 'curia-999999' }) // nothing ever wrote it
+  return keys
+}
+
+function checkEquivalence(db, journal, keys) {
+  const out = { checks: 0, mismatches: [] }
+  for (const q of QUERIES) {
+    const stmt = db.prepare(q.sql)
+    if (q.whole) {
+      const got = q.read(stmt.all())
+      const want = oracle[q.oracle](journal)
+      try {
+        assert.deepStrictEqual([...got.entries()].sort(), [...want.entries()].sort())
+      } catch (e) {
+        out.mismatches.push({ n: q.n, key: 'every ticket', why: e.message.split('\n')[0] })
+      }
+      out.checks++
+      continue
+    }
+    for (const key of keys) {
+      const got = q.read(stmt.all(q.args(key)))
+      const want = oracle[q.oracle](journal, key)
+      out.checks++
+      try {
+        assert.deepStrictEqual(got, want)
+      } catch (e) {
+        if (out.mismatches.length < 8) out.mismatches.push({ n: q.n, key: `${key.ticket}/${key.agent}`, why: e.message.split('\n')[0] })
+      }
+    }
+  }
+  return out
+}
+
+// ------------------------------------------------------------------ the costs
+
+function benchQueries(fixture, journal, keys) {
+  const db = fixture.j.db
+  const plainDb = fixture.plain.db
+  const sample = keys.filter((k) => k.ticket !== '999999').slice(0, 40)
+  const sqlIters = fixture.lines.length > 100000 ? 50 : 200
+  const scanIters = fixture.lines.length > 100000 ? 2 : (fixture.lines.length > 20000 ? 5 : 20)
+  const rows = []
+  for (const q of QUERIES) {
+    const stmt = db.prepare(q.sql)
+    // The same question on the table with NO epoch column: its own SQL, its
+    // own database, so the comparison is honest about both.
+    const plainStmt = plainDb.prepare(q.plain ?? q.sql)
+    let i = 0
+    const next = () => sample[i++ % sample.length]
+    const sqlMs = q.whole
+      ? timed(() => stmt.all(), 10)
+      : timed(() => stmt.all(q.args(next())), sqlIters)
+    const plainMs = q.whole
+      ? timed(() => plainStmt.all(), 10)
+      : timed(() => plainStmt.all(q.args(next())), sqlIters)
+    // The scan the daemon runs today, WITHOUT the read that feeds it. The read
+    // is one number per size (`wholeReadMs`), and it dominates both.
+    const scanMs = q.whole
+      ? timed(() => oracle[q.oracle](journal), Math.max(2, Math.floor(scanIters / 4)))
+      : timed(() => oracle[q.oracle](journal, next()), scanIters)
+    rows.push({
+      n: q.n,
+      shape: q.shape,
+      where: q.where,
+      question: q.question,
+      note: q.note ?? null,
+      sql: q.sql,
+      plain: q.plain ?? null,
+      sqlMs: Number(sqlMs.toFixed(4)),
+      plainMs: Number(plainMs.toFixed(4)),
+      scanMs: Number(scanMs.toFixed(4)),
+      plan: db.prepare(`explain query plan ${q.sql}`).all(q.whole ? {} : q.args(sample[0])).map((r) => r.detail),
+    })
+  }
+  return rows
+}
+
+// The write path: one event, committed, the way the daemon commits it.
+function benchWrite(size) {
+  const { lines } = synthesize(2000, { seed: 11, firstTicket: 5000 })
+  const out = {}
+  for (const epochColumn of [true, false]) {
+    const file = path.join(tmp, `write-${epochColumn}-${size}.db`)
+    const j = openJournal(file, { epochColumn })
+    j.appendAll(synthesize(size, { seed: 3 }).lines) // a journal of realistic depth first
+    const t0 = now()
+    for (const line of lines) j.append(line) // one implicit transaction each
+    const per = Number(now() - t0) / 1e6 / lines.length
+    out[epochColumn ? 'stamped' : 'plain'] = Number(per.toFixed(3))
+    j.close()
+  }
+  return out
+}
+
+function dbSizes(fixture) {
+  const db = fixture.j.db
+  db.exec('pragma wal_checkpoint(truncate)')
+  const bytes = (f) => (fs.existsSync(f) ? fs.statSync(f).size : 0)
+  const perIndex = db.prepare(`
+    select name, sum(pgsize) as bytes from dbstat where name like 'events%' group by name order by 2 desc
+  `).all().map((r) => ({ name: r.name, bytes: Number(r.bytes) }))
+  return {
+    journalFileBytes: bytes(fixture.file),
+    dbBytes: bytes(fixture.dbFile),
+    plainDbBytes: bytes(fixture.plainFile),
+    perIndex,
+  }
+}
+
+// ------------------------------------------------------- the operator's five
+
+function operatorRun(fixture, journal) {
+  const db = fixture.j.db
+  // A ticket out of the OLD part of the journal, so query one and query five
+  // both run against pre-#184 lines. That is the harder case, and the one the
+  // operator hits at 2 a.m. on a ticket from July.
+  const ticket = journal.find((e) => e.type === 'dispatch_claimed').ticket
+  const agent = `curia-${ticket}`
+  const id = Math.floor(fixture.lines.length / 2)
+  const rows = []
+  for (const q of OPERATOR_QUERIES) {
+    const sql = q.sql({ ticket, id, agent })
+    const t0 = now()
+    const result = db.prepare(sql).all()
+    rows.push({
+      title: q.title,
+      sql,
+      note: q.note ?? null,
+      ms: ms(now() - t0),
+      count: result.length,
+      sample: result.slice(0, 4).map((r) => Object.fromEntries(Object.entries(r).map(([k, v]) => [k, typeof v === 'string' && v.length > 200 ? `${v.slice(0, 200)}…` : v]))),
+    })
+  }
+  return rows
+}
+
+// The two claims the schema makes about the record itself.
+function fidelity(fixture, journal) {
+  const db = fixture.j.db
+  const lines = fs.readFileSync(fixture.file, 'utf8').split('\n').filter(Boolean)
+  const back = db.prepare('select body from events order by id').all().map((r) => r.body)
+  const byteForByte = back.length === lines.length && back.every((b, i) => b === lines[i])
+
+  // The #184 proof: a row whose body says "worker", found through the agent column.
+  const legacyRow = db.prepare(`
+    select id, agent, type, body from events
+     where body like '%"worker":%' and agent is not null
+     order by id limit 1`).get()
+  const foundByAgent = legacyRow
+    ? db.prepare('select count(*) as n from events where agent = :a').get({ a: legacyRow.agent }).n
+    : 0
+  const legacyTypeNormalized = legacyRow
+    ? db.prepare("select count(*) as n from events where type = 'agent_spawned' and body like '%worker_spawned%'").get().n
+    : 0
+
+  // The affinity proof: `where ticket=320`, a bare integer literal against a
+  // TEXT column, typed exactly as the README types it.
+  const t = journal.find((e) => e.ticket != null).ticket
+  const asNumber = db.prepare(`select count(*) as n from events where ticket=${t}`).get().n
+  const asText = db.prepare(`select count(*) as n from events where ticket='${t}'`).get().n
+
+  // The write-path hazard this prototype found. node:sqlite binds a JS number
+  // as a REAL, so `ticket: 321` straight off the event lands in a TEXT column
+  // as the string "321.0" — and every `where ticket=321` then misses it. The
+  // extraction stringifies for exactly this reason.
+  const numbers = (() => {
+    const probe = (value) => {
+      db.prepare('insert into events (ts, type, ticket, agent, body) values (?, ?, ?, ?, ?)')
+        .run('2026-08-16T00:00:00.000Z', 'probe', value, null, '{"probe":true}')
+      const row = db.prepare("select ticket, typeof(ticket) as t from events where type='probe'").get()
+      db.exec("delete from events where type='probe'")
+      return { stored: row.ticket, typeof: row.t }
+    }
+    return { bound_number: probe(321), bound_string: probe('321') }
+  })()
+
+  // STRICT is the point of #320's ruling that the shell comes out of the image.
+  const strict = (() => {
+    try {
+      db.exec("insert into events (ts, type, ticket, agent, body) values (x'00', 'probe', null, null, '{}')")
+      db.exec("delete from events where type='probe'")
+      return { blobIntoText: 'accepted' }
+    } catch (e) {
+      return { blobIntoText: 'refused', message: e.message }
+    }
+  })()
+
+  return {
+    byteForByte,
+    lines: lines.length,
+    legacy: legacyRow
+      ? { id: legacyRow.id, agent: legacyRow.agent, type: legacyRow.type, body: legacyRow.body.slice(0, 200), foundByAgent, legacyTypeNormalized }
+      : null,
+    affinity: { ticket: String(t), asNumber, asText, equal: asNumber === asText && asNumber > 0 },
+    numbers,
+    strict,
+    types: db.prepare('select count(distinct type) as n from events').get().n,
+    bytesPerLine: Math.round(fs.statSync(fixture.file).size / lines.length),
+  }
+}
+
+// ----------------------------------------------------------------------- main
+
+const results = { node: process.version, sqlite: new DatabaseSync(':memory:').prepare('select sqlite_version() as v').get().v, sizes: [] }
+
+for (const size of SIZES) {
+  process.stdout.write(`building ${size}…`)
+  const fixture = buildFixture(size)
+  const journal = wholeRead(fixture.file)
+  const keys = keysFor(journal, fixture.tickets)
+
+  const readMs = timed(() => wholeRead(fixture.file), size > 100000 ? 3 : 10)
+  const entry = {
+    size,
+    live: size === LIVE,
+    tickets: fixture.tickets.length,
+    loadMs: fixture.loadMs,
+    wholeReadMs: Number(readMs.toFixed(2)),
+    sizes: dbSizes(fixture),
+  }
+
+  // Equivalence is checked over every ticket and every agent the journal
+  // holds, up to a cap. Above the cap the keys are taken evenly across the
+  // whole journal, so the oldest dispatches are checked too, and the page says
+  // the sample was capped.
+  const CAP = 400
+  const sample = keys.length > CAP ? keys.filter((_, i) => i % Math.ceil(keys.length / CAP) === 0) : keys
+  entry.equivalence = { ...checkEquivalence(fixture.j.db, journal, sample), keys: sample.length, capped: sample.length !== keys.length }
+  entry.queries = benchQueries(fixture, journal, keys)
+  if (size === LIVE || size === 60000) {
+    entry.operator = operatorRun(fixture, journal)
+    entry.fidelity = fidelity(fixture, journal)
+    entry.write = benchWrite(size)
+  }
+  results.sizes.push(entry)
+  fixture.j.close()
+  fixture.plain.close()
+  process.stdout.write(` ${entry.equivalence.mismatches.length ? 'MISMATCHES' : 'ok'}\n`)
+}
+
+fs.writeFileSync(path.join(here, 'results.json'), `${JSON.stringify(results, null, 2)}\n`)
+
+// The console verdict. The page says it again, for a phone.
+for (const s of results.sizes) {
+  const q = s.queries
+  const worst = q.reduce((a, b) => (b.sqlMs > a.sqlMs ? b : a))
+  const keyed = q.filter((x) => x.n !== 12)
+  const total = keyed.reduce((a, b) => a + b.sqlMs, 0)
+  console.log(`\n${s.size} events${s.live ? ' (the live journal today)' : ''}`)
+  console.log(`  db ${(s.sizes.dbBytes / 1e6).toFixed(2)} MB against a ${(s.sizes.journalFileBytes / 1e6).toFixed(2)} MB file`)
+  console.log(`  one whole read today: ${s.wholeReadMs} ms`)
+  console.log(`  the thirteen keyed queries, all of them: ${total.toFixed(3)} ms; worst single ${worst.sqlMs} ms (q${worst.n})`)
+  console.log(`  q12, every ticket at once: ${q.find((x) => x.n === 12).sqlMs} ms`)
+  console.log(`  equivalence: ${s.equivalence.checks} checks over ${s.equivalence.keys} keys, ${s.equivalence.mismatches.length} mismatches`)
+  for (const m of s.equivalence.mismatches) console.log(`    q${m.n} ${m.key}: ${m.why}`)
+  if (s.write) console.log(`  one committed insert: ${s.write.stamped} ms stamped, ${s.write.plain} ms without the epoch column`)
+}
+console.log(`\nresults.json written. Temp fixtures in ${tmp}`)

--- a/prototypes/journal-schema/schema-no-epoch.sql
+++ b/prototypes/journal-schema/schema-no-epoch.sql
@@ -10,6 +10,7 @@ create table events (
   type   text    not null,
   ticket text,
   agent  text,
+  repo   text,
   body   text    not null
 ) strict;
 

--- a/prototypes/journal-schema/schema-no-epoch.sql
+++ b/prototypes/journal-schema/schema-no-epoch.sql
@@ -1,0 +1,18 @@
+-- The alternative measured against `schema.sql`: the same table with NO epoch
+-- column and no trigger. Every "since the epoch" question then carries its own
+-- subquery for the epoch, which is what the queries in `queries.mjs` marked
+-- `noEpochSql` type out. Kept so the cost of the stamp is a number and not an
+-- argument.
+
+create table events (
+  id     integer primary key,
+  ts     text    not null,
+  type   text    not null,
+  ticket text,
+  agent  text,
+  body   text    not null
+) strict;
+
+create index events_ticket_type on events (ticket, type, id);
+create index events_agent_type  on events (agent, type, id);
+create index events_type on events (type, id);

--- a/prototypes/journal-schema/schema.sql
+++ b/prototypes/journal-schema/schema.sql
@@ -32,6 +32,12 @@ create table events (
   -- `"worker": "curia-170"` in `body` and `curia-170` here.
   agent  text,
 
+  -- The repo the event is about, or null. A column because the operator types
+  -- it, which is the rule that made `agent` one. It gets NO index of its own:
+  -- curia runs one or two repos, so `where repo='alp82/curia'` selects nearly
+  -- every row and SQLite scans whatever we build.
+  repo   text,
+
   -- The dispatch this row belongs to: the id of the `dispatch_claimed` or
   -- `agent_spawned` row that opened the ticket's latest epoch at the moment
   -- this row was written. An epoch-opening row carries its own id. 0 for a row

--- a/prototypes/journal-schema/schema.sql
+++ b/prototypes/journal-schema/schema.sql
@@ -1,0 +1,81 @@
+-- The journal schema, prototyped for alp82/curia#321.
+--
+-- One table. 96 event types share it, because the boot replay reads every
+-- event in write order and the fourteen questions all key by ticket, by agent
+-- or by type. Ninety-six tables would make the operator's "last thirty events"
+-- a ninety-six-way union.
+--
+-- STRICT is permitted: #320 ruled the operator's sqlite3 comes out of the
+-- daemon image, which carries SQLite 3.53. The host's 3.31 does not read this
+-- file and does not constrain it.
+
+create table events (
+  -- The write order. `id` IS the position the ten scans used when they said
+  -- "after the epoch", so every ordering below is `order by id`, never by ts.
+  -- Two events inside one millisecond keep their order.
+  id     integer primary key,
+
+  -- ISO-8601 UTC, exactly as `_append` stamps it.
+  ts     text    not null,
+
+  -- The event type, in TODAY's spelling. A line written before #184 says
+  -- `worker_spawned` in `body` and `agent_spawned` here.
+  type   text    not null,
+
+  -- The ticket, as text. Null when the event names none (image builds, bridge
+  -- health, deploys). Text and not integer, so `where ticket='320'` works —
+  -- and `where ticket=320` works too, because SQLite applies the column's TEXT
+  -- affinity to a bare numeric literal.
+  ticket text,
+
+  -- The agent session, in today's spelling. A pre-#184 line carries
+  -- `"worker": "curia-170"` in `body` and `curia-170` here.
+  agent  text,
+
+  -- The dispatch this row belongs to: the id of the `dispatch_claimed` or
+  -- `agent_spawned` row that opened the ticket's latest epoch at the moment
+  -- this row was written. An epoch-opening row carries its own id. 0 for a row
+  -- with no ticket, or one written before its ticket was ever dispatched.
+  --
+  -- This is the "after the epoch" of the three shapes, precomputed. Four of the
+  -- fourteen questions become an equality on it, and the operator gets
+  -- `where epoch=(select max(epoch) from events where ticket=321)` — one
+  -- dispatch, whole, at 2 a.m.
+  epoch  integer not null default 0,
+
+  -- The line curia wrote, byte for byte, old spelling and all (ADR-0017).
+  -- `select body from events order by id` regenerates events.jsonl.
+  body   text    not null
+) strict;
+
+-- Shape A ("the last event of type T for key K") and the type-narrowed halves
+-- of B and C. Both directions, because six of the fourteen key by agent.
+create index events_ticket_type on events (ticket, type, id);
+create index events_agent_type  on events (agent, type, id);
+
+-- The current epoch of a ticket, as one index probe: the rightmost entry for
+-- the ticket. Without it, `max(epoch)` reads every row the ticket ever wrote.
+create index events_ticket_epoch on events (ticket, epoch);
+
+-- Shapes B and C ("since the epoch"), and the operator's "this dispatch, whole".
+create index events_epoch_type  on events (epoch, type);
+
+-- The census, `group by type`. Also the type-only reads the reduction does at
+-- boot for the recent-outcome rings.
+create index events_type on events (type, id);
+
+-- The epoch stamp is a property of the TABLE, not of the write path. 129
+-- `logEvent` call sites stay ignorant of it, and a migrated row gets the same
+-- stamp as a live one because both arrive through this trigger.
+create trigger events_stamp_epoch after insert on events
+when new.ticket is not null
+begin
+  update events set epoch = coalesce((
+    select e.id from events e
+     where e.ticket = new.ticket
+       and e.type in ('dispatch_claimed', 'agent_spawned')
+       and e.id <= new.id
+     order by e.id desc limit 1
+  ), 0)
+  where id = new.id;
+end;

--- a/prototypes/journal-schema/synth.mjs
+++ b/prototypes/journal-schema/synth.mjs
@@ -1,0 +1,224 @@
+// A synthetic journal of the same shape as the real one, for #321.
+//
+// The live file lives on the operator's box and no agent container mounts it
+// (#317), so the prototype makes its own. The shape it copies is measured:
+// about 343 bytes a line, 96 event types, a tail of long-text lines for
+// prompts, summaries, verdicts and the review-gate diff digest.
+//
+// Two properties matter beyond the size. Dispatches INTERLEAVE, because curia
+// runs several agents at once, so "the last event of a type for a key" is not
+// "the last line of a block". And the oldest lines carry the pre-#184
+// spelling: `worker_spawned`, `"worker"`, `"backend"`.
+
+// Deterministic: the same seed gives the same journal, so a number in the
+// verdict can be reproduced.
+function rng(seed) {
+  let s = seed >>> 0
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 4294967296
+  }
+}
+
+const REPOS = ['alp82/curia', 'alp82/curia-site', 'alp82/scratch']
+const MODELS = ['opus', 'sonnet', 'codex-high', 'gemini-pro']
+const HARNESSES = ['claude', 'codex', 'gemini']
+
+// Filler that makes a long-text line long, the way a prompt or a verdict is.
+function words(rnd, n) {
+  const bag = ['the', 'journal', 'holds', 'one', 'line', 'per', 'event', 'and', 'the', 'reviewer',
+    'read', 'the', 'diff', 'cold', 'so', 'a', 'finding', 'stands', 'on', 'its', 'own', 'evidence']
+  let out = []
+  for (let i = 0; i < n; i++) out.push(bag[Math.floor(rnd() * bag.length)])
+  return out.join(' ')
+}
+
+// The operational types that carry a ticket and an agent but decide nothing —
+// the noise the fourteen questions read past.
+const FILLER = [
+  'notify', 'agent_ready', 'agent_mcp_first', 'command', 'preview', 'agent_note_refused',
+  'agent_mute', 'lease_kept', 'confirm_lapsed', 'note_interrupt', 'note_interrupt_delivered',
+  'judgement_commented', 'escalation_orphaned', 'agent_blocked_on_human', 'limit_resume_armed',
+  'cross_check_announced', 'reconcile_identity_unknown', 'result_parked', 'result_refused',
+  'charting_paths_unread', 'resolve_skipped', 'verdict_carried', 'agent_done',
+]
+
+// The types with no ticket at all: the daemon talking about itself.
+const TICKETLESS = [
+  'bridge_health', 'bridge_recovered', 'bridge_wedged', 'agent_image_built', 'agent_image_pinned',
+  'agent_image_pruned', 'reconcile', 'deploy_requested', 'deploy_landed', 'model_cooling',
+  'provider_cooling', 'credentials_swept', 'restart_requested', 'tracker_doc_missing',
+]
+
+// The rest of the inventory: every remaining type curia writes, read off the
+// 129 `logEvent` call sites in `daemon/src`. They are rare in the real journal
+// and they decide nothing here — they are in so that one table really does
+// carry the whole vocabulary, and so the census query has the whole census to
+// group.
+const RARE = [
+  'agent_abnormal_exit', 'agent_cancelled', 'agent_died', 'agent_image_pruned', 'agent_token_refused',
+  'bridge_render_failed', 'charting_ended', 'charting_push_refused', 'charting_unreviewed',
+  'confirm_voided', 'container_route_refused', 'cross_check_rejoined', 'cross_check_requested',
+  'cross_check_returned', 'cross_check_unannounced', 'dead_claim_kept_awaiting_review',
+  'dead_claim_released', 'deploy_rolled_back', 'deploy_unresolved', 'dispatch_exhausted',
+  'dispatch_unclaimed', 'escalation_agent_died', 'escalation_stale_at_result', 'land_failed',
+  'lease_released', 'limit_resume', 'note_interrupt_failed', 'orphan_container_swept',
+  'orphan_reviewer_swept', 'orphan_sweep_skipped', 'orphan_swept', 'orphan_worktree_kept',
+  'overseer_container_turn', 'overseer_turn_refused', 'reconcile_repo_skipped',
+  'reconcile_sessions_indeterminate', 'reset_unparseable', 'resolve_failed', 'resolved_unreviewed',
+  'result_ticket_mismatch', 'review_refused', 'reviewer_abnormal_exit', 'reviewer_cancelled',
+  'reviewer_ended', 'reviewer_spawn_failed', 'reviewer_tool_refused', 'side_channel_ready',
+  'stop_budget_exhausted', 'unclaim_failed', 'usage_limit_ignored_ambiguous',
+  'verdict_delivery_failed', 'verdict_failed', 'verdict_late', 'verdict_skipped',
+  'verdict_undelivered', 'agent_notes_drained', 'agent_notes_expired', 'agent_note_interrupted',
+]
+
+// One dispatch of one ticket: the events it writes, in order, without stamps.
+function dispatchEvents(rnd, ticket, opts) {
+  const repo = REPOS[Math.floor(rnd() * (opts.oneRepo ? 1 : REPOS.length))]
+  const agent = `curia-${ticket}`
+  const charting = rnd() < 0.12
+  const model = MODELS[Math.floor(rnd() * MODELS.length)]
+  const harness = HARNESSES[Math.floor(rnd() * HARNESSES.length)]
+  const base = { repo, ticket, agent }
+  const evs = []
+  const push = (type, data) => evs.push({ type, ...base, ...data })
+
+  push('dispatch_claimed', { by: 'auto', kind: charting ? 'charting' : 'ticket' })
+  push('agent_spawned', {
+    instance: `${agent}@1755300000000`, model, harness,
+    kind: charting ? 'charting' : 'ticket',
+    instruction: charting ? 'chart the store map' : null,
+    newMap: charting && rnd() < 0.3,
+    sandbox: 'docker', image: 'curia-agent:node22', ports: [9006, 9007, 9008],
+  })
+  if (charting && rnd() < 0.7) push('map_adopted', { map: String(240 + Math.floor(rnd() * 90)), title: words(rnd, 6) })
+
+  const noise = 3 + Math.floor(rnd() * 10)
+  for (let i = 0; i < noise; i++) {
+    const common = rnd() < 0.8
+    const type = common
+      ? FILLER[Math.floor(rnd() * FILLER.length)]
+      : RARE[Math.floor(rnd() * RARE.length)]
+    push(type, { message: words(rnd, 12 + Math.floor(rnd() * 20)) })
+  }
+
+  // The Stop hook, the hot path: it holds an agent that has not finished.
+  const blocks = Math.floor(rnd() * 4)
+  for (let i = 1; i <= blocks; i++) {
+    push('stop_blocked', { attempt: i, outstanding: ['no pull request', 'no approved review'], stop_hook_active: true })
+  }
+
+  const pushed = rnd() < 0.85
+  if (pushed) {
+    push(rnd() < 0.2 ? 'pr_reused' : 'pr_opened', {
+      branch: `curia/${ticket}`, url: `https://github.com/${repo}/pull/${300 + Math.floor(rnd() * 99)}`,
+      commits: 1 + Math.floor(rnd() * 4),
+    })
+  }
+
+  if (pushed) {
+    // The review gate carries the diff digest (#355): the long line of the file.
+    const files = 3 + Math.floor(rnd() * 12)
+    push('review_requested', {
+      summary: words(rnd, 40 + Math.floor(rnd() * 60)),
+      charting,
+      diff: {
+        files, added: files * 20, removed: files * 4,
+        list: Array.from({ length: files }, (_, i) => ({ path: `daemon/src/file${i}.mjs`, added: 20, removed: 4 })),
+      },
+    })
+    // A rejected round first, sometimes, then the approval. Both are
+    // `review_answered`, and only `approved` tells them apart — question 2.
+    if (rnd() < 0.4) push('review_answered', { approved: false, via: 'gate', feedback: words(rnd, 25) })
+
+    // The cross-check: a second session on the same ticket, whose own
+    // `agent_spawned` moves this ticket's epoch — as it does in the daemon today.
+    if (rnd() < 0.2) {
+      const reviewer = `curia-review-${ticket}`
+      evs.push({
+        type: 'reviewer_spawned', repo, ticket, agent: reviewer, builder: agent,
+        model: MODELS[Math.floor(rnd() * MODELS.length)], harness, builder_model: model,
+        same_provider: rnd() < 0.5, sha: 'a'.repeat(40), checkout: `/w/review/${ticket}`,
+        base_branch: 'main', by: 'gate', sandbox: 'docker', image: 'curia-agent:node22',
+      })
+      evs.push({ type: 'agent_spawned', repo, ticket, agent: reviewer, model, harness, kind: 'reviewer' })
+      evs.push({ type: 'verdict_captured', repo, ticket, agent: reviewer, status: 'resolved', verdict: words(rnd, 80) })
+      evs.push({ type: 'result', agent: reviewer, ticket, status: 'resolved', summary: words(rnd, 30) })
+    }
+    push('review_answered', { approved: true, via: 'gate' })
+  }
+
+  const clean = pushed && rnd() < 0.8
+  if (clean && charting) {
+    push('charting_finished', {
+      map: String(240 + Math.floor(rnd() * 90)), status: 'resolved', commented: true,
+      pr: `https://github.com/${repo}/pull/${400 + Math.floor(rnd() * 99)}`, pr_state: 'MERGED',
+      summary: `🗺️ ${words(rnd, 30)}`,
+    })
+  } else if (clean) {
+    push('ticket_resolved', {
+      comment: 'posted', close: 'closed', map: 'appended', land: 'merged',
+      pr: `https://github.com/${repo}/pull/${400 + Math.floor(rnd() * 99)}`, repaired: false,
+      summary: `✅ ${repo}#${ticket} resolved — ${words(rnd, 30)}`,
+    })
+  } else {
+    push('nonclean_noted', { status: 'blocked', released: true, noted: true, summary: `↩️ ${words(rnd, 25)}` })
+  }
+  push('result', { status: clean ? 'resolved' : 'blocked', summary: words(rnd, 30 + Math.floor(rnd() * 40)), details: { ticket } })
+  push('lifecycle_closed', { reason: 'result' })
+  return evs
+}
+
+// The pre-#184 spelling, put BACK on a line: this is what the old lines in the
+// real file look like, and the columns must still find them.
+function toLegacy(ev) {
+  const out = {}
+  for (const [k, v] of Object.entries(ev)) {
+    if (k === 'type') out.type = String(v).replaceAll('agent', 'worker')
+    else if (k === 'agent') out.worker = v
+    else if (k === 'harness') out.backend = v
+    else out[k] = v
+  }
+  return out
+}
+
+// `lines` of journal text, oldest first, plus the facts a checker needs.
+export function synthesize(target, { seed = 7, legacyFraction = 0.2, firstTicket = 100 } = {}) {
+  const rnd = rng(seed)
+  const streams = []
+  let ticket = firstTicket
+  const events = []
+  const tickets = new Set()
+
+  // Interleave: keep a few dispatches in flight and take one event from a
+  // random live one each step, exactly as several agents running at once do.
+  while (events.length < target) {
+    while (streams.length < 4 && events.length + streams.length < target) {
+      const t = ticket++
+      // A third of the tickets get dispatched twice, which is what makes the
+      // epoch cut load-bearing: the earlier dispatch's approval is not this one's.
+      const rounds = rnd() < 0.33 ? 2 : 1
+      for (let r = 0; r < rounds; r++) streams.push(dispatchEvents(rnd, t, {}).reverse())
+      tickets.add(String(t))
+    }
+    if (rnd() < 0.06) {
+      const type = TICKETLESS[Math.floor(rnd() * TICKETLESS.length)]
+      events.push({ type, detail: words(rnd, 10 + Math.floor(rnd() * 25)) })
+      continue
+    }
+    const i = Math.floor(rnd() * streams.length)
+    const ev = streams[i].pop()
+    if (!streams[i].length) streams.splice(i, 1)
+    events.push(ev)
+  }
+
+  const legacyUntil = Math.floor(events.length * legacyFraction)
+  const start = Date.UTC(2026, 4, 1, 8, 0, 0)
+  const lines = events.map((ev, i) => {
+    const ts = new Date(start + i * 21000).toISOString()
+    const shaped = i < legacyUntil ? toLegacy(ev) : ev
+    return JSON.stringify({ ts, ...shaped })
+  })
+  return { lines, tickets: [...tickets], legacyUntil }
+}


### PR DESCRIPTION
Ticket: alp82/curia#321 — [The schema and the fourteen queries](https://github.com/alp82/curia/issues/321)

#321 prototypes the journal schema under `prototypes/journal-schema/`.

One table, eight columns, four indexes, one epoch trigger. The fourteen questions read as indexed queries over it, and every one is checked against the daemon's own loop, ported out of `dispatch.mjs`. About 17,000 checks over four journal sizes, no mismatches.

The thirteen keyed questions cost 0.20 ms together, and the number does not move with history. Question 12 asks about every ticket at once and stays proportional. The five queries in the daemon README run as written, on a journal whose oldest fifth carries the pre-#184 spelling.

Two schema choices went to the operator and both are ruled: `repo` is a column, and the epoch id is stored on the row rather than probed by each query. The evidence for the second is in the run: 2,000 events through the daemon's own writer carried 58 distinct millisecond stamps, and a claim tied with the pull request it earned on the first pair. Cut by the id the answer is true. Cut by the stamp it is false.

`demo.html` carries the verdict and the numbers. Nothing in `daemon/` changed. The daemon suite is green: 2020 pass, 0 fail, 0 cancelled.

---

Dispatched by the curia daemon — session `curia-321`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `39cb771` The epoch id is stored, ruled at the escalation (alp82/curia#321)
- `67dfeca` The repo column, and why the epoch cut is an id (alp82/curia#321)
- `994cb22` The schema and the fourteen queries, prototyped (alp82/curia#321)