### PR TITLE
The turn a restart killed is replayed (alp82/curia#388)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,6 +160,14 @@ _Avoid_: using it for the model's own steps inside one message (`maxTurns` count
 How a message becomes a turn once the brain is in a container. The daemon posts one message to the overseer service on its published loopback port, and the container streams events back: the session id, the checkout verdict, then the answer. The container holds no conversation, because the resume id travels out with the message and the session id travels back. The model's verb tools reach the other way, over the same MCP side channel every agent container uses, so the daemon composes the canonical text itself and posts it to `/command`. Every effect crosses that one seam, and the ✅/❌ confirm on `cancel` survives the move. See [#314](https://github.com/alp82/curia/issues/314).
 _Avoid_: turn (that is the operator's message, whoever answers it).
 
+**Killed turn**:
+A turn a restart ended before it answered. The routine deploy recreates the daemon and the overseer together, so both halves of a turn in flight die at once. The daemon journals the message when a turn starts and journals the end when it ends, so whatever is still open at a boot is what the restart killed.
+_Avoid_: failed turn (that one ran and the model did not answer, and nothing is sent again for it).
+
+**Replay**:
+Sending a killed turn's message again, instead of asking the operator to type it twice. The test is the seam count: a turn that crossed `/command` zero times is sent again, and a turn that ran a verb is not — sending that one again would run the verb twice. curia sends one message again once, never twice, and it holds the replay if the conversation has already spoken, if the message is over fifteen minutes old, or if the container did not come back. Every turn it does not send again gets one line naming what that turn ran, and the operator decides. A Discord conversation reads that line in its thread. A browser conversation has no thread, so it reads it on its row in the Chat picker until it takes its next turn. See [ADR-0015](docs/adr/0015-the-overseer-is-a-service.md) and [#388](https://github.com/alp82/curia/issues/388).
+_Avoid_: retry (that names the fallback the in-daemon host ran on a second model, and it is gone).
+
 **Turn secret**:
 What opens the daemon's verb tools to one turn of the overseer container. The daemon mints it per turn, hands it over inside the turn request, and forgets it when the turn ends. It is not an agent token: an agent's is a file, because a restarted daemon adopts the agents its predecessor spawned, and a turn survives no restart at all. See [#314](https://github.com/alp82/curia/issues/314).
 _Avoid_: agent token (that one is per agent, on disk, and it opens a different route).

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -150,7 +150,15 @@ The transport for the verbs is MCP rather than a route that takes canonical text
 
 What each side owns: the daemon keeps the conversation (`store.overseerSession`), the one-turn-at-a-time rule, the operator notes and every effect. The container keeps the model, the shell, the checkouts and its own two directories under `<workspace_root>/cfg/curia-overseer`. The container holds no conversation, so a deploy that recreates it loses none.
 
-The model there is `claude-sonnet-5` and there is no fallback: Sonnet IS the model, where the in-daemon host tried Haiku first. A turn the container never answers is a failure the operator reads, and ADR-0015's replay rule is not built yet.
+The model there is `claude-sonnet-5` and there is no fallback: Sonnet IS the model, where the in-daemon host tried Haiku first. A turn the container never answers is a failure the operator reads.
+
+### The turn a restart killed (#388)
+
+The routine deploy recreates the daemon and the overseer together, so both halves of a turn in flight die at once. ADR-0015 says that turn is sent again, never retyped, and `overseerreplay.mjs` is that pass.
+
+The message lives in the journal: `overseer_turn_started` carries it and `overseer_turn_ended` closes it, so whatever is open at a boot is what the restart killed. The seam crossings ride the `command` event the daemon already writes, which now carries the conversation key — the in-memory tally dies with the process holding it. The pass reads that list once, before the listener binds, and waits for the container health check.
+
+It sends the message again only for a turn that crossed the seam zero times. Three more things hold it: a message curia already sent again once, a conversation that has spoken since the boot, and a message over fifteen minutes old. Every held message leaves one line naming what that turn ran. A Discord conversation reads it in its thread. A browser conversation has no thread, so it reads it on its row in the Chat picker until it takes its next turn.
 
 **Nothing routes to it yet.** #315 is the cutover, and it is one swap at two doors: the bridge's `overseerTurn` and the Chat screen's `driverFor`. Until then `POST /overseer/turn` is how the container is soaked.
 

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -357,6 +357,9 @@
   table.chats tr:last-child td { border-bottom: 0; }
   table.chats a { display: block; }
   table.chats .over { color: var(--warn); }
+  /* The turn a restart killed on this conversation (#388). A browser
+     conversation has no thread, so its row is where that line goes. */
+  table.chats .killed { display: block; margin: 3px 0 0; font-size: 12px; color: var(--warn); }
 
   /* ---------- the screens that land later ---------- */
   .later {
@@ -1089,6 +1092,12 @@ const EVENTS = {
      because that is the half of it nobody can undo. */
   console_conversation_opened: ["chat", "", (e) => `${esc(e.key)} opened — a new browser conversation`],
   console_conversation_deleted: ["chat", "", (e) => `${esc(e.key)} deleted — its number is spent, and the next one counts past it`],
+  /* The replay (#388, ADR-0015). The turn's own start and end are not in the
+     feed — they are bookkeeping, one pair per message. This is the news. */
+  overseer_turn_dropped: ["chat", "warn", (e) => e.replayed
+    ? `a restart killed the turn on ${esc(e.key)} — curia sent the message again`
+    : `a restart killed the turn on ${esc(e.key)} — not sent again${
+      e.commands?.length ? `, it had run ${esc(e.commands.join(", "))}` : ""}${e.why ? ` (${esc(e.why)})` : ""}`],
   map_adopted: ["charting", "", (e) => `${who(e)} adopted map ${esc(e.map)} — ${esc(snip(e.title, 80))}`],
   charting_finished: ["charting", "", (e) => `${who(e)} finished charting ${tkt(e)} — ${esc(e.status)}`],
 };
@@ -1752,9 +1761,17 @@ function chatRow(c) {
     ? `<b>${esc(c.label)}</b>`
     : `<span class="dim-note">no turn yet</span>`;
   const answer = said(k);
+  /* A browser conversation has no thread, so the line ADR-0015 gives a killed
+     turn lands here — on the row the operator picks it from. It clears itself:
+     the next turn on this conversation ends the drop. */
+  const dropped = c.dropped && !c.dropped.replayed
+    ? `<span class="killed">⚠️ A restart killed a turn here${
+      c.dropped.commands?.length ? `, and it had run ${esc(c.dropped.commands.join(", "))}` : ""
+    }. curia did not send your message again${c.dropped.why ? ` — ${esc(c.dropped.why)}` : ""}.</span>`
+    : "";
   return `<tr>
     <td><a href="${esc(chatHref(c.session))}">${label}</a>
-      <span class="dim-note mono" style="display:block;margin:2px 0 0">${esc(c.key)} · ${esc(ago(c.last_turn_at))}</span></td>
+      <span class="dim-note mono" style="display:block;margin:2px 0 0">${esc(c.key)} · ${esc(ago(c.last_turn_at))}</span>${dropped}</td>
     <td class="num">${ctxCell(c)}</td>
     <td><button class="btn sm" ${anyBusy() ? "disabled" : ""} onclick="doDeleteConversation('${js(c.key)}')">
       ${busy(k) ? "…" : "delete"}</button></td>

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1767,7 +1767,9 @@ function chatRow(c) {
   const dropped = c.dropped && !c.dropped.replayed
     ? `<span class="killed">⚠️ A restart killed a turn here${
       c.dropped.commands?.length ? `, and it had run ${esc(c.dropped.commands.join(", "))}` : ""
-    }. curia did not send your message again${c.dropped.why ? ` — ${esc(c.dropped.why)}` : ""}.</span>`
+    }. curia did not send your message again${
+      /* The commands are the reason when there are any: not said twice. */
+      !c.dropped.commands?.length && c.dropped.why ? ` — ${esc(c.dropped.why)}` : ""}.</span>`
     : "";
   return `<tr>
     <td><a href="${esc(chatHref(c.session))}">${label}</a>

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -1578,7 +1578,7 @@ export class DiscordBridge {
   // revives that thread's session with full memory. The bridge owns only the
   // transport (thread, typing, the 2000-char cap, and #95's one edited status
   // message); everything said comes from the host through `say`/`status`.
-  async #overseerTurn(thread, prompt) {
+  async #overseerTurn(thread, prompt, opts = {}) {
     const typing = setInterval(() => thread.sendTyping().catch(() => {}), 8000)
     thread.sendTyping().catch(() => {})
     // #95: one status message per turn — sent on the first status(), edited in
@@ -1586,7 +1586,8 @@ export class DiscordBridge {
     // message is exactly what the discipline forbids.
     let statusMsg = null
     try {
-      await this.handlers.overseerTurn(thread.id, prompt, {
+      return await this.handlers.overseerTurn(thread.id, prompt, {
+        ...opts,
         say: (text) => this.#sayChunked(thread, text),
         status: async (text) => {
           if (statusMsg) return statusMsg.edit(text.slice(0, 1900)).catch(() => {})
@@ -1596,6 +1597,28 @@ export class DiscordBridge {
     } finally {
       clearInterval(typing)
     }
+  }
+
+  // The boot's two calls into a conversation thread (#388, ADR-0015). A killed
+  // turn either comes back as the same message or as one line saying why it did
+  // not, and both land in the thread that turn died in.
+  //
+  // The replay takes the SAME path an operator message takes — the small-print
+  // notice first, then `#overseerTurn` — so the status line, the chunking and
+  // the one-turn-at-a-time rule are the ones the surface already has.
+  async sayInThread(threadId, text) {
+    const thread = await this.client.channels.fetch(threadId).catch(() => null)
+    if (!thread) return false
+    await this.#sendChunked(thread, { content: text })
+    return true
+  }
+
+  async replayOverseerTurn(threadId, prompt, notice) {
+    const thread = await this.client.channels.fetch(threadId).catch(() => null)
+    if (!thread) return false
+    if (notice) await this.#sendChunked(thread, { content: notice }).catch(() => {})
+    await this.#overseerTurn(thread, prompt, { replay: true })
+    return true
   }
 
   // Discord caps a message at 2000 chars; the split respects paragraphs (#119).

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -58,6 +58,7 @@ import {
   isConsoleKey, consoleKeyForSession, sessionForConsoleKey,
 } from './attach.mjs'
 import { probeOverseer } from './overseerservice.mjs'
+import { replayKilledTurns, replayLine } from './overseerreplay.mjs'
 import { LIVE_PATHS, DISPATCH_KEYS, liveSettings, liveDiff, frozenDifference } from './settings.mjs'
 import { TimelineSurface } from './timeline.mjs'
 import { IdentityProxy, identityRefusal, hostsForPorts, tailnetSelf } from './identity.mjs'
@@ -485,7 +486,12 @@ const gate = {
     // #18 seam unchanged: the bridge only macro-expands; the far side is now
     // the deterministic command router (stated deviation — the overseer agent
     // session is a later ticket).
-    store.logEvent('command', { canonical, by: userId })
+    // `overseer_key` rides the command event when the overseer's own seam
+    // wrapper issued it (#388). It is what lets a boot count the seam crossings
+    // of a turn whose in-memory tally died with the process that held it.
+    store.logEvent('command', {
+      canonical, by: userId, ...(ctx.overseerKey ? { overseer_key: ctx.overseerKey } : {}),
+    })
     log(`command: "${canonical}"`)
     return router.handle(canonical, userId, ctx)
   },
@@ -987,6 +993,13 @@ const overseerContainer = new OverseerClient({
   turns: overseerTurns,
   log,
 })
+
+// The turns the restart killed (#388, ADR-0015). Read HERE, before the listener
+// binds and before the bridge starts, because after that a pending turn is one
+// that is merely running. `bootAt` is the same instant: a conversation whose
+// turn started after it is one the operator spoke to themselves.
+const killedTurns = store.pendingOverseerTurns()
+const bootAt = Date.now()
 
 // ---- agent-facing MCP surface (#29 shape) ---------------------------------
 
@@ -1647,6 +1660,7 @@ function consoleOnWire() {
   return consoleConversationsOnWire({
     conversations: store.consoleConversationList(),
     sessionIdFor: (key) => store.overseerSession(key),
+    droppedFor: (key) => store.droppedOverseerTurn(key),
     harness: detectHarness(cfgDir),
     cfgDir,
     model: overseerContainer.model,
@@ -2140,6 +2154,30 @@ for (const r of store.openEscalations()) {
 // lands and the announce falls back to the log.
 selfDeploy.resolvePending({ announce: (text) => (bridge ? bridge.announce(text) : Promise.resolve()) })
   .catch((e) => log(`deploy resolution failed: ${e.message}`))
+
+// #388, ADR-0015: the turn the restart killed is sent again, never retyped. The
+// pass waits for the overseer container to answer its health check and, for a
+// Discord conversation, for the bridge to come back — the two things a deploy
+// takes down beside this process. It runs off the boot rather than inside it:
+// nothing else waits for it, and a conversation with nothing pending costs one
+// journal read.
+replayKilledTurns({
+  killed: killedTurns,
+  store,
+  bootAt,
+  probe: () => probeOverseer({ port: curiaConfig.overseer.port }),
+  // A turn already in flight on this key means the operator got here first.
+  live: (key) => overseerContainer.busy.has(key),
+  discord: {
+    ready: () => Boolean(bridge),
+    // Optional on purpose: the wedge watchdog throws the bridge away and builds
+    // a new one, so a bridge that was up when the wait ended can be gone here.
+    say: (threadId, text) => bridge?.sayInThread(threadId, text) ?? false,
+    replay: (threadId, prompt) => bridge?.replayOverseerTurn(threadId, prompt, replayLine()) ?? false,
+  },
+  browser: { replay: (key, prompt) => overseerContainer.browserTurn(key, prompt, { replay: true }) },
+  log,
+}).catch((e) => log(`the killed-turn replay failed: ${e.message}`))
 
 // #56 bridge health. The outage clock lives HERE rather than on the bridge
 // object, because a wedge recovery throws the bridge away and builds a new one —

--- a/daemon/src/overseerclient.mjs
+++ b/daemon/src/overseerclient.mjs
@@ -82,7 +82,11 @@ export class OverseerTurns {
       try {
         await narrate(text)
       } catch { /* the status line is not the effect */ }
-      return command(text, { threadId: routeThreadId, interpreted: true })
+      // `overseerKey` is what makes the command event countable after this
+      // process dies (#388): the daemon journals every crossing as a `command`
+      // already, and the key is what ties one to the conversation it crossed
+      // for. The boot counts the crossings of a killed turn off those lines.
+      return command(text, { threadId: routeThreadId, interpreted: true, overseerKey: key })
     }
     const turn = { id, token, key, routeThreadId, crossed, crossings: 0, command: seam }
     this.#turns.set(id, turn)
@@ -172,7 +176,7 @@ export class OverseerClient {
   // Discord thread: the answer is not posted, because the timeline surface
   // tails the transcript, and the verb tools run with NO origin thread, so a
   // confirm lands in the channel and in the console's needs-you list.
-  async browserTurn(key, text) {
+  async browserTurn(key, text, { replay = false } = {}) {
     if (!this.store.hasConsoleConversation?.(key)) {
       throw new Error(`there is no conversation \`${key}\` — it was deleted, and its number is spent; open a new one from the Chat screen`)
     }
@@ -181,6 +185,7 @@ export class OverseerClient {
       say: (t) => { said.push(t) },
       status: () => {},
       routeThreadId: null,
+      replay,
     })
     if (out.busy) throw new Error('curia is still on your last message — one turn at a time')
     if (!out.ok) throw new Error(said.join('\n') || `the turn ended without an answer (${out.why})`)
@@ -190,7 +195,11 @@ export class OverseerClient {
   // One operator message → one turn, and one turn posts exactly two messages
   // (#95, per #89): status(text) upserts the single small-print status line,
   // and say(text) posts the answer. Failures land in the answer slot.
-  async runTurn(key, prompt, { say, status, routeThreadId = key }) {
+  //
+  // `replay` marks a turn the boot is sending again (#388). It changes nothing
+  // about how the turn runs — it rides the journal so a SECOND restart can tell
+  // a replay from an operator's own message, and never replay a replay.
+  async runTurn(key, prompt, { say, status, routeThreadId = key, replay = false }) {
     if (this.busy.has(key)) {
       await say(smallPrint(`${SIGNALS.warn} still on your last message — one turn at a time per thread`))
       return { ok: false, busy: true }
@@ -208,7 +217,11 @@ export class OverseerClient {
       const fullPrompt = notes.length
         ? `${notes.map((t) => `[curia: ${t}]`).join('\n')}\n\n${prompt}`
         : prompt
-      const out = await this.#turn(key, fullPrompt, { say, step, routeThreadId })
+      // The journal keeps THIS text, notes and all (#388). The drain already
+      // happened, so a turn a restart kills has taken those notes off the queue
+      // without ever showing them to the model — and the replay is the one thing
+      // that can still deliver them.
+      const out = await this.#turn(key, fullPrompt, { say, step, routeThreadId, replay })
       if (!out.ok) await say(`${SIGNALS.warn} ${out.said}`)
       return out
     } finally {
@@ -216,18 +229,36 @@ export class OverseerClient {
     }
   }
 
-  // THE HOP. One POST, one NDJSON stream back, one registered turn for as long
-  // as it runs. There is no second model attempt: the in-daemon host retried a
-  // failed Haiku turn on Sonnet, and Sonnet IS the model here (ADR-0014), so
-  // the failure goes to the operator. ADR-0015 gives a killed turn a replay
-  // instead, and it is the same test — a turn that crossed the seam zero times.
-  async #turn(key, prompt, { say, step, routeThreadId }) {
-    const resume = this.store.overseerSession(key)
+  // THE REGISTERED TURN, and the two journal lines that bracket it (#388).
+  // Everything between them is one turn in flight, so a turn still open when
+  // this process dies is the turn the restart killed — and the boot finds it by
+  // reading the journal rather than a map this process took with it.
+  async #turn(key, prompt, { say, step, routeThreadId, replay = false }) {
     // The status line states the text the SEAM carried and nothing else (#275),
     // in code because it is a command line and not prose.
     const turn = this.turns.begin({
       key, routeThreadId, command: this.command, narrate: (text) => step(`\`${text}\``),
     })
+    this.store.beginOverseerTurn({ key, turn: turn.id, prompt, threadId: routeThreadId, replay })
+    let out
+    try {
+      out = await this.#hop(key, prompt, turn, { say, step })
+    } finally {
+      this.turns.end(turn.id)
+      this.store.endOverseerTurn({
+        key, turn: turn.id, ok: out?.ok ?? false, crossings: turn.crossings, why: out?.why ?? null,
+      })
+    }
+    return out
+  }
+
+  // THE HOP. One POST, one NDJSON stream back, one registered turn for as long
+  // as it runs. There is no second model attempt: the in-daemon host retried a
+  // failed Haiku turn on Sonnet, and Sonnet IS the model here (ADR-0014), so
+  // the failure goes to the operator. ADR-0015 gives a killed turn a replay
+  // instead, and it is the same test — a turn that crossed the seam zero times.
+  async #hop(key, prompt, turn, { say, step }) {
+    const resume = this.store.overseerSession(key)
     this.log(`[overseer] turn key=${key} resume=${resume ?? 'fresh'} model=${this.model} → ${this.base}${TURN_PATH}`)
     let sessionId = null
     let toolCalls = 0
@@ -288,8 +319,6 @@ export class OverseerClient {
         crossings: turn.crossings,
         sessionId,
       }
-    } finally {
-      this.turns.end(turn.id)
     }
     if (!end) {
       return {

--- a/daemon/src/overseerreplay.mjs
+++ b/daemon/src/overseerreplay.mjs
@@ -1,0 +1,167 @@
+// The replay (#388, building ADR-0015): a turn a restart killed is sent again,
+// never retyped.
+//
+// WHY THIS EXISTS. The routine deploy is `docker compose up -d --build --no-deps
+// daemon dashboard overseer`, so it recreates the daemon and the overseer
+// together and every turn in flight on both dies with them. Before this, the
+// operator read `⚠️ the overseer container did not answer (...)` and typed their
+// message a second time.
+//
+// THE TEST IS THE SEAM COUNT, and ADR-0015 names it: a turn that crossed
+// `/command` zero times is replayed, and a turn that ran a verb is not. Sending
+// a message again that already dispatched an agent would dispatch a second one.
+// So a turn that DID cross gets a line naming what it ran, and the operator
+// decides from there.
+//
+// WHERE THE COUNT COMES FROM after the process holding it died: the seam
+// journals every crossing as a `command` event, and #388 put the conversation
+// key on that event. The store counts them onto the pending turn, so the boot
+// reads a number this process never saw.
+//
+// WHAT MAKES A TURN "KILLED": the journal started it and never ended it. A turn
+// survives no restart, so anything still open when a process boots was killed by
+// the restart that ended the last one. The list is read ONCE, before this daemon
+// can start a turn of its own.
+//
+// FOUR THINGS STOP A REPLAY, and each one leaves the same line rather than
+// silence:
+//
+//   1. The turn crossed the seam. It already did something.
+//   2. The turn was itself a replay. curia sends one message again once, never
+//      twice — a daemon in a crash loop must not replay one message forever.
+//   3. The conversation has spoken since the boot. The operator retyped it, and
+//      a replay landing behind their own words is the second message ADR-0015
+//      exists to avoid.
+//   4. The message is stale, or the container never came back. A daemon down for
+//      an hour must not wake a conversation with an hour-old message.
+
+import { isConsoleKey } from './attach.mjs'
+import { SIGNALS, smallPrint } from './messaging.mjs'
+
+// How long the boot waits for the container to answer its health check, how
+// often it asks, and how old a message may be and still be sent again. The wait
+// is generous because a deploy rebuilds the overseer image; the freshness window
+// is short because it bounds a surprise, not a failure.
+export const REPLAY_WAIT_MS = 120_000
+export const REPLAY_POLL_MS = 3_000
+export const REPLAY_FRESH_MS = 15 * 60_000
+
+// The line the conversation gets when curia did NOT send the message again. It
+// names what that turn ran when it ran anything, because that is the fact the
+// operator decides from.
+export function droppedLine({ commands = [], why = null }) {
+  const parts = [`${SIGNALS.warn} a restart killed the turn on your last message here.`]
+  if (commands.length) parts.push(`It had already run ${commands.map((c) => `\`${c}\``).join(', ')}.`)
+  parts.push(`curia did not send the message again${why ? ` — ${why}` : ''}. Say it again if you still want it.`)
+  return parts.join(' ')
+}
+
+// The line that goes in FRONT of a replay, so the operator reads their own words
+// coming back as curia's doing rather than as an echo they did not ask for.
+export function replayLine() {
+  return smallPrint('a restart killed the turn on your last message — curia is sending it again.')
+}
+
+function ageMs(at, nowMs) {
+  const t = at ? Date.parse(at) : NaN
+  return Number.isNaN(t) ? Infinity : nowMs - t
+}
+
+// Why this killed turn must not be sent again, or null when it may be. Pure, so
+// the whole decision is readable without a container, a bridge or a clock.
+export function refuseReplay(killed, { nowMs, bootAt, lastTurnAt = null, live = false, freshMs = REPLAY_FRESH_MS }) {
+  if (killed.crossings > 0) return 'it already crossed the seam'
+  if (killed.replay) return 'curia already sent this message again once'
+  if (live) return 'you were already talking here'
+  if (lastTurnAt && Date.parse(lastTurnAt) > bootAt) return 'you were already talking here'
+  if (ageMs(killed.at, nowMs) > freshMs) return `the message is older than ${Math.round(freshMs / 60_000)} minutes`
+  return null
+}
+
+const sleepFor = (ms) => new Promise((r) => setTimeout(r, ms).unref?.())
+
+// Poll `ready()` until it answers true or the deadline passes.
+async function waitUntil(ready, { deadline, pollMs, nowMs, sleep }) {
+  for (;;) {
+    if (await ready()) return true
+    if (nowMs() >= deadline) return false
+    await sleep(pollMs)
+  }
+}
+
+// THE BOOT PASS. Everything it touches is injected, so the suite drives it with
+// no container, no bridge and no clock.
+//
+//   `killed`    the pending turns, read off the journal before this daemon
+//               could start one of its own
+//   `probe`     the container health check — the same one the overview reads
+//   `discord`   `{ ready(), say(threadId, text), replay(threadId, prompt) }`,
+//               or null when this daemon runs without a bridge
+//   `browser`   `replay(key, prompt)` for a browser conversation, which has no
+//               thread: its answer reaches the Chat screen through the
+//               transcript, and the dropped line reaches it through the journal
+export async function replayKilledTurns({
+  killed, store, probe, discord = null, browser = null, live = () => false,
+  bootAt, log = console.log, nowMs = () => Date.now(), sleep = sleepFor,
+  waitMs = REPLAY_WAIT_MS, pollMs = REPLAY_POLL_MS, freshMs = REPLAY_FRESH_MS,
+}) {
+  if (!killed.length) return []
+  log(`[overseer] the restart killed ${killed.length} turn(s) — reading what may be sent again`)
+  const deadline = nowMs() + waitMs
+
+  const up = await waitUntil(async () => (await probe()).up, { deadline, pollMs, nowMs, sleep })
+  // The bridge is only in the way of a Discord conversation. A browser one is
+  // replayed whatever Discord is doing.
+  const needsBridge = killed.some((k) => !isConsoleKey(k.key))
+  const bridgeUp = up && needsBridge && discord
+    ? await waitUntil(async () => discord.ready(), { deadline, pollMs, nowMs, sleep })
+    : Boolean(discord)
+
+  // EVERY VERDICT IS DECIDED AND JOURNALLED FIRST, before one word is sent.
+  // The drop event ends the killed turn as well as reporting it, so a daemon
+  // that dies in the middle of this finds the replays' own turns on its next
+  // boot and never one of these twice.
+  const out = killed.map((k) => {
+    const browserKey = isConsoleKey(k.key)
+    let why = refuseReplay(k, {
+      nowMs: nowMs(), bootAt, lastTurnAt: store.lastOverseerTurnAt(k.key), live: live(k.key), freshMs,
+    })
+    if (!why && !up) why = 'the overseer container did not come back'
+    if (!why && !browserKey && !bridgeUp) why = 'the Discord bridge did not come back'
+    if (!why && !browserKey && !k.thread_id) why = 'that turn names no thread to answer in'
+    store.dropOverseerTurn({
+      key: k.key, turn: k.turn, crossings: k.crossings, commands: k.commands,
+      replayed: !why, why,
+    })
+    log(`[overseer] killed turn on ${k.key}: ${why ? `not sent again — ${why}` : 'sending the message again'}`)
+    return { key: k.key, replayed: !why, why }
+  })
+
+  // THEN THEY RUN TOGETHER. A replayed turn takes as long as any turn, and one
+  // conversation must not wait on another's — the one-turn rule is per
+  // conversation, and these are different ones by construction.
+  await Promise.all(killed.map(async (k, i) => {
+    const { why } = out[i]
+    const browserKey = isConsoleKey(k.key)
+    try {
+      if (why) {
+        // A browser conversation has no thread. Its line is the journal event
+        // above: the feed carries it, and the Chat picker draws it on that
+        // conversation's row until it takes its next turn.
+        if (!browserKey && discord && k.thread_id) await discord.say(k.thread_id, droppedLine({ commands: k.commands, why }))
+        return
+      }
+      // A thread the operator deleted takes the replay with it. Nothing is
+      // retried and nothing is moved: there is no second place those words
+      // belong, and the journal already says curia sent them.
+      const sent = browserKey ? await browser?.replay(k.key, k.prompt) : await discord?.replay(k.thread_id, k.prompt)
+      if (sent === false) log(`[overseer] the replay on ${k.key} reached no thread — it is gone`)
+    } catch (e) {
+      // A replay that fails is a turn that failed, and the conversation already
+      // carries whatever the turn said about it. Nothing is retried: one message
+      // is sent again once.
+      log(`[overseer] the replay on ${k.key} failed: ${String(e.message ?? e).split('\n')[0]}`)
+    }
+  }))
+  return out
+}

--- a/daemon/src/overseerreplay.mjs
+++ b/daemon/src/overseerreplay.mjs
@@ -51,8 +51,12 @@ export const REPLAY_FRESH_MS = 15 * 60_000
 // operator decides from.
 export function droppedLine({ commands = [], why = null }) {
   const parts = [`${SIGNALS.warn} a restart killed the turn on your last message here.`]
+  // The commands ARE the reason when there are any, so the reason is not said
+  // twice: "it had already run `start 256`" and "it already crossed the seam"
+  // are one fact in two sentences.
   if (commands.length) parts.push(`It had already run ${commands.map((c) => `\`${c}\``).join(', ')}.`)
-  parts.push(`curia did not send the message again${why ? ` — ${why}` : ''}. Say it again if you still want it.`)
+  const reason = commands.length ? '' : `${why ? ` — ${why}` : ''}`
+  parts.push(`curia did not send the message again${reason}. Say it again if you still want it.`)
   return parts.join(' ')
 }
 

--- a/daemon/src/overseerreplay.mjs
+++ b/daemon/src/overseerreplay.mjs
@@ -84,10 +84,14 @@ export function refuseReplay(killed, { nowMs, bootAt, lastTurnAt = null, live = 
 
 const sleepFor = (ms) => new Promise((r) => setTimeout(r, ms).unref?.())
 
-// Poll `ready()` until it answers true or the deadline passes.
+// Poll `ready()` until it answers true or the deadline passes. A check that
+// throws reads as not ready: the health check is a fact about the container, and
+// a failure to take it must not throw away every killed turn behind it.
 async function waitUntil(ready, { deadline, pollMs, nowMs, sleep }) {
   for (;;) {
-    if (await ready()) return true
+    let ok = false
+    try { ok = await ready() } catch { ok = false }
+    if (ok) return true
     if (nowMs() >= deadline) return false
     await sleep(pollMs)
   }

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -112,6 +112,14 @@ export function noteDisposition(agent) {
   return { reads, instance: reads ? agent.instance ?? null : null }
 }
 
+// The two events the FEED does not carry (#388). One operator message to the
+// overseer writes both, and they exist so a restart can find a turn it killed —
+// they are bookkeeping, not news. The feed ring holds a hundred events and Home
+// draws four of them, so a pair per chat message would push every dispatch,
+// death and gate off the screen. What the operator DOES read about a killed
+// turn is `overseer_turn_dropped`, which the feed carries.
+const FEED_SILENT = new Set(['overseer_turn_started', 'overseer_turn_ended'])
+
 // The events lastAgentEvent must not count (#236) — see _apply.
 const NOTE_EVENTS = new Set([
   'agent_note', 'agent_notes_drained', 'agent_notes_expired', 'agent_note_refused', 'agent_note_interrupted',
@@ -152,6 +160,9 @@ export class EscalationStore {
     this.outcomes = { cancelled: [], finished: [], died: [] } // the last RECENT_OUTCOMES of each (#289)
     this.pullRequests = new Map() // agent session -> the pull request its CURRENT dispatch pushed (#289)
     this.limitResumes = new Map() // ticket -> the limit resume curia still owes it (#346)
+    this.pendingTurns = new Map() // conversation key -> the overseer turn still in flight (#388)
+    this.droppedTurns = new Map() // conversation key -> the last turn a restart killed (#388)
+    this.turnStarts = new Map() // conversation key -> when its last turn started (#388)
     this.seq = 0
     this.noteSeq = 0
     this._replay()
@@ -196,8 +207,10 @@ export class EscalationStore {
     // The feed's tail (#262). Every event passes here exactly once, on replay
     // and on append alike, so the ring is right the instant the boot replay
     // ends and stays right for the rest of the run.
-    this.recent.push(this.#feedShape(ev))
-    if (this.recent.length > RECENT_EVENTS) this.recent.shift()
+    if (!FEED_SILENT.has(ev.type)) {
+      this.recent.push(this.#feedShape(ev))
+      if (this.recent.length > RECENT_EVENTS) this.recent.shift()
+    }
 
     // The last thing the journal says about an agent (#236): the direct answer
     // under a question in its thread reads it as progress evidence. The
@@ -441,8 +454,67 @@ export class EscalationStore {
         // the next boot replays for a conversation that is not there.
         this.overseerSessions.delete(ev.key)
         this.overseerNotes.delete(ev.key)
+        this.pendingTurns.delete(ev.key)
+        this.droppedTurns.delete(ev.key)
         break
       }
+      // ---- the turn a restart can kill (#388, ADR-0015) --------------------
+      //
+      // The pending map holds ONE turn per conversation, which is the rule the
+      // client already enforces: one turn at a time per conversation. Whatever
+      // is still in this map when a process boots was killed by the restart
+      // that ended the last one, because a turn survives no restart.
+      case 'overseer_turn_started': {
+        this.pendingTurns.set(ev.key, {
+          key: ev.key,
+          turn: ev.turn ?? null,
+          prompt: ev.prompt ?? '',
+          thread_id: ev.thread_id ?? null,
+          replay: ev.replay ?? false,
+          at: ev.ts ?? null,
+          crossings: 0,
+          commands: [],
+        })
+        // A new turn answers whatever the last drop left on the surfaces.
+        this.droppedTurns.delete(ev.key)
+        // When this conversation last SPOKE, which the boot reads to tell a
+        // message the operator has already sent again by hand from one that
+        // still waits for its replay.
+        if (ev.ts) this.turnStarts.set(ev.key, ev.ts)
+        break
+      }
+      case 'overseer_turn_ended':
+      case 'overseer_turn_dropped': {
+        this.pendingTurns.delete(ev.key)
+        break
+      }
+    }
+
+    // The seam crossings of the pending turn, counted off the COMMAND event the
+    // seam already writes (#388). One voice per fact, ADR-0013: a second event
+    // saying "the overseer crossed" would state what this one states. The
+    // in-memory `turn.crossings` dies with the process, and this is what the
+    // boot reads in its place.
+    if (ev.type === 'command' && ev.overseer_key) {
+      const pending = this.pendingTurns.get(ev.overseer_key)
+      if (pending) {
+        pending.crossings += 1
+        pending.commands.push(ev.canonical)
+      }
+    }
+
+    // What the surfaces say about a turn a restart killed, until that
+    // conversation takes its next one. The Chat picker draws it for a browser
+    // conversation, which has no thread to put the line in.
+    if (ev.type === 'overseer_turn_dropped') {
+      this.droppedTurns.set(ev.key, {
+        key: ev.key,
+        crossings: ev.crossings ?? 0,
+        commands: ev.commands ?? [],
+        replayed: ev.replayed ?? false,
+        why: ev.why ?? null,
+        at: ev.ts ?? null,
+      })
     }
   }
 
@@ -572,6 +644,52 @@ export class EscalationStore {
 
   overseerSession(threadId) {
     return this.overseerSessions.get(threadId)
+  }
+
+  // ---- the turn a restart can kill (#388, ADR-0015) -------------------------
+  //
+  // ADR-0015 promises that a turn a restart kills is replayed, never retyped.
+  // The message therefore cannot live in this process: the routine deploy
+  // recreates the daemon and the overseer together, so both halves die at once.
+  // It lives here, as one event when a turn starts and one when it ends, and
+  // the boot reads whatever is left between them.
+  //
+  // The prompt is journalled whole, because the message IS the thing to send
+  // again. The journal already holds the operator's words: every canonical
+  // command line, every escalation prompt, every answer.
+
+  beginOverseerTurn({ key, turn, prompt, threadId = null, replay = false }) {
+    this._append({ type: 'overseer_turn_started', key, turn, prompt, thread_id: threadId, replay })
+  }
+
+  endOverseerTurn({ key, turn, ok, crossings = 0, why = null }) {
+    this._append({ type: 'overseer_turn_ended', key, turn, ok, crossings, why })
+  }
+
+  // The boot's verdict on one killed turn: replayed, or named and left. It ENDS
+  // the turn as well as reporting it, so a second boot never reads the same
+  // corpse twice.
+  dropOverseerTurn({ key, turn = null, crossings = 0, commands = [], replayed = false, why = null }) {
+    this._append({ type: 'overseer_turn_dropped', key, turn, crossings, commands, replayed, why })
+  }
+
+  // Every turn the journal has started and not ended. Read ONCE, at boot,
+  // before this process can start a turn of its own — after that the answer
+  // includes turns that are merely running.
+  pendingOverseerTurns() {
+    return [...this.pendingTurns.values()].map((t) => ({ ...t, commands: [...t.commands] }))
+  }
+
+  // What a surface says about the last turn a restart killed on one
+  // conversation. Null once that conversation takes its next turn.
+  droppedOverseerTurn(key) {
+    return this.droppedTurns.get(key) ?? null
+  }
+
+  // When one conversation last started a turn, as an ISO string. Null for a
+  // conversation that has never spoken.
+  lastOverseerTurnAt(key) {
+    return this.turnStarts.get(key) ?? null
   }
 
   // ---- the browser conversations (#333, ADR-0016) ---------------------------

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -864,7 +864,8 @@ export function ctxOnWire(read) {
 // `store.overseerSession`. Every conversation shares one config dir, so only
 // that id names a conversation's own file.
 export function consoleConversationsOnWire({
-  conversations, sessionIdFor, harness, cfgDir, model, routing, account, models, now = Date.now(),
+  conversations, sessionIdFor, harness, cfgDir, model, routing, account, models,
+  droppedFor = () => null, now = Date.now(),
 }) {
   return conversations.map((c) => {
     const file = harness ? transcriptForSession(harness, cfgDir, sessionIdFor(c.key) ?? null) : null
@@ -883,6 +884,10 @@ export function consoleConversationsOnWire({
       // The row's label: what the operator opened this conversation with. Null
       // for one with no turn yet, and the page falls back to the key.
       label: file ? firstPrompt(harness, file) : null,
+      // The turn a restart killed on THIS conversation (#388). A Discord
+      // conversation gets that line in its thread; a browser one has no thread,
+      // so the row it is picked from carries it until it takes its next turn.
+      dropped: droppedFor(c.key),
       // A conversation with no turn yet has no file, and `agentMeters` then
       // reads NOTHING rather than falling back to whoever answered last
       // (#332). The percent is null, which the page prints as "—", never 0%.

--- a/daemon/test/overseerreplay.test.mjs
+++ b/daemon/test/overseerreplay.test.mjs
@@ -255,6 +255,27 @@ describe('the boot pass (#388)', () => {
     assert.match(h.said[0][1], /did not come back/)
   })
 
+  test('a health check that throws reads as a container that is down, never as a lost turn', async () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    let clock = Date.now()
+    const out = await replayKilledTurns({
+      killed: [killedTurn()],
+      store,
+      bootAt: clock,
+      nowMs: () => clock,
+      probe: async () => { throw new Error('the socket is gone') },
+      sleep: async (ms) => { clock += ms },
+      waitMs: 30,
+      pollMs: 10,
+      discord: { ready: () => true, say: async () => {}, replay: async () => {} },
+      log: quiet,
+    })
+    assert.equal(out[0].why, 'the overseer container did not come back')
+    // And the turn is closed, not left pending for a boot an hour from now.
+    assert.deepEqual(new EscalationStore(dir).pendingOverseerTurns(), [])
+  })
+
   test('a bridge that never comes back holds the Discord replay', async () => {
     const h = harness({ killed: [killedTurn()], bridge: false })
     const out = await h.run()

--- a/daemon/test/overseerreplay.test.mjs
+++ b/daemon/test/overseerreplay.test.mjs
@@ -1,0 +1,351 @@
+// The replay (#388, building ADR-0015): a turn a restart killed is sent again,
+// never retyped.
+//
+// Three halves are driven here, and each one is the real thing:
+//
+//   1. The journal reduction, on a real `EscalationStore` over a real file —
+//      including the second store that reads the same file cold, because the
+//      whole point is that the message survives the process.
+//   2. `refuseReplay`, which is the whole decision and is pure.
+//   3. `replayKilledTurns`, the boot pass, with the container, the bridge and
+//      the clock injected.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { EscalationStore } from '../src/store.mjs'
+import {
+  replayKilledTurns, refuseReplay, droppedLine, replayLine, REPLAY_FRESH_MS,
+} from '../src/overseerreplay.mjs'
+
+const quiet = () => {}
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'curia-replay-'))
+
+// One started turn, as the client writes it.
+function start(store, { key = '111', prompt = 'what is on the frontier', threadId = '111', replay = false } = {}) {
+  store.beginOverseerTurn({ key, turn: 'abc', prompt, threadId, replay })
+}
+
+// One seam crossing, as index.mjs writes it: the command event the daemon
+// already journals, carrying the conversation key.
+function cross(store, key, canonical) {
+  store.logEvent('command', { canonical, by: 'overseer', overseer_key: key })
+}
+
+describe('the journal holds the pending turn (#388)', () => {
+  test('a started turn is pending, and an ended one is not', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    start(store)
+    assert.equal(store.pendingOverseerTurns().length, 1)
+    assert.equal(store.pendingOverseerTurns()[0].prompt, 'what is on the frontier')
+    store.endOverseerTurn({ key: '111', turn: 'abc', ok: true, crossings: 0 })
+    assert.deepEqual(store.pendingOverseerTurns(), [])
+  })
+
+  test('a fresh store reads the same pending turn off the file — the message survives the process', () => {
+    const dir = tmp()
+    const first = new EscalationStore(dir)
+    start(first, { prompt: 'start 256' })
+    // No end event: this is the process the restart killed.
+    const booted = new EscalationStore(dir)
+    const killed = booted.pendingOverseerTurns()
+    assert.equal(killed.length, 1)
+    assert.equal(killed[0].prompt, 'start 256')
+    assert.equal(killed[0].thread_id, '111')
+    assert.equal(killed[0].crossings, 0)
+  })
+
+  test('the crossings are counted off the command event the seam already writes', () => {
+    const dir = tmp()
+    const first = new EscalationStore(dir)
+    start(first)
+    cross(first, '111', 'start 256 in alp82/curia')
+    cross(first, '111', 'status')
+    const booted = new EscalationStore(dir)
+    const killed = booted.pendingOverseerTurns()[0]
+    assert.equal(killed.crossings, 2)
+    assert.deepEqual(killed.commands, ['start 256 in alp82/curia', 'status'])
+  })
+
+  test('a command with no conversation key counts against nothing', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    start(store)
+    store.logEvent('command', { canonical: 'start 256', by: 'alp82' })
+    assert.equal(store.pendingOverseerTurns()[0].crossings, 0)
+  })
+
+  test('a drop ends the turn and leaves the line for the surfaces', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    start(store, { key: 'console-1', threadId: null })
+    store.dropOverseerTurn({ key: 'console-1', crossings: 1, commands: ['cancel 3'], replayed: false, why: 'it already crossed the seam' })
+    assert.deepEqual(store.pendingOverseerTurns(), [])
+    assert.equal(store.droppedOverseerTurn('console-1').why, 'it already crossed the seam')
+    // And the next boot reads no corpse twice.
+    assert.deepEqual(new EscalationStore(dir).pendingOverseerTurns(), [])
+  })
+
+  test('the conversation\'s next turn clears the dropped line', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    start(store, { key: 'console-1', threadId: null })
+    store.dropOverseerTurn({ key: 'console-1', crossings: 1, commands: [], replayed: false, why: 'no' })
+    assert.ok(store.droppedOverseerTurn('console-1'))
+    start(store, { key: 'console-1', threadId: null })
+    assert.equal(store.droppedOverseerTurn('console-1'), null)
+  })
+
+  test('a deleted conversation takes its pending and dropped turns with it', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    store.openConsoleConversation()
+    start(store, { key: 'console-1', threadId: null })
+    store.deleteConsoleConversation('console-1')
+    assert.deepEqual(store.pendingOverseerTurns(), [])
+    assert.equal(store.droppedOverseerTurn('console-1'), null)
+  })
+
+  test('the turn bookkeeping stays out of the feed, and the drop does not', () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    start(store)
+    store.endOverseerTurn({ key: '111', turn: 'abc', ok: true })
+    assert.deepEqual(store.recentEvents().map((e) => e.type), [])
+    store.dropOverseerTurn({ key: '111', replayed: true })
+    assert.deepEqual(store.recentEvents().map((e) => e.type), ['overseer_turn_dropped'])
+  })
+})
+
+describe('what stops a replay (#388, ADR-0015)', () => {
+  const now = Date.parse('2026-08-16T12:00:00.000Z')
+  const bootAt = now - 30_000
+  const fresh = { key: '111', crossings: 0, replay: false, at: '2026-08-16T11:59:00.000Z' }
+
+  test('a turn that crossed nothing is sent again', () => {
+    assert.equal(refuseReplay(fresh, { nowMs: now, bootAt }), null)
+  })
+
+  test('a turn that ran a verb is not', () => {
+    assert.equal(refuseReplay({ ...fresh, crossings: 1 }, { nowMs: now, bootAt }), 'it already crossed the seam')
+  })
+
+  test('a replay is not replayed', () => {
+    assert.equal(
+      refuseReplay({ ...fresh, replay: true }, { nowMs: now, bootAt }),
+      'curia already sent this message again once',
+    )
+  })
+
+  test('a conversation with a turn in flight is left alone', () => {
+    assert.equal(refuseReplay(fresh, { nowMs: now, bootAt, live: true }), 'you were already talking here')
+  })
+
+  test('a conversation that spoke since the boot is left alone', () => {
+    assert.equal(
+      refuseReplay(fresh, { nowMs: now, bootAt, lastTurnAt: new Date(bootAt + 5_000).toISOString() }),
+      'you were already talking here',
+    )
+  })
+
+  test('the killed turn\'s own start does not read as the operator retyping', () => {
+    assert.equal(refuseReplay(fresh, { nowMs: now, bootAt, lastTurnAt: fresh.at }), null)
+  })
+
+  test('a stale message is not sent again', () => {
+    const old = { ...fresh, at: new Date(now - REPLAY_FRESH_MS - 1_000).toISOString() }
+    assert.equal(refuseReplay(old, { nowMs: now, bootAt }), 'the message is older than 15 minutes')
+  })
+})
+
+// ---- the boot pass ---------------------------------------------------------
+
+function harness({ killed, up = true, bridge = true, live = () => false, bootAt = Date.now() }) {
+  const dir = tmp()
+  const store = new EscalationStore(dir)
+  const said = []
+  const replayed = []
+  const browsed = []
+  // A clock the sleep moves, so the wait for a container that never answers
+  // reaches its deadline without the suite waiting two real minutes.
+  let clock = bootAt
+  return {
+    dir,
+    store,
+    said,
+    replayed,
+    browsed,
+    run: () => replayKilledTurns({
+      killed,
+      store,
+      bootAt,
+      nowMs: () => clock,
+      probe: async () => ({ up }),
+      live,
+      sleep: async (ms) => { clock += ms },
+      waitMs: 30, // the deadline is crossed after one poll, so a down container is fast
+      pollMs: 10,
+      discord: {
+        ready: () => bridge,
+        say: async (threadId, text) => { said.push([threadId, text]) },
+        replay: async (threadId, prompt) => { replayed.push([threadId, prompt]) },
+      },
+      browser: { replay: async (key, prompt) => { browsed.push([key, prompt]) } },
+      log: quiet,
+    }),
+  }
+}
+
+const killedTurn = (over = {}) => ({
+  key: '111', turn: 'abc', prompt: 'what is on the frontier', thread_id: '111',
+  replay: false, crossings: 0, commands: [], at: new Date().toISOString(), ...over,
+})
+
+describe('the boot pass (#388)', () => {
+  test('nothing pending is nothing done', async () => {
+    const h = harness({ killed: [] })
+    assert.deepEqual(await h.run(), [])
+  })
+
+  test('a clean Discord turn is sent again, and journalled as sent', async () => {
+    const h = harness({ killed: [killedTurn()] })
+    const out = await h.run()
+    assert.deepEqual(out, [{ key: '111', replayed: true, why: null }])
+    assert.deepEqual(h.replayed, [['111', 'what is on the frontier']])
+    assert.equal(h.said.length, 0)
+    assert.equal(h.store.droppedOverseerTurn('111').replayed, true)
+  })
+
+  test('a turn that ran a verb gets one line naming what it ran, and no replay', async () => {
+    const h = harness({ killed: [killedTurn({ crossings: 1, commands: ['start 256 in alp82/curia'] })] })
+    await h.run()
+    assert.equal(h.replayed.length, 0)
+    assert.equal(h.said.length, 1)
+    const [threadId, text] = h.said[0]
+    assert.equal(threadId, '111')
+    assert.match(text, /start 256 in alp82\/curia/)
+    assert.match(text, /did not send the message again/)
+  })
+
+  test('a browser conversation is replayed with no thread line — the journal is its surface', async () => {
+    const h = harness({ killed: [killedTurn({ key: 'console-2', thread_id: null })] })
+    await h.run()
+    assert.deepEqual(h.browsed, [['console-2', 'what is on the frontier']])
+    assert.equal(h.said.length, 0)
+  })
+
+  test('a browser conversation that crossed the seam leaves its line on the record', async () => {
+    const h = harness({ killed: [killedTurn({ key: 'console-2', thread_id: null, crossings: 1, commands: ['cancel 3'] })] })
+    await h.run()
+    assert.equal(h.browsed.length, 0)
+    assert.equal(h.said.length, 0)
+    const dropped = h.store.droppedOverseerTurn('console-2')
+    assert.equal(dropped.replayed, false)
+    assert.deepEqual(dropped.commands, ['cancel 3'])
+  })
+
+  test('a container that never comes back sends nothing again, and says so', async () => {
+    const h = harness({ killed: [killedTurn()], up: false })
+    const out = await h.run()
+    assert.equal(out[0].why, 'the overseer container did not come back')
+    assert.equal(h.replayed.length, 0)
+    assert.match(h.said[0][1], /did not come back/)
+  })
+
+  test('a bridge that never comes back holds the Discord replay', async () => {
+    const h = harness({ killed: [killedTurn()], bridge: false })
+    const out = await h.run()
+    assert.equal(out[0].why, 'the Discord bridge did not come back')
+    assert.equal(h.replayed.length, 0)
+  })
+
+  test('a conversation the operator is already talking in is left alone', async () => {
+    const h = harness({ killed: [killedTurn()], live: (key) => key === '111' })
+    const out = await h.run()
+    assert.equal(out[0].why, 'you were already talking here')
+    assert.equal(h.replayed.length, 0)
+    assert.match(h.said[0][1], /already talking/)
+  })
+
+  test('a replay a second restart killed is not replayed a third time', async () => {
+    const h = harness({ killed: [killedTurn({ replay: true })] })
+    const out = await h.run()
+    assert.equal(out[0].why, 'curia already sent this message again once')
+    assert.equal(h.replayed.length, 0)
+  })
+
+  test('the verdict is journalled before the replay runs, so a second boot finds nothing', async () => {
+    const killed = [killedTurn()]
+    const h = harness({ killed })
+    await h.run()
+    // The pass ended the killed turn. A store reading the same file cold — the
+    // next boot — has no corpse to read.
+    assert.deepEqual(new EscalationStore(h.dir).pendingOverseerTurns(), [])
+  })
+
+  test('every verdict is on the record before one word is sent', async () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    const drops = () => fs.readFileSync(path.join(dir, 'events.jsonl'), 'utf8')
+      .split('\n').filter((l) => l.includes('"overseer_turn_dropped"')).length
+    let atFirstSend = null
+    await replayKilledTurns({
+      killed: [killedTurn(), killedTurn({ key: '222', thread_id: '222' })],
+      store,
+      bootAt: Date.now(),
+      probe: async () => ({ up: true }),
+      sleep: async () => {},
+      discord: {
+        ready: () => true,
+        say: async () => {},
+        replay: async () => { atFirstSend ??= drops() },
+      },
+      log: quiet,
+    })
+    // Both, not one: a daemon that dies while the first replay runs must not
+    // find the second killed turn still open and replay it a second time.
+    assert.equal(atFirstSend, 2)
+  })
+
+  test('a replay that throws does not stop the next conversation', async () => {
+    const dir = tmp()
+    const store = new EscalationStore(dir)
+    const browsed = []
+    const out = await replayKilledTurns({
+      killed: [killedTurn(), killedTurn({ key: 'console-3', thread_id: null })],
+      store,
+      bootAt: Date.now(),
+      probe: async () => ({ up: true }),
+      sleep: async () => {},
+      discord: {
+        ready: () => true,
+        say: async () => {},
+        replay: async () => { throw new Error('the thread is gone') },
+      },
+      browser: { replay: async (key, prompt) => { browsed.push([key, prompt]) } },
+      log: quiet,
+    })
+    assert.equal(out.length, 2)
+    assert.deepEqual(browsed, [['console-3', 'what is on the frontier']])
+  })
+})
+
+describe('the lines the operator reads (#388)', () => {
+  test('the dropped line names the commands and stays one line', () => {
+    const text = droppedLine({ commands: ['start 256', 'status'], why: 'it already crossed the seam' })
+    assert.match(text, /`start 256`, `status`/)
+    assert.match(text, /Say it again if you still want it\./)
+    assert.equal(text.includes('\n'), false)
+  })
+
+  test('a drop with no command names no command', () => {
+    assert.equal(droppedLine({ commands: [], why: 'you were already talking here' }).includes('had already run'), false)
+  })
+
+  test('the replay notice is small print, because it is curia talking about curia', () => {
+    assert.match(replayLine(), /^-# /)
+  })
+})

--- a/daemon/test/overseerreplay.test.mjs
+++ b/daemon/test/overseerreplay.test.mjs
@@ -339,10 +339,14 @@ describe('the lines the operator reads (#388)', () => {
     assert.match(text, /`start 256`, `status`/)
     assert.match(text, /Say it again if you still want it\./)
     assert.equal(text.includes('\n'), false)
+    // The commands are the reason, so the reason is not said a second time.
+    assert.equal(text.includes('it already crossed the seam'), false)
   })
 
-  test('a drop with no command names no command', () => {
-    assert.equal(droppedLine({ commands: [], why: 'you were already talking here' }).includes('had already run'), false)
+  test('a drop with no command names the reason instead', () => {
+    const text = droppedLine({ commands: [], why: 'you were already talking here' })
+    assert.equal(text.includes('had already run'), false)
+    assert.match(text, /did not send the message again — you were already talking here\./)
   })
 
   test('the replay notice is small print, because it is curia talking about curia', () => {

--- a/daemon/test/overseerturn.test.mjs
+++ b/daemon/test/overseerturn.test.mjs
@@ -97,10 +97,15 @@ async function startDaemonSeam(turns, { log = quiet } = {}) {
 function storeDouble({ sessions = {}, notes = [], conversations = ['console-1'] } = {}) {
   return {
     bound: [],
+    // The pending-turn journal (#388): the client brackets every turn with
+    // these two, and the boot reads whatever is left between them.
+    turns: [],
     overseerSession: (key) => sessions[key],
     bindOverseerSession(key, id) { sessions[key] = id; this.bound.push([key, id]) },
     takeOverseerNotes: () => notes.splice(0, notes.length),
     hasConsoleConversation: (key) => conversations.includes(key),
+    beginOverseerTurn(ev) { this.turns.push({ type: 'started', ...ev }) },
+    endOverseerTurn(ev) { this.turns.push({ type: 'ended', ...ev }) },
   }
 }
 
@@ -168,7 +173,10 @@ describe('the per-turn secret (#314)', () => {
     assert.equal(reply, 'the confirm was posted')
     assert.deepEqual(said, ['cancel 314'])
     // #94: interpreted text routes a destructive verb through the ✅/❌ confirm.
-    assert.deepEqual(seen, [['cancel 314', { threadId: 'thread-9', interpreted: true }]])
+    // #388: the conversation key rides along, so the command event the daemon
+    // journals for this crossing can be counted against this turn after the
+    // process holding the tally is gone.
+    assert.deepEqual(seen, [['cancel 314', { threadId: 'thread-9', interpreted: true, overseerKey: '999' }]])
     assert.equal(turn.crossed.get('cancel'), 1)
   })
 
@@ -440,6 +448,15 @@ describe('the daemon half: OverseerClient (#314)', () => {
     // ADR-0015: the container holds no conversation, so the daemon sends the
     // resume id and the model reads its own words back.
     assert.equal(client.configDir, overseerConfigDirFor(root))
+    // #388: the turn is bracketed in the journal, message and all, so a restart
+    // between these two lines can find it and send the message again.
+    assert.deepEqual(store.turns.map((t) => t.type), ['started', 'ended'])
+    assert.equal(store.turns[0].prompt, 'what is takeable?')
+    assert.equal(store.turns[0].replay, false)
+    assert.deepEqual(
+      { ok: store.turns[1].ok, crossings: store.turns[1].crossings },
+      { ok: true, crossings: 0 },
+    )
     await c.stop()
   })
 
@@ -569,7 +586,7 @@ describe('the whole crossing: a verb reaches /command from inside the container 
     })
     assert.equal(out.ok, true)
     // The daemon executed the effect, from text the DAEMON composed.
-    assert.deepEqual(posted, [['cancel 314', { threadId: '4242', interpreted: true }]])
+    assert.deepEqual(posted, [['cancel 314', { threadId: '4242', interpreted: true, overseerKey: '4242' }]])
     assert.match(said[0], /the confirm is posted: ✅\/❌ posted in #curia/)
     // The status line grew live, from the seam rather than from the stream.
     assert.ok(status.some((s) => s.includes('`cancel 314`')))

--- a/docs/adr/0015-the-overseer-is-a-service.md
+++ b/docs/adr/0015-the-overseer-is-a-service.md
@@ -1,6 +1,6 @@
 # ADR-0015: The overseer is a service, not an agent-shaped pane
 
-**Status**: accepted (2026-08). Not built. The build is charted on [the container map (#309)](https://github.com/alp82/curia/issues/309).
+**Status**: accepted (2026-08). Built. The service and its image are [#327](https://github.com/alp82/curia/issues/327), and the replay below is [#388](https://github.com/alp82/curia/issues/388) — the last decision here that nothing had built.
 **Provenance**: [The chat and the overseer become one thing, in a container (#301)](https://github.com/alp82/curia/issues/301), [The hosting shape: a service, a pane, or one container per thread (#310)](https://github.com/alp82/curia/issues/310)
 
 ## Context
@@ -26,6 +26,8 @@ The overseer also has no screen to hold. A turn is a call. The model starts, ans
 - **Its config dir is `<workspace_root>/cfg/curia-overseer`**, mounted at that same path inside the container. The name was the session name the timeline served when this was written. [ADR-0016](0016-the-conversation-key.md) then gave the browser many conversations, so the timeline serves `curia-console-<n>` and this one directory holds every conversation's transcript. The directory name is a name now, and nothing reads it as a session. It sits beside the agent config dirs, so the daemon's `data/` stays out of a second container. The Chat screen reads the transcript from that directory, so the path must be identical on both sides.
 - **A deploy recreates it.** The routine deploy becomes `docker compose up -d --build --no-deps daemon dashboard overseer`. The rule at the head of `deploy/compose.yaml` guards `tmux`, because recreating `tmux` kills every live agent. Recreating the overseer kills none.
 - **A turn killed by a restart is replayed, never retyped.** The daemon keeps the message and sends it again once the overseer answers. It replays only a turn that crossed `/command` zero times, which is the test the fallback retry already uses. A turn that ran a verb is not replayed. The thread gets one line naming what that turn did, and the operator decides from there.
+
+  Built on [#388](https://github.com/alp82/curia/issues/388), which settled the four things this line left open. The message lives in the journal, as one event when a turn starts and one when it ends, so the boot reads whatever is open between them. The crossings are counted off the `command` event the seam already writes, which now carries the conversation key — the in-memory tally dies with the process that held it, and a second event stating the same fact would break [ADR-0013](0013-one-voice-per-fact.md). The boot pass sends the message once the container answers its health check. Three more things hold it beside a crossing: a message the operator has already sent again, a message over fifteen minutes old, and a replay a second restart killed. Every held message gets the same line. A browser conversation has no thread to put that line in, so it reads it on its row in the Chat picker, until it takes its next turn.
 
 ## Considered options
 


### PR DESCRIPTION
Ticket: alp82/curia#388 — [The turn a restart killed is replayed](https://github.com/alp82/curia/issues/388)

ADR-0015 promised that a turn a restart kills is sent again, never retyped. Nothing built it. The routine deploy recreates the daemon and the overseer together, so every turn in flight on both died and the operator retyped the message.

**Where the pending message lives.** The journal, as one event when a turn starts and one when it ends. Whatever is open at a boot is what the restart killed, because a turn survives no restart. The seam crossings ride the `command` event the daemon already writes, which now carries the conversation key — a second event stating the same fact would break ADR-0013, and the in-memory `turn.crossings` dies with the process holding it.

**Who sends it again, and when.** A boot pass in `daemon/src/overseerreplay.mjs`. It reads the killed list once, before the listener binds, and waits for the container health check and, for a Discord conversation, for the bridge. It sends the message again only for a turn that crossed the seam zero times: sending one that ran a verb again would run the verb twice. Three more things hold it — a message curia already sent again once, a conversation that has spoken since the boot, and a message over fifteen minutes old. Every verdict is journalled before one word is sent, so a daemon that dies mid-pass never replays the same message twice. The replays then run together, because one conversation must not wait on another's turn.

**The line for a turn that did cross.** One message in the thread naming every command that turn ran. The commands are the reason, so the reason is not stated a second time.

**The console conversation.** It has no thread, so it reads that line on its row in the Chat picker, until it takes its next turn. The drop is also a journal event, so the dashboard feed carries it. The two bookkeeping events stay out of the feed: one pair per chat message would push every dispatch, death and gate off the screen.

ADR-0015 flips to built, and CONTEXT.md takes **Killed turn** and **Replay**. `npm test` in `daemon/` is green.

---

Dispatched by the curia daemon — session `curia-388`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `acac632` A health check that throws is a container that is down (alp82/curia#388)
- `ec5b030` The reason is not said twice (alp82/curia#388)
- `92bfbc3` The turn a restart killed is sent again (alp82/curia#388)