### PR TITLE
The codex half of a channel that breaks mid-session (alp82/curia#371)

### DIFF
--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -506,6 +506,19 @@ function curiaMcpUrl(daemonPort, agent, ticket, host = LOOPBACK) {
 // longest real block on record (7 h 53 m, #56), and a block that outlives it
 // re-dispatches rather than resolving anything (#11/#12). The keepalive stays on
 // for the claude harness and costs nothing here.
+//
+// #371 then measured what else this number bounds, and it is more than the human
+// wait. Codex has NO transport-drop watchdog: when the daemon dies holding a
+// call, the client is told nothing and waits out this deadline from the moment
+// the CALL was made. Measured three ways in
+// docs/research/tool-channel-mid-session-codex.md — still waiting 595 s and
+// 295 s after the death at this value, and dying at 60.009 s and 60.007 s with
+// the value cut to 60. The claude row above is told in ~120 s instead, which is
+// why #341's retry ladder works there and cannot fire here.
+//
+// So one number serves two jobs that pull apart: generous to a slow human, and
+// a day of silence for an agent a restart stranded. Changing it is a decision
+// against #34, not a tuning.
 const CODEX_TOOL_TIMEOUT_S = 86_400
 
 // The Stop hook, identical on both harnesses: POST the hook's own stdin payload to

--- a/docs/research/tool-channel-mid-session-codex.md
+++ b/docs/research/tool-channel-mid-session-codex.md
@@ -1,0 +1,123 @@
+# The codex half of a channel that breaks mid-session
+
+Evidence for [wayfinder #371](https://github.com/alp82/curia/issues/371), on [map #244](https://github.com/alp82/curia/issues/244). Measured on 2026-08-16 inside an ordinary agent container, on the codex harness, CLI `0.146.0`. Read it beside [tool-channel-mid-session.md](tool-channel-mid-session.md), which took the same two readings on the claude harness.
+
+## The question
+
+[#341](https://github.com/alp82/curia/issues/341) measured the claude harness and said what it had not measured. An agent container carries no codex credential, so its probe could not run there.
+
+The claude reading is that the tool channel survives a daemon restart whole. The server is stateless, the client opens a connection per call, and only the call in flight dies. That call is reported after about 120 seconds, and the retry in the standing orders then works.
+
+Nothing said codex behaves the same. Its client bounds one tool call at 24 hours (`CODEX_TOOL_TIMEOUT_S` in `daemon/src/workspace.mjs`), which is a hard deadline and not an idle timer. [#34](https://github.com/alp82/curia/issues/34) already found that the keepalive which saves the claude lane does nothing for it.
+
+## What the credential problem cost, and what replaced it
+
+The claude probe needed a model credential, and that is why it could not measure codex. [tool-channel-mid-session-codex.probe.mjs](tool-channel-mid-session-codex.probe.mjs) removes the credential from the path. It stands in for the MODEL as well as for the daemon.
+
+Codex takes a local model provider on the Responses wire API, so the probe serves one and scripts the turn. The codex CLI is the real one, with the real MCP client and the real `tool_timeout_sec` the daemon writes. What it talks to is a script. The claude probe already made this trade in the other direction, and stated it: "the model is haiku. The transport is what is under test, and it carries no model."
+
+So this probe needs no credential of any kind. It runs in an ordinary agent container, which is where these three runs were taken.
+
+The stand-in daemon is the claude probe's, unchanged. It serves `POST /mcp?agent=&ticket=` with a stateless `StreamableHTTPServerTransport` and the `x-curia-agent-token` header, the way `daemon/src/index.mjs:1558` does. A supervisor respawns it after it exits, the way `restart: on-failure` respawns the daemon.
+
+Six deviations, all stated rather than hidden:
+
+1. The model is a script, not a model. See above.
+2. The agent runs headless (`codex exec`), not in a tmux pane.
+3. The stand-in sends no keepalive, writes no journal and has no Discord bridge.
+4. Client and server share one container, so the docker host gateway is not in the path.
+5. The scripted model paces itself. A real model takes seconds to answer, and a script takes milliseconds, so every step carries a pause. Without it the `refused` case spent all its retries before the daemon had even died.
+6. Run 2 cuts `tool_timeout_sec` from a day to 60 seconds. That run exists to name the deadline, and the run beside it holds the daemon's own value.
+
+## Run 1: the daemon dies under a blocking call
+
+The agent calls `ask_human`. The stand-in dies three seconds later, while it holds the call. The supervisor brings it back 5.5 seconds after that.
+
+| Time | What happened |
+| --- | --- |
+| 11:58:12.179 | `tools/call` `ask_human` arrives |
+| 11:58:15.191 | the daemon exits, holding the call |
+| 11:58:20.742 | a new daemon process listens on the same port |
+| 12:08:10.677 | the probe's cap ends the run, with the agent still waiting |
+
+**The agent is never told.** Codex sat in the call for the whole 595.5 seconds between the death and the cap, and the daemon had been back for 590 of them. The CLI printed `mcp: curia/ask_human started` and nothing after it. A second run agrees: 295.5 seconds to its own cap, and the same silence.
+
+The claude harness reports this same drop in about 120 seconds. Codex has no such watchdog.
+
+## Run 2: the same death, with the deadline cut to 60 seconds
+
+Run 1 ends at a cap, so it names no deadline. This run cuts `tool_timeout_sec` to 60 seconds and lets the call die of its own accord.
+
+| Time | What happened |
+| --- | --- |
+| 12:08:46.391 | `tools/call` `ask_human` arrives |
+| 12:08:49.396 | the daemon exits, holding the call |
+| 12:08:55.022 | a new daemon process listens on the same port |
+| 12:09:46.437 | the call fails, 60.009 seconds after it was made |
+
+This is what the model was told, verbatim:
+
+> tool call error: tool call failed for `curia/ask_human`
+>
+> Caused by:
+>     timed out awaiting tools/call after 60s
+
+**So `tool_timeout_sec` is the only bound on a call whose daemon died.** The call failed at its deadline to the millisecond, 57.0 seconds after the death. A second run agrees at 60.007 seconds. The clock belongs to the CALL and not to the death, so an agent whose daemon dies waits the deadline minus whatever the call had already run. At curia's own value that is up to 24 hours.
+
+The message is the shape [#34](https://github.com/alp82/curia/issues/34) already recorded from a live agent, `timed out awaiting tools/call after 300s`. It is the deadline speaking, not the transport.
+
+**Nothing else was lost.** The two `notify` calls after the failed one succeeded on the new process, with no new handshake and no `initialize`.
+
+## Run 3: the daemon is down when the call is made
+
+The stand-in dies with no call in flight and stays down 20 seconds. The scripted agent calls `notify` once a second until it succeeds.
+
+| Time | What happened |
+| --- | --- |
+| 11:57:37.569 | the daemon exits |
+| 11:57:39.167 | the first refused attempt reaches the model, 1.6 s after the death |
+| 11:57:58.154 | a new daemon process listens |
+| 11:57:59.228 | the next attempt arrives and succeeds |
+
+Every attempt into the outage failed in about 2 milliseconds. This is the first one, verbatim:
+
+> tool call error: tool call failed for `curia/notify`
+>
+> Caused by:
+>     Transport send error: Transport [rmcp::transport::worker::WorkerTransport<rmcp::transport::streamable_http_client::StreamableHttpClientWorker<codex_rmcp_client::http_client_adapter::StreamableHttpClientAdapter>>] error: Client error: HTTP request failed: http/request failed: error sending request for url (http://127.0.0.1:9010/mcp?agent=curia-371&ticket=371)
+
+**The channel needs no recovery.** 19 attempts failed and the 20th succeeded, 1.07 seconds after the new process came up. It was an ordinary `tools/call` and not a handshake. A second run took 18 failures and landed 0.06 seconds after the new process.
+
+So a call made INTO an outage fails fast and says so plainly, and the tools come back by themselves. That half matches the claude reading exactly.
+
+## The two harnesses, side by side
+
+| | claude | codex |
+| --- | --- | --- |
+| a call the daemon dies under | reported in about 120 s | NOT reported. The only bound is `tool_timeout_sec`, which curia sets to 24 hours |
+| what the agent is told | `MCP server "curia" transport dropped mid-call; response for tool "<tool>" was lost` | `timed out awaiting tools/call after <n>s`, at the deadline |
+| a call made into an outage | fails in about 1.5 s | fails in about 2 ms |
+| the tools after the restart | work, with no handshake | work, with no handshake |
+
+## What this means
+
+**One half matches and one half does not.** A restarted daemon is invisible to every call after the outage on both harnesses. The call in flight is where they part.
+
+**The retry rule cannot fire on the codex lane.** #341 gave the standing orders a ladder: retry at once, then after two minutes, then after five. Every rung needs an error to retry, and a codex agent gets no error for up to a day. It is not that the agent retries too early. It never gets its turn back.
+
+**The deadline now serves two jobs, and they pull apart.** #34 raised `CODEX_TOOL_TIMEOUT_S` to a day because the 300 second default killed calls where a human simply took their time. That same number is the only thing that ends a call whose daemon died. A value that is generous to a slow human is a value that parks a stranded agent for a day, and one number cannot be both.
+
+**The cost is bigger than the wait.** A claude agent loses about two minutes and the answer. A codex agent loses its whole session to a restart it never hears about: no error, no retry, no Stop hook, and no report. Every deploy and every `POST /restart` can do this to a live codex agent that holds a blocking call.
+
+**What to do about it is a decision, not a reading.** This ticket took the reading. The trade against #34 belongs to its own ticket.
+
+## What else the probe saw
+
+The pinned codex does not offer an MCP tool as a function of its own. It offers the SERVER as one tool of type `namespace`, named `mcp__curia`, with the server's tools nested inside it. The model names one with a `function_call` that carries the namespace beside the bare tool name. A flat `mcp__curia__notify` name is answered by the CLI's router with `unsupported call`. This is the tool surface [#172](https://github.com/alp82/curia/issues/172) bounds, seen from the wire.
+
+## What this does not measure
+
+- **The live daemon's keepalive.** The stand-in sends none, so this adds nothing to #34's finding that the keepalive does not move the codex deadline. It also changes nothing here: a dead daemon sends no keepalive either way.
+- **A daemon that never comes back.** The agent's Stop hook rides curl to the same dead port, so its turn ends with nothing told to anyone. Section 5 of the [#56](https://github.com/alp82/curia/issues/56) record is the only account of that state.
+- **The pane.** A headless agent has no composer and no keystroke channel, so the note interrupt was not exercised. That channel matters more here than on the claude lane, because it is the one wire that still reaches a parked codex agent.
+- **A real model.** The script never gets tired, never gives up and never misreads an error. What an actual codex model does with a 24 hour silence is not a transport question, and no run here answers it.

--- a/docs/research/tool-channel-mid-session-codex.probe.mjs
+++ b/docs/research/tool-channel-mid-session-codex.probe.mjs
@@ -1,0 +1,404 @@
+// The codex half of what a harness does when the daemon dies UNDER it (#371).
+//
+// [tool-channel-mid-session.probe.mjs](tool-channel-mid-session.probe.mjs)
+// measured the claude harness and said so: an agent container carries no codex
+// credential, so that probe cannot run there. This file removes the credential
+// from the path. It stands in for the MODEL as well as the daemon, so the codex
+// CLI under test is the real one and the thing it talks to is not.
+//
+// That is the same trade the claude probe already made in the other direction.
+// Its deviation 2 reads "the model is haiku. The transport is what is under
+// test, and it carries no model." Here the transport is still the real codex MCP
+// client, with the real `tool_timeout_sec` the daemon writes, and the model is a
+// script.
+//
+// The stand-in daemon is the claude probe's, unchanged in shape: it serves
+// `POST /mcp?agent=&ticket=` with a stateless `StreamableHTTPServerTransport`
+// and the `x-curia-agent-token` header, exactly as `daemon/src/index.mjs` does.
+// The agent reaches it through the `config.toml` that `daemon/src/workspace.mjs`
+// writes for a codex agent, with `tool_timeout_sec` at the daemon's own day.
+//
+// Two cases, the claude probe's two:
+//   drop     the daemon dies while it holds a blocking `ask_human`, and is back
+//            5 s later. Measures what the agent is told, and how long it waits.
+//   refused  the daemon dies with no call in flight and stays down 20 s while
+//            the agent retries. Measures whether the tools come back by
+//            themselves.
+//
+// Run:  node docs/research/tool-channel-mid-session-codex.probe.mjs <drop|refused> [scratch-dir]
+// Needs the `codex` binary and `npm ci` in `daemon/`. It needs NO credential of
+// any kind, which is the whole point of it.
+//
+// PROBE_CAP_S bounds the drop case. Codex bounds one tool call at 24 hours, so a
+// client that never notices the drop would hang the probe for a day; the cap
+// ends the run and the reading is then "still waiting at the cap".
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import http from 'node:http'
+import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SELF = fileURLToPath(import.meta.url)
+
+// The MCP SDK is the daemon's dependency and this file lives outside its
+// package, so it is resolved from `daemon/package.json` rather than imported by
+// name. Run `npm ci` in `daemon/` first.
+const dep = createRequire(path.join(SELF, '../../../daemon/package.json'))
+const load = async (spec) => import(pathToFileURL(dep.resolve(spec)).href)
+const { McpServer } = await load('@modelcontextprotocol/sdk/server/mcp.js')
+const { StreamableHTTPServerTransport } = await load('@modelcontextprotocol/sdk/server/streamableHttp.js')
+const { z } = await load('zod')
+
+const PORT = Number(process.env.PROBE_PORT ?? 9010)
+const MODEL_PORT = Number(process.env.PROBE_MODEL_PORT ?? 9011)
+const TOKEN = 'probe-token'
+const TOKEN_HEADER = 'x-curia-agent-token'
+const AGENT = 'curia-371'
+// The value `daemon/src/workspace.mjs` writes as CODEX_TOOL_TIMEOUT_S. A day.
+const TOOL_TIMEOUT_S = Number(process.env.PROBE_TOOL_TIMEOUT_S ?? 86_400)
+const CAP_MS = Number(process.env.PROBE_CAP_S ?? 900) * 1000
+
+// ---- the stand-in daemon ---------------------------------------------------
+
+function log(dir, entry) {
+  fs.appendFileSync(path.join(dir, 'log.jsonl'), `${JSON.stringify({ ts: new Date().toISOString(), pid: process.pid, ...entry })}\n`)
+}
+
+// The daemon dies once, under the tool this case names, and the flag file is
+// what keeps the respawned process from dying again.
+function maybeDie(dir, tool, dieUnder, afterMs) {
+  const flag = path.join(dir, 'died')
+  if (tool !== dieUnder || fs.existsSync(flag)) return
+  fs.writeFileSync(flag, String(Date.now()))
+  setTimeout(() => {
+    log(dir, { ev: 'daemon_dies', while_holding: tool })
+    process.exit(1)
+  }, afterMs)
+}
+
+function buildMcpServer(dir, dieUnder, afterMs) {
+  const s = new McpServer({ name: 'curia', version: '0.0.1' })
+  s.tool('notify', 'Fire-and-forget status line.', { message: z.string() }, async ({ message }) => {
+    log(dir, { ev: 'tool', tool: 'notify', message })
+    maybeDie(dir, 'notify', dieUnder, afterMs)
+    return { content: [{ type: 'text', text: `noted: ${message}` }] }
+  })
+  s.tool('ask_human', 'Blocking question to a human.', { prompt: z.string() }, async ({ prompt }) => {
+    log(dir, { ev: 'tool', tool: 'ask_human', prompt })
+    maybeDie(dir, 'ask_human', dieUnder, afterMs)
+    // Blocks the way the real one does: an answer takes as long as a human takes.
+    await new Promise((r) => setTimeout(r, 300_000))
+    return { content: [{ type: 'text', text: 'the human said: go ahead' }] }
+  })
+  return s
+}
+
+async function readBody(req) {
+  const chunks = []
+  for await (const c of req) chunks.push(c)
+  try { return JSON.parse(Buffer.concat(chunks).toString()) } catch { return {} }
+}
+
+function serve(dir, dieUnder, afterMs) {
+  http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${PORT}`)
+    if (url.pathname !== '/mcp') { res.writeHead(404).end('{}'); return }
+    const body = await readBody(req)
+    log(dir, {
+      ev: 'request', method: req.method, rpc: body?.method ?? null, id: body?.id ?? null,
+      tool: body?.params?.name ?? null, token_ok: req.headers[TOKEN_HEADER] === TOKEN,
+    })
+    if (req.method !== 'POST') { res.writeHead(405).end('{}'); return }
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    res.on('close', () => { transport.close() })
+    const mcp = buildMcpServer(dir, dieUnder, afterMs)
+    await mcp.connect(transport)
+    await transport.handleRequest(req, res, body)
+  }).listen(PORT, '127.0.0.1', () => log(dir, { ev: 'listening', port: PORT }))
+}
+
+// ---- the stand-in model ----------------------------------------------------
+
+// Codex speaks the Responses wire API and no other: `wire_api = "chat"` is
+// refused by the pinned CLI with "no longer supported". So this serves
+// `POST /v1/responses` and streams the three events codex needs to accept a
+// turn — created, one output item, completed.
+//
+// What it replaces is the model's JUDGEMENT, not the harness. The claude probe
+// wrote its steps in a prompt and trusted haiku to follow them; this one names
+// the same steps as function calls. That is the point in the `refused` case,
+// where the claude run ended because its model gave up after 25 tries — a
+// reading of a model's patience rather than of a transport.
+//
+// A script has the opposite problem: it answers in milliseconds. Its first run
+// of `refused` spent every attempt inside one second and finished before the
+// daemon had even died. So each step carries a pause, standing in for the
+// seconds a model takes, and the retry budget is a wall clock rather than a
+// count: 40 attempts at a second each outlive the 20 s outage.
+const THINK_MS = Number(process.env.PROBE_THINK_MS ?? 300)
+const RETRY_MAX = Number(process.env.PROBE_RETRY_MAX ?? 40)
+
+function nextStep(which, calls) {
+  const n = calls.length
+  const last = calls[n - 1]
+  if (which === 'drop') {
+    // 1. notify one   2. ask_human (the daemon dies under it)   3. notify two
+    // 4. notify three, then say what happened.
+    if (n === 0) return { tool: 'notify', args: { message: 'one' }, waitMs: THINK_MS }
+    if (n === 1) return { tool: 'ask_human', args: { prompt: 'blocking' }, waitMs: THINK_MS }
+    if (n === 2) return { tool: 'notify', args: { message: 'two' }, waitMs: THINK_MS }
+    if (n === 3) return { tool: 'notify', args: { message: 'three' }, waitMs: THINK_MS }
+    return { done: true }
+  }
+  // refused: one call that succeeds, then call again until THAT one succeeds.
+  if (n === 0) return { tool: 'notify', args: { message: 'one' }, waitMs: THINK_MS }
+  const retries = n - 1
+  if (retries > 0 && last?.ok) return { done: true }
+  if (retries >= RETRY_MAX) return { done: true }
+  // The daemon dies a second after the first call, so the first retry waits past
+  // that death rather than racing it.
+  return { tool: 'notify', args: { message: 'two' }, waitMs: retries === 0 ? 2500 : 1000 }
+}
+
+// The stand-in daemon answers `notify` with this text, so its presence in a
+// function_call_output is what "the call succeeded" means here.
+const OK_MARK = 'noted:'
+
+// The pinned codex (0.146) does not offer an MCP tool as a function of its own.
+// It offers the SERVER as one tool of type `namespace`, named `mcp__curia`, with
+// the server's tools nested inside it. The name the model calls is the two
+// joined by the same double underscore — `mcp__curia__notify`, the
+// `mcp__<server>__<tool>` identifier the CLI's own prompt text names. So the
+// names are read off the offer rather than spelled here, and a codex that
+// changes this shape breaks loudly at the lookup below.
+function toolNames(tools) {
+  return (tools ?? []).flatMap((t) => (
+    t?.type === 'namespace' ? (t.tools ?? []).map((n) => `${t.name}__${n.name}`) : [t?.name ?? t?.type]
+  ))
+}
+
+// Codex sends the whole conversation on every request, so the turn so far is
+// read off the input rather than counted in a variable. A request codex retries
+// therefore cannot double-count.
+function callsSoFar(input) {
+  const outputs = new Map()
+  for (const item of input ?? []) {
+    if (item?.type === 'function_call_output') outputs.set(item.call_id, item.output)
+  }
+  const calls = []
+  for (const item of input ?? []) {
+    if (item?.type !== 'function_call') continue
+    const raw = outputs.get(item.call_id)
+    const text = typeof raw === 'string' ? raw : JSON.stringify(raw ?? null)
+    calls.push({ name: item.name, output: text, ok: typeof text === 'string' && text.includes(OK_MARK) })
+  }
+  return calls
+}
+
+function serveModel(dir, which, state) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${MODEL_PORT}`)
+    if (req.method !== 'POST' || !url.pathname.endsWith('/responses')) { res.writeHead(404).end('{}'); return }
+    const body = await readBody(req)
+    const calls = callsSoFar(body.input)
+    state.turns += 1
+    // The verbatim thing the model is told about the call the daemon died under
+    // is the whole reading of the drop case, so every output is journalled.
+    log(dir, {
+      ev: 'model_request',
+      turn: state.turns,
+      calls: calls.map((c) => ({ name: c.name, ok: c.ok, output: c.output })),
+    })
+    if (state.turns === 1) {
+      log(dir, { ev: 'tools_offered', names: toolNames(body.tools) })
+    }
+
+    const step = nextStep(which, calls)
+    if (step.waitMs) await new Promise((r) => setTimeout(r, step.waitMs))
+    // The names the MCP tools carry on the wire are the CLI's business, not this
+    // file's, so they are looked up rather than spelled.
+    const named = (suffix) => toolNames(body.tools).find((n) => typeof n === 'string' && n.endsWith(`__${suffix}`))
+
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' })
+    const send = (type, o) => res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...o })}\n\n`)
+    const response = { id: `resp_${state.turns}`, object: 'response', status: 'completed', output: [], usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+    send('response.created', { response: { ...response, status: 'in_progress' } })
+    if (step.done) {
+      const report = calls.map((c, i) => `${i + 1}. ${c.name} -> ${c.output}`).join('\n')
+      send('response.output_item.done', {
+        output_index: 0,
+        item: { type: 'message', id: `msg_${state.turns}`, status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: `${calls.length} call(s):\n${report}` }] },
+      })
+    } else {
+      const name = named(step.tool)
+      if (!name) {
+        send('response.output_item.done', {
+          output_index: 0,
+          item: { type: 'message', id: `msg_${state.turns}`, status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: `no MCP tool ending in "${step.tool}" was offered — the curia server did not attach` }] },
+        })
+      } else {
+        // A namespaced call is a `function_call` with the namespace beside the
+        // bare tool name, not one flat `mcp__curia__notify` name: the CLI's
+        // router answers that with "unsupported call" (observed).
+        const [ns, tool] = [name.slice(0, name.lastIndexOf('__')), name.slice(name.lastIndexOf('__') + 2)]
+        send('response.output_item.done', {
+          output_index: 0,
+          item: { type: 'function_call', id: `fc_${state.turns}`, call_id: `call_${state.turns}`, name: tool, namespace: ns, arguments: JSON.stringify(step.args), status: 'completed' },
+        })
+      }
+    }
+    send('response.completed', { response })
+    res.end()
+  })
+  server.listen(MODEL_PORT, '127.0.0.1', () => log(dir, { ev: 'model_listening', port: MODEL_PORT }))
+  return server
+}
+
+// ---- the agent's side ------------------------------------------------------
+
+// What `daemon/src/workspace.mjs` writes for a codex agent, with this probe's
+// two URLs in it. Everything the codex harness needs is in the config dir, so
+// nothing is written into the worktree at all.
+function seed(dir) {
+  const ws = path.join(dir, 'ws')
+  const cfg = path.join(dir, 'cfg')
+  fs.mkdirSync(ws, { recursive: true })
+  fs.mkdirSync(cfg, { recursive: true })
+  fs.writeFileSync(path.join(cfg, 'config.toml'), [
+    '# Written by the probe, in the shape daemon/src/workspace.mjs writes.',
+    '',
+    'model = "stand-in"',
+    'model_provider = "standin"',
+    '',
+    '[model_providers.standin]',
+    'name = "stand-in"',
+    `base_url = "http://127.0.0.1:${MODEL_PORT}/v1"`,
+    'wire_api = "responses"',
+    '',
+    `[projects."${ws}"]`,
+    'trust_level = "trusted"',
+    '',
+    '[mcp_servers.curia]',
+    `url = "http://127.0.0.1:${PORT}/mcp?agent=${AGENT}&ticket=371"`,
+    `tool_timeout_sec = ${TOOL_TIMEOUT_S}`,
+    `http_headers = { "${TOKEN_HEADER}" = "${TOKEN}" }`,
+    '',
+  ].join('\n'), { mode: 0o600 })
+  return { ws, cfg }
+}
+
+// The claude probe put its steps here, because a model read them. This one puts
+// them in `nextStep`, so the prompt is only what codex needs to start a turn.
+const PROMPT = 'Follow the steps you are given and do not stop early.'
+
+const CASES = {
+  drop: { dieUnder: 'ask_human', dieAfterMs: 3000, downMs: 5000 },
+  refused: { dieUnder: 'notify', dieAfterMs: 1000, downMs: 20_000 },
+}
+
+async function main() {
+  const which = process.argv[2]
+  const kase = CASES[which]
+  if (!kase) {
+    console.error(`usage: node ${path.basename(SELF)} <${Object.keys(CASES).join('|')}> [scratch-dir]`)
+    process.exit(2)
+  }
+  const dir = process.argv[3] || path.join(os.tmpdir(), `curia-channel-probe-codex-${which}`)
+  fs.rmSync(dir, { recursive: true, force: true })
+  fs.mkdirSync(dir, { recursive: true })
+  const { ws, cfg } = seed(dir)
+  const state = { turns: 0 }
+  const model = serveModel(dir, which, state)
+
+  // The supervisor the box has: `restart: on-failure`, one respawn after the
+  // outage this case asks for.
+  let stop = false
+  let daemon = null
+  const supervise = async () => {
+    while (!stop) {
+      await new Promise((done) => {
+        daemon = spawn(process.execPath, [SELF], {
+          env: {
+            ...process.env,
+            PROBE_ROLE: 'server', PROBE_DIR: dir,
+            PROBE_DIE_UNDER: kase.dieUnder, PROBE_DIE_AFTER_MS: String(kase.dieAfterMs),
+          },
+          stdio: 'inherit',
+        })
+        daemon.on('exit', done)
+      })
+      if (stop) return
+      console.log(`[${new Date().toISOString()}] daemon down for ${kase.downMs / 1000}s`)
+      await new Promise((r) => setTimeout(r, kase.downMs))
+    }
+  }
+  supervise()
+  await new Promise((r) => setTimeout(r, 2000))
+
+  const started = Date.now()
+  const agent = spawn('codex', [
+    'exec', '--skip-git-repo-check',
+    '--dangerously-bypass-approvals-and-sandbox', '--dangerously-bypass-hook-trust',
+    '--color', 'never', PROMPT,
+  ], {
+    cwd: ws,
+    // stdin is closed rather than inherited: `codex exec` reads a piped stdin as
+    // more of the prompt, and an inherited terminal never closes it at all.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      HOME: process.env.HOME, PATH: process.env.PATH, TERM: 'xterm',
+      CODEX_HOME: cfg,
+    },
+  })
+  let out = ''
+  agent.stdout.on('data', (b) => { out += b })
+  agent.stderr.on('data', (b) => { out += b })
+  // Codex bounds one tool call at a DAY, so a client that never notices the drop
+  // would hold this process for that long. The cap turns that into a reading.
+  let capped = false
+  const cap = setTimeout(() => {
+    capped = true
+    log(dir, { ev: 'capped', after_s: CAP_MS / 1000 })
+    agent.kill('SIGKILL')
+  }, CAP_MS)
+  await new Promise((done) => agent.on('exit', done))
+  clearTimeout(cap)
+  // The stand-in outlives this process otherwise, and the next run of the probe
+  // then meets its own port held by the last one.
+  stop = true
+  daemon?.kill()
+  model.close()
+
+  console.log(`\n=== ${which}: the timeline ===`)
+  const journal = path.join(dir, 'log.jsonl')
+  if (!fs.existsSync(journal)) {
+    console.log(`no requests reached the stand-in. Check that ports ${PORT} and ${MODEL_PORT} were free.`)
+  }
+  const entries = (fs.existsSync(journal) ? fs.readFileSync(journal, 'utf8').trim().split('\n') : []).filter(Boolean).map((l) => JSON.parse(l))
+  for (const e of entries) {
+    const tail = e.ev === 'model_request' ? ` turn ${e.turn}` : ''
+    console.log(`${e.ts}  pid ${e.pid}  ${e.ev}${e.rpc ? ` ${e.rpc}` : ''}${e.tool ? ` ${e.tool}` : ''}${tail}`)
+  }
+
+  const death = entries.find((e) => e.ev === 'daemon_dies')
+  const heard = entries.find((e) => e.ev === 'model_request' && e.calls?.some((c) => c.output && !c.ok))
+  if (death && heard) {
+    console.log(`\nthe agent was told ${((Date.parse(heard.ts) - Date.parse(death.ts)) / 1000).toFixed(1)}s after the death:`)
+    for (const c of heard.calls.filter((c) => c.output && !c.ok)) console.log(`  ${c.name}: ${c.output}`)
+  } else if (death && capped) {
+    console.log(`\nthe agent was NEVER told: still waiting ${CAP_MS / 1000}s after the death, when the cap ended the run.`)
+  }
+
+  console.log(`\n=== ${which}: what the agent reported (${Math.round((Date.now() - started) / 1000)}s) ===`)
+  console.log(out.trim())
+  process.exit(0)
+}
+
+// One file, two roles: the supervisor respawns this same script as the daemon.
+if (process.env.PROBE_ROLE === 'server') {
+  serve(process.env.PROBE_DIR, process.env.PROBE_DIE_UNDER, Number(process.env.PROBE_DIE_AFTER_MS))
+} else {
+  await main()
+}

--- a/docs/research/tool-channel-mid-session.md
+++ b/docs/research/tool-channel-mid-session.md
@@ -77,7 +77,7 @@ The same shape as run 2, with the outage cut to 20 seconds so the agent outlives
 
 ## What this does not measure
 
-- **The codex harness.** An agent container carries no codex credential, so this probe cannot run there. Codex bounds one tool call at 24 hours (`CODEX_TOOL_TIMEOUT_S`), and nothing on record says its client survives a transport drop the way this one does. That reading needs a dev session or a codex-lane dispatch.
+- **The codex harness**, which [#371](https://github.com/alp82/curia/issues/371) then measured in [tool-channel-mid-session-codex.md](tool-channel-mid-session-codex.md). It needed no dev session and no credential: its probe stands in for the MODEL as well as the daemon, which is the step this one did not take. The reading differs on the call in flight. Codex is never told the transport dropped, and only `CODEX_TOOL_TIMEOUT_S` ends the call, so the two minutes below are up to 24 hours there. The rest matches: the tools come back by themselves, with no handshake.
 - **A daemon that never comes back.** The agent's Stop hook rides curl to the same dead port, so its turn ends with nothing told to anyone. Section 5 of the #56 record is the only account of that state.
 - **The live daemon on the box.** The stand-in has no keepalive, so this says nothing about a call that is held for hours and answered.
 - **The pane.** A headless agent has no composer and no keystroke channel, so the note interrupt was not exercised.


### PR DESCRIPTION
Ticket: alp82/curia#371 — [The codex half of a channel that breaks mid-session](https://github.com/alp82/curia/issues/371)

Takes the codex reading #341 could not take, and records it beside the claude one.

**The credential problem, removed.** An agent container carries no codex credential, so the claude probe could not run there. The new probe (`docs/research/tool-channel-mid-session-codex.probe.mjs`) stands in for the MODEL as well as the daemon: codex takes a local model provider on the Responses wire API, so the probe serves one and scripts the turn. The codex CLI, its MCP client and the real `tool_timeout_sec` are under test. It needs no credential of any kind, and these runs were taken in an ordinary agent container.

**Run 1, the daemon dies under a blocking call.** The agent is NEVER told. Two runs sat in the call for 595.5 s and 295.5 s until the probe's cap ended them, with the daemon back for nearly all of it. The claude harness reports the same drop in about 120 s.

**Run 2, the same death with `tool_timeout_sec` cut to 60 s.** The call died at 60.009 s and 60.007 s, to the millisecond of its deadline. So `tool_timeout_sec` is the only bound on a call whose daemon died, and the clock belongs to the call rather than to the death. At curia's own value that is up to 24 hours.

**Run 3, a call made into an outage.** Fails in about 2 ms with a named transport error, and the tools come back by themselves: 1.07 s and 0.06 s after the new process, an ordinary `tools/call` with no handshake. That half matches claude exactly.

**What it means.** #341's retry ladder cannot fire on the codex lane, because the agent never gets an error to retry. `CODEX_TOOL_TIMEOUT_S` now serves two jobs that pull apart: generous to a slow human, and a day of silence for an agent a restart stranded.

Also in the diff: the reading in `docs/research/tool-channel-mid-session-codex.md`, a pointer from the claude doc's "what this does not measure", and the fact added to the `CODEX_TOOL_TIMEOUT_S` comment. No behavior change. Suite green at 2095 tests.

---

Dispatched by the curia daemon — session `curia-371`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `97162fe` The codex half of the channel that breaks mid-session (#371)