### PR TITLE
The token expiry warning reaches the operator, not the log (alp82/curia#380)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,6 +193,11 @@ _Avoid_: OAuth app.
 What the daemon mints from the app key, one per resource owner and per role. Two roles: read-write for agents, read-only for the overseer. A minted token scopes down from what the installation grants, which is what lets one key hold both. It lives one hour, so a holder reads a file the daemon rewrites and never an environment variable frozen at spawn.
 _Avoid_: app token (that name is the JWT the daemon signs, and a JWT mints installation tokens rather than reaching a repo).
 
+**Credential watch**:
+What tells the operator a GitHub token is dying, in time to mint a new one. The daemon probes every watched repo with the token that repo is read with, once at boot, once at every watch reload, and every six hours after that. It measures two facts and says both where the operator reads. The first is reach: a token that answers 404, 403 or 401 on a watched repo. The second is expiry, on a ladder of 14 days, 7, 3, 1 and expired. Each step is said once, in `#curia`, and it also stands on the dashboard Needs-you list until the reading clears. A step already said is never repeated, so a deploy is silent, and a line that did not reach Discord is re-said at the next pass and at bridge start. The expiry is keyed on the token and the reach on the token and the repo together, because one token covers every repo of an owner. It files no ticket and dispatches nothing, which is what keeps [#345](https://github.com/alp82/curia/issues/345)'s refusal of a scheduler intact. Lives in `daemon/src/tokenwatch.mjs`. See [#380](https://github.com/alp82/curia/issues/380).
+_Avoid_: token alarm, expiry cron.
+The expiry half is a PAT-only fact and it dies holder by holder as [ADR-0018](docs/adr/0018-the-daemon-is-a-github-app.md) cuts over: an installation token lives one hour and the daemon refreshes it, so its expiry is nothing the operator can act on and curia must never warn about one. The reach half survives for every holder and for the installation itself.
+
 **The verbs**:
 `tickets`, `next`, `status`, `start`, `map`, `cancel`, `resume`, `attach`, `review`. The whole command surface, identical over Discord and REST. Each verb has one meaning. `start` works a thing, and `map` updates a map.
 _Avoid_: the five verbs (the pre-#81 count, wrong since `next`, `resume` and `review` joined).
@@ -476,7 +481,7 @@ Open escalations shown on the timeline from the daemon's record, because a trans
 The timeline's refusal to send text while a native terminal dialog holds the pane.
 
 **Overview**:
-The daemon's one loopback read of itself, `GET /overview`. It joins every section the dashboard draws. These are the live agents with their context meters and their last contact, the open escalations, the review gate, bridge health, the usage windows, the journal tail, the frontier snapshot, and the six reloadable settings the daemon is running with the instant it read them. The sidecar polls it, and holds no secret, no GitHub token and no journal handle. Each section is nullable on its own, so an unreadable one costs the page nothing else.
+The daemon's one loopback read of itself, `GET /overview`. It joins every section the dashboard draws. These are the live agents with their context meters and their last contact, the open escalations, the review gate, bridge health, the usage windows, the standing credential warnings, the journal tail, the frontier snapshot, and the six reloadable settings the daemon is running with the instant it read them. The sidecar polls it, and holds no secret, no GitHub token and no journal handle. Each section is nullable on its own, so an unreadable one costs the page nothing else.
 
 **Dashboard**:
 The browser console for the box, on loopback `4273` and Serve `8445`. It draws the overview behind the same identity check every other surface uses.

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -157,6 +157,9 @@
   .att-item .opts { margin-top: 5px; font-size: 12.5px; color: var(--ink-dim); }
   .att-item.gate { border-left-color: var(--accent); background: var(--chip-ok-bg); }
   .att-item.limit { border-left-color: var(--bad); background: var(--chip-bad-bg); }
+  /* A credential that is dying reads as bad, not as a warning: nothing on this
+     page fixes it, and an agent meets it as a failed first `gh` call (#380). */
+  .att-item.token { border-left-color: var(--bad); background: var(--chip-bad-bg); }
 
   .prov-strip { display: flex; gap: 26px; flex-wrap: wrap; align-items: center; margin-top: 14px; font-size: 12px; color: var(--ink-dim); }
   .prov { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
@@ -453,9 +456,16 @@ function ticketName(repo, ticket) {
 /* How many things want the operator. The nav badge, the tab title and the tile
    read one function, so they can never disagree. Usage limits are NOT counted:
    a spent window is on the attention list because it explains a slow box, but
-   nobody can answer it. */
+   nobody can answer it.
+
+   A credential warning IS counted (#380). The test is whether an operator act
+   ends it, which is exactly what separates it from a spent window: a window
+   rolls on its own clock, and a token that nobody mints stays dead and takes
+   every agent's first `gh` call with it. So the badge stays hot until the act
+   happens, which is the whole point of moving this off a log line. */
 function needsYou(o) {
-  return (o?.escalations?.length ?? 0) + (o?.review_gate?.length ?? 0);
+  return (o?.escalations?.length ?? 0) + (o?.review_gate?.length ?? 0)
+    + (o?.token_warnings?.length ?? 0);
 }
 
 /* ---- the operator verbs (#266) ----------------------------------------------
@@ -1027,10 +1037,29 @@ function gateCard(r) {
     ${said("esc:" + r.id)}</div>`;
 }
 
+/* A credential warning (#380). It sits above the spent windows because it is
+   the only item on this list nobody else will fix: a window rolls by itself,
+   and a token does not. The words are the daemon's own measurement — the days,
+   the instant and the act — so this composes no second account of them. */
+function tokenCard(w) {
+  const head = w.fault === "unreachable"
+    ? `cannot reach ${esc(w.repo)} — ${esc(w.message)}`
+    : (w.days <= 0
+      ? "has expired"
+      : `expires in ${esc(w.days)} day${w.days === 1 ? "" : "s"}`);
+  const act = w.fault === "unreachable"
+    ? `add ${esc(w.repo)} to the token on GitHub, or mint a new one into ${esc(w.where)}`
+    : `mint a new token into ${esc(w.where)}`;
+  return `<div class="att-item token">
+    <span class="who">${esc(w.key)}</span>${head}
+    <div class="dim">${esc(w.refusal)} — ${act}</div></div>`;
+}
+
 function attentionList(o) {
   const items = [
     ...(o.escalations ?? []).map(escCard),
     ...(o.review_gate ?? []).map(gateCard),
+    ...(o.token_warnings ?? []).map(tokenCard),
     ...spentWindows(o.usage).map((w) => `<div class="att-item limit">
       <span class="who">${esc(w.provider)}</span>the ${esc(w.label)} window is spent at ${esc(w.pct)}%
       <div class="dim">${w.at ? `it rolls at ${esc(clock(w.at))}` : "no reset instant is stated"}</div></div>`),
@@ -1099,6 +1128,14 @@ const EVENTS = {
   deploy_requested: ["deploy", "", (e) => `deploy ordered by ${esc(e.by)}`],
   deploy_landed: ["deploy", "", (e) => `deploy landed${e.next ? ` at ${esc(String(e.next).slice(0, 7))}` : ""}`],
   deploy_rolled_back: ["deploy", "bad", (e) => `deploy rolled back — ${esc(e.reason ?? "the health check failed")}`],
+  /* The credential watch (#380). The feed says what curia measured; the
+     Needs-you item beside it says the condition still stands. */
+  token_warned: ["credential", "bad", (e) => (e.fault === "unreachable"
+    ? `${esc(e.key)} cannot reach ${esc(e.repo)} — ${esc(e.message)}`
+    : `${esc(e.key)} ${e.days <= 0 ? "has expired" : `expires in ${esc(e.days)} day(s)`}`)],
+  token_cleared: ["credential", "", (e) => (e.fault === "unreachable"
+    ? `${esc(e.key)} reaches ${esc(e.repo)} again`
+    : `${esc(e.key)} is renewed`)],
   bridge_wedged: ["bridge", "bad", (e) => `the Discord bridge is wedged`],
   bridge_recovered: ["bridge", "", (e) => `the Discord bridge is back`],
   bridge_health: ["bridge", "", (e) => `bridge ${esc(e.previous)} → ${esc(e.state)} — ${esc(e.reason)}`],

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -53,6 +53,7 @@ import {
 } from './overseertoken.mjs'
 import { TOKEN_HEADER, AGENT_ROUTES, tokensDir, agentTokenMatches } from './agenttoken.mjs'
 import { probeRepoToken, tokenExpiryDays, viewerLogin, ghJSONL } from './github.mjs'
+import { TokenWatch, TOKEN_EXPIRY_WARN_DAYS } from './tokenwatch.mjs'
 import {
   probeTtyd, assertServe, serveOff, attachBase, attachSessionUrl, validSessionName,
   isConsoleKey, consoleKeyForSession, sessionForConsoleKey,
@@ -173,33 +174,73 @@ log(overseerEnv.CLAUDE_CODE_OAUTH_TOKEN || overseerEnv.ANTHROPIC_API_KEY
 // One pass per holder. The overseer's token is the one whose expiry is a
 // certainty rather than a risk — an org caps its lifetime — so the same warning
 // has to speak for both.
-const TOKEN_EXPIRY_WARN_DAYS = 14
-function probeWatchedTokens({ holder, tokenFor, keyFor, refusal }) {
-  Promise.all(curiaConfig.watch.map(async ({ repo }) => {
+//
+// #380 moved the JUDGEMENT out of here. This function now only measures, and
+// hands every answer to the credential watch, which decides what the operator
+// is told and where. The log lines stay, because the boot output is the one
+// place an operator reads a healthy credential — but a log line is no longer
+// the whole of what a dying one gets.
+const HOLDERS = [
+  {
+    holder: 'agent',
+    tokenFor: (repo) => agentGhToken(repo),
+    keyFor: ghTokenKeyFor,
+    refusal: 'an agent on it will fail at its first gh call',
+    where: 'daemon/.env.daemon',
+  },
+  {
+    holder: 'overseer',
+    tokenFor: (repo) => overseerGhToken(repo, overseerEnv),
+    keyFor: overseerTokenKeyFor,
+    refusal: 'the overseer cannot read it',
+    where: `daemon/${OVERSEER_ENV_FILE}`,
+  },
+]
+
+async function probeWatchedTokens({ holder, tokenFor, keyFor, refusal, where }) {
+  const answers = await Promise.all(curiaConfig.watch.map(async ({ repo }) => {
     const token = tokenFor(repo)
-    if (!token) return
+    if (!token) return null
     const key = keyFor(repo)
+    const at = { holder, key, repo, where, refusal }
     try {
       const { ok, message, expiresAt } = await probeRepoToken(repo, token)
       if (!ok) {
         log(`WARNING: ${key} cannot reach ${repo} (${message}) — ${refusal}`)
-        return
+        return { ...at, ok: false, message }
       }
       const days = tokenExpiryDays(expiresAt)
-      if (days === null) return
-      if (days <= TOKEN_EXPIRY_WARN_DAYS) log(`WARNING: ${key} expires in ${days} day(s), on ${expiresAt} — mint a new one before it dies`)
+      if (days === null) log(`${key} reaches ${repo}, and does not expire`)
+      else if (days <= TOKEN_EXPIRY_WARN_DAYS) log(`WARNING: ${key} expires in ${days} day(s), on ${expiresAt} — mint a new one before it dies`)
       else log(`${key} reaches ${repo}, expires in ${days} days`)
+      return { ...at, ok: true, expiresAt }
     } catch (e) {
-      // A network failure is a fact about the network, not about the token.
+      // A network failure is a fact about the network, not about the token. It
+      // is not silence either: `unmeasured` is what stops the watch reading it
+      // as a credential that came good (#380).
       log(`could not check the ${holder} token for ${repo} (${e.message}) — not treating that as a bad token`)
+      return { ...at, unmeasured: true }
     }
-  })).catch(() => {})
+  }))
+  return answers.filter(Boolean)
 }
+
+// Every reading one pass takes, across both holders. The watch calls this and
+// nothing else does.
+async function probeWatchedCredentials() {
+  const perHolder = await Promise.all(HOLDERS.map((h) => probeWatchedTokens(h)))
+  return perHolder.flat()
+}
+
 // Everything the boot says about the credentials behind the WATCH LIST, in one
 // function, because a reload runs it again (#362). A repo added from the
 // settings screen gets the same per-owner warning and the same GitHub probe a
 // booted one gets — without this, a live add looks watched and the failure
 // arrives as a 401 in the middle of the first agent's first `gh` call.
+//
+// The probe is still detached from the boot chain on purpose: it is one network
+// round-trip per repo per holder, and GitHub being slow or down must never hold
+// up a daemon whose other duties do not need it.
 function checkWatchedCredentials() {
   WATCHED_OWNERS = new Set(curiaConfig.watch.map((w) => w.repo.split('/')[0]))
   for (const owner of WATCHED_OWNERS) {
@@ -208,20 +249,8 @@ function checkWatchedCredentials() {
     const overseerKey = overseerTokenKeyFor(owner)
     if (!overseerGhToken(`${owner}/x`, overseerEnv)) log(`WARNING: no ${overseerKey} — the overseer holds no credential for ${owner}/*`)
   }
-  probeWatchedTokens({
-    holder: 'agent',
-    tokenFor: (repo) => agentGhToken(repo),
-    keyFor: ghTokenKeyFor,
-    refusal: 'an agent on it will fail at its first gh call',
-  })
-  probeWatchedTokens({
-    holder: 'overseer',
-    tokenFor: (repo) => overseerGhToken(repo, overseerEnv),
-    keyFor: overseerTokenKeyFor,
-    refusal: 'the overseer cannot read it',
-  })
+  tokenWatch.pass().catch((e) => log(`the credential watch failed (${e.message})`))
 }
-checkWatchedCredentials()
 
 // #352, building ADR-0018: the GitHub App that replaces every token above. It
 // SWAPS NO HOLDER YET — each one cuts over on its own ticket, and no PAT comes
@@ -307,6 +336,25 @@ const pending = new Map() // escalation id -> resolve(answerText) — ephemeral,
 const renderRetries = new Map() // escalation id -> timeout handles — ephemeral, rebuilt on boot
 
 let bridge = null
+
+// The credential watch (#380). It lives here rather than beside the probe
+// because it needs both the store, which remembers what was already said, and
+// the bridge, which is where the operator reads. A warning that reaches neither
+// is the log line this ticket exists to replace.
+//
+// `bridge` is read per call rather than captured: it is null at boot, it is
+// replaced whole by the wedge watchdog (#56), and a watch holding the dead
+// instance would announce into nothing for the rest of the process.
+const tokenWatch = new TokenWatch({
+  probe: () => probeWatchedCredentials(),
+  entries: () => store.standingTokenWarnings(),
+  entryFor: (key) => store.tokenWarning(key),
+  journal: (type, detail) => store.logEvent(type, detail),
+  announce: (text) => (bridge ? bridge.announce(text).then(() => true) : false),
+  log: (line) => log(line),
+})
+tokenWatch.start()
+checkWatchedCredentials()
 
 // #190: one control character anywhere in a message makes journalctl print
 // `[NNNB blob data]` and drop the words, so the streamed `docker build` output
@@ -1663,6 +1711,11 @@ async function overview() {
     bridge: health?.state ?? 'down',
     bridge_health: health ?? { state: 'down', since: null, unhealthy_for_s: 0, last_error: null },
     usage: providerUsage(),
+    // The credential warnings still standing (#380). Discord states each one
+    // once, at its instant, and this is where it STAYS until the operator mints
+    // the token — the half a Discord line cannot do, because a message scrolls
+    // away and a dying token does not.
+    token_warnings: store.standingTokenWarnings(),
     events: store.recentEvents(),
     frontier: dispatcher.frontierSnapshot(),
   }
@@ -2299,6 +2352,11 @@ if (process.env.DISCORD_BOT_TOKEN) {
           if (!r.discord) renderEscalation(r)
         }
         announceStart(b)
+        // #380 rule 4: a credential warning measured while there was no bridge
+        // is not said yet. Nothing is re-probed — the reduction already holds
+        // every reading this process took, so a bridge that flaps costs GitHub
+        // nothing. Never fails a start.
+        tokenWatch.flush().catch((e) => log(`the held credential warnings did not land: ${e.message}`))
         // #257: a ✅ the last process owed but never sent. Never fails a start.
         b.settleEndedThreads().catch((e) => log(`settling ended thread names failed: ${e.message}`))
       }).catch((e) => {

--- a/daemon/src/store.mjs
+++ b/daemon/src/store.mjs
@@ -161,6 +161,7 @@ export class EscalationStore {
     this.pullRequests = new Map() // agent session -> the pull request its CURRENT dispatch pushed (#289)
     this.limitResumes = new Map() // ticket -> the limit resume curia still owes it (#346)
     this.coolings = { models: new Map(), providers: new Map() } // the caps that have LANDED, key -> reset instant (#377)
+    this.tokenWarnings = new Map() // credential key -> the last warning curia said about it (#380)
     this.pendingTurns = new Map() // conversation key -> the overseer turn still in flight (#388)
     this.droppedTurns = new Map() // conversation key -> the last turn a restart killed (#388)
     this.turnStarts = new Map() // conversation key -> when its last turn started (#388)
@@ -278,6 +279,24 @@ export class EscalationStore {
     }
     if (ev.type === 'provider_cooling' && ev.provider && ev.reset_at) {
       this.coolings.providers.set(ev.provider, ev.reset_at)
+    }
+
+    // The credential warnings still standing (#380). A reduction for the two
+    // reasons the coolings above are one: the ladder must not re-say at every
+    // boot what it already said, and the dashboard's Needs-you item has to
+    // survive the deploy that happens between the warning and the operator
+    // acting on it. The write path adds nothing for this — `token_warned` and
+    // `token_cleared` are the events the watch already states.
+    //
+    // The key is composed here rather than carried, so one rule decides it: an
+    // expiry belongs to the TOKEN and a reach failure to the token and the repo
+    // together (ADR-0013, and see tokenwatch.mjs rule 3).
+    if (ev.type === 'token_warned' || ev.type === 'token_cleared') {
+      const key = ev.fault === 'expiring'
+        ? `${ev.holder}:${ev.key}`
+        : `${ev.holder}:${ev.key}:${ev.repo}`
+      if (ev.type === 'token_cleared') this.tokenWarnings.delete(key)
+      else this.tokenWarnings.set(key, { ...ev, at: ev.ts ?? null })
     }
 
     switch (ev.type) {
@@ -1073,6 +1092,20 @@ export class EscalationStore {
   // capped per kind. A copy, for the reason `recentEvents` hands out one.
   recentOutcomes() {
     return [...this.outcomes.cancelled, ...this.outcomes.finished, ...this.outcomes.died]
+  }
+
+  // Every credential warning still standing, oldest first (#380). A copy, for
+  // the reason `recentEvents` hands out one: the route serializes it while the
+  // watch keeps appending.
+  standingTokenWarnings() {
+    return [...this.tokenWarnings.values()].map((w) => ({ ...w }))
+  }
+
+  // The last warning curia said about one credential key, or null. The ladder
+  // reads this to decide whether a reading is news.
+  tokenWarning(key) {
+    const w = this.tokenWarnings.get(key)
+    return w ? { ...w } : null
   }
 
   // The pull request an agent's CURRENT dispatch pushed, or null (#289). This

--- a/daemon/src/tokenwatch.mjs
+++ b/daemon/src/tokenwatch.mjs
@@ -1,0 +1,272 @@
+// The credential watch (#380).
+//
+// The daemon has probed every watched repo's GitHub token since #155, and it
+// learned two things per repo: whether the token reaches it, and how many days
+// are left on the token. Both went to `log()`, at boot, where nobody reads
+// them. A token that dies takes every agent's first `gh` call with it, so the
+// one fact the operator must act on was the one written where they never look.
+//
+// #345 refused a scheduler and named this need a WATCH rather than a clock:
+// one event, at its own instant, stated where the operator reads. That is what
+// this file is. It files no ticket and it dispatches nothing, so the refusal
+// stands — it is a daemon-internal timer beside the Serve assert and the
+// render retry.
+//
+// Four rules settle it, and each one keeps a wrong answer out.
+//
+//   1. TWO SURFACES, ONE MEASUREMENT. A plain line in #curia states the event
+//      at its instant, and the dashboard's Needs-you list holds the standing
+//      item until the reading clears. One journal event feeds both, so Discord
+//      and the console can never state different numbers. An escalation record
+//      was put up and turned down: an escalation has an agent and an answer,
+//      and this has neither.
+//
+//   2. A STEP LADDER, NOT A REPEAT. The line is said once at each step the
+//      reading crosses — 14 days, 7, 3, 1, and expired. The journal remembers
+//      what was already said, so a deploy repeats nothing and a restart
+//      inherits the ladder. Without this the warning would be re-said on every
+//      boot, which is how a warning teaches its reader to skip it.
+//
+//   3. THE EXPIRY KEYS ON THE TOKEN, THE REACH KEYS ON THE REPO. One token
+//      covers every repo of an owner, so an expiry warned per repo would say
+//      one fact as many times as the watch list is long (ADR-0013). Reach is
+//      the other way round: the same token reads one repo and fails another,
+//      because the repository list lives on GitHub.
+//
+//   4. A LINE THAT DID NOT REACH DISCORD IS NOT SAID. The boot probe can run
+//      before the bridge is up, and the bridge can be down for hours. So the
+//      event carries `said`, and an unsaid reading is re-announced by the next
+//      pass and by `flush()` at bridge start. The journal still holds it, so
+//      the console shows it either way.
+//
+// What this does NOT survive is stated rather than hidden. The expiry half is a
+// PAT-only fact and it dies holder by holder as #389, #390 and #392 cut over to
+// the GitHub App (#338, ADR-0018): a minted installation token lives one hour
+// and the daemon refreshes it, so its expiry is nothing an operator can act on
+// and curia must never warn about one. No branch in the code says so, because
+// after a cutover the probe finds no PAT to read. The REACH half survives for
+// every holder and for the installation itself — a repo watched but left off
+// the installation answers 404 exactly as a PAT missing it does.
+
+import { tokenExpiryDays } from './github.mjs'
+
+// The ladder. Descending, and 0 is the expired step rather than a day count.
+// Kept as a list because the rule is "the tightest step the reading has
+// crossed", and a list states that where four comparisons would hide it.
+export const TOKEN_STEPS = [14, 7, 3, 1, 0]
+
+// The widest step is also the threshold: a reading above it is healthy and
+// says nothing. One name for one thing — the old `TOKEN_EXPIRY_WARN_DAYS` in
+// index.mjs was this number.
+export const TOKEN_EXPIRY_WARN_DAYS = TOKEN_STEPS[0]
+
+// Six hours, so a one-day step gets four chances to be seen rather than one.
+// One HTTP request per repo per holder, which is what makes this cheap enough
+// to state as an interval instead of arming a timer per instant. Arming the
+// next step instant was put up and turned down: it cannot see a token revoked
+// by hand, and a revoked token is the failure that arrives with no warning at
+// all.
+export const PROBE_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+// The tightest step a day count has crossed, or null when the reading is
+// healthy. `days` is already floored by `tokenExpiryDays`, and a token with no
+// expiry at all reads null there and never reaches this.
+export function expiryStep(days) {
+  if (days === null || days === undefined) return null
+  // The steps descend, so the last one the reading is still inside is the
+  // tightest one it has crossed.
+  let crossed = null
+  for (const step of TOKEN_STEPS) {
+    if (days > step) break
+    crossed = step
+  }
+  return crossed
+}
+
+// Rule 3. The expiry is a property of the TOKEN and the reach is a property of
+// the pair, so they cannot share a key.
+export function warningKey({ fault, holder, key, repo }) {
+  return fault === 'expiring' ? `${holder}:${key}` : `${holder}:${key}:${repo}`
+}
+
+// Rule 2 and rule 4, in one predicate. `entry` is the last `token_warned` this
+// key has, out of the store's reduction, or null.
+export function shouldSay(entry, reading) {
+  if (!entry) return true
+  if (!entry.said) return true // rule 4: it was measured, not said
+  if (entry.fault !== reading.fault) return true
+  if (reading.fault === 'expiring') return reading.step < entry.step
+  return entry.message !== reading.message
+}
+
+// One probe answer becomes one reading, or null when the credential is well.
+// The caller hands over what `probeRepoToken` returned plus who holds it.
+//
+// `unmeasured` is the third answer and it is not a fault: GitHub being slow or
+// down says nothing about the token. It reads as null here, so nothing is said
+// — and `keysOf` below is what stops it being read as good news either.
+export function readingOf({ holder, key, repo, where, refusal, ok, unmeasured, message, expiresAt }) {
+  if (unmeasured) return null
+  if (!ok) {
+    return { fault: 'unreachable', holder, key, repo, where, refusal, message: message ?? 'HTTP error' }
+  }
+  const days = tokenExpiryDays(expiresAt)
+  const step = expiryStep(days)
+  if (step === null) return null
+  return { fault: 'expiring', holder, key, repo, where, refusal, days, expires_at: expiresAt ?? null, step }
+}
+
+// Rule 3 again, at the point it bites: the probe answers once per repo, and a
+// token that covers four repos would otherwise carry four identical expiry
+// readings into the pass. The FIRST one per token wins, because they are the
+// same measurement of the same token.
+export function dedupe(readings) {
+  const seen = new Set()
+  const out = []
+  for (const r of readings) {
+    if (!r) continue
+    const k = warningKey(r)
+    if (seen.has(k)) continue
+    seen.add(k)
+    out.push(r)
+  }
+  return out
+}
+
+// Both keys one probe answer could ever hold, whatever it measured. A pass
+// clears a standing warning by NOT re-measuring it, so an answer that measured
+// nothing must still protect its own keys — otherwise one slow GitHub call
+// posts a ✅ for a token that is still dying.
+export function keysOf({ holder, key, repo }) {
+  return [`${holder}:${key}`, `${holder}:${key}:${repo}`]
+}
+
+// An instant a phone can read, as a DATE rather than a clock time: an expiry is
+// days away, so `discordTime`'s time-of-day form would state the least useful
+// half of it. `:R` beside it answers the question the operator actually has.
+export function expiryInstant(raw) {
+  const t = Date.parse(String(raw ?? '').replace(' UTC', 'Z').replace(' ', 'T'))
+  if (Number.isNaN(t)) return null
+  const s = Math.floor(t / 1000)
+  return `<t:${s}:D> (<t:${s}:R>)`
+}
+
+// ---- the lines --------------------------------------------------------------
+//
+// CuriaBot's own voice: these state mechanics, which is the half ADR-0013 gives
+// the bot. Every one of them names the act that ends it, because a warning the
+// reader cannot act on is a log line with an emoji on it.
+
+export function warningLine(r) {
+  if (r.fault === 'unreachable') {
+    return `${'⚠️'} \`${r.key}\` cannot reach ${r.repo} (${r.message}). ${r.refusal}. The repository list lives on GitHub, so add ${r.repo} to the token there, or mint a new one into \`${r.where}\`.`
+  }
+  const when = expiryInstant(r.expires_at)
+  const head = r.days <= 0
+    ? `\`${r.key}\` has EXPIRED${when ? `, on ${when}` : ''}.`
+    : `\`${r.key}\` expires in ${r.days} day${r.days === 1 ? '' : 's'}${when ? `, on ${when}` : ''}.`
+  return `${'⚠️'} ${head} ${r.refusal}. Mint a new token and put it in \`${r.where}\`.`
+}
+
+export function clearedLine(entry) {
+  if (entry.fault === 'unreachable') return `${'✅'} \`${entry.key}\` reaches ${entry.repo} again.`
+  return `${'✅'} \`${entry.key}\` is renewed. It is more than ${TOKEN_EXPIRY_WARN_DAYS} days from expiry.`
+}
+
+// ---- the watch --------------------------------------------------------------
+
+export class TokenWatch {
+  // `probe` returns every reading this pass measured, one per repo per holder,
+  // in the shape `readingOf` takes. `entries` and `entryFor` read the store's
+  // reduction. `announce` resolves true when the words reached Discord.
+  constructor({ probe, entries, entryFor, journal, announce, log = () => {}, intervalMs = PROBE_INTERVAL_MS }) {
+    this.probe = probe
+    this.entries = entries
+    this.entryFor = entryFor
+    this.journal = journal
+    this.announce = announce
+    this.log = log
+    this.intervalMs = intervalMs
+    this.timer = null
+  }
+
+  // One measurement, and whatever it makes curia say. It never throws: a
+  // network failure is a fact about the network rather than about the token,
+  // which is the rule the boot probe has held since #155.
+  async pass() {
+    let answers
+    try {
+      answers = await this.probe()
+    } catch (e) {
+      this.log(`the credential watch could not probe (${e.message}) — not treating that as a bad token`)
+      return
+    }
+    const readings = dedupe(answers.map((a) => readingOf(a)).filter(Boolean))
+    const standing = new Set(readings.map((r) => warningKey(r)))
+    // An answer curia could not take says nothing in either direction, so its
+    // keys stand exactly as they were.
+    for (const a of answers) {
+      if (!a.unmeasured) continue
+      for (const k of keysOf(a)) standing.add(k)
+    }
+
+    // The clear comes FIRST, so an operator who minted a token overnight reads
+    // the ✅ above whatever else this pass says. It is journalled whether or not
+    // the words landed: the console must not keep showing a warning curia has
+    // measured away, and a lost ✅ costs nothing a warning does not.
+    for (const entry of this.entries()) {
+      if (standing.has(warningKey(entry))) continue
+      await this.#say(clearedLine(entry))
+      this.journal('token_cleared', {
+        holder: entry.holder, key: entry.key, repo: entry.repo, fault: entry.fault,
+      })
+    }
+
+    for (const r of readings) {
+      const entry = this.entryFor(warningKey(r))
+      if (!shouldSay(entry, r)) continue
+      const said = await this.#say(warningLine(r))
+      this.journal('token_warned', { ...r, said })
+    }
+  }
+
+  // Rule 4, without a second measurement: the bridge has just come up, and the
+  // reduction already holds every reading this process took. Nothing is
+  // re-probed, so a bridge that flaps costs GitHub nothing.
+  async flush() {
+    for (const entry of this.entries()) {
+      if (entry.said) continue
+      const said = await this.#say(warningLine(entry))
+      if (said) this.journal('token_warned', { ...entry, said: true })
+    }
+  }
+
+  start() {
+    this.stop()
+    this.timer = setInterval(() => { this.pass().catch(() => {}) }, this.intervalMs)
+    this.timer.unref?.()
+    return this.timer
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer)
+    this.timer = null
+  }
+
+  // The one place `said` is decided. A missing bridge and a failing send are
+  // the same answer to the ladder: the operator did not read it.
+  //
+  // A landed line is NOT logged. The probe writes its own plain line for every
+  // reading it takes, and this text carries Discord markup, so logging it would
+  // put the same fact in the boot output twice and in two vocabularies.
+  async #say(text) {
+    try {
+      const res = await this.announce(text)
+      if (res === false) this.log('a credential warning could not be said — there is no bridge yet, so it stands until there is')
+      return res !== false
+    } catch (e) {
+      this.log(`the credential warning did not reach Discord (${e.message}) — it stands until it does`)
+      return false
+    }
+  }
+}

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -125,6 +125,9 @@ const OVERVIEW = () => ({
       { label: '5h', pct: 97, elapsed_pct: 48, resets_at: ahead(30), fresh: true },
     ] },
   ],
+  // The credential warnings still standing (#380). The ordinary state is none:
+  // the tests that want one say so.
+  token_warnings: [],
   events: [
     { ts: at(600), type: 'agent_spawned', agent: 'curia-255', repo: 'alp82/curia', ticket: '255', model: 'gpt-5.6-sol', harness: 'codex' },
     { ts: at(400), type: 'esc_open', id: 'esc-7', agent: 'curia-255', ticket: '255', kind: 'choice', prompt: 'Two notes race the same expiry line.' },
@@ -199,6 +202,59 @@ describe('the read screens (#264)', () => {
       const t = text(page.screenHome(payload()))
       assert.match(t, /openai the 5h window is spent at 97%/)
       assert.match(t, /it rolls at \d\d:\d\d/)
+    })
+
+    // The credential watch (#380). The warning used to be a boot log line, so
+    // what these pin is that it now reaches a surface the operator reads and
+    // STAYS there: a Discord line scrolls away, and a dying token does not.
+    test('a dying token joins the attention list, with the act that ends it', () => {
+      const t = text(page.screenHome(payload({
+        token_warnings: [{
+          holder: 'agent', key: 'GH_TOKEN_ALP82', repo: 'alp82/curia', fault: 'expiring',
+          days: 3, expires_at: '2026-08-19 06:20:31 UTC', step: 3, said: true,
+          where: 'daemon/.env.daemon', refusal: 'an agent on it will fail at its first gh call',
+        }],
+      })))
+      assert.match(t, /GH_TOKEN_ALP82 expires in 3 days/)
+      assert.match(t, /an agent on it will fail at its first gh call/)
+      assert.match(t, /mint a new token into daemon\/\.env\.daemon/)
+    })
+
+    test('a token that cannot reach a repo names the repo and GitHub\'s own words', () => {
+      const t = text(page.screenHome(payload({
+        token_warnings: [{
+          holder: 'overseer', key: 'OVERSEER_GH_TOKEN_ALP82', repo: 'alp82/aistack', fault: 'unreachable',
+          message: 'HTTP 404: Not Found', said: true,
+          where: 'daemon/.env.overseer', refusal: 'the overseer cannot read it',
+        }],
+      })))
+      assert.match(t, /OVERSEER_GH_TOKEN_ALP82 cannot reach alp82\/aistack — HTTP 404: Not Found/)
+      assert.match(t, /add alp82\/aistack to the token on GitHub/)
+    })
+
+    test('an expired token says it is dead rather than counting past zero', () => {
+      const t = text(page.screenHome(payload({
+        token_warnings: [{
+          holder: 'agent', key: 'GH_TOKEN_ALP82', repo: 'alp82/curia', fault: 'expiring',
+          days: -2, expires_at: '2026-08-14 06:20:31 UTC', step: 0, said: true,
+          where: 'daemon/.env.daemon', refusal: 'an agent on it will fail at its first gh call',
+        }],
+      })))
+      assert.match(t, /GH_TOKEN_ALP82 has expired/)
+      assert.doesNotMatch(t, /expires in -/)
+    })
+
+    test('a credential warning IS counted, because an operator act is what ends it', () => {
+      // The rule that separates it from a spent window, which the count skips:
+      // a window rolls on its own clock, and a token nobody mints stays dead.
+      const one = payload({
+        token_warnings: [{
+          holder: 'agent', key: 'GH_TOKEN_ALP82', repo: 'alp82/curia', fault: 'expiring',
+          days: 3, step: 3, said: true, where: 'daemon/.env.daemon', refusal: 'r',
+        }],
+      })
+      assert.equal(page.needsYou(one.overview), 3)
+      assert.match(text(page.screenHome(one)), /3 needs you/)
     })
 
     test('the needs-you count is escalations plus the gate, and the tab title carries it', () => {

--- a/daemon/test/journal.test.mjs
+++ b/daemon/test/journal.test.mjs
@@ -104,3 +104,68 @@ describe('the pre-#184 journal reads as one vocabulary', () => {
     assert.equal('nudges' in open, false, 'the counter nothing read is gone from the record')
   })
 })
+
+// The credential warnings still standing (#380). A reduction rather than a
+// re-read, for the two reasons the coolings (#377) are one: the ladder must not
+// re-say at every boot what it already said, and the Needs-you item has to
+// survive the deploy that happens between the warning and the operator acting
+// on it.
+describe('the credential warnings survive the restart (#380)', () => {
+  const dir = () => tmpdir()
+  const warn = (over = {}) => ({
+    holder: 'agent', key: 'GH_TOKEN_ALP82', repo: 'alp82/curia', fault: 'expiring',
+    days: 3, step: 3, said: true, where: 'daemon/.env.daemon', refusal: 'r', ...over,
+  })
+
+  test('a warning is read back after a boot, with what it said', () => {
+    const d = dir()
+    new EscalationStore(d).logEvent('token_warned', warn())
+    const [w] = new EscalationStore(d).standingTokenWarnings()
+    assert.equal(w.key, 'GH_TOKEN_ALP82')
+    assert.equal(w.step, 3)
+    assert.equal(w.said, true)
+  })
+
+  test('a tighter step replaces the entry rather than adding a second', () => {
+    const d = dir()
+    const store = new EscalationStore(d)
+    store.logEvent('token_warned', warn({ days: 10, step: 14 }))
+    store.logEvent('token_warned', warn({ days: 2, step: 3 }))
+    const back = new EscalationStore(d).standingTokenWarnings()
+    assert.equal(back.length, 1)
+    assert.equal(back[0].step, 3)
+  })
+
+  test('the expiry keys on the TOKEN, so a long watch list cannot repeat it', () => {
+    const d = dir()
+    const store = new EscalationStore(d)
+    store.logEvent('token_warned', warn({ repo: 'alp82/curia' }))
+    store.logEvent('token_warned', warn({ repo: 'alp82/aistack' }))
+    assert.equal(new EscalationStore(d).standingTokenWarnings().length, 1)
+  })
+
+  test('a reach failure keys on the token AND the repo', () => {
+    const d = dir()
+    const store = new EscalationStore(d)
+    const reach = { ...warn(), fault: 'unreachable', message: 'HTTP 404' }
+    store.logEvent('token_warned', { ...reach, repo: 'alp82/curia' })
+    store.logEvent('token_warned', { ...reach, repo: 'alp82/aistack' })
+    assert.equal(new EscalationStore(d).standingTokenWarnings().length, 2)
+  })
+
+  test('a clear removes it, and a restart does not hand it back', () => {
+    const d = dir()
+    const store = new EscalationStore(d)
+    store.logEvent('token_warned', warn())
+    store.logEvent('token_cleared', { holder: 'agent', key: 'GH_TOKEN_ALP82', repo: 'alp82/curia', fault: 'expiring' })
+    assert.deepEqual(new EscalationStore(d).standingTokenWarnings(), [])
+  })
+
+  test('one key is read on its own, which is what the ladder asks', () => {
+    const d = dir()
+    const store = new EscalationStore(d)
+    store.logEvent('token_warned', warn())
+    assert.equal(store.tokenWarning('agent:GH_TOKEN_ALP82').step, 3)
+    assert.equal(store.tokenWarning('agent:GH_TOKEN_NOBODY'), null)
+  })
+})

--- a/daemon/test/tokenwatch.test.mjs
+++ b/daemon/test/tokenwatch.test.mjs
@@ -1,0 +1,345 @@
+// The credential watch (#380). What is pinned here is the LADDER and the
+// dedupe, because those are the two rules that decide whether the operator
+// reads a warning once, four times, or never.
+//
+// The watch itself is driven with a fake probe and a fake announce, so a whole
+// pass runs with no network, no Discord and no timer.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  TOKEN_STEPS, TOKEN_EXPIRY_WARN_DAYS, PROBE_INTERVAL_MS,
+  expiryStep, warningKey, keysOf, shouldSay, readingOf, dedupe,
+  expiryInstant, warningLine, clearedLine, TokenWatch,
+} from '../src/tokenwatch.mjs'
+
+const AGENT = {
+  holder: 'agent',
+  key: 'GH_TOKEN_ALP82',
+  repo: 'alp82/curia',
+  where: 'daemon/.env.daemon',
+  refusal: 'an agent on it will fail at its first gh call',
+}
+
+// GitHub's own instant format, which `Date.parse` does not accept unaided. The
+// extra hour is what keeps `tokenExpiryDays`'s floor on the day this helper
+// names: the format carries no milliseconds, so an exact N days lands a moment
+// SHORT of N and floors to N-1.
+const inDays = (n) => new Date(Date.now() + n * 86_400_000 + 3_600_000)
+  .toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')
+
+// A store stand-in: the reduction store.mjs builds, with the same key rule.
+function fakeStore() {
+  const map = new Map()
+  return {
+    map,
+    entries: () => [...map.values()],
+    entryFor: (k) => map.get(k) ?? null,
+    journal: (type, ev) => {
+      const k = ev.fault === 'expiring' ? `${ev.holder}:${ev.key}` : `${ev.holder}:${ev.key}:${ev.repo}`
+      if (type === 'token_cleared') map.delete(k)
+      else map.set(k, { ...ev })
+    },
+  }
+}
+
+// `said` is what reached Discord, which is the only thing that counts as said.
+function watchOver(store, { answers, bridge = true }) {
+  const said = []
+  const watch = new TokenWatch({
+    probe: async () => (typeof answers === 'function' ? answers() : answers),
+    entries: store.entries,
+    entryFor: store.entryFor,
+    journal: store.journal,
+    announce: (text) => {
+      if (!bridge) return false
+      said.push(text)
+      return Promise.resolve(true)
+    },
+    log: () => {},
+  })
+  return { watch, said }
+}
+
+describe('the expiry ladder', () => {
+  test('the steps are 14, 7, 3, 1 and expired, and 14 is the threshold', () => {
+    assert.deepEqual(TOKEN_STEPS, [14, 7, 3, 1, 0])
+    assert.equal(TOKEN_EXPIRY_WARN_DAYS, 14)
+  })
+
+  test('a reading above the threshold says nothing at all', () => {
+    assert.equal(expiryStep(15), null)
+    assert.equal(expiryStep(366), null)
+    // A token with no expiry reads null from tokenExpiryDays and never lands here.
+    assert.equal(expiryStep(null), null)
+    assert.equal(expiryStep(undefined), null)
+  })
+
+  test('each reading takes the TIGHTEST step it has crossed', () => {
+    assert.equal(expiryStep(14), 14)
+    assert.equal(expiryStep(8), 14)
+    assert.equal(expiryStep(7), 7)
+    assert.equal(expiryStep(4), 7)
+    assert.equal(expiryStep(3), 3)
+    assert.equal(expiryStep(2), 3)
+    assert.equal(expiryStep(1), 1)
+  })
+
+  test('an expired token is its own step, and so is one long dead', () => {
+    assert.equal(expiryStep(0), 0)
+    assert.equal(expiryStep(-1), 0)
+    assert.equal(expiryStep(-400), 0)
+  })
+})
+
+describe('what a warning is keyed on', () => {
+  test('an expiry belongs to the token, so the watch list cannot repeat it', () => {
+    const a = warningKey({ fault: 'expiring', holder: 'agent', key: 'K', repo: 'o/one' })
+    const b = warningKey({ fault: 'expiring', holder: 'agent', key: 'K', repo: 'o/two' })
+    assert.equal(a, b)
+  })
+
+  test('a reach failure belongs to the token AND the repo', () => {
+    const a = warningKey({ fault: 'unreachable', holder: 'agent', key: 'K', repo: 'o/one' })
+    const b = warningKey({ fault: 'unreachable', holder: 'agent', key: 'K', repo: 'o/two' })
+    assert.notEqual(a, b)
+  })
+
+  test('the two holders never share a key, even on the same repo', () => {
+    const a = warningKey({ fault: 'expiring', holder: 'agent', key: 'K', repo: 'o/one' })
+    const b = warningKey({ fault: 'expiring', holder: 'overseer', key: 'K', repo: 'o/one' })
+    assert.notEqual(a, b)
+  })
+
+  test('one probe answer protects both of its possible keys', () => {
+    assert.deepEqual(keysOf({ holder: 'agent', key: 'K', repo: 'o/one' }), ['agent:K', 'agent:K:o/one'])
+  })
+
+  test('one token over four repos is ONE expiry reading', () => {
+    const answers = ['o/a', 'o/b', 'o/c', 'o/d'].map((repo) =>
+      readingOf({ ...AGENT, repo, ok: true, expiresAt: inDays(5) }))
+    assert.equal(answers.length, 4)
+    assert.equal(dedupe(answers).length, 1)
+  })
+
+  test('four repos that all refuse the same token are FOUR reach readings', () => {
+    const answers = ['o/a', 'o/b', 'o/c', 'o/d'].map((repo) =>
+      readingOf({ ...AGENT, repo, ok: false, message: 'HTTP 404: Not Found' }))
+    assert.equal(dedupe(answers).length, 4)
+  })
+})
+
+describe('what makes a reading news', () => {
+  const expiring = { fault: 'expiring', step: 7, message: null }
+
+  test('a key nobody has warned about is always news', () => {
+    assert.equal(shouldSay(null, expiring), true)
+  })
+
+  test('the same step twice is not news — a deploy repeats nothing', () => {
+    assert.equal(shouldSay({ ...expiring, said: true }, expiring), false)
+  })
+
+  test('a tighter step IS news, and a looser one is not', () => {
+    const entry = { ...expiring, said: true }
+    assert.equal(shouldSay(entry, { ...expiring, step: 3 }), true)
+    assert.equal(shouldSay(entry, { ...expiring, step: 14 }), false)
+  })
+
+  test('a reading measured but never said is news again', () => {
+    assert.equal(shouldSay({ ...expiring, said: false }, expiring), true)
+  })
+
+  test('a token that stops reaching a repo is news even at the same step', () => {
+    const entry = { ...expiring, said: true }
+    assert.equal(shouldSay(entry, { fault: 'unreachable', message: 'HTTP 404' }), true)
+  })
+
+  test('a reach failure re-says itself only when the refusal changes', () => {
+    const entry = { fault: 'unreachable', message: 'HTTP 404: Not Found', said: true }
+    assert.equal(shouldSay(entry, { fault: 'unreachable', message: 'HTTP 404: Not Found' }), false)
+    assert.equal(shouldSay(entry, { fault: 'unreachable', message: 'HTTP 401: Bad credentials' }), true)
+  })
+})
+
+describe('the reading a probe answer becomes', () => {
+  test('a healthy token far from expiry is no reading at all', () => {
+    assert.equal(readingOf({ ...AGENT, ok: true, expiresAt: inDays(90) }), null)
+  })
+
+  test('a token with no expiry header is no reading either', () => {
+    assert.equal(readingOf({ ...AGENT, ok: true, expiresAt: null }), null)
+  })
+
+  test('a refusal is a reach reading, carrying GitHub\'s own words', () => {
+    const r = readingOf({ ...AGENT, ok: false, message: 'HTTP 404: Not Found' })
+    assert.equal(r.fault, 'unreachable')
+    assert.equal(r.message, 'HTTP 404: Not Found')
+  })
+
+  test('a network failure is NOT a reading — it says nothing either way', () => {
+    assert.equal(readingOf({ ...AGENT, unmeasured: true }), null)
+  })
+})
+
+describe('the words the operator reads', () => {
+  test('an expiry names the days, the instant and the act', () => {
+    const r = readingOf({ ...AGENT, ok: true, expiresAt: inDays(6) })
+    const line = warningLine(r)
+    assert.match(line, /GH_TOKEN_ALP82/)
+    assert.match(line, /expires in 6 days/)
+    assert.match(line, /<t:\d+:D>/) // a date a phone renders in its own timezone
+    assert.match(line, /Mint a new token/)
+    assert.match(line, /daemon\/\.env\.daemon/)
+  })
+
+  test('one day is not "1 days"', () => {
+    const r = readingOf({ ...AGENT, ok: true, expiresAt: inDays(1) })
+    assert.match(warningLine(r), /expires in 1 day\b/)
+  })
+
+  test('a dead token says it is dead rather than counting down past zero', () => {
+    const r = readingOf({ ...AGENT, ok: true, expiresAt: inDays(-3) })
+    assert.match(warningLine(r), /has EXPIRED/)
+    assert.doesNotMatch(warningLine(r), /expires in -/)
+  })
+
+  test('a reach failure names the repo and where the token lives', () => {
+    const r = readingOf({ ...AGENT, ok: false, message: 'HTTP 404: Not Found' })
+    const line = warningLine(r)
+    assert.match(line, /cannot reach alp82\/curia/)
+    assert.match(line, /HTTP 404: Not Found/)
+    assert.match(line, /an agent on it will fail at its first gh call/)
+  })
+
+  test('a clear says which fact came good', () => {
+    assert.match(clearedLine({ fault: 'expiring', key: 'K' }), /renewed/)
+    assert.match(clearedLine({ fault: 'unreachable', key: 'K', repo: 'o/a' }), /reaches o\/a again/)
+  })
+
+  test('an unreadable instant leaves the sentence standing', () => {
+    assert.equal(expiryInstant('not a date'), null)
+    assert.equal(expiryInstant(undefined), null)
+    const line = warningLine({ fault: 'expiring', key: 'K', days: 5, expires_at: 'not a date', where: 'w', refusal: 'r' })
+    assert.match(line, /expires in 5 days\./)
+  })
+})
+
+describe('a pass over a whole watch list', () => {
+  test('the interval is six hours, so a one-day step gets four chances', () => {
+    assert.equal(PROBE_INTERVAL_MS, 6 * 60 * 60 * 1000)
+  })
+
+  test('one warning, then silence, then a tighter step speaks again', async () => {
+    const store = fakeStore()
+    let days = 10
+    const { watch, said } = watchOver(store, {
+      answers: () => [{ ...AGENT, ok: true, expiresAt: inDays(days) }],
+    })
+
+    await watch.pass()
+    assert.equal(said.length, 1)
+    assert.match(said[0], /expires in 10 days/)
+
+    // Two more passes at the same step — a deploy, and six hours later.
+    await watch.pass()
+    await watch.pass()
+    assert.equal(said.length, 1)
+
+    days = 2
+    await watch.pass()
+    assert.equal(said.length, 2)
+    assert.match(said[1], /expires in 2 days/)
+  })
+
+  test('a renewed token clears the standing warning and says so once', async () => {
+    const store = fakeStore()
+    let days = 3
+    const { watch, said } = watchOver(store, {
+      answers: () => [{ ...AGENT, ok: true, expiresAt: inDays(days) }],
+    })
+    await watch.pass()
+    assert.equal(store.map.size, 1)
+
+    days = 90
+    await watch.pass()
+    assert.equal(store.map.size, 0)
+    assert.match(said[1], /renewed/)
+
+    // And the ladder is re-armed: the next token to get near speaks from 14.
+    await watch.pass()
+    assert.equal(said.length, 2)
+  })
+
+  test('a probe curia could not take clears nothing', async () => {
+    const store = fakeStore()
+    let answers = [{ ...AGENT, ok: true, expiresAt: inDays(3) }]
+    const { watch, said } = watchOver(store, { answers: () => answers })
+    await watch.pass()
+    assert.equal(store.map.size, 1)
+
+    // GitHub was slow. That is a fact about the network, and the token is still
+    // three days from dying.
+    answers = [{ ...AGENT, unmeasured: true }]
+    await watch.pass()
+    assert.equal(store.map.size, 1)
+    assert.equal(said.length, 1) // no ✅, and no repeat of the ⚠️
+  })
+
+  test('a probe that throws leaves every standing warning alone', async () => {
+    const store = fakeStore()
+    let answers = () => [{ ...AGENT, ok: true, expiresAt: inDays(3) }]
+    const { watch } = watchOver(store, { answers: () => answers() })
+    await watch.pass()
+    answers = () => { throw new Error('getaddrinfo ENOTFOUND api.github.com') }
+    await watch.pass()
+    assert.equal(store.map.size, 1)
+  })
+
+  test('a warning measured with no bridge is not said, and lands at bridge start', async () => {
+    const store = fakeStore()
+    const answers = [{ ...AGENT, ok: true, expiresAt: inDays(4) }]
+
+    // Boot: the probe runs before the bridge is up.
+    const dark = watchOver(store, { answers, bridge: false })
+    await dark.watch.pass()
+    assert.equal(store.map.size, 1)
+    assert.equal([...store.map.values()][0].said, false)
+
+    // The bridge comes up. flush() re-announces from the reduction — it probes
+    // nothing, so a bridge that flaps costs GitHub nothing.
+    let probed = 0
+    const lit = new TokenWatch({
+      probe: async () => { probed++; return [] },
+      entries: store.entries,
+      entryFor: store.entryFor,
+      journal: store.journal,
+      announce: () => Promise.resolve(true),
+      log: () => {},
+    })
+    await lit.flush()
+    assert.equal(probed, 0)
+    assert.equal([...store.map.values()][0].said, true)
+
+    // And now it is said, so it is not said again.
+    await lit.flush()
+    assert.equal([...store.map.values()][0].said, true)
+  })
+
+  test('both holders warn separately about the same repo', async () => {
+    const store = fakeStore()
+    const overseer = {
+      holder: 'overseer', key: 'OVERSEER_GH_TOKEN_ALP82', repo: 'alp82/curia',
+      where: 'daemon/.env.overseer', refusal: 'the overseer cannot read it',
+    }
+    const { watch, said } = watchOver(store, {
+      answers: [
+        { ...AGENT, ok: true, expiresAt: inDays(5) },
+        { ...overseer, ok: true, expiresAt: inDays(5) },
+      ],
+    })
+    await watch.pass()
+    assert.equal(said.length, 2)
+    assert.equal(store.map.size, 2)
+  })
+})


### PR DESCRIPTION
Ticket: alp82/curia#380 — [The token expiry warning reaches the operator, not the log](https://github.com/alp82/curia/issues/380)

The token expiry warning now reaches the operator instead of the boot log (#380).

**Where it lands.** Two surfaces, one measurement. A plain line in `#curia` states the event at its instant. The dashboard Needs-you list holds the standing item until the reading clears, and the needs-you count carries it — a spent usage window rolls on its own clock, and a token nobody mints stays dead.

**What says it.** `daemon/src/tokenwatch.mjs`. The daemon states the days, the instant as a Discord date, and the act that ends it. The probe in `index.mjs` now only measures and hands every answer over.

**How often it repeats.** A step ladder: 14 days, 7, 3, 1, and expired. Each step is said once. A store reduction over `token_warned` and `token_cleared` remembers what was already said, so a deploy repeats nothing and a restart inherits the ladder.

**How often it is checked.** At boot, at every watch reload, and every six hours. It files no ticket and dispatches nothing, so #345's refusal of a scheduler stands.

Four rules keep a wrong answer out. The expiry is keyed on the TOKEN and the reach on the token and the repo together, so one token over four repos says one fact once (ADR-0013). A line that did not reach Discord is not said, and it returns at the next pass and at bridge start. A probe curia could not take clears nothing, so one slow GitHub call cannot post a ✅ for a dying token. A renewed token clears the item and re-arms the ladder.

**#338.** The expiry half is a PAT-only fact and it dies holder by holder as #389, #390 and #392 cut over: an installation token lives one hour and the daemon refreshes it, so its expiry is nothing the operator can act on. No branch says so — after a cutover the probe finds no PAT. The reach half survives for every holder and for the installation itself.

`CONTEXT.md` gains the term **Credential watch**. Suite 2196 pass.

---

Dispatched by the curia daemon — session `curia-380`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `167a921` The token expiry warning reaches the operator (#380)