### PR TITLE
The select menu, built and judged (alp82/curia#431)

### DIFF
--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -31,26 +31,31 @@ import { CONFIRM_KIND } from './store.mjs'
 import { chunkMessage, smallPrint, elapsedLabel } from './messaging.mjs'
 import { ThreadRenamer } from './threadname.mjs'
 
-const MAX_BUTTON_OPTIONS = 23 // 25 buttons max, minus cancel; keep rows tidy
-
-// The long-choice surface (#431, on the #413 map). Above the button cap a
-// `choice` card used to drop its buttons, print a numbered list and ask for a
-// typed reply — the worst answer surface the daemon has on a phone (#414). A
-// string select menu takes that case back to one tap.
+// The `choice` surface, in three bands (#431, on the #413 map).
 //
-// The numbers are Discord's, not ours. One menu holds 25 options, and a message
-// holds five component rows. Four rows carry menus and the fifth stays free for
-// the surface link buttons (#108 item 22) that ride every card, so the menu
-// reaches 100 options. A list longer than that keeps the numbered list, because
-// a card that silently drops option 101 is worse than a card that scrolls.
+// It used to be two. Buttons held up to 23 options, and above that the card
+// dropped its buttons, printed a numbered list and asked for a typed reply.
+// #414 named that list the worst answer surface the daemon has on a phone, and
+// it could not judge the alternative, because the bridge built buttons and link
+// buttons only. A string select menu is that alternative, and it takes the case
+// back to a tap.
+//
+// The operator set both edges on #431:
+//
+//  - buttons keep 2 to 4 options. Five buttons fill a row, and a card that
+//    wraps into a wall of blurple is what the menu exists to stop;
+//  - one menu holds 5 to 25 options. Twenty-five is Discord's cap on a string
+//    select, and the operator wants no more than that on a card: past 25 the
+//    list has stopped being a choice a human makes by reading it;
+//  - past 25 the numbered list stays. It is the surface of last resort, and it
+//    loses nothing, which a menu that silently dropped option 26 would.
+const MAX_BUTTON_OPTIONS = 4
 export const MAX_SELECT_OPTIONS = 25
-export const MAX_SELECT_MENUS = 4
-export const MAX_SELECT_TOTAL = MAX_SELECT_OPTIONS * MAX_SELECT_MENUS
 
 // One select option shows a 100-char label and a 100-char description under it.
 // An option longer than the label spills its tail into the description, so 200
 // chars ride the menu whole. Past that the menu clips, and the body keeps the
-// numbered list beside it — an option never loses its words to this component.
+// numbered list beside it. An option never loses its words to this component.
 const SELECT_LABEL = 100
 const SELECT_DESC = 100
 
@@ -58,7 +63,7 @@ const SELECT_DESC = 100
 // unclipped. Two separate questions: the first picks the component, the second
 // picks whether the numbered list stays under it.
 export const selectFits = (options) => options.length > MAX_BUTTON_OPTIONS
-  && options.length <= MAX_SELECT_TOTAL
+  && options.length <= MAX_SELECT_OPTIONS
 export const selectClips = (options) => options.some((o) => String(o).length > SELECT_LABEL + SELECT_DESC)
 
 // The option payload. `value` is the index into `record.options`, the same key
@@ -69,21 +74,6 @@ export function selectOption(text, idx) {
   const tail = s.slice(SELECT_LABEL)
   if (tail) option.description = tail.length > SELECT_DESC ? `${tail.slice(0, SELECT_DESC - 1)}…` : tail
   return option
-}
-
-// Where each menu starts. One menu says "Pick one"; several say which stretch
-// of the list each one holds, because a phone shows one closed menu at a time
-// and an unlabeled stack of four says nothing about where option 40 lives.
-export function selectPages(options) {
-  const pages = []
-  for (let start = 0; start < options.length; start += MAX_SELECT_OPTIONS) {
-    const slice = options.slice(start, start + MAX_SELECT_OPTIONS)
-    const placeholder = options.length > MAX_SELECT_OPTIONS
-      ? `Pick one — options ${start + 1}-${start + slice.length}`
-      : 'Pick one'
-    pages.push({ start, slice, placeholder })
-  }
-  return pages
 }
 
 // The round's one-tap answer (#285, ADR-0005). It rides `free-text` and it is
@@ -1159,22 +1149,18 @@ export class DiscordBridge {
           .setLabel(label.slice(0, 80)).setStyle(ButtonStyle.Primary))
       })
     }
-    // Above the button cap the same options ride select menus (#431). Buttons
-    // stay the short-list surface: a button is one tap and a menu is two, so
-    // the menu earns the card only where the buttons cannot fit on it.
+    // Above the button cap the same options ride one select menu (#431).
     //
     // A menu owns its whole row, so any half-filled row is flushed first. A
     // choice card carries no other button, so that row is empty here today.
     if (record.kind === 'choice' && selectFits(record.options ?? [])) {
       if (row.components.length) { rows.push(row); row = new ActionRowBuilder() }
-      for (const page of selectPages(record.options)) {
-        rows.push(new ActionRowBuilder().addComponents(
-          new StringSelectMenuBuilder()
-            .setCustomId(`esc|${record.id}|sel|${page.start}`)
-            .setPlaceholder(page.placeholder)
-            .addOptions(page.slice.map((text, i) => selectOption(text, page.start + i))),
-        ))
-      }
+      rows.push(new ActionRowBuilder().addComponents(
+        new StringSelectMenuBuilder()
+          .setCustomId(`esc|${record.id}|sel`)
+          .setPlaceholder('Pick one')
+          .addOptions(record.options.map(selectOption)),
+      ))
     }
     // The round's one tap (#285). It is the ONLY button a free-text card ever
     // gets, and the agent asks for it by promising every question in the prompt

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -22,6 +22,7 @@ import { finished } from 'node:stream/promises'
 import {
   Client, Events, GatewayIntentBits, ChannelType, REST, Routes,
   ActionRowBuilder, ButtonBuilder, ButtonStyle, SlashCommandBuilder,
+  StringSelectMenuBuilder,
 } from 'discord.js'
 import { isChatHandle } from './attach.mjs'
 import { safeLeaf } from './images.mjs'
@@ -31,6 +32,59 @@ import { chunkMessage, smallPrint, elapsedLabel } from './messaging.mjs'
 import { ThreadRenamer } from './threadname.mjs'
 
 const MAX_BUTTON_OPTIONS = 23 // 25 buttons max, minus cancel; keep rows tidy
+
+// The long-choice surface (#431, on the #413 map). Above the button cap a
+// `choice` card used to drop its buttons, print a numbered list and ask for a
+// typed reply — the worst answer surface the daemon has on a phone (#414). A
+// string select menu takes that case back to one tap.
+//
+// The numbers are Discord's, not ours. One menu holds 25 options, and a message
+// holds five component rows. Four rows carry menus and the fifth stays free for
+// the surface link buttons (#108 item 22) that ride every card, so the menu
+// reaches 100 options. A list longer than that keeps the numbered list, because
+// a card that silently drops option 101 is worse than a card that scrolls.
+export const MAX_SELECT_OPTIONS = 25
+export const MAX_SELECT_MENUS = 4
+export const MAX_SELECT_TOTAL = MAX_SELECT_OPTIONS * MAX_SELECT_MENUS
+
+// One select option shows a 100-char label and a 100-char description under it.
+// An option longer than the label spills its tail into the description, so 200
+// chars ride the menu whole. Past that the menu clips, and the body keeps the
+// numbered list beside it — an option never loses its words to this component.
+const SELECT_LABEL = 100
+const SELECT_DESC = 100
+
+// Whether the menu can carry this list at all, and whether it can carry it
+// unclipped. Two separate questions: the first picks the component, the second
+// picks whether the numbered list stays under it.
+export const selectFits = (options) => options.length > MAX_BUTTON_OPTIONS
+  && options.length <= MAX_SELECT_TOTAL
+export const selectClips = (options) => options.some((o) => String(o).length > SELECT_LABEL + SELECT_DESC)
+
+// The option payload. `value` is the index into `record.options`, the same key
+// the `idx` buttons use, so every answer path resolves a pick the one way.
+export function selectOption(text, idx) {
+  const s = String(text)
+  const option = { label: s.slice(0, SELECT_LABEL), value: String(idx) }
+  const tail = s.slice(SELECT_LABEL)
+  if (tail) option.description = tail.length > SELECT_DESC ? `${tail.slice(0, SELECT_DESC - 1)}…` : tail
+  return option
+}
+
+// Where each menu starts. One menu says "Pick one"; several say which stretch
+// of the list each one holds, because a phone shows one closed menu at a time
+// and an unlabeled stack of four says nothing about where option 40 lives.
+export function selectPages(options) {
+  const pages = []
+  for (let start = 0; start < options.length; start += MAX_SELECT_OPTIONS) {
+    const slice = options.slice(start, start + MAX_SELECT_OPTIONS)
+    const placeholder = options.length > MAX_SELECT_OPTIONS
+      ? `Pick one — options ${start + 1}-${start + slice.length}`
+      : 'Pick one'
+    pages.push({ start, slice, placeholder })
+  }
+  return pages
+}
 
 // The round's one-tap answer (#285, ADR-0005). It rides `free-text` and it is
 // pure capture: the press records this word, the agent reads it, and the agent
@@ -1105,6 +1159,23 @@ export class DiscordBridge {
           .setLabel(label.slice(0, 80)).setStyle(ButtonStyle.Primary))
       })
     }
+    // Above the button cap the same options ride select menus (#431). Buttons
+    // stay the short-list surface: a button is one tap and a menu is two, so
+    // the menu earns the card only where the buttons cannot fit on it.
+    //
+    // A menu owns its whole row, so any half-filled row is flushed first. A
+    // choice card carries no other button, so that row is empty here today.
+    if (record.kind === 'choice' && selectFits(record.options ?? [])) {
+      if (row.components.length) { rows.push(row); row = new ActionRowBuilder() }
+      for (const page of selectPages(record.options)) {
+        rows.push(new ActionRowBuilder().addComponents(
+          new StringSelectMenuBuilder()
+            .setCustomId(`esc|${record.id}|sel|${page.start}`)
+            .setPlaceholder(page.placeholder)
+            .addOptions(page.slice.map((text, i) => selectOption(text, page.start + i))),
+        ))
+      }
+    }
     // The round's one tap (#285). It is the ONLY button a free-text card ever
     // gets, and the agent asks for it by promising every question in the prompt
     // carries a recommendation. There is no ❌ beside it: the opposite of "all
@@ -1148,7 +1219,19 @@ export class DiscordBridge {
     const head = `**[${record.id}]** \`${record.agent}\` asks (*${record.kind}*):\n${record.prompt}`
     const parts = [head]
     if (record.kind === 'choice' && (record.options ?? []).length > MAX_BUTTON_OPTIONS) {
-      parts.push(record.options.map((o, i) => `**${i + 1}.** ${o}`).join('\n'), '_Reply in this thread with a number._')
+      // The numbered list is now the FALLBACK, not the surface (#431). It is
+      // printed in the two cases the menu cannot serve: a list past the menu's
+      // reach, and a list whose options are too long for the menu to show
+      // whole. Otherwise the menu carries every option and the list would say
+      // the same thing twice, which is what makes this card scroll on a phone.
+      const numbered = record.options.map((o, i) => `**${i + 1}.** ${o}`).join('\n')
+      if (!selectFits(record.options)) {
+        parts.push(numbered, '_Reply in this thread with a number._')
+      } else if (selectClips(record.options)) {
+        parts.push(numbered, '_Pick from the menu below, or reply with a number._')
+      } else {
+        parts.push('_Pick from the menu below._')
+      }
     } else if (record.kind === 'free-text') {
       // A round says what the tap means and what a partial reply does (#285).
       // The second sentence is the load-bearing one: a question you do not
@@ -1547,7 +1630,10 @@ export class DiscordBridge {
       return
     }
 
-    if (i.isButton() && i.customId.startsWith('esc|')) {
+    // A pick on a long-choice menu (#431) lands here beside the buttons: same
+    // custom id, same record, same answer path. The only difference is where
+    // the picked index rides — `i.values[0]` instead of the id's last field.
+    if ((i.isButton() || i.isStringSelectMenu()) && i.customId.startsWith('esc|')) {
       const [, id, action, value] = i.customId.split('|')
       // A message posted before #200 still carries the old cancel button, and
       // Discord keeps it pressable forever. The act it named is gone, so the
@@ -1562,8 +1648,13 @@ export class DiscordBridge {
         return
       }
       const record = this.handlers.get(id)
-      const answer = action === 'idx' ? record?.options?.[Number(value)] ?? value : value
-      const result = this.handlers.answer(id, { answer, by: i.user.id, via: 'button' })
+      const picked = action === 'sel' ? i.values?.[0] : value
+      const answer = action === 'idx' || action === 'sel'
+        ? record?.options?.[Number(picked)] ?? picked
+        : picked
+      const result = this.handlers.answer(id, {
+        answer, by: i.user.id, via: action === 'sel' ? 'select menu' : 'button',
+      })
       if (result.ok) {
         // #253, ADR-0013: the card is the only record. `answer` above already
         // edits the mark onto it, so this press is acknowledged SILENTLY —

--- a/daemon/test/selectmenu.test.mjs
+++ b/daemon/test/selectmenu.test.mjs
@@ -1,0 +1,199 @@
+// The long-choice select menu (#431, on the #413 map).
+//
+// Above `MAX_BUTTON_OPTIONS` a `choice` card used to drop its buttons, print a
+// numbered list and ask for a typed reply. #414 named that the worst answer
+// surface the daemon has on a phone, and it could not judge the alternative,
+// because the bridge built buttons and link buttons only.
+//
+// The shape settled here:
+//   - buttons keep the short list. A button is one tap and a menu is two, so
+//     the menu takes only the case the buttons cannot fit;
+//   - one menu holds 25 options and four rows carry menus, so the menu reaches
+//     100. The fifth row stays free for the surface link buttons;
+//   - past 100 options the numbered list comes back, because a card that drops
+//     option 101 in silence is worse than a card that scrolls;
+//   - a pick answers through the same path a button press takes.
+
+import { test, describe, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  DiscordBridge, MAX_SELECT_OPTIONS, MAX_SELECT_TOTAL, selectOption, selectPages,
+} from '../src/bridge.mjs'
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'curia-select-test-'))
+
+const rowsOf = (components) => components.map((row) => row.toJSON().components)
+const menusOf = (components) => rowsOf(components)
+  .flat()
+  .filter((c) => c.type === 3) // ComponentType.StringSelect
+
+const opts = (n, text = (i) => `option ${i + 1}`) => Array.from({ length: n }, (_, i) => text(i))
+
+describe('a long choice card answers through a select menu (#431)', () => {
+  let bridge, sent, thread, answered
+
+  beforeEach(() => {
+    sent = []
+    answered = []
+    thread = {
+      id: 't-431',
+      name: '🎫 431 · prototype',
+      send: async (payload) => { sent.push(payload); return { id: 'm-1' } },
+      setName: async () => {},
+    }
+    bridge = new DiscordBridge({
+      token: 'x', allowedUsers: [], dataDir: tmp(), handlers: {}, log: () => {},
+    })
+    bridge.channel = { id: 'C', send: async (payload) => { sent.push(payload); return { id: 'm-C' } } }
+    bridge.client = { channels: { fetch: async () => thread } }
+    bridge.ensureThread = async () => thread
+  })
+
+  const render = async (options) => {
+    await bridge.renderEscalation({
+      id: 'esc-1', ticket: '431', agent: 'curia-431', kind: 'choice', prompt: 'Which one?', options,
+    })
+    return sent.at(-1)
+  }
+
+  test('at the button cap the card still uses buttons', async () => {
+    const msg = await render(opts(23))
+    assert.equal(menusOf(msg.components).length, 0, 'a list the buttons fit gets no menu')
+    assert.equal(rowsOf(msg.components).flat().filter((c) => c.type === 2).length, 23)
+  })
+
+  test('one option past the cap turns the list into one menu', async () => {
+    const msg = await render(opts(24))
+    const menus = menusOf(msg.components)
+    assert.equal(menus.length, 1)
+    assert.equal(menus[0].options.length, 24)
+    assert.equal(menus[0].placeholder, 'Pick one')
+    assert.equal(menus[0].custom_id, 'esc|esc-1|sel|0')
+  })
+
+  test('the numbered list goes away when the menu carries every option', async () => {
+    const msg = await render(opts(30))
+    assert.doesNotMatch(msg.content, /\*\*1\.\*\*/, 'the list would say what the menu already shows')
+    assert.match(msg.content, /Pick from the menu below\./)
+    assert.doesNotMatch(msg.content, /with a number/, 'no numbers are printed, so none are offered')
+  })
+
+  test('a long option keeps the numbered list beside the menu', async () => {
+    // The menu shows 100 chars of label and 100 of description. An option past
+    // both is clipped, so the full text must stay somewhere on the card.
+    const msg = await render([...opts(23), 'x'.repeat(250)])
+    assert.equal(menusOf(msg.components).length, 1, 'the menu still carries the taps')
+    assert.match(msg.content, /\*\*24\.\*\*/, 'and the list carries the words')
+    assert.match(msg.content, /or reply with a number/)
+  })
+
+  test('the menus page across four rows and label their stretch', async () => {
+    const msg = await render(opts(60))
+    const menus = menusOf(msg.components)
+    assert.equal(menus.length, 3)
+    assert.deepEqual(menus.map((m) => m.options.length), [25, 25, 10])
+    assert.deepEqual(menus.map((m) => m.placeholder), [
+      'Pick one — options 1-25', 'Pick one — options 26-50', 'Pick one — options 51-60',
+    ])
+  })
+
+  test('the link row survives a full stack of menus', async () => {
+    bridge.handlers.previewUrl = () => 'https://example.test/p'
+    const msg = await render(opts(MAX_SELECT_TOTAL))
+    assert.equal(menusOf(msg.components).length, 4)
+    assert.equal(msg.components.length, 5, 'four menu rows plus the link row')
+    const links = rowsOf(msg.components).at(-1)
+    assert.deepEqual(links.map((c) => c.label), ['🔗 preview'])
+  })
+
+  test('past the menu reach the numbered list comes back whole', async () => {
+    const msg = await render(opts(MAX_SELECT_TOTAL + 1))
+    assert.equal(menusOf(msg.components).length, 0, 'no menu may hide the options it cannot hold')
+    assert.match(msg.content, /\*\*101\.\*\* option 101/)
+    assert.match(msg.content, /Reply in this thread with a number\./)
+  })
+
+  test('the value on every option is its index into the record', async () => {
+    const msg = await render(opts(40))
+    const values = menusOf(msg.components).flatMap((m) => m.options).map((o) => o.value)
+    assert.deepEqual(values, Array.from({ length: 40 }, (_, i) => String(i)))
+  })
+})
+
+describe('a pick answers the record (#431)', () => {
+  let bridge, answered, deferred, replies
+
+  beforeEach(() => {
+    answered = []
+    deferred = 0
+    replies = []
+    bridge = new DiscordBridge({
+      token: 'x',
+      allowedUsers: ['u1'],
+      dataDir: tmp(),
+      handlers: {
+        get: () => ({ id: 'esc-1', kind: 'choice', options: opts(40) }),
+        answer: (id, payload) => { answered.push({ id, ...payload }); return { ok: true } },
+      },
+      log: () => {},
+    })
+    bridge.channel = { id: 'C' }
+  })
+
+  const pick = async (values) => bridge.handleInteraction({
+    isButton: () => false,
+    isStringSelectMenu: () => true,
+    isChatInputCommand: () => false,
+    isRepliable: () => true,
+    customId: 'esc|esc-1|sel|25',
+    values,
+    user: { id: 'u1' },
+    deferUpdate: async () => { deferred++ },
+    reply: async (r) => { replies.push(r) },
+  })
+
+  test('the picked index resolves to the option text', async () => {
+    await pick(['27'])
+    assert.equal(answered.at(-1).answer, 'option 28')
+    assert.equal(answered.at(-1).by, 'u1')
+  })
+
+  test('the answer records that the menu carried it', async () => {
+    await pick(['3'])
+    assert.equal(answered.at(-1).via, 'select menu')
+  })
+
+  test('a pick is acknowledged silently, like a press', async () => {
+    // #253, ADR-0013: the card is the only record of an answer.
+    await pick(['0'])
+    assert.equal(deferred, 1)
+    assert.deepEqual(replies, [])
+  })
+})
+
+describe('the pure pieces (#431)', () => {
+  test('a short option is one label and no description', () => {
+    assert.deepEqual(selectOption('navy', 7), { label: 'navy', value: '7' })
+  })
+
+  test('a long option spills its tail into the description', () => {
+    const o = selectOption(`${'a'.repeat(100)}${'b'.repeat(40)}`, 0)
+    assert.equal(o.label, 'a'.repeat(100))
+    assert.equal(o.description, 'b'.repeat(40))
+  })
+
+  test('an option past both fields is marked as clipped', () => {
+    const o = selectOption('c'.repeat(400), 0)
+    assert.equal(o.description.length, MAX_SELECT_OPTIONS * 4)
+    assert.match(o.description, /…$/, 'the reader must see that words are missing')
+  })
+
+  test('the pages tile the list with no gap and no overlap', () => {
+    const pages = selectPages(opts(60))
+    assert.deepEqual(pages.map((p) => p.start), [0, 25, 50])
+    assert.deepEqual(pages.flatMap((p) => p.slice), opts(60))
+  })
+})

--- a/daemon/test/selectmenu.test.mjs
+++ b/daemon/test/selectmenu.test.mjs
@@ -1,43 +1,39 @@
-// The long-choice select menu (#431, on the #413 map).
+// The `choice` select menu (#431, on the #413 map).
 //
-// Above `MAX_BUTTON_OPTIONS` a `choice` card used to drop its buttons, print a
-// numbered list and ask for a typed reply. #414 named that the worst answer
+// The card used to have two bands: buttons up to 23 options, and above that a
+// numbered list with a typed reply. #414 named that list the worst answer
 // surface the daemon has on a phone, and it could not judge the alternative,
 // because the bridge built buttons and link buttons only.
 //
-// The shape settled here:
-//   - buttons keep the short list. A button is one tap and a menu is two, so
-//     the menu takes only the case the buttons cannot fit;
-//   - one menu holds 25 options and four rows carry menus, so the menu reaches
-//     100. The fifth row stays free for the surface link buttons;
-//   - past 100 options the numbered list comes back, because a card that drops
-//     option 101 in silence is worse than a card that scrolls;
-//   - a pick answers through the same path a button press takes.
+// The operator set three bands on #431:
+//   - 2 to 4 options stay buttons. Five buttons fill a row;
+//   - 5 to 25 options are one select menu. Twenty-five is Discord's cap on a
+//     string select, and the operator wants no more than that on a card;
+//   - past 25 the numbered list stays, whole. It loses nothing, which a menu
+//     that dropped option 26 in silence would.
+//
+// A pick answers through the same path a button press takes.
 
 import { test, describe, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import {
-  DiscordBridge, MAX_SELECT_OPTIONS, MAX_SELECT_TOTAL, selectOption, selectPages,
-} from '../src/bridge.mjs'
+import { DiscordBridge, MAX_SELECT_OPTIONS, selectOption } from '../src/bridge.mjs'
 
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'curia-select-test-'))
 
 const rowsOf = (components) => components.map((row) => row.toJSON().components)
-const menusOf = (components) => rowsOf(components)
-  .flat()
-  .filter((c) => c.type === 3) // ComponentType.StringSelect
+const menusOf = (components) => rowsOf(components).flat().filter((c) => c.type === 3)
+const buttonsOf = (components) => rowsOf(components).flat().filter((c) => c.type === 2)
 
-const opts = (n, text = (i) => `option ${i + 1}`) => Array.from({ length: n }, (_, i) => text(i))
+const opts = (n) => Array.from({ length: n }, (_, i) => `option ${i + 1}`)
 
-describe('a long choice card answers through a select menu (#431)', () => {
-  let bridge, sent, thread, answered
+describe('a choice card picks its surface by option count (#431)', () => {
+  let bridge, sent, thread
 
   beforeEach(() => {
     sent = []
-    answered = []
     thread = {
       id: 't-431',
       name: '🎫 431 · prototype',
@@ -59,23 +55,24 @@ describe('a long choice card answers through a select menu (#431)', () => {
     return sent.at(-1)
   }
 
-  test('at the button cap the card still uses buttons', async () => {
-    const msg = await render(opts(23))
-    assert.equal(menusOf(msg.components).length, 0, 'a list the buttons fit gets no menu')
-    assert.equal(rowsOf(msg.components).flat().filter((c) => c.type === 2).length, 23)
+  test('four options stay four buttons', async () => {
+    const msg = await render(opts(4))
+    assert.equal(menusOf(msg.components).length, 0, 'the buttons fit on one row')
+    assert.equal(buttonsOf(msg.components).length, 4)
   })
 
-  test('one option past the cap turns the list into one menu', async () => {
-    const msg = await render(opts(24))
+  test('the fifth option turns the card into one menu', async () => {
+    const msg = await render(opts(5))
     const menus = menusOf(msg.components)
     assert.equal(menus.length, 1)
-    assert.equal(menus[0].options.length, 24)
+    assert.equal(menus[0].options.length, 5)
     assert.equal(menus[0].placeholder, 'Pick one')
-    assert.equal(menus[0].custom_id, 'esc|esc-1|sel|0')
+    assert.equal(menus[0].custom_id, 'esc|esc-1|sel')
+    assert.equal(buttonsOf(msg.components).length, 0, 'no card carries both surfaces')
   })
 
   test('the numbered list goes away when the menu carries every option', async () => {
-    const msg = await render(opts(30))
+    const msg = await render(opts(12))
     assert.doesNotMatch(msg.content, /\*\*1\.\*\*/, 'the list would say what the menu already shows')
     assert.match(msg.content, /Pick from the menu below\./)
     assert.doesNotMatch(msg.content, /with a number/, 'no numbers are printed, so none are offered')
@@ -84,42 +81,45 @@ describe('a long choice card answers through a select menu (#431)', () => {
   test('a long option keeps the numbered list beside the menu', async () => {
     // The menu shows 100 chars of label and 100 of description. An option past
     // both is clipped, so the full text must stay somewhere on the card.
-    const msg = await render([...opts(23), 'x'.repeat(250)])
+    const msg = await render([...opts(5), 'x'.repeat(250)])
     assert.equal(menusOf(msg.components).length, 1, 'the menu still carries the taps')
-    assert.match(msg.content, /\*\*24\.\*\*/, 'and the list carries the words')
+    assert.match(msg.content, /\*\*6\.\*\*/, 'and the list carries the words')
     assert.match(msg.content, /or reply with a number/)
   })
 
-  test('the menus page across four rows and label their stretch', async () => {
-    const msg = await render(opts(60))
+  test('twenty-five options are still one menu and one row', async () => {
+    const msg = await render(opts(MAX_SELECT_OPTIONS))
     const menus = menusOf(msg.components)
-    assert.equal(menus.length, 3)
-    assert.deepEqual(menus.map((m) => m.options.length), [25, 25, 10])
-    assert.deepEqual(menus.map((m) => m.placeholder), [
-      'Pick one — options 1-25', 'Pick one — options 26-50', 'Pick one — options 51-60',
-    ])
+    assert.equal(menus.length, 1)
+    assert.equal(menus[0].options.length, 25)
   })
 
-  test('the link row survives a full stack of menus', async () => {
+  test('the link row rides beside the menu', async () => {
     bridge.handlers.previewUrl = () => 'https://example.test/p'
-    const msg = await render(opts(MAX_SELECT_TOTAL))
-    assert.equal(menusOf(msg.components).length, 4)
-    assert.equal(msg.components.length, 5, 'four menu rows plus the link row')
-    const links = rowsOf(msg.components).at(-1)
-    assert.deepEqual(links.map((c) => c.label), ['🔗 preview'])
+    const msg = await render(opts(MAX_SELECT_OPTIONS))
+    assert.equal(msg.components.length, 2, 'the menu row and the link row')
+    assert.deepEqual(rowsOf(msg.components).at(-1).map((c) => c.label), ['🔗 preview'])
   })
 
-  test('past the menu reach the numbered list comes back whole', async () => {
-    const msg = await render(opts(MAX_SELECT_TOTAL + 1))
+  test('past the menu cap the numbered list comes back whole', async () => {
+    const msg = await render(opts(MAX_SELECT_OPTIONS + 1))
     assert.equal(menusOf(msg.components).length, 0, 'no menu may hide the options it cannot hold')
-    assert.match(msg.content, /\*\*101\.\*\* option 101/)
+    assert.match(msg.content, /\*\*26\.\*\* option 26/)
     assert.match(msg.content, /Reply in this thread with a number\./)
   })
 
   test('the value on every option is its index into the record', async () => {
-    const msg = await render(opts(40))
+    const msg = await render(opts(20))
     const values = menusOf(msg.components).flatMap((m) => m.options).map((o) => o.value)
-    assert.deepEqual(values, Array.from({ length: 40 }, (_, i) => String(i)))
+    assert.deepEqual(values, Array.from({ length: 20 }, (_, i) => String(i)))
+  })
+
+  test('two options that read the same still answer apart', async () => {
+    // Discord refuses a menu with a repeated value. The index is the value, so
+    // a duplicated label costs nothing.
+    const msg = await render(['keep', 'drop', 'keep', 'hold', 'keep'])
+    const options = menusOf(msg.components)[0].options
+    assert.deepEqual(options.map((o) => o.value), ['0', '1', '2', '3', '4'])
   })
 })
 
@@ -135,7 +135,7 @@ describe('a pick answers the record (#431)', () => {
       allowedUsers: ['u1'],
       dataDir: tmp(),
       handlers: {
-        get: () => ({ id: 'esc-1', kind: 'choice', options: opts(40) }),
+        get: () => ({ id: 'esc-1', kind: 'choice', options: opts(20) }),
         answer: (id, payload) => { answered.push({ id, ...payload }); return { ok: true } },
       },
       log: () => {},
@@ -148,7 +148,7 @@ describe('a pick answers the record (#431)', () => {
     isStringSelectMenu: () => true,
     isChatInputCommand: () => false,
     isRepliable: () => true,
-    customId: 'esc|esc-1|sel|25',
+    customId: 'esc|esc-1|sel',
     values,
     user: { id: 'u1' },
     deferUpdate: async () => { deferred++ },
@@ -156,8 +156,8 @@ describe('a pick answers the record (#431)', () => {
   })
 
   test('the picked index resolves to the option text', async () => {
-    await pick(['27'])
-    assert.equal(answered.at(-1).answer, 'option 28')
+    await pick(['17'])
+    assert.equal(answered.at(-1).answer, 'option 18')
     assert.equal(answered.at(-1).by, 'u1')
   })
 
@@ -174,7 +174,7 @@ describe('a pick answers the record (#431)', () => {
   })
 })
 
-describe('the pure pieces (#431)', () => {
+describe('the option payload (#431)', () => {
   test('a short option is one label and no description', () => {
     assert.deepEqual(selectOption('navy', 7), { label: 'navy', value: '7' })
   })
@@ -187,13 +187,7 @@ describe('the pure pieces (#431)', () => {
 
   test('an option past both fields is marked as clipped', () => {
     const o = selectOption('c'.repeat(400), 0)
-    assert.equal(o.description.length, MAX_SELECT_OPTIONS * 4)
+    assert.equal(o.description.length, 100)
     assert.match(o.description, /…$/, 'the reader must see that words are missing')
-  })
-
-  test('the pages tile the list with no gap and no overlap', () => {
-    const pages = selectPages(opts(60))
-    assert.deepEqual(pages.map((p) => p.start), [0, 25, 50])
-    assert.deepEqual(pages.flatMap((p) => p.slice), opts(60))
   })
 })

--- a/prototypes/select-menu/index.html
+++ b/prototypes/select-menu/index.html
@@ -150,12 +150,13 @@
     Does a Discord select menu read better than a numbered list on a phone?
     Pick an option count below. The same <code>choice</code> card is drawn twice:
     as the daemon draws it today, and as this branch draws it.
+    Every menu here opens on one tap and answers on one more.
   </p>
 </header>
 
 <main>
   <h2>How many options</h2>
-  <p class="lede">The button cap is 23. The menu reaches 100. Both edges are in the row.</p>
+  <p class="lede">Buttons hold 4. The menu holds 25. Both edges are in the row.</p>
   <div class="picker" id="picker"></div>
 
   <section class="pane before">
@@ -169,22 +170,23 @@
   </section>
 
   <h2>The rule</h2>
+  <p class="lede">Three bands. The operator set both edges on #431.</p>
   <table>
     <tr><th>Options</th><th>Surface</th><th>Why</th></tr>
     <tr>
-      <td><code>2-23</code></td>
+      <td><code>2-4</code></td>
       <td>Buttons</td>
-      <td>A button is one tap and a menu is two. Buttons keep the short list.</td>
+      <td>Five buttons fill a row. A card that wraps into a wall of blurple is what the menu stops.</td>
     </tr>
     <tr>
-      <td><code>24-100</code></td>
+      <td><code>5-25</code></td>
       <td>Select menu</td>
-      <td>25 options per menu, four menu rows. The fifth row keeps the preview, timeline and terminal links.</td>
+      <td>25 is Discord's cap on one menu. It is also as many options as a person picks by reading.</td>
     </tr>
     <tr>
-      <td><code>101+</code></td>
+      <td><code>26+</code></td>
       <td>Numbered list</td>
-      <td>The menu cannot hold them. A card that drops option 101 in silence is worse than a card that scrolls.</td>
+      <td>The menu cannot hold them. A card that drops option 26 in silence is worse than a card that scrolls.</td>
     </tr>
   </table>
 
@@ -197,7 +199,7 @@
     <li>
       <b>Past 200 characters the menu clips.</b>
       Then the numbered list stays under it and carries the full words. The menu carries the tap.
-      Pick the 24-option count to see that card.
+      Pick the third count to see that card.
     </li>
     <li>
       <b>The typed number still answers.</b>
@@ -220,9 +222,9 @@
 // The daemon's numbers, restated here so the page cannot drift from the rule
 // it draws. Changing one here changes nothing in the bridge — read
 // daemon/src/bridge.mjs for the truth.
-const MAX_BUTTON_OPTIONS = 23
+const OLD_BUTTON_CAP = 23        // what main does today
+const MAX_BUTTON_OPTIONS = 4     // what this branch does
 const MAX_SELECT_OPTIONS = 25
-const MAX_SELECT_TOTAL = 100
 const SELECT_LABEL = 100
 const SELECT_DESC = 100
 
@@ -247,17 +249,17 @@ const LONG = 'The overseer service holds the shell, so the module that owns this
   + 'other context to hand.'
 
 const COUNTS = [
-  { n: 23, note: 'buttons' },
-  { n: 24, note: 'one long' },
-  { n: 30, note: 'one menu' },
-  { n: 60, note: 'three' },
-  { n: 101, note: 'past it' },
+  { n: 4, note: 'buttons' },
+  { n: 5, note: 'the menu' },
+  { n: 8, long: true, note: 'a long one' },
+  { n: 25, note: 'the cap' },
+  { n: 26, note: 'past it' },
 ]
 
-const optionsFor = (n) => {
+const optionsFor = ({ n, long }) => {
   const out = []
   for (let i = 0; i < n; i++) out.push(MODULES[i % MODULES.length])
-  if (n === 24) out[23] = LONG
+  if (long) out[n - 1] = LONG
   return out
 }
 
@@ -281,11 +283,11 @@ const linkRow = '<div class="row"><button class="btn link">🔗 preview</button>
   + '<button class="btn link">timeline</button>'
   + '<button class="btn link">terminal</button></div>'
 
-// The card as main draws it: buttons under the cap, a numbered list over it.
+// The card as main draws it: buttons up to 23, a numbered list over that.
 function drawBefore(options) {
-  if (options.length <= MAX_BUTTON_OPTIONS) {
+  if (options.length <= OLD_BUTTON_CAP) {
     return head + prompt + buttonRow(options) + linkRow
-      + '<p class="taps">One tap. <b>' + options.length + ' buttons.</b></p>'
+      + '<p class="taps">One tap, and <b>' + options.length + ' buttons</b> to read through.</p>'
   }
   return head + prompt + numbered(options)
     + '<p class="hint">Reply in this thread with a number.</p>' + linkRow
@@ -297,12 +299,12 @@ function drawBefore(options) {
 function drawAfter(options) {
   if (options.length <= MAX_BUTTON_OPTIONS) {
     return head + prompt + buttonRow(options) + linkRow
-      + '<p class="taps">Unchanged. <b>The menu takes only what the buttons cannot fit.</b></p>'
+      + '<p class="taps">Unchanged. <b>Four buttons fit one row.</b></p>'
   }
-  if (options.length > MAX_SELECT_TOTAL) {
+  if (options.length > MAX_SELECT_OPTIONS) {
     return head + prompt + numbered(options)
       + '<p class="hint">Reply in this thread with a number.</p>' + linkRow
-      + '<p class="taps">Past the menu reach. <b>The list stays, whole.</b></p>'
+      + '<p class="taps">Past the menu cap. <b>The list stays, whole.</b></p>'
   }
   const clips = options.some((o) => o.length > SELECT_LABEL + SELECT_DESC)
   let html = head + prompt
@@ -312,22 +314,16 @@ function drawAfter(options) {
   } else {
     html += '<p class="hint">Pick from the menu below.</p>'
   }
-  for (let start = 0; start < options.length; start += MAX_SELECT_OPTIONS) {
-    const slice = options.slice(start, start + MAX_SELECT_OPTIONS)
-    const label = options.length > MAX_SELECT_OPTIONS
-      ? `Pick one — options ${start + 1}-${start + slice.length}`
-      : 'Pick one'
-    html += `<div class="menu" data-menu><button aria-expanded="false" data-toggle>`
-      + `<span>${esc(label)}</span><span class="caret">▾</span></button><div class="list">`
-      + slice.map((o, i) => {
-        const main = o.slice(0, SELECT_LABEL)
-        let tail = o.slice(SELECT_LABEL)
-        if (tail.length > SELECT_DESC) tail = tail.slice(0, SELECT_DESC - 1) + '…'
-        return `<button data-pick="${esc(o)}">${esc(main)}`
-          + (tail ? `<em>${esc(tail)}</em>` : '') + '</button>'
-      }).join('')
-      + '</div></div>'
-  }
+  html += '<div class="menu" data-menu><button aria-expanded="false" data-toggle>'
+    + '<span>Pick one</span><span class="caret">▾</span></button><div class="list">'
+    + options.map((o) => {
+      const main = o.slice(0, SELECT_LABEL)
+      let tail = o.slice(SELECT_LABEL)
+      if (tail.length > SELECT_DESC) tail = tail.slice(0, SELECT_DESC - 1) + '…'
+      return `<button data-pick="${esc(o)}">${esc(main)}`
+        + (tail ? `<em>${esc(tail)}</em>` : '') + '</button>'
+    }).join('')
+    + '</div></div>'
   html += linkRow
   html += '<p class="taps">Tap the menu, tap the option. <b>Two taps, no typing.</b></p>'
   html += '<div class="picked" hidden data-picked></div>'
@@ -338,20 +334,20 @@ const before = document.getElementById('before')
 const after = document.getElementById('after')
 const picker = document.getElementById('picker')
 
-function render(n) {
-  const options = optionsFor(n)
+function render(i) {
+  const options = optionsFor(COUNTS[i])
   before.innerHTML = drawBefore(options)
   after.innerHTML = drawAfter(options)
   for (const b of picker.querySelectorAll('button')) {
-    b.setAttribute('aria-pressed', String(Number(b.dataset.n) === n))
+    b.setAttribute('aria-pressed', String(Number(b.dataset.i) === i))
   }
 }
 
-picker.innerHTML = COUNTS.map((c) =>
-  `<button data-n="${c.n}" aria-pressed="false">${c.n}<small>${c.note}</small></button>`).join('')
+picker.innerHTML = COUNTS.map((c, i) =>
+  `<button data-i="${i}" aria-pressed="false">${c.n}<small>${c.note}</small></button>`).join('')
 picker.addEventListener('click', (e) => {
-  const b = e.target.closest('button[data-n]')
-  if (b) render(Number(b.dataset.n))
+  const b = e.target.closest('button[data-i]')
+  if (b) render(Number(b.dataset.i))
 })
 
 // One tap opens a menu, one tap answers it. No double-click anywhere on this
@@ -374,7 +370,7 @@ after.addEventListener('click', (e) => {
   out.textContent = '✅ answered via select menu: ' + pick.dataset.pick.slice(0, 80)
 })
 
-render(30)
+render(1)
 </script>
 </body>
 </html>

--- a/prototypes/select-menu/index.html
+++ b/prototypes/select-menu/index.html
@@ -1,0 +1,380 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>#431 — The select menu, built and judged</title>
+<style>
+  :root {
+    --bg: #16181d;
+    --card: #1e2128;
+    --thread: #313338;
+    --line: #2f333d;
+    --ink: #e3e6ea;
+    --dim: #98a0ad;
+    --blurple: #5865f2;
+    --keep: #57f287;
+    --drop: #ed4245;
+    --hold: #fee75c;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 0 0 4rem;
+    background: var(--bg);
+    color: var(--ink);
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    -webkit-text-size-adjust: 100%;
+  }
+  header {
+    padding: 1.6rem 1.1rem 1.3rem;
+    border-bottom: 1px solid var(--line);
+    background: linear-gradient(180deg, #1b1f27, var(--bg));
+  }
+  header .tag {
+    display: inline-block; margin-bottom: .55rem; padding: .18rem .5rem;
+    border: 1px solid var(--line); border-radius: 999px;
+    font: 600 .72rem/1 var(--mono); color: var(--keep); letter-spacing: .04em;
+  }
+  header h1 { margin: 0 0 .3rem; font-size: 1.35rem; line-height: 1.25; }
+  header p { margin: .5rem 0 0; color: var(--dim); font-size: .93rem; max-width: 46rem; }
+  main { padding: 0 1.1rem; max-width: 48rem; margin: 0 auto; }
+  h2 {
+    margin: 2.1rem 0 .8rem; font-size: .78rem; letter-spacing: .11em;
+    text-transform: uppercase; color: var(--dim); font-weight: 700;
+  }
+  p.lede { margin: .2rem 0 1rem; color: var(--dim); font-size: .92rem; }
+
+  /* the one control: how many options the card carries */
+  .picker { display: flex; flex-wrap: wrap; gap: .45rem; margin: 0 0 1.2rem; }
+  .picker button {
+    flex: 1 1 4.4rem; min-height: 2.9rem; padding: .5rem .3rem;
+    background: var(--card); color: var(--ink);
+    border: 1px solid var(--line); border-radius: 8px;
+    font: 600 .84rem/1.2 var(--mono); cursor: pointer;
+  }
+  .picker button[aria-pressed="true"] { border-color: var(--blurple); background: #262a45; color: #fff; }
+  .picker button small { display: block; font: 400 .64rem/1.3 var(--mono); color: var(--dim); }
+  .picker button[aria-pressed="true"] small { color: #b6bdf5; }
+
+  .pane { margin: 0 0 1.3rem; }
+  .pane > h3 {
+    margin: 0 0 .5rem; font-size: .95rem; display: flex; gap: .5rem;
+    align-items: baseline; flex-wrap: wrap;
+  }
+  .pane > h3 .badge {
+    padding: .18rem .48rem; border-radius: 5px;
+    font: 700 .68rem/1.3 var(--mono); letter-spacing: .04em;
+  }
+  .before .badge { background: rgba(237,66,69,.14); color: var(--drop); }
+  .after .badge { background: rgba(87,242,135,.13); color: var(--keep); }
+
+  /* a Discord thread, at the width a phone gives it */
+  .msg {
+    background: var(--thread); border: 1px solid var(--line); border-radius: 10px;
+    padding: .85rem .8rem .9rem; font-size: .93rem;
+  }
+  .msg .who { display: flex; gap: .5rem; align-items: center; margin: 0 0 .35rem; }
+  .msg .who .av {
+    width: 1.6rem; height: 1.6rem; border-radius: 50%;
+    background: var(--blurple); flex: none;
+  }
+  .msg .who b { font-size: .88rem; }
+  .msg .who .bot {
+    background: var(--blurple); color: #fff; border-radius: 4px;
+    padding: .05rem .3rem; font: 700 .6rem/1.5 var(--mono);
+  }
+  .msg .body { margin: 0 0 .6rem; }
+  .msg code { font: .86rem var(--mono); background: #2b2d31; padding: .05rem .28rem; border-radius: 4px; }
+  .msg .hint { color: var(--dim); font-style: italic; font-size: .85rem; }
+  .scroller { max-height: 17rem; overflow-y: auto; margin: .4rem 0 .5rem; }
+  ol.opts { margin: 0; padding: 0 0 0 .2rem; list-style: none; }
+  ol.opts li { padding: .1rem 0; }
+  ol.opts li b { color: var(--ink); }
+
+  /* the mock components */
+  .row { display: flex; flex-wrap: wrap; gap: .35rem; margin: .35rem 0 0; }
+  .btn {
+    background: var(--blurple); color: #fff; border: none; border-radius: 6px;
+    padding: .5rem .7rem; font: 500 .82rem/1.2 inherit; cursor: pointer;
+  }
+  .btn.link { background: #4e5058; }
+  .menu { margin: .35rem 0 0; }
+  .menu > button {
+    width: 100%; text-align: left; display: flex; justify-content: space-between;
+    align-items: center; gap: .5rem;
+    background: #1e1f22; color: var(--dim); border: 1px solid #43444b;
+    border-radius: 6px; padding: .65rem .7rem; font: 500 .87rem/1.25 inherit; cursor: pointer;
+  }
+  .menu > button[aria-expanded="true"] { border-color: var(--blurple); color: var(--ink); }
+  .menu > button .caret { color: var(--dim); font-size: .7rem; }
+  .menu .list {
+    display: none; margin: .25rem 0 0; padding: .3rem;
+    background: #111214; border: 1px solid #43444b; border-radius: 6px;
+    max-height: 15rem; overflow-y: auto;
+  }
+  .menu.open .list { display: block; }
+  .menu .list button {
+    display: block; width: 100%; text-align: left;
+    background: none; border: none; color: var(--ink);
+    padding: .5rem .55rem; border-radius: 4px; font: 500 .87rem/1.25 inherit; cursor: pointer;
+  }
+  .menu .list button em { display: block; font: 400 .76rem/1.3 inherit; color: var(--dim); font-style: normal; }
+  .menu .list button:hover, .menu .list button:focus { background: #3f4147; }
+  .picked {
+    margin: .55rem 0 0; padding: .45rem .6rem; border-radius: 6px;
+    background: rgba(87,242,135,.1); color: var(--keep);
+    font: 600 .82rem/1.3 var(--mono);
+  }
+
+  .taps { margin: .55rem 0 0; color: var(--dim); font-size: .82rem; }
+  .taps b { color: var(--ink); }
+
+  table { width: 100%; border-collapse: collapse; margin: .3rem 0 0; font-size: .87rem; }
+  th, td { text-align: left; padding: .5rem .55rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--dim); font-size: .74rem; text-transform: uppercase; letter-spacing: .07em; }
+  td code { font: .82rem var(--mono); color: var(--hold); }
+
+  ul.notes { margin: .3rem 0 0; padding-left: 1.1rem; color: var(--dim); font-size: .9rem; }
+  ul.notes li { margin: .35rem 0; }
+  ul.notes b { color: var(--ink); }
+  footer { margin-top: 2.4rem; padding-top: 1rem; border-top: 1px solid var(--line); color: var(--dim); font-size: .83rem; }
+</style>
+</head>
+<body>
+<header>
+  <span class="tag">alp82/curia#431</span>
+  <h1>The select menu, built and judged</h1>
+  <p>
+    Does a Discord select menu read better than a numbered list on a phone?
+    Pick an option count below. The same <code>choice</code> card is drawn twice:
+    as the daemon draws it today, and as this branch draws it.
+  </p>
+</header>
+
+<main>
+  <h2>How many options</h2>
+  <p class="lede">The button cap is 23. The menu reaches 100. Both edges are in the row.</p>
+  <div class="picker" id="picker"></div>
+
+  <section class="pane before">
+    <h3>Today <span class="badge">on main</span></h3>
+    <div class="msg" id="before"></div>
+  </section>
+
+  <section class="pane after">
+    <h3>This branch <span class="badge">#431</span></h3>
+    <div class="msg" id="after"></div>
+  </section>
+
+  <h2>The rule</h2>
+  <table>
+    <tr><th>Options</th><th>Surface</th><th>Why</th></tr>
+    <tr>
+      <td><code>2-23</code></td>
+      <td>Buttons</td>
+      <td>A button is one tap and a menu is two. Buttons keep the short list.</td>
+    </tr>
+    <tr>
+      <td><code>24-100</code></td>
+      <td>Select menu</td>
+      <td>25 options per menu, four menu rows. The fifth row keeps the preview, timeline and terminal links.</td>
+    </tr>
+    <tr>
+      <td><code>101+</code></td>
+      <td>Numbered list</td>
+      <td>The menu cannot hold them. A card that drops option 101 in silence is worse than a card that scrolls.</td>
+    </tr>
+  </table>
+
+  <h2>What the menu cannot show</h2>
+  <ul class="notes">
+    <li>
+      <b>An option shows 100 characters of label and 100 of description.</b>
+      A longer option spills its tail into the description, so 200 characters ride the menu whole.
+    </li>
+    <li>
+      <b>Past 200 characters the menu clips.</b>
+      Then the numbered list stays under it and carries the full words. The menu carries the tap.
+      Pick the 24-option count to see that card.
+    </li>
+    <li>
+      <b>The typed number still answers.</b>
+      The reply path in the bridge is unchanged, so an old card and a stale phone both still work.
+    </li>
+  </ul>
+
+  <h2>The verdict</h2>
+  <p class="lede">
+    This page is the design. The verdict is taken on a real card in the ticket thread,
+    after the merge and the deploy. It goes into the resolution comment on #431.
+  </p>
+</main>
+
+<footer>
+  prototypes/select-menu · map: Typed HITL payloads (#413) · code: <code>daemon/src/bridge.mjs</code>
+</footer>
+
+<script>
+// The daemon's numbers, restated here so the page cannot drift from the rule
+// it draws. Changing one here changes nothing in the bridge — read
+// daemon/src/bridge.mjs for the truth.
+const MAX_BUTTON_OPTIONS = 23
+const MAX_SELECT_OPTIONS = 25
+const MAX_SELECT_TOTAL = 100
+const SELECT_LABEL = 100
+const SELECT_DESC = 100
+
+const MODULES = [
+  'agenttoken.mjs', 'attach.mjs', 'bridge.mjs', 'checkouts.mjs', 'commands.mjs',
+  'config.mjs', 'dashboard.mjs', 'deploy.mjs', 'diffdigest.mjs', 'dispatch.mjs',
+  'exec.mjs', 'github.mjs', 'githubapp.mjs', 'health.mjs', 'identity.mjs',
+  'image.mjs', 'images.mjs', 'index.mjs', 'lifecycle.mjs', 'logline.mjs',
+  'messaging.mjs', 'overseerclient.mjs', 'overseercreds.mjs', 'overseerprompt.mjs',
+  'overseerreplay.mjs', 'overseerservice.mjs', 'overseerturn.mjs', 'overseertoken.mjs',
+  'overseerverbs.mjs', 'preview.mjs', 'renderretry.mjs', 'resolve.mjs', 'routing.mjs',
+  'sandbox.mjs', 'settings.mjs', 'statusline.mjs', 'store.mjs', 'threadname.mjs',
+  'timeline.mjs', 'tmux.mjs', 'transcript.mjs', 'usage.mjs', 'workspace.mjs',
+]
+
+// A long option, so the clipping case is real and not described. It rides the
+// 24-option card only.
+const LONG = 'The overseer service holds the shell, so the module that owns this '
+  + 'change is the one that composes its turn, and that module is the one to open '
+  + 'first even though the fault shows up two hops away in the bridge, where the '
+  + 'card is drawn and where the operator reads the failure on a phone with no '
+  + 'other context to hand.'
+
+const COUNTS = [
+  { n: 23, note: 'buttons' },
+  { n: 24, note: 'one long' },
+  { n: 30, note: 'one menu' },
+  { n: 60, note: 'three' },
+  { n: 101, note: 'past it' },
+]
+
+const optionsFor = (n) => {
+  const out = []
+  for (let i = 0; i < n; i++) out.push(MODULES[i % MODULES.length])
+  if (n === 24) out[23] = LONG
+  return out
+}
+
+const esc = (s) => s.replace(/[&<>"]/g, (c) =>
+  ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]))
+
+const head = '<div class="who"><span class="av"></span><b>curia</b>'
+  + '<span class="bot">APP</span></div>'
+const prompt = '<div class="body"><b>[esc-1]</b> <code>curia-431</code> asks (<i>choice</i>):<br>'
+  + 'Which daemon module should the follow-up touch first?</div>'
+
+const numbered = (options) => '<div class="scroller"><ol class="opts">'
+  + options.map((o, i) => `<li><b>${i + 1}.</b> ${esc(o)}</li>`).join('')
+  + '</ol></div>'
+
+const buttonRow = (options) => '<div class="row">'
+  + options.map((o) => `<button class="btn">${esc(o)}</button>`).join('')
+  + '</div>'
+
+const linkRow = '<div class="row"><button class="btn link">🔗 preview</button>'
+  + '<button class="btn link">timeline</button>'
+  + '<button class="btn link">terminal</button></div>'
+
+// The card as main draws it: buttons under the cap, a numbered list over it.
+function drawBefore(options) {
+  if (options.length <= MAX_BUTTON_OPTIONS) {
+    return head + prompt + buttonRow(options) + linkRow
+      + '<p class="taps">One tap. <b>' + options.length + ' buttons.</b></p>'
+  }
+  return head + prompt + numbered(options)
+    + '<p class="hint">Reply in this thread with a number.</p>' + linkRow
+    + '<p class="taps">Scroll the list, hold the number, leave the card, type it, send it. '
+    + '<b>No tap answers this.</b></p>'
+}
+
+// The card as this branch draws it.
+function drawAfter(options) {
+  if (options.length <= MAX_BUTTON_OPTIONS) {
+    return head + prompt + buttonRow(options) + linkRow
+      + '<p class="taps">Unchanged. <b>The menu takes only what the buttons cannot fit.</b></p>'
+  }
+  if (options.length > MAX_SELECT_TOTAL) {
+    return head + prompt + numbered(options)
+      + '<p class="hint">Reply in this thread with a number.</p>' + linkRow
+      + '<p class="taps">Past the menu reach. <b>The list stays, whole.</b></p>'
+  }
+  const clips = options.some((o) => o.length > SELECT_LABEL + SELECT_DESC)
+  let html = head + prompt
+  if (clips) {
+    html += numbered(options)
+      + '<p class="hint">Pick from the menu below, or reply with a number.</p>'
+  } else {
+    html += '<p class="hint">Pick from the menu below.</p>'
+  }
+  for (let start = 0; start < options.length; start += MAX_SELECT_OPTIONS) {
+    const slice = options.slice(start, start + MAX_SELECT_OPTIONS)
+    const label = options.length > MAX_SELECT_OPTIONS
+      ? `Pick one — options ${start + 1}-${start + slice.length}`
+      : 'Pick one'
+    html += `<div class="menu" data-menu><button aria-expanded="false" data-toggle>`
+      + `<span>${esc(label)}</span><span class="caret">▾</span></button><div class="list">`
+      + slice.map((o, i) => {
+        const main = o.slice(0, SELECT_LABEL)
+        let tail = o.slice(SELECT_LABEL)
+        if (tail.length > SELECT_DESC) tail = tail.slice(0, SELECT_DESC - 1) + '…'
+        return `<button data-pick="${esc(o)}">${esc(main)}`
+          + (tail ? `<em>${esc(tail)}</em>` : '') + '</button>'
+      }).join('')
+      + '</div></div>'
+  }
+  html += linkRow
+  html += '<p class="taps">Tap the menu, tap the option. <b>Two taps, no typing.</b></p>'
+  html += '<div class="picked" hidden data-picked></div>'
+  return html
+}
+
+const before = document.getElementById('before')
+const after = document.getElementById('after')
+const picker = document.getElementById('picker')
+
+function render(n) {
+  const options = optionsFor(n)
+  before.innerHTML = drawBefore(options)
+  after.innerHTML = drawAfter(options)
+  for (const b of picker.querySelectorAll('button')) {
+    b.setAttribute('aria-pressed', String(Number(b.dataset.n) === n))
+  }
+}
+
+picker.innerHTML = COUNTS.map((c) =>
+  `<button data-n="${c.n}" aria-pressed="false">${c.n}<small>${c.note}</small></button>`).join('')
+picker.addEventListener('click', (e) => {
+  const b = e.target.closest('button[data-n]')
+  if (b) render(Number(b.dataset.n))
+})
+
+// One tap opens a menu, one tap answers it. No double-click anywhere on this
+// page: the operator reads it on a phone.
+after.addEventListener('click', (e) => {
+  const toggle = e.target.closest('[data-toggle]')
+  if (toggle) {
+    const menu = toggle.closest('[data-menu]')
+    const open = menu.classList.toggle('open')
+    toggle.setAttribute('aria-expanded', String(open))
+    return
+  }
+  const pick = e.target.closest('[data-pick]')
+  if (!pick) return
+  const menu = pick.closest('[data-menu]')
+  menu.classList.remove('open')
+  menu.querySelector('[data-toggle]').setAttribute('aria-expanded', 'false')
+  const out = after.querySelector('[data-picked]')
+  out.hidden = false
+  out.textContent = '✅ answered via select menu: ' + pick.dataset.pick.slice(0, 80)
+})
+
+render(30)
+</script>
+</body>
+</html>


### PR DESCRIPTION
Ticket: alp82/curia#431 — [The select menu, built and judged](https://github.com/alp82/curia/issues/431)

A `choice` card now picks its answer surface in three bands (#431). The operator set both edges in round 1.

| Options | Surface |
|---|---|
| 2-4 | Buttons |
| 5-25 | One select menu |
| 26+ | Numbered list, whole |

- `daemon/src/bridge.mjs`: the bridge builds a `StringSelectMenuBuilder` for the middle band. The button cap drops from 23 to 4. Past 25 options the numbered list and the typed reply stay as they are.
- The numbered list also stays beside the menu when an option runs past what the menu shows (100-char label plus 100-char description). No option ever loses its words.
- A pick answers through the same path a button press takes. The card records `via select menu`. The option value is the index, so repeated option text still answers apart.
- `daemon/test/selectmenu.test.mjs`: 15 tests over the three bands, the clipping, the link row and the pick. Full suite green at 2153.
- `prototypes/select-menu/index.html`: draws today's card and this branch's card side by side at all five edge cases.

The keep or drop verdict is taken on a live card in the ticket thread, after the merge and the deploy. The `deploy` verb only fast-forwards to `origin/main`, so no select menu can reach a thread before this lands.

---

Dispatched by the curia daemon — session `curia-431`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `79bbe59` The operator's bands: buttons to 4, the menu to 25 (#431)
- `cef0ba5` A long choice card answers through a select menu (#431)