### PR TITLE
What reaches a codex agent a restart has stranded (alp82/curia#426)

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -2807,6 +2807,12 @@ export class Dispatcher {
   // opened a PLAIN approve/reject gate — the restarted daemon knew the reviewer
   // (reconcile re-adopts it) and never asked — so the operator approved and the
   // merge outran the verdict by three seconds.
+  //
+  // "The builder's client sees an error" is the CLAUDE lane, about 120 s after
+  // the death. A codex builder sees nothing and sits in the park for up to
+  // `CODEX_TOOL_TIMEOUT_S`, so on that lane the rejoin never gets its chance
+  // (#371). This map is the second blocking call a restart strands, beside the
+  // escalation resolvers in `index.mjs`, and #426's goodbye has to wake both.
   async #parkForVerdict(agentName, { repo, ticket, w }) {
     const out = await this.#awaitVerdict(ticket, agentName)
     if (w) w.state = 'ready'

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -519,6 +519,14 @@ function curiaMcpUrl(daemonPort, agent, ticket, host = LOOPBACK) {
 // So one number serves two jobs that pull apart: generous to a slow human, and
 // a day of silence for an agent a restart stranded. Changing it is a decision
 // against #34, not a tuning.
+//
+// #426 took that decision and left the number ALONE. One value cannot be both
+// jobs, so the second job moves off it: the daemon says goodbye. Before it
+// exits, a restart, a SIGTERM and a crash each end every blocked call with a
+// tool ERROR, which is the error #341's ladder needs and the thing codex never
+// gets by itself. That reaches the agent in about a second rather than in a
+// day, and it costs the slow human nothing. What the goodbye cannot reach is a
+// SIGKILL, and this deadline is still the only bound there.
 const CODEX_TOOL_TIMEOUT_S = 86_400
 
 // The Stop hook, identical on both harnesses: POST the hook's own stdin payload to

--- a/docs/research/tool-channel-mid-session-codex.md
+++ b/docs/research/tool-channel-mid-session-codex.md
@@ -109,7 +109,7 @@ So a call made INTO an outage fails fast and says so plainly, and the tools come
 
 **The cost is bigger than the wait.** A claude agent loses about two minutes and the answer. A codex agent loses its whole session to a restart it never hears about: no error, no retry, no Stop hook, and no report. Every deploy and every `POST /restart` can do this to a live codex agent that holds a blocking call.
 
-**What to do about it is a decision, not a reading.** This ticket took the reading. The trade against #34 belongs to its own ticket.
+**What to do about it is a decision, not a reading.** This ticket took the reading. [#426](https://github.com/alp82/curia/issues/426) then took the decision, and it left this number alone: the daemon says goodbye instead. Before it exits, a restart, a SIGTERM and a crash each end every blocked call with a tool error, which is the error the ladder needs. A SIGKILL reaches nobody, and the pane is measured on its own before anything is built on it.
 
 ## What else the probe saw
 


### PR DESCRIPTION
Ticket: alp82/curia#426 — [What reaches a codex agent a restart has stranded](https://github.com/alp82/curia/issues/426)

#426 decides what reaches a codex agent that a restart has stranded, and records the decision where the old reading is written.

**The decision: the daemon says goodbye.** Both deaths in the ticket are planned. `POST /restart` exits 50 ms after it answers, and a deploy recreates the container with a SIGTERM that nothing catches. In both cases the daemon is alive, it holds every blocked call, and it knows it is about to die. Before it exits it now ends each of those calls with a tool ERROR. That is the error #341's retry ladder needs, and it is the thing codex never gets by itself. The operator also took the crash exit, as a best-effort last word.

**What was refused.** `CODEX_TOOL_TIMEOUT_S` stays at a day, so #34 keeps its slow human. The drain before the restart is refused, because a held call can last 8 hours and a drain that waits holds the deploy. The pane stays as the backstop for a SIGKILL alone, and it gets measured before anything is built on it.

**This commit carries comments and one research doc, and no behavior.** The build is a separate ticket.

- `workspace.mjs`: the `CODEX_TOOL_TIMEOUT_S` comment said the change is a decision against #34. It now says which decision was taken, and why the number did not move.
- `dispatch.mjs`: the `#parkForVerdict` comment rests on a severed call reporting an error. That holds on the claude lane only. The comment now says so, and names that park as the second wait a restart strands.
- `docs/research/tool-channel-mid-session-codex.md`: the closing line said the decision belongs to its own ticket. It now points at the answer.

Daemon suite: 2228 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-426`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `0b4e862` Record what reaches a stranded codex agent (#426)