### PR TITLE
Auto-dispatch starts a ticket whose worktree survives (alp82/curia#376)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,6 +103,7 @@ The ordered act: claim, prepare, spawn. A failure before the spawn releases the 
 
 **Auto-dispatch**:
 The `dispatch.auto_dispatch` flag. The dispatch tick runs either way, because the liveness sweep rides it. While the flag is true, that same tick also starts takeable tickets, the map lane first, up to `max_concurrent`. It ships false, so the operator's press is the only door from a ticket to an agent.
+A takeable ticket whose worktree still stands is resumed, and never started: `start` recreates the worktree from origin and takes every uncommitted file with it. The path is the evidence, as it is for `resume` and `resume all`. The thread says curia resumed rather than started, and the journal records an `auto_resume`. See [#376](https://github.com/alp82/curia/issues/376).
 It is also the only door a clock could use. curia refuses scheduled tickets for that reason: a schedule that files one is auto-dispatch with a calendar in front of it. The demand behind the idea is a watch, not a clock. A watch states one event at its own instant, where the operator reads it. See [#345](https://github.com/alp82/curia/issues/345).
 _Avoid_: scheduler, cron.
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -5573,6 +5573,28 @@ export class Dispatcher {
       // resume exists to hand back.
       if (this.limitResumes.has(String(num))) continue
       if (await this.deps.hasSession(session)) continue // collision or leftover: skip, never churn
+      // #376: the same rule for the whole class. A takeable ticket with a
+      // worktree still on disk is the work of an agent that ended without
+      // landing it — it died, or the daemon went down under it — and `start`
+      // would delete every uncommitted file in that worktree. So the auto loop
+      // RESUMES it, which is the verb the death notify already promises the
+      // operator, and which inherits the worktree and the last model.
+      //
+      // The path is the evidence, exactly as it is for `resume <n>` and
+      // `resume all`. Nothing else leaves a worktree at a TAKEABLE ticket: a
+      // cancel removes it, a live agent holds a session (skipped above), and an
+      // armed limit resume is stepped over above.
+      if (fs.existsSync(worktreePathFor(this.root, repo, num))) {
+        const reply = await this.resume(num, { repo, by: 'auto' })
+        this.store.logEvent('auto_resume', { repo, ticket: String(num) })
+        // The death notify promised `resume <n>` in this thread. Saying that
+        // curia made that resume itself is what closes the promise — without
+        // it the operator reads an ordinary dispatch line and cannot tell
+        // whether the surviving files were kept or thrown away.
+        this.notify(num, `▶️ a worktree from an earlier agent stands at ${repo}#${num}, so auto-dispatch RESUMED this ticket instead of starting it. Nothing was recreated from origin. ${reply}`)
+        this.log(`[auto] ${reply}`)
+        continue
+      }
       const msg = await this.start(num, { repo, by: 'auto' })
       this.log(`[auto] ${msg}`)
     }

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -1761,6 +1761,72 @@ describe('the limit resume: the window rolls and curia puts the agent back (#346
     assert.ok(!started.includes('42'), 'the armed ticket is the resume\'s, and a start would recreate its worktree')
   })
 
+  // #376: #346 closed ONE instance of this and not the class. A ticket whose
+  // agent died is unclaimed and back on the frontier with its worktree
+  // standing, and it carries no arm — so the auto loop used to `start` it, and
+  // `start` calls createPrivateClone, which deletes that worktree first.
+  describe('and it resumes a surviving worktree rather than starting over one (#376)', () => {
+    test('the uncommitted files of the dead agent stand, and the resumed agent runs in them', async () => {
+      const clones = []
+      const d = makeDispatcher({
+        repoMaps: async () => MAP,
+        mapFrontier: async () => [child(42)],
+        createPrivateClone: async (r, repo, n) => { clones.push(String(n)); return fakePrivateClone(r, repo, n) },
+      })
+      // what the dead agent wrote and never committed
+      const wt = fakePrivateClone(d.root, 'o/r', '42')
+      fs.writeFileSync(path.join(wt, 'work-in-progress.txt'), 'half a day of it')
+      d.config.dispatch.auto_dispatch = true
+      d.config.dispatch.poll_interval_s = 0.05
+
+      d.startAutoLoop()
+      await waitFor(() => d.agents.has('curia-42'))
+      d.stopAutoLoop()
+
+      assert.deepEqual(clones, [], 'createPrivateClone deletes the worktree first, so the auto loop must never reach it')
+      assert.equal(fs.readFileSync(path.join(wt, 'work-in-progress.txt'), 'utf8'), 'half a day of it')
+      assert.equal(d.agents.get('curia-42').wtPath, wt, 'the resumed agent runs in the worktree that survived')
+    })
+
+    test('the thread is told curia resumed, and the journal records it', async () => {
+      const d = makeDispatcher({
+        repoMaps: async () => MAP,
+        mapFrontier: async () => [child(42)],
+      })
+      fakePrivateClone(d.root, 'o/r', '42')
+      d.config.dispatch.auto_dispatch = true
+      d.config.dispatch.poll_interval_s = 0.05
+
+      d.startAutoLoop()
+      await waitFor(() => events.some((e) => e.type === 'auto_resume'))
+      d.stopAutoLoop()
+
+      const said = notifies.find((n) => String(n.ticket) === '42' && /RESUMED/.test(n.message))
+      assert.ok(said, 'the death notify promised `resume 42` in this thread — curia says it made that resume itself')
+      assert.match(said.message, /Nothing was recreated from origin/)
+      const rec = events.find((e) => e.type === 'auto_resume')
+      assert.equal(String(rec.ticket), '42')
+      assert.equal(rec.repo, 'o/r')
+    })
+
+    test('a takeable ticket with no worktree is still started', async () => {
+      const clones = []
+      const d = makeDispatcher({
+        repoMaps: async () => MAP,
+        mapFrontier: async () => [child(43)],
+        createPrivateClone: async (r, repo, n) => { clones.push(String(n)); return fakePrivateClone(r, repo, n) },
+      })
+      d.config.dispatch.auto_dispatch = true
+      d.config.dispatch.poll_interval_s = 0.05
+
+      d.startAutoLoop()
+      await waitFor(() => clones.includes('43'))
+      d.stopAutoLoop()
+
+      assert.equal(events.some((e) => e.type === 'auto_resume'), false, 'no worktree stood, so nothing was resumed')
+    })
+  })
+
   // #362: `poll_interval_s` is the one reloadable setting the daemon CAPTURES —
   // it lives in the interval this arms. So a reload re-arms the loop, and the
   // old timer has to die with it: two timers on one dispatcher would tick twice


### PR DESCRIPTION
Ticket: alp82/curia#376 — [Auto-dispatch starts a ticket whose worktree survives](https://github.com/alp82/curia/issues/376)

Auto-dispatch now resumes a ticket whose worktree still stands, instead of starting it.

`#autoTick` dispatched every takeable frontier ticket with `start`. `start` calls `createPrivateClone`, which deletes the worktree at that path before it clones. So an auto dispatch of a ticket whose agent died threw away every uncommitted file that agent wrote. #346 guarded only the armed limit resume, and a dead agent leaves no arm.

The loop now checks `worktreePathFor`. A worktree that stands is resumed, which inherits it and the last model. The path is the evidence, exactly as it is for `resume <n>` and `resume all`. The thread says curia resumed rather than started, and the journal records an `auto_resume` event.

Three tests in `daemon/test/dispatch.test.mjs`: the uncommitted files stand and the resumed agent runs in them, the thread and journal say so, and a ticket with no worktree is still started. The full daemon suite is green (2132 pass, 0 fail).

---

Dispatched by the curia daemon — session `curia-376`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `2f5f7bb` Auto-dispatch resumes a surviving worktree (#376)