### PR TITLE
A stable way to arm the wayfinder skill on codex (alp82/curia#399)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -240,11 +240,15 @@ The MCP servers an agent can reach: curia's own, and nothing else. Two settings 
 **Skills**:
 The skill set curia symlinks into every agent's config dir, so an agent resolves in the same idiom as a hand session.
 
+**Skill pointer**:
+A small skill curia writes into the codex agent's config dir, one per skill codex hides from its own catalog (`wayfinder` and `implement` today). Codex lists a skill whose manifest sets `allow_implicit_invocation: false` nowhere, so the model never learns it exists. The pointer carries the real skill's own description, names the installed file, and restates none of it. Its point is the channel: the catalog is a developer message, so it is world state and it is restated every turn, where the old `$wayfinder` mention was one user message that went stale and could not be repeated without pasting the skill again (#360, #399). Curia patches no vendored byte, and it reads upstream's manifest to decide which skills need one, so a release that lists them stops the pointers by itself. The claude lane has none and needs none: `/wayfinder` is a slash command that expands the whole file into the first user message.
+_Avoid_: patched manifest, catalog flip.
+
 **Standing orders**:
 The bounds, the tools and the ending: what holds for every turn of a ticket, not procedure. Procedure lives in the installed skills. They ride the CLI's global-memory file in the agent's config dir, because both harnesses load that file as instructions and a user message goes stale (#340).
 
 **Spawn prompt**:
-The parameters of one dispatch: the ticket, the map, the worktree, the ports, the inherited exchange, and the line that invokes the skill. It states no bound and no procedure, and it points at the standing orders.
+The parameters of one dispatch: the ticket, the map, the worktree, the ports and the inherited exchange. It states no bound and no procedure, and it points at the standing orders. On the claude lane it also carries the `/wayfinder` line, which loads the skill. The codex lane carries no such line since #399: a mention there pasted the whole skill into the conversation, and the skill pointer reaches it through the catalog instead.
 
 **Bounds**:
 The hard limits in the standing orders. Read anything. Write only inside the worktree, the ticket, and the map subtree. No browser. Never answer for the human. A failed call is not an answer, and silence is not an answer.

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -19,6 +19,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
 import { execFileP } from './exec.mjs'
 import { endingProse, CHARTING_NEVER, REVIEWER_NEVER, dutyLines, ALL_AS_RECOMMENDED } from './lifecycle.mjs'
 import { TOKEN_HEADER } from './agenttoken.mjs'
@@ -688,6 +689,11 @@ const HARNESS = {
   codex: {
     // See the claude row: this is the durable channel, and #340 measured it.
     memoryFile: 'AGENTS.md',
+    // Codex hides a skill whose manifest says so, and its catalog is the only
+    // channel that re-arms a skill without pasting it (#399). See
+    // writeSkillPointers. A new harness answers this row for itself: a CLI with
+    // no catalog of its own writes no pointers and needs none.
+    skillPointers: writeSkillPointers,
     // CODEX_HOME is the whole config dir: settings, skills, sessions, logs AND
     // the credential file, with no second variable to split them (Claude's
     // CLAUDE_SECURESTORAGE_CONFIG_DIR has no codex equivalent). Sharing the
@@ -1045,6 +1051,137 @@ export function installSkills(cfgDir, skills, { copy = false } = {}) {
   return names
 }
 
+// The skills codex HIDES from its own catalog, read off upstream's manifest
+// rather than decided here (#399). A skill whose `agents/openai.yaml` carries
+// `policy.allow_implicit_invocation: false` is absent from the
+// `<skills_instructions>` developer message, so the model never learns it
+// exists. Today that is `wayfinder` and `implement`.
+//
+// The manifest IS the question, so it is the thing read. If upstream lists a
+// skill in a later release, curia writes no pointer for it and the pointer
+// simply stops existing — no list here to fall out of date, and no patched byte
+// to break in silence.
+//
+// A skill with no manifest at all is listed: `allow_implicit_invocation`
+// defaults to true. That is why a pointer needs no manifest of its own.
+function hiddenSkillNames(cfgDir, names) {
+  return (names ?? []).filter((name) => {
+    const manifest = path.join(cfgDir, 'skills', name, 'agents', 'openai.yaml')
+    let doc
+    try {
+      doc = parseYaml(fs.readFileSync(manifest, 'utf8'))
+    } catch {
+      return false // no manifest, or one codex itself could not read: codex lists it
+    }
+    return doc?.policy?.allow_implicit_invocation === false
+  })
+}
+
+// The one line a `SKILL.md` contributes to the codex catalog. Read from the
+// installed file, never held as a copy here, so a skill-tree bump carries into
+// the pointer at the next seed with nothing to synchronise.
+//
+// PARSED as YAML rather than matched with a regex, and the reason is a real bug
+// this caught: `implement` writes its description as a QUOTED scalar, so the
+// obvious `description:[ \t]*(.+)` capture returns the quotes too. Appending a
+// sentence to that produced `description: "..." Read ...`, which is invalid
+// YAML — and codex answers invalid frontmatter by dropping the skill from its
+// catalog IN SILENCE. The pointer existed on disk and reached no model.
+function skillDescription(cfgDir, name) {
+  let text
+  try {
+    text = fs.readFileSync(path.join(cfgDir, 'skills', name, 'SKILL.md'), 'utf8')
+  } catch {
+    return null
+  }
+  if (!text.startsWith('---')) return null
+  const end = text.indexOf('\n---', 3)
+  if (end === -1) return null
+  let front
+  try {
+    front = parseYaml(text.slice(3, end))
+  } catch {
+    return null
+  }
+  const description = front?.description
+  return typeof description === 'string' && description.trim() ? description.trim() : null
+}
+
+// A pointer per hidden skill, so the codex catalog names it again (#399).
+//
+// #360 closed every cheap way to re-arm a skill on codex: a second `$wayfinder`
+// adds an 11,867-character copy and keeps the first, and neither a tool result
+// nor `AGENTS.md` resolves a mention at all. What survives is the catalog — a
+// developer message, world state, restated every turn and never stale. The
+// operator rejected the obvious way in (flip `allow_implicit_invocation` in the
+// vendored manifest) on 2026-08-16: a patched vendored byte is brittle, and a
+// skill-tree update breaks it without a word.
+//
+// So curia writes a file it OWNS instead, beside the `standing.md` it already
+// writes here, and patches nothing. Measured on the pinned codex
+// (docs/live-checks/399): a listed skill costs about 270 characters per turn and
+// NEVER pastes its body. The 11,867 characters arrive only from a `$name` typed
+// by a user, which is why the codex spawn prompt no longer types one.
+//
+// Three properties make this stable rather than clever:
+//
+//   - The description is READ from the installed skill, so the trigger fires on
+//     the same tasks the real skill claims, and an upstream reword carries
+//     through at the next seed.
+//   - Hidden-ness is read from upstream's manifest, so upstream stays the
+//     authority on which skills need a pointer at all.
+//   - The name is `curia-<name>` and not `<name>`. Codex keys a skill on the
+//     name in its frontmatter, so a pointer claiming `wayfinder` would put two
+//     skills under one name — the ambiguity #224 measured, created on purpose.
+//     The prefix also says whose file it is to anyone reading the config dir.
+//
+// It is GENERATED per agent rather than committed to the tree, for the same
+// reason `standing.md` is: it names an absolute path that only exists once the
+// config dir does. And it is written from `seedConfigDir`, AFTER
+// `installSkills` — that call wipes `<cfgDir>/skills` on every re-arm, and a
+// pointer written anywhere else would vanish on the respawn a usage limit
+// forces. That is #340's `standing.md` trap, one directory over.
+export function writeSkillPointers(cfgDir, names) {
+  const written = []
+  for (const name of hiddenSkillNames(cfgDir, names)) {
+    const description = skillDescription(cfgDir, name)
+    if (!description) continue // a skill with no description contributes no catalog line to match on
+    const target = path.join(cfgDir, 'skills', name, 'SKILL.md')
+    const pointer = path.join(cfgDir, 'skills', `curia-${name}`)
+    fs.mkdirSync(pointer, { recursive: true })
+    // Both values are emitted as JSON strings, which are valid YAML
+    // double-quoted scalars. The description is upstream's prose and carries
+    // whatever upstream put in it — quotes, colons, em-dashes — and a
+    // hand-spliced line is how the `implement` pointer broke in silence.
+    fs.writeFileSync(path.join(pointer, 'SKILL.md'), [
+      '---',
+      `name: ${JSON.stringify(`curia-${name}`)}`,
+      `description: ${JSON.stringify(`${description} Read ${target} in full before you act on this.`)}`,
+      '---',
+      '',
+      `This is the \`${name}\` skill. Read \`${target}\` completely, then follow it.`,
+      '',
+      'Curia installed that file and it is the whole skill. This pointer exists because codex does',
+      'not list `' + name + '` in its own skill catalog, and it restates none of the skill itself.',
+      '',
+      // The read-once rule, and it is the whole reason this file is worth
+      // owning (#399). Codex tells the model to read a skill completely every
+      // time it uses one, and not to carry a skill across turns. A model that
+      // obeys both re-reads on every turn: measured at 12,299 characters per
+      // turn for wayfinder, which STACKS, so it is worse than the 11,867-char
+      // mention this replaced. Curia cannot edit codex's rule and it can write
+      // its own, in the one file upstream does not own.
+      `Read \`${target}\` ONCE in a session. If you have already read it, you are still running it,`,
+      'and reading it again only repeats what you have. Say that you are using this skill, then act.',
+      '',
+      'The curia standing orders win wherever the two disagree.',
+      '',
+    ].join('\n'))
+    written.push(`curia-${name}`)
+  }
+  return written
+}
+
 // The second skill root the codex harness reads, and the reason #171 exists.
 // CODEX_HOME does not bound skills: the pinned codex (0.146) reads
 // `$HOME/.agents/skills` unconditionally, beside `$CODEX_HOME/skills`
@@ -1156,7 +1293,11 @@ export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude',
   // MCP connectors, no saved permission mode (#23/#29). Both CLIs read
   // `<config dir>/skills/<name>/SKILL.md`, so #57's install is harness-blind —
   // a curia skill loaded and ran under codex unchanged.
-  installSkills(cfgDir, skills, { copy: sandboxed })
+  const installed = installSkills(cfgDir, skills, { copy: sandboxed })
+  // AFTER the install, because that call wipes the directory these are written
+  // into (#399). Harness-specific, so it hangs off the table rather than off a
+  // name test here.
+  h.skillPointers?.(cfgDir, installed)
 }
 
 // The curia side channel: the MCP server the agent's tools come from, and the
@@ -1431,34 +1572,41 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   // body's shape and refer-by-name are all doctrine a charting agent needs and
   // curia does not restate.
   //
-  // One line, two spellings (#173, see the header above): `/wayfinder` is the
-  // claude slash command, `$wayfinder` is codex's own way of naming a skill.
-  // Everything after the sigil is identical, so a human reading two prompts
-  // side by side reads one document.
+  // ONE harness types a sigil now, and it is claude (#399). `/wayfinder` is a
+  // slash command: Claude Code expands the whole `SKILL.md` into the first user
+  // message, the session has no fade to cure, and this line is still what loads
+  // the skill at all.
   //
-  // The `$` is LOAD-BEARING, and #340 measured why. On the codex lane
-  // `wayfinder` is deliberately absent from the auto-listed skill catalog: the
-  // vendored tree carries `agents/openai.yaml` with
-  // `policy.allow_implicit_invocation: false`, which is upstream's pair to
-  // `disable-model-invocation` and means "reachable only by the human typing
-  // its name". Codex answers the explicit mention anyway and injects the whole
-  // `SKILL.md` inline, but the plain prose "use the wayfinder skill" injects
-  // NOTHING. Both measured from a real rollout
-  // (docs/live-checks/340-codex-skill-fade.md).
+  // The codex lane types NOTHING. It used to type `$wayfinder`, which injected
+  // the whole 11,867-character `SKILL.md` as a user message on turn one — and a
+  // user message is conversation, which codex tells the model to treat as stale
+  // after the turn that carried it (#340). #360 then closed every way to re-arm
+  // it: a second mention adds a second copy and keeps the first, and nothing
+  // curia owns except a pane send resolves a mention at all.
   //
-  // So a missing skill in `codex debug prompt-input` is not a fault to fix:
-  // that renderer never resolves a mention, and the vendored bytes are correct.
-  // Patching the tree here would break the design rather than repair it.
+  // So the skill reaches a codex agent the way every other skill does — through
+  // the catalog, which is a developer message and world state. Curia puts it
+  // back on that catalog with a pointer it owns (writeSkillPointers), and the
+  // model reads the file when a task matches. Measured: the catalog entry costs
+  // about 270 characters per turn and pastes no body, where the mention cost
+  // 11,867 once and re-armed nothing (docs/live-checks/399).
+  //
+  // Dropping the line rather than keeping both is the operator's call
+  // (2026-08-16): use all skills normally. Keeping it would pay the 11,867
+  // characters for a turn-one load the catalog already reaches, and pay it in
+  // the one channel that goes stale.
   //
   // A NEW-map dispatch (#241) names no map, because there is none: the bare
   // sigil is the skill's OTHER invocation, "chart the map", which starts from a
   // loose idea. The operator's sentence IS that idea, and it rides the params
   // below rather than the invocation line — the line is one line, and this one
   // is a paragraph the operator wrote.
-  const sigil = harness === 'codex' ? '$wayfinder' : '/wayfinder'
-  const invocation = newMap
-    ? [sigil, '']
-    : mapNumber ? [`${sigil} ${mapUrl}${charting ? '' : ` ticket #${n}`}`, ''] : []
+  const sigil = harness === 'codex' ? null : '/wayfinder'
+  const invocation = !sigil || !(newMap || mapNumber)
+    ? []
+    : newMap
+      ? [sigil, '']
+      : [`${sigil} ${mapUrl}${charting ? '' : ` ticket #${n}`}`, '']
 
   // The params of a NEW-map dispatch (#241). The difference from a map dispatch
   // is one fact with consequences everywhere: the map does not exist. So this
@@ -1466,7 +1614,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   // breadth-first, then create the map and the tickets it can already state —
   // and it owes curia the number the moment it has one.
   const newMapParams = [
-    '- **This is a NEW-MAP DISPATCH.** No map exists yet. Run the skill\'s "Chart the map" mode from the',
+    '- **This is a NEW-MAP DISPATCH.** No map exists yet. Run the wayfinder skill\'s "Chart the map" mode from the',
     '  top: name the destination with the operator, map the frontier breadth-first, then create the',
     `  \`wayfinder:map\` issue in ${repo} and the tickets you can already state. Its "work through the map"`,
     '  mode does not apply — there is nothing to work through until you have built it.',
@@ -1490,7 +1638,7 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
   const chartingParams = [
     `- **This is a MAP DISPATCH.** ${repo}#${n} is the map itself, not a ticket under it. Your job is to`,
     '  CHANGE THE MAP: its body sections, and its child tickets. Do not choose a frontier ticket, and do',
-    '  not resolve one. The skill\'s step "choose the ticket" does not apply to this session.',
+    '  not resolve one. The wayfinder skill\'s step "choose the ticket" does not apply to this session.',
     `- The map is ${repo}#${n} — ${ticketUrl}. curia has loaded it for you. It has NOT assigned the map`,
     '  to you, and no dispatch ever does (#221): a claim means "off the frontier", and a map is never on',
     '  one. What keeps a second charting agent off this body is the session name — curia refuses a second',
@@ -1518,7 +1666,10 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     `- The ticket is ${repo}#${n} — ${ticketUrl}. curia has already CLAIMED it in your name: you start at`,
     '  resolving it, not at choosing it.',
     ...(type
-      ? [`- Ticket type: \`${type}\`. The skill's Ticket Types section says what that means for how you work it.`]
+      // The skill is NAMED here rather than pointed at (#399). The codex lane
+      // types no sigil now, so "the skill" would name nothing on that harness —
+      // and naming it in plain text is also how codex triggers a listed skill.
+      ? [`- Ticket type: \`${type}\`. The wayfinder skill's Ticket Types section says what that means for how you work it.`]
       : ['- This ticket carries no `wayfinder:` type label.']),
   ]
 

--- a/daemon/test/prompt.test.mjs
+++ b/daemon/test/prompt.test.mjs
@@ -69,21 +69,28 @@ describe('the wayfinder invocation', () => {
     assert.match(p, /belongs to no map/)
   })
 
-  // #173, gap 4 of the codex-lane inventory. `/wayfinder` is a claude
-  // mechanism: on codex the same line arrived as plain text and loaded
-  // nothing. `$wayfinder` is codex's own way of naming a skill, and codex
-  // answers it with "you must use that skill for that turn" plus "read its
-  // SKILL.md completely" (measured, docs/live-checks/173).
-  describe('the codex harness spells it its own way (#173)', () => {
-    test('a map ticket starts with the $wayfinder line', () => {
+  // #173 gave the codex lane its own spelling, `$wayfinder`, and #399 took the
+  // line away entirely. The mention was the ONLY thing that injected the
+  // 11,867-character skill body into a codex session, and it injected it as a
+  // user message — conversation, which codex tells the model is stale after the
+  // turn that carried it. #360 then closed every way to re-arm it.
+  //
+  // So the codex lane now reaches the skill the way it reaches every other
+  // skill: through the catalog, which is world state. `writeSkillPointers` puts
+  // it back on that catalog. Measured in docs/live-checks/399: zero `<skill>`
+  // blocks on every turn, against 11,867 characters for the mention.
+  describe('the codex harness types no sigil at all (#399)', () => {
+    test('a map ticket starts at the ticket heading, with no mention anywhere', () => {
       const p = write({ mapNumber: 1, harness: 'codex' })
-      assert.equal(p.split('\n')[0], '$wayfinder https://github.com/o/r/issues/1 ticket #42')
-      assert.ok(!p.includes('/wayfinder'), 'the claude slash command is gone, not doubled')
+      assert.equal(p.split('\n')[0], '# o/r#42: Close the loop')
+      assert.ok(!p.includes('$wayfinder'), 'the mention is what pasted the body — it is gone')
+      assert.ok(!p.includes('/wayfinder'), 'and the claude slash command never belonged here')
     })
 
-    test('a map dispatch names the map and no ticket, on this harness too', () => {
+    test('a map dispatch types no mention either', () => {
       const p = write({ mapNumber: 42, charting: true, harness: 'codex' })
-      assert.equal(p.split('\n')[0], '$wayfinder https://github.com/o/r/issues/42')
+      assert.equal(p.split('\n')[0], '# o/r#42: Close the loop')
+      assert.ok(!p.includes('$wayfinder'))
     })
 
     test('a mapless ticket invokes nothing, in either spelling', () => {
@@ -92,26 +99,44 @@ describe('the wayfinder invocation', () => {
       assert.equal(p.split('\n')[0], '# o/r#42: Close the loop')
     })
 
-    test('the sigil and the file it points at are the ONLY differences', () => {
+    // The skill is still NAMED in prose on both lanes, and that is deliberate.
+    // With no sigil, "the skill's Ticket Types section" would point at nothing
+    // a codex agent can resolve — and naming a listed skill in plain text is
+    // also how codex triggers one.
+    test('the prose names the skill, so no reference dangles on the lane with no sigil', () => {
+      for (const harness of ['codex', 'claude']) {
+        const p = write({ mapNumber: 1, type: 'wayfinder:grilling', harness })
+        assert.match(p, /The wayfinder skill's Ticket Types section/, `${harness} names the skill`)
+      }
+    })
+
+    test('the invocation line and the memory file are the ONLY differences', () => {
       // The bounds, the tools and the ending are harness-blind on purpose: a
       // human reading two agents' prompts side by side must read the same
       // text. A rule that belongs to one lane belongs in the harness table,
       // not here.
       //
-      // #340 added the second difference, and it is the same KIND as the
-      // sigil: each CLI's own name for its global-memory file. The orders
-      // themselves stay one document, which is what the standing check below
-      // pins.
+      // #340 added the memory-file difference, and it is the same KIND as the
+      // sigil was: each CLI's own name for its global-memory file. #399 turned
+      // the first difference from two spellings of one line into one lane
+      // having the line and the other not, so the comparison is by CONTENT and
+      // not by line number.
       const codex = writeParts({ mapNumber: 1, harness: 'codex' })
       const claude = writeParts({ mapNumber: 1, harness: 'claude' })
       assert.equal(codex.standing, claude.standing, 'the orders are one document on both lanes')
-      const differ = codex.prompt.split('\n')
-        .map((l, i) => [l, claude.prompt.split('\n')[i]])
+
+      const claudeLines = claude.prompt.split('\n')
+      const codexLines = codex.prompt.split('\n')
+      // The claude prompt is the codex one plus the invocation line and its
+      // blank, with one line reworded.
+      assert.deepEqual(claudeLines.slice(0, 2), ['/wayfinder https://github.com/o/r/issues/1 ticket #42', ''])
+      const rest = claudeLines.slice(2)
+      const differ = codexLines
+        .map((l, i) => [l, rest[i]])
         .filter(([a, b]) => a !== b)
-      assert.equal(differ.length, 2, `expected two differing lines, got ${differ.length}`)
-      assert.match(differ[0][0], /^\$wayfinder /)
-      assert.match(differ[1][0], /`AGENTS\.md`/)
-      assert.match(differ[1][1], /`CLAUDE\.md`/)
+      assert.equal(differ.length, 1, `expected one differing line, got ${differ.length}: ${JSON.stringify(differ)}`)
+      assert.match(differ[0][0], /`AGENTS\.md`/)
+      assert.match(differ[0][1], /`CLAUDE\.md`/)
     })
 
     test('an unknown harness is refused, never quietly spelled the claude way', () => {

--- a/daemon/test/workspace.test.mjs
+++ b/daemon/test/workspace.test.mjs
@@ -6,6 +6,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { execFileSync } from 'node:child_process'
+import { parse as parseYaml } from 'yaml'
 import {
   seedConfigDir, agentEnv, agentGhToken, ghTokenKeyFor, assertGhTokens, hostStorageDir, installSkills, defaultSkillsRoot, DEFAULT_SKILLS,
   writeConnectionSettings, removeCredentials, untrustedProjectConfig, plantedSkills, MCP_SERVER_NAME,
@@ -232,6 +233,167 @@ describe('the agent skill set (#57)', () => {
     // checklist to a phone through `ask_human`.
     assert.equal(DEFAULT_SKILLS.includes('wizard'), false, 'wizard is deliberately withheld (#348)')
     assert.equal(defaultSkillsRoot(), path.join(os.homedir(), '.claude', 'skills'))
+  })
+
+  // #399. Codex hides a skill whose manifest says `allow_implicit_invocation:
+  // false`, so the model is never told it exists. `$wayfinder` used to reach it
+  // and paste all 11,867 characters into the conversation, where they went
+  // stale. Curia writes a pointer instead: a skill it owns, listed by default,
+  // naming the real file. Nothing upstream is patched.
+  describe('the pointer that puts a hidden skill back on the codex catalog (#399)', () => {
+    let ptmp
+    let proot
+
+    // Four shapes, and each one decides a different branch.
+    before(() => {
+      ptmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-ptr-'))
+      proot = path.join(ptmp, 'skills')
+      const skill = (name, front, manifest) => {
+        fs.mkdirSync(path.join(proot, name), { recursive: true })
+        fs.writeFileSync(path.join(proot, name, 'SKILL.md'), `---\n${front}\n---\n\n# ${name}\n`)
+        if (manifest) {
+          fs.mkdirSync(path.join(proot, name, 'agents'), { recursive: true })
+          fs.writeFileSync(path.join(proot, name, 'agents', 'openai.yaml'), manifest)
+        }
+      }
+      // hidden, plain description
+      skill('wayfinder', 'name: wayfinder\ndescription: Chart a map of decision tickets.',
+        'policy:\n  allow_implicit_invocation: false\n')
+      // hidden, and its description is a QUOTED scalar — the `implement` shape
+      skill('implement', 'name: implement\ndescription: "Implement work: from a spec, or tickets."',
+        'policy:\n  allow_implicit_invocation: false\n')
+      // a manifest that ALLOWS it: codex lists this one itself
+      skill('grilling', 'name: grilling\ndescription: Grill the user.',
+        'policy:\n  allow_implicit_invocation: true\n')
+      // no manifest at all: listed by default
+      skill('tdd', 'name: tdd\ndescription: Test first.')
+    })
+    after(() => { fs.rmSync(ptmp, { recursive: true, force: true }) })
+
+    const seedCodex = (n, install) => {
+      const cfgDir = path.join(ptmp, 'cfg', `curia-${n}`)
+      seedConfigDir(cfgDir, path.join(ptmp, 'wt', String(n)), { root: proot, install }, 'codex')
+      return cfgDir
+    }
+
+    // Frontmatter is PARSED here rather than matched, because the bug this
+    // guards was invisible to a match: see the quoted-description test below.
+    const frontmatter = (file) => {
+      const text = fs.readFileSync(file, 'utf8')
+      assert.ok(text.startsWith('---'), `${file} has no frontmatter at all`)
+      const end = text.indexOf('\n---', 3)
+      assert.notEqual(end, -1, `${file} has an unterminated frontmatter block`)
+      return parseYaml(text.slice(3, end))
+    }
+
+    test('upstream decides which skills need one, and the manifest is what is read', () => {
+      const cfgDir = seedCodex(20, ['wayfinder', 'implement', 'grilling', 'tdd'])
+      assert.deepEqual(fs.readdirSync(path.join(cfgDir, 'skills')).sort(),
+        ['curia-implement', 'curia-wayfinder', 'grilling', 'implement', 'tdd', 'wayfinder'])
+      // A skill codex already lists gets no pointer, whether it says so in a
+      // manifest or carries none. If upstream lists `wayfinder` in a later
+      // release, the pointer stops being written with no edit here.
+      assert.equal(fs.existsSync(path.join(cfgDir, 'skills', 'curia-grilling')), false)
+      assert.equal(fs.existsSync(path.join(cfgDir, 'skills', 'curia-tdd')), false)
+    })
+
+    test('the pointer names the installed file and restates none of the skill', () => {
+      const cfgDir = seedCodex(21, ['wayfinder'])
+      const target = path.join(cfgDir, 'skills', 'wayfinder', 'SKILL.md')
+      const pointer = path.join(cfgDir, 'skills', 'curia-wayfinder', 'SKILL.md')
+      const front = frontmatter(pointer)
+
+      assert.equal(front.name, 'curia-wayfinder')
+      // The description is the real skill's own, so the codex trigger fires on
+      // the tasks the skill claims rather than on a sentence curia invented.
+      assert.match(front.description, /^Chart a map of decision tickets\./)
+      assert.match(front.description, new RegExp(`Read ${target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} in full`))
+      // The name is prefixed, never the skill's own: codex keys a skill on this
+      // name, so two skills claiming `wayfinder` would be #224's ambiguity made
+      // on purpose.
+      assert.notEqual(front.name, 'wayfinder')
+      // A copy would go stale in silence, which is the whole reason the patched
+      // manifest was refused. The body carries the path and nothing else.
+      const body = fs.readFileSync(pointer, 'utf8')
+      assert.ok(body.includes(target), 'the pointer must name the file it points at')
+      assert.ok(!body.includes('# wayfinder'), 'the pointer copies no skill text')
+    })
+
+    // The regression that shipped and had to be caught by a live render: the
+    // `implement` skill writes its description as a QUOTED scalar. Splicing a
+    // sentence onto the raw captured text produced `description: "..." Read
+    // ...`, which is invalid YAML — and codex answers invalid frontmatter by
+    // dropping the skill from its catalog WITHOUT A WORD. The pointer existed
+    // on disk and reached no model.
+    test('a quoted description still yields frontmatter that parses', () => {
+      const cfgDir = seedCodex(22, ['implement'])
+      const front = frontmatter(path.join(cfgDir, 'skills', 'curia-implement', 'SKILL.md'))
+      assert.equal(front.name, 'curia-implement')
+      assert.match(front.description, /^Implement work: from a spec, or tickets\. Read /,
+        'the quotes and the colon must survive as VALUE, not as syntax')
+    })
+
+    test('every pointer curia can write parses, whatever upstream put in the description', () => {
+      // The bound stated as a rule rather than as two examples: a description
+      // is upstream's prose, and it may carry anything.
+      const cfgDir = seedCodex(23, ['wayfinder', 'implement'])
+      for (const name of ['curia-wayfinder', 'curia-implement']) {
+        const front = frontmatter(path.join(cfgDir, 'skills', name, 'SKILL.md'))
+        assert.equal(front.name, name)
+        assert.equal(typeof front.description, 'string')
+        assert.ok(front.description.length > 0)
+      }
+    })
+
+    test('the read-once rule is in the file curia owns, because codex says the opposite', () => {
+      // Codex tells the model to read a skill completely every time it uses one
+      // AND not to carry a skill across turns. Obeyed literally that is 12,299
+      // characters per turn, stacking (docs/live-checks/399). Curia cannot edit
+      // codex's rule, so it writes its own where it can.
+      const cfgDir = seedCodex(24, ['wayfinder'])
+      const body = fs.readFileSync(path.join(cfgDir, 'skills', 'curia-wayfinder', 'SKILL.md'), 'utf8')
+      assert.match(body, /ONCE in a session/)
+    })
+
+    test('a re-seed rebuilds the pointer, because installSkills wipes the directory it lives in', () => {
+      // #340's `standing.md` trap, one directory over: `seedConfigDir` runs
+      // again on the respawn a usage limit forces, and a pointer written
+      // anywhere but after the install would be gone for the rest of the run.
+      const cfgDir = seedCodex(25, ['wayfinder'])
+      const pointer = path.join(cfgDir, 'skills', 'curia-wayfinder', 'SKILL.md')
+      assert.ok(fs.existsSync(pointer))
+      seedConfigDir(cfgDir, path.join(ptmp, 'wt', '25'), { root: proot, install: ['wayfinder'] }, 'codex')
+      assert.ok(fs.existsSync(pointer), 'the re-arm must not leave the agent with a hidden skill')
+    })
+
+    test('a pointer for a skill that has left the install list does not survive', () => {
+      const cfgDir = seedCodex(26, ['wayfinder', 'implement'])
+      assert.ok(fs.existsSync(path.join(cfgDir, 'skills', 'curia-implement')))
+      seedConfigDir(cfgDir, path.join(ptmp, 'wt', '26'), { root: proot, install: ['wayfinder'] }, 'codex')
+      assert.deepEqual(fs.readdirSync(path.join(cfgDir, 'skills')).sort(), ['curia-wayfinder', 'wayfinder'])
+    })
+
+    test('the claude harness gets none, because it has no catalog to be missing from', () => {
+      // `/wayfinder` is a slash command: Claude Code expands the whole SKILL.md
+      // into the first user message, so that lane never had the fade this
+      // cures. The row is the harness table's, not a name test in the seed.
+      const cfgDir = path.join(ptmp, 'cfg', 'curia-27')
+      seedConfigDir(cfgDir, path.join(ptmp, 'wt', '27'), { root: proot, install: ['wayfinder'] }, 'claude')
+      assert.deepEqual(fs.readdirSync(path.join(cfgDir, 'skills')), ['wayfinder'])
+    })
+
+    test('the vendored tree still hides exactly the two skills this exists for', () => {
+      // A tree bump that lists them upstream makes the pointers stop being
+      // written, and this is where that shows up as a decision rather than as
+      // silence.
+      const vendored = path.resolve(import.meta.dirname, '..', '..', 'skills')
+      const hidden = DEFAULT_SKILLS.filter((name) => {
+        const manifest = path.join(vendored, name, 'agents', 'openai.yaml')
+        if (!fs.existsSync(manifest)) return false
+        return parseYaml(fs.readFileSync(manifest, 'utf8'))?.policy?.allow_implicit_invocation === false
+      })
+      assert.deepEqual(hidden.sort(), ['implement', 'wayfinder'])
+    })
   })
 
   // The vendored tree carries every promoted skill, so a name in the list that

--- a/docs/live-checks/399-codex-skill-arming.md
+++ b/docs/live-checks/399-codex-skill-arming.md
@@ -29,9 +29,14 @@ removes a listed skill. `enabled = true` does not add an unlisted one.
 no `agents/openai.yaml` is listed by default. Curia already writes files into the agent
 config dir at seed time, so it can write that directory too.
 
+**So curia ships a pointer, and stops typing a mention.** `seedConfigDir` writes
+`<cfgDir>/skills/curia-<name>/SKILL.md` for each skill codex hides, and the codex spawn prompt
+types no `$wayfinder`. Turn one falls from 46,682 characters to 34,825, and the arm is durable
+instead of spent (section 5).
+
 One half stays out of reach here, and it is a MODEL behavior rather than a CLI one. Codex
-tells the model to read a skill's `SKILL.md` completely each time it decides to use it. How
-often a real model re-reads is section 5.
+tells the model to read a skill's `SKILL.md` completely each time it decides to use it. Its
+cost is measured both ways in section 6, and the frequency is what still needs a real model.
 
 ## The instrument
 
@@ -146,13 +151,40 @@ The entry survives curia's own bounds. `codexSkillDenyList` denies names the HOS
 carries that the seed did not install, and a generated name is in neither, so nothing denies
 it.
 
-## 5. What a credential would still answer
+## 5. What curia ships, measured on curia's own seed
 
-The CLI half is settled: no catalog mechanism pastes a body. The model half is not, and it is
-a different question from the one the ticket asked.
+The `shipped` case builds nothing by hand. It calls `seedConfigDir`,
+`writeConnectionSettings` and `writePrompt`, so a regression in the daemon shows up as a
+number here.
 
-Codex states the protocol in `base_instructions`, which is world state and reaches the model
-on every turn:
+```
+pointers curia wrote: curia-implement, curia-wayfinder
+prompt.md first line: "# alp82/curia#399: x"
+```
+
+| turn | `<skill>` blocks | catalog chars | wayfinder entry | input chars |
+|---|---|---|---|---|
+| 1 | 0 | 3,246 | 381 | 34,825 |
+| 2 | 0 | 3,246 | 381 | 34,835 |
+| 3 | 0 | 3,246 | 381 | 34,847 |
+
+Both hidden skills are back on the catalog, for 623 characters per turn (381 for
+`curia-wayfinder`, 242 for `curia-implement`). No body reaches the input on any turn. The
+prompt types no sigil, so turn one is 34,825 characters against 46,682 for the same dispatch
+before this ticket.
+
+One bug was caught here and only here, and it is the reason the probe is committed.
+`implement` writes its description as a QUOTED YAML scalar. Splicing a sentence onto the
+captured text produced `description: "..." Read ...`, which is invalid YAML, and **codex
+answers invalid frontmatter by dropping the skill from its catalog in silence**. The pointer
+existed on disk, parsed nowhere, and reached no model. The daemon now parses the frontmatter
+with a YAML parser and re-emits both values as quoted scalars.
+
+## 6. The worst case, measured rather than guessed
+
+The ticket asked whether the chosen mechanism pastes the skill body on every turn. Section 2
+answers that for the CLI: it does not. What remains is the MODEL, and codex points it both
+ways at once. From `base_instructions`, which is world state and reaches the model every turn:
 
 > Trigger rules: If the user names an available skill (with `$SkillName` or plain text) OR the
 > task clearly matches an available skill's description, you must use that skill for that turn.
@@ -161,18 +193,48 @@ on every turn:
 > After deciding to use a skill, the main agent must read its `SKILL.md` completely before
 > taking task actions.
 
-Read together, those two put the re-arm and the cost in the same place. A listed skill
-re-triggers on every turn the task matches, because its description never goes stale. And
-each trigger tells the model to read the file completely. A model that obeys both literally
-puts 11,867 characters into a tool result every turn, which is #360's duplication under
-another name.
+A listed skill re-triggers on every turn the task matches, because its description never goes
+stale. That is the re-arm. And each trigger tells the model to read the file completely. A
+model that obeys both literally re-reads every turn.
 
-A pointer is what bounds that. The model re-reads the file the catalog names, so a short
-pointer costs a short read, and the full skill is read when the model reaches for it rather
-than on every turn.
+That behavior needs a real model. Its COST does not, so it is measured. The `reread` case
+scripts a model that re-reads on every turn and counts what lands in the input:
 
-How often a real model actually re-reads needs a credential and a long session. The stub
-cannot answer it, because there is no model behind it to obey anything.
+| what the model re-reads every turn | per read | after 3 turns | input chars, turn 1 → 3 |
+|---|---|---|---|
+| the pointer (736 bytes) | 999 | 2,997 | 34,907 → 37,926 |
+| the whole wayfinder skill (11,887 bytes) | 12,299 | 36,897 | 34,865 → 71,784 |
+
+The read lands in a tool result, so it STACKS exactly as a repeated mention did. Re-reading
+the whole skill every turn costs 12,299 characters per turn, which is worse than the
+11,867-character mention this replaced. Re-reading the pointer costs 999.
+
+Three things follow, and the third is the change this ticket makes.
+
+1. **The mechanism itself is sound.** Curia's unconditional cost fell from 11,867 characters
+   on turn one to 623 per turn, and the arm is now durable instead of spent.
+2. **The body is no longer curia's to pay.** It used to be pasted on every codex dispatch
+   whether the skill was needed or not. Now the model reads it when a task matches.
+3. **The worst case is worth a rule, and curia owns the file to put it in.** The pointer says
+   to read the target ONCE in a session. Curia cannot edit codex's instruction, and this is
+   the one file in the path that upstream does not own.
+
+How often a real model re-reads is still unmeasured, and it needs a credential. What changed
+is that the number it would produce is now bounded on both sides and written down.
+
+## 7. What is still not measured here
+
+Two things, and both need a real model rather than a credential-free rig.
+
+**How often a model re-reads.** Section 6 bounds the cost at both ends and says what curia
+wrote to hold it down. The frequency itself is a model behavior, and the stub has no model
+behind it to obey or disobey anything.
+
+**Whether the catalog survives a compaction.** The catalog is a developer message and codex
+restates it, which is the whole claim this mechanism rests on. #360 could observe that at rest
+over three turns and not under load, and the same holds here. That question already sits on
+the map, and this ticket sharpens it: it is now the catalog that must survive, not
+`AGENTS.md` alone.
 
 ## How to re-run it
 
@@ -180,9 +242,11 @@ cannot answer it, because there is no model behind it to obey anything.
 node docs/live-checks/399-codex-skill-arming.probe.mjs all
 ```
 
-Cases: `mention`, `flip`, `pointer`, `lever`. Each writes its request bodies under
-`/tmp/curia-399-arm/<case>/`, so a number in this file can be read back off the wire.
+Cases: `mention`, `flip`, `pointer`, `shipped`, `reread`, `lever`. Each writes its request
+bodies under `/tmp/curia-399-arm/<case>/`, so every number in this file can be read back off
+the wire.
 
-A codex version bump owes a re-run. Section 3 depends on the config schema and section 5
+A codex version bump owes a re-run. Section 3 depends on the config schema and section 6
 quotes `base_instructions`, and both live in the CLI. A skill-tree bump owes one too: the
-manifest that decides section 2 lives in the tree.
+manifest that decides section 2 lives in the tree, and section 5's `implement` trap lives in
+a description upstream writes.

--- a/docs/live-checks/399-codex-skill-arming.md
+++ b/docs/live-checks/399-codex-skill-arming.md
@@ -1,0 +1,188 @@
+# Live check: what arms a skill on codex, and what it costs (#399)
+
+Ticket: [alp82/curia#399](https://github.com/alp82/curia/issues/399), on the map
+[The operator sees and steers curia](https://github.com/alp82/curia/issues/244). Run on
+2026-08-16 inside an agent container, against codex 0.146.0. That is the version
+`config/curia.yaml` pins. No codex credential was used.
+
+This check continues [#360](https://github.com/alp82/curia/issues/360), which closed every
+cheap way to re-arm a skill and left the stable one to find. The probe is committed beside
+this file: [399-codex-skill-arming.probe.mjs](399-codex-skill-arming.probe.mjs).
+
+## Summary
+
+**A listed skill never pastes its body.** The catalog entry is one line of name, description
+and path, in a developer message, byte-identical on every turn. The 11,867-character
+`<skill>` block reaches the model from one place only: a `$name` mention in a user message.
+Listing a skill does not change that, and a listed skill that the task matches carries no
+block at all.
+
+So the question the ticket called untested is answered, for the CLI half. Whatever lists
+`wayfinder` costs about 270 characters per turn and no body. The duplication does not return
+by that door.
+
+**`config.toml` holds no additive lever, and it now has a control.** `enabled = false`
+removes a listed skill. `enabled = true` does not add an unlisted one.
+`allow_implicit_invocation` is a manifest field, and codex ignores it in `config.toml`.
+
+**Curia can own a listed skill without patching one byte upstream.** A skill directory with
+no `agents/openai.yaml` is listed by default. Curia already writes files into the agent
+config dir at seed time, so it can write that directory too.
+
+One half stays out of reach here, and it is a MODEL behavior rather than a CLI one. Codex
+tells the model to read a skill's `SKILL.md` completely each time it decides to use it. How
+often a real model re-reads is section 5.
+
+## The instrument
+
+[#360](https://github.com/alp82/curia/issues/360)'s: a local stub of the Responses API behind
+`-c model_provider=fake`. A real `codex exec` runs a real multi-turn session against it, with
+no credential anywhere, and every request body is written to disk. The input list the model
+would have read is the reading.
+
+The fixture is curia's own spawn. The probe calls `seedConfigDir`, `writeConnectionSettings`
+and `writePrompt` from `daemon/src/workspace.mjs`, with `harness: 'codex'` and the vendored
+tree at `skills/`.
+
+#360 described its stub in prose and committed no code, so this ticket rebuilt it from the
+description. The probe is committed for that reason. A codex version bump owes a re-run, and
+a re-run should not start at a blank page.
+
+## 1. The control: a mention, and what it costs after it
+
+`$wayfinder` on turn one, nothing on the two turns after it.
+
+| turn | input items | user msgs | `<skill>` blocks | body chars | catalog chars | input chars |
+|---|---|---|---|---|---|---|
+| 1 | 8 | 3 | 1 | 11,867 | 2,621 | 46,682 |
+| 2 | 10 | 4 | 1 | 11,867 | 2,621 | 46,704 |
+| 3 | 12 | 5 | 1 | 11,867 | 2,621 | 46,716 |
+
+The block arrives once and stays. It is never restated and never removed. #360 measured the
+other half of this: a SECOND mention adds a second copy and keeps the first.
+
+## 2. A listed skill pastes no body
+
+The route the operator rejected on 2026-08-16, measured for the question it left open. A
+patched copy of the tree carries `policy.allow_implicit_invocation: true`. The checkout is
+never written to.
+
+| turn | prompt | `<skill>` blocks | body chars | catalog chars | wayfinder entry | input chars |
+|---|---|---|---|---|---|---|
+| 1 | `chart a map for the new effort` | 0 | 0 | 3,023 | 273 | 35,207 |
+| 2 | `$wayfinder go` | 1 | 11,884 | 3,023 | 273 | 47,106 |
+| 3 | `continue charting` | 1 | 11,884 | 3,023 | 273 | 47,125 |
+
+Three readings:
+
+1. **Turn one carries no body**, on a prompt that matches the skill's own description word
+   for word. Listing arms the trigger. It injects nothing.
+2. **The mention still resolves for a listed skill.** Turn two adds the block, exactly as it
+   does for an unlisted one. The mention is the injector, and listing does not replace it.
+3. **The entry is world state.** 273 characters, byte-identical on all three turns, in the
+   `<skills_instructions>` developer message.
+
+The entry is `- <name>: <description> (file: <path>)`, so its length follows the description
+and the path. The 273 above holds for the probe's own paths. #360 measured 257 for the same
+entry under the checkout path.
+
+## 3. `config.toml` has no additive lever
+
+Rendered with `codex debug prompt-input`, which answers a catalog question without a model.
+The `grilling` column is the control: without it, an entry codex ignores and an entry codex
+never read look the same.
+
+| `[[skills.config]]` entry | wayfinder listed | grilling listed | codex |
+|---|---|---|---|
+| (none) | no | yes | rendered |
+| `name = "grilling"`, `enabled = false` | no | **no** | rendered |
+| `name = "wayfinder"`, `enabled = true` | no | yes | rendered |
+| `name = "wayfinder"`, `enabled = true`, `allow_implicit_invocation = true` | no | yes | rendered |
+| `name = "wayfinder"`, `allow_implicit_invocation = true` | — | — | **refused**: missing field `enabled` |
+
+Row 2 is the control and it passes: the entry is read, and `enabled = false` takes a skill
+off the list. That is the lever curia already uses for the [#171](https://github.com/alp82/curia/issues/171)
+deny list.
+
+Rows 3 and 4 close [#340](https://github.com/alp82/curia/issues/340)'s question with a
+control behind it. The list is SUBTRACTIVE. An entry cannot add a skill the manifest hides,
+and `allow_implicit_invocation` in `config.toml` changes nothing.
+
+Row 5 is a trap worth stating, because curia writes these entries itself. `enabled` is a
+REQUIRED field. An entry without it is a hard config error, and codex renders nothing at all.
+Curia is safe today, because `codexSkillDenyList` always writes `enabled = false`. A future
+entry that forgets it takes the whole agent down at startup.
+
+The binary agrees with the readings. `SkillConfig` carries three fields, and its own refusals
+name them: an entry needs a `path` or a `name` selector, never both, plus `enabled`. There is
+no fourth field to reach for. `allow_implicit_invocation` appears only in the `openai.yaml`
+manifest schema, beside `interface`, `dependencies` and `policy`.
+
+## 4. Curia can own a listed skill, and patch nothing
+
+A skill needs no manifest to be listed. `allow_implicit_invocation` defaults to true, so a
+directory with a `SKILL.md` and no `agents/openai.yaml` is on the list.
+
+The probe writes one into the agent config dir, beside the `standing.md` curia already writes
+there:
+
+```
+<cfgDir>/skills/curia-wayfinder/SKILL.md
+```
+
+Its description names the dispatch and points at the installed `wayfinder` SKILL.md. Its body
+does the same in one sentence. It restates no rule.
+
+| turn | prompt | `<skill>` blocks | catalog chars | pointer entry | input chars |
+|---|---|---|---|---|---|
+| 1 | `$wayfinder hello` | 1 | 2,892 | 270 | 46,953 |
+| 2 | `turn two, no mention` | 1 | 2,892 | 270 | 46,975 |
+
+270 characters per turn, byte-identical, and no body of its own. The vendored tree is
+untouched, so a skill-tree update cannot break it in silence. That is the property the
+patched manifest lacked.
+
+The entry survives curia's own bounds. `codexSkillDenyList` denies names the HOST root
+carries that the seed did not install, and a generated name is in neither, so nothing denies
+it.
+
+## 5. What a credential would still answer
+
+The CLI half is settled: no catalog mechanism pastes a body. The model half is not, and it is
+a different question from the one the ticket asked.
+
+Codex states the protocol in `base_instructions`, which is world state and reaches the model
+on every turn:
+
+> Trigger rules: If the user names an available skill (with `$SkillName` or plain text) OR the
+> task clearly matches an available skill's description, you must use that skill for that turn.
+> Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
+
+> After deciding to use a skill, the main agent must read its `SKILL.md` completely before
+> taking task actions.
+
+Read together, those two put the re-arm and the cost in the same place. A listed skill
+re-triggers on every turn the task matches, because its description never goes stale. And
+each trigger tells the model to read the file completely. A model that obeys both literally
+puts 11,867 characters into a tool result every turn, which is #360's duplication under
+another name.
+
+A pointer is what bounds that. The model re-reads the file the catalog names, so a short
+pointer costs a short read, and the full skill is read when the model reaches for it rather
+than on every turn.
+
+How often a real model actually re-reads needs a credential and a long session. The stub
+cannot answer it, because there is no model behind it to obey anything.
+
+## How to re-run it
+
+```sh
+node docs/live-checks/399-codex-skill-arming.probe.mjs all
+```
+
+Cases: `mention`, `flip`, `pointer`, `lever`. Each writes its request bodies under
+`/tmp/curia-399-arm/<case>/`, so a number in this file can be read back off the wire.
+
+A codex version bump owes a re-run. Section 3 depends on the config schema and section 5
+quotes `base_instructions`, and both live in the CLI. A skill-tree bump owes one too: the
+manifest that decides section 2 lives in the tree.

--- a/docs/live-checks/399-codex-skill-arming.probe.mjs
+++ b/docs/live-checks/399-codex-skill-arming.probe.mjs
@@ -1,0 +1,277 @@
+// What arms a skill on codex, and what each arming costs per turn (#399).
+//
+// The instrument is [#360](https://github.com/alp82/curia/issues/360)'s: a local
+// stub of the Responses API behind `-c model_provider=fake`. A real codex CLI
+// runs a real multi-turn session against it, and no credential is needed
+// anywhere. Every request body is written to disk, so the input list the model
+// would have read IS the reading.
+//
+// #360 described its stub in prose and committed no code, so this ticket rebuilt
+// it. The file is committed for that reason: the next codex version bump owes a
+// re-run, and a re-run should not start at a blank page.
+//
+// The fixture is curia's own spawn. `seedConfigDir`, `writeConnectionSettings`
+// and `writePrompt` from `daemon/src/workspace.mjs` write the config dir, with
+// `harness: 'codex'` and the vendored tree at `skills/`.
+//
+// Run:  node docs/live-checks/399-codex-skill-arming.probe.mjs <case>
+//       node docs/live-checks/399-codex-skill-arming.probe.mjs all
+//
+// Cases:
+//   mention  the #360 control. `$wayfinder` on turn one, nothing after it.
+//   flip     `policy.allow_implicit_invocation: true` in a PATCHED copy of the
+//            tree. The route the operator rejected, measured for its price.
+//   pointer  a skill curia GENERATES into the agent config dir, carrying no
+//            manifest at all. Nothing upstream is patched.
+//   lever    can `config.toml` list a skill? Rendered, not run, with a control.
+//
+// Needs the `codex` binary on PATH. It needs no credential and no network.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import http from 'node:http'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const SELF = fileURLToPath(import.meta.url)
+const REPO = path.resolve(path.dirname(SELF), '../..')
+const ROOT = process.env.PROBE_DIR || path.join(os.tmpdir(), 'curia-399-arm')
+const PORT = Number(process.env.PROBE_MODEL_PORT ?? 8899)
+
+const { seedConfigDir, writeConnectionSettings, writePrompt, DEFAULT_SKILLS } =
+  await import(path.join(REPO, 'daemon/src/workspace.mjs'))
+
+// ---- the fixture -----------------------------------------------------------
+
+// curia's own spawn, into a throwaway CODEX_HOME. `skillsRoot` is a parameter so
+// the `flip` case can point at a patched copy of the tree without touching the
+// checkout.
+function seed(dir, { skillsRoot = path.join(REPO, 'skills'), install = DEFAULT_SKILLS } = {}) {
+  const cfg = path.join(dir, 'ch')
+  const ws = path.join(dir, 'ws')
+  fs.rmSync(dir, { recursive: true, force: true })
+  fs.mkdirSync(ws, { recursive: true })
+  const skills = { root: skillsRoot, install }
+  seedConfigDir(cfg, ws, skills, 'codex', { sandboxed: false })
+  writeConnectionSettings({
+    wtPath: ws, cfgDir: cfg, agent: 'curia-399', ticket: '399',
+    daemonPort: 4271, harness: 'codex', reasoningEffort: 'high',
+    daemonHost: '127.0.0.1', token: 'a'.repeat(64), skills,
+  })
+  writePrompt(cfg, { number: 399, title: 'x', body: 'Part of #244' }, {
+    repo: 'alp82/curia', wtPath: ws, mapNumber: 244,
+    type: 'wayfinder:grilling', ports: [9018, 9019, 9020], harness: 'codex',
+  })
+  return { cfg, ws }
+}
+
+// A copy of the vendored tree with one line changed. The checkout is never
+// written to: `skills/` is upstream's bytes, pinned in `skills/UPSTREAM.md`.
+function flippedTree(dir) {
+  const root = path.join(dir, 'skills-flipped')
+  fs.rmSync(root, { recursive: true, force: true })
+  fs.cpSync(path.join(REPO, 'skills'), root, { recursive: true, dereference: true })
+  const manifest = path.join(root, 'wayfinder/agents/openai.yaml')
+  fs.writeFileSync(manifest, fs.readFileSync(manifest, 'utf8')
+    .replace('allow_implicit_invocation: false', 'allow_implicit_invocation: true'))
+  return root
+}
+
+// The pointer. Curia would write this at seed time, beside `standing.md`. It
+// carries no `agents/openai.yaml`, and codex lists a skill with no manifest by
+// default, so nothing upstream is patched and nothing is restated.
+function writePointer(cfg) {
+  const dir = path.join(cfg, 'skills/curia-wayfinder')
+  const target = path.join(cfg, 'skills/wayfinder/SKILL.md')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), [
+    '---',
+    'name: curia-wayfinder',
+    `description: This dispatch runs the wayfinder skill. Read ${target} in full before you chart a map, resolve a ticket, or write a resolution comment.`,
+    '---',
+    '',
+    `Read \`${target}\` completely, then follow it. It is the skill this dispatch runs.`,
+    'The curia standing orders win where the two disagree.',
+    '',
+  ].join('\n'))
+  return dir
+}
+
+// ---- the stub model --------------------------------------------------------
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    let raw = ''
+    req.on('data', (c) => { raw += c })
+    req.on('end', () => { try { resolve(JSON.parse(raw)) } catch { resolve({}) } })
+  })
+}
+
+// Three server-sent events are the whole Responses wire protocol codex needs:
+// `response.created`, `response.output_item.done` and `response.completed`. The
+// model says one word, because what is under test is the input list codex builds
+// and never the answer it gets back.
+function serveModel(dir, requests) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${PORT}`)
+    if (req.method !== 'POST' || !url.pathname.endsWith('/responses')) { res.writeHead(404).end('{}'); return }
+    const body = await readBody(req)
+    requests.push(body)
+    fs.writeFileSync(path.join(dir, `request-${String(requests.length).padStart(2, '0')}.json`), JSON.stringify(body, null, 2))
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' })
+    const send = (type, o) => res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...o })}\n\n`)
+    const n = requests.length
+    const response = { id: `resp_${n}`, object: 'response', status: 'completed', output: [], usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+    send('response.created', { response: { ...response, status: 'in_progress' } })
+    send('response.output_item.done', {
+      output_index: 0,
+      item: { type: 'message', id: `msg_${n}`, status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] },
+    })
+    send('response.completed', { response })
+    res.end()
+  })
+  return new Promise((r) => server.listen(PORT, '127.0.0.1', () => r(server)))
+}
+
+// `</dev/null` matters: the CLI waits on stdin and never returns without it.
+function codex(args, { cfg, ws }) {
+  return new Promise((resolve) => {
+    const p = spawn('codex', [
+      'exec', '--skip-git-repo-check',
+      '-c', 'model_providers.fake.name=fake',
+      '-c', `model_providers.fake.base_url=http://127.0.0.1:${PORT}/v1`,
+      '-c', 'model_providers.fake.wire_api=responses',
+      '-c', 'model_providers.fake.env_key=FAKE_KEY',
+      '-c', 'model_provider=fake',
+      ...args,
+    ], { cwd: ws, env: { ...process.env, CODEX_HOME: cfg, FAKE_KEY: 'x' }, stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    p.stdout.on('data', (c) => { out += c })
+    p.stderr.on('data', (c) => { out += c })
+    p.on('exit', (code) => resolve({ code, out }))
+  })
+}
+
+// ---- the readings ----------------------------------------------------------
+
+// The catalog is the second content part of the third input item, and the
+// `<skill>` body is a user message. Both are read off the request rather than
+// counted here, so a codex that moves either one reads as a zero and not as a
+// wrong number.
+function readings(body) {
+  const items = body.input ?? []
+  const parts = items.flatMap((m) => (m.content ?? []).map((c) => ({ role: m.role, text: c.text ?? '' })))
+  const catalog = parts.find((p) => p.text.startsWith('<skills_instructions>'))?.text ?? ''
+  const line = catalog.split('\n').find((l) => l.startsWith('- wayfinder:') || l.startsWith('- curia-wayfinder:')) ?? ''
+  return {
+    items: items.length,
+    users: items.filter((m) => m.role === 'user').length,
+    blocks: parts.filter((p) => p.text.startsWith('<skill>')).length,
+    body: parts.filter((p) => p.text.startsWith('<skill>')).reduce((a, p) => a + p.text.length, 0),
+    catalog: catalog.length,
+    entry: line.length,
+    chars: parts.reduce((a, p) => a + p.text.length, 0),
+  }
+}
+
+function table(name, requests) {
+  console.log(`\n### ${name}`)
+  console.log('\n| turn | input items | user msgs | `<skill>` blocks | body chars | catalog chars | wayfinder entry | input chars |')
+  console.log('|---|---|---|---|---|---|---|---|')
+  requests.forEach((b, i) => {
+    const r = readings(b)
+    console.log(`| ${i + 1} | ${r.items} | ${r.users} | ${r.blocks} | ${r.body} | ${r.catalog} | ${r.entry || '—'} | ${r.chars} |`)
+  })
+}
+
+async function turns(name, dir, seeded, prompts) {
+  const requests = []
+  const server = await serveModel(dir, requests)
+  for (const [i, prompt] of prompts.entries()) {
+    const { code, out } = await codex(i === 0 ? [prompt] : ['resume', '--last', prompt], seeded)
+    if (code !== 0) console.error(`turn ${i + 1} exited ${code}\n${out.slice(-1200)}`)
+  }
+  await new Promise((r) => server.close(r))
+  table(`${name} — prompts: ${prompts.map((p) => JSON.stringify(p)).join(', ')}`, requests)
+  return requests
+}
+
+// `codex debug prompt-input` renders the session context without a model. It
+// does NOT resolve skill mentions (#340 section 1), so it answers a catalog
+// question and never an injection one.
+//
+// stderr and the exit code are read as well as stdout, because a config codex
+// REFUSES renders nothing at all — and a skill that is absent from an empty
+// render looks exactly like a skill codex chose not to list. One of the four
+// rows below is that case, and without this it reads as a wrong answer.
+function rendered(cfg) {
+  const p = spawn('codex', ['debug', 'prompt-input', 'x'], { env: { ...process.env, CODEX_HOME: cfg }, stdio: ['ignore', 'pipe', 'pipe'] })
+  return new Promise((resolve) => {
+    let out = ''
+    let err = ''
+    p.stdout.on('data', (c) => { out += c })
+    p.stderr.on('data', (c) => { err += c })
+    p.on('exit', (code) => resolve({ out, err, code }))
+  })
+}
+
+const CASES = {
+  // The #360 control. Without it, an absent block proves nothing about the rig.
+  async mention() {
+    const dir = path.join(ROOT, 'mention')
+    const seeded = seed(dir)
+    await turns('mention', dir, seeded, ['$wayfinder hello', 'turn two, no mention', 'turn three'])
+  },
+
+  // The route the operator rejected on 2026-08-16, measured for its price and
+  // for the question it left open: does a LISTED skill paste its body?
+  async flip() {
+    const dir = path.join(ROOT, 'flip')
+    const seeded = seed(dir, { skillsRoot: flippedTree(ROOT) })
+    await turns('flip', dir, seeded, ['chart a map for the new effort', '$wayfinder go', 'continue charting'])
+  },
+
+  // Curia's own file, in curia's own directory, patching nothing.
+  async pointer() {
+    const dir = path.join(ROOT, 'pointer')
+    const seeded = seed(dir)
+    writePointer(seeded.cfg)
+    await turns('pointer', dir, seeded, ['$wayfinder hello', 'turn two, no mention'])
+  },
+
+  // Is there a supported lever in `config.toml` today? The control is what makes
+  // the answer readable: an entry codex ignores and an entry codex never read
+  // look the same from outside.
+  async lever() {
+    const dir = path.join(ROOT, 'lever')
+    const { cfg } = seed(dir)
+    const base = fs.readFileSync(path.join(cfg, 'config.toml'), 'utf8')
+
+    console.log('\n### lever — can config.toml list a skill?\n')
+    console.log('| config.toml entry | wayfinder listed | grilling listed | codex |')
+    console.log('|---|---|---|---|')
+    const rows = [
+      ['(none)', ''],
+      ['name = "grilling", enabled = false', '\n[[skills.config]]\nname = "grilling"\nenabled = false\n'],
+      ['name = "wayfinder", enabled = true', '\n[[skills.config]]\nname = "wayfinder"\nenabled = true\n'],
+      ['name = "wayfinder", enabled = true, allow_implicit_invocation = true', '\n[[skills.config]]\nname = "wayfinder"\nenabled = true\nallow_implicit_invocation = true\n'],
+      ['name = "wayfinder", allow_implicit_invocation = true', '\n[[skills.config]]\nname = "wayfinder"\nallow_implicit_invocation = true\n'],
+    ]
+    for (const [label, extra] of rows) {
+      fs.writeFileSync(path.join(cfg, 'config.toml'), base + extra)
+      const { out, err, code } = await rendered(cfg)
+      const refused = code !== 0
+      const verdict = refused ? `refused: ${(/Error: .*/.exec(err)?.[0] ?? '').slice(0, 80)}` : 'rendered'
+      const seen = (name) => (refused ? '—' : (out.includes(`- ${name}:`) ? 'yes' : 'no'))
+      console.log(`| \`${label}\` | ${seen('wayfinder')} | ${seen('grilling')} | ${verdict} |`)
+    }
+  },
+}
+
+const which = process.argv[2]
+if (which === 'all') for (const run of Object.values(CASES)) await run()
+else if (CASES[which]) await CASES[which]()
+else {
+  console.error(`usage: node ${path.relative(REPO, SELF)} <${Object.keys(CASES).join('|')}|all>`)
+  process.exit(2)
+}

--- a/docs/live-checks/399-codex-skill-arming.probe.mjs
+++ b/docs/live-checks/399-codex-skill-arming.probe.mjs
@@ -108,10 +108,14 @@ function readBody(req) {
 }
 
 // Three server-sent events are the whole Responses wire protocol codex needs:
-// `response.created`, `response.output_item.done` and `response.completed`. The
-// model says one word, because what is under test is the input list codex builds
-// and never the answer it gets back.
-function serveModel(dir, requests) {
+// `response.created`, `response.output_item.done` and `response.completed`.
+//
+// `reads` is what the scripted model does with its turn: by default it says one
+// word, because what is under test is the input list codex builds and never the
+// answer it gets back. The `reread` case passes a list of files instead, so the
+// model does what codex's own protocol tells it to do with a skill — read the
+// `SKILL.md` completely before acting. A turn is over once its reads are done.
+function serveModel(dir, requests, reads = []) {
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url, `http://127.0.0.1:${PORT}`)
     if (req.method !== 'POST' || !url.pathname.endsWith('/responses')) { res.writeHead(404).end('{}'); return }
@@ -123,21 +127,53 @@ function serveModel(dir, requests) {
     const n = requests.length
     const response = { id: `resp_${n}`, object: 'response', status: 'completed', output: [], usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
     send('response.created', { response: { ...response, status: 'in_progress' } })
-    send('response.output_item.done', {
-      output_index: 0,
-      item: { type: 'message', id: `msg_${n}`, status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] },
-    })
+    // How many files THIS TURN has already read. Counted after the last user
+    // message rather than over the whole input, because the point of the case
+    // is a read that repeats on every turn — a session-wide count would read
+    // once and then think it was done.
+    const items = body.input ?? []
+    const lastUser = items.map((i) => i?.role).lastIndexOf('user')
+    const done = items.slice(lastUser + 1).filter((i) => i?.type === 'custom_tool_call' && i?.name === 'exec').length
+    const next = reads[done]
+    if (next) {
+      // `exec` takes raw JavaScript, not a shell line: it evaluates in a V8
+      // isolate with no filesystem, and the shell is a nested tool reached as
+      // `tools.exec_command`. A shell string here comes back as
+      // "SyntaxError: Unexpected token ':'" — which is what the first run of
+      // this case got, and it is why the reading is a script.
+      send('response.output_item.done', {
+        output_index: 0,
+        item: {
+          type: 'custom_tool_call', id: `ct_${n}`, call_id: `call_${n}`, name: 'exec',
+          input: `const r = await tools.exec_command({ cmd: ${JSON.stringify(`cat ${next}`)} });\ntext(r)\n`,
+          status: 'completed',
+        },
+      })
+    } else {
+      send('response.output_item.done', {
+        output_index: 0,
+        item: { type: 'message', id: `msg_${n}`, status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] },
+      })
+    }
     send('response.completed', { response })
     res.end()
   })
   return new Promise((r) => server.listen(PORT, '127.0.0.1', () => r(server)))
 }
 
-// `</dev/null` matters: the CLI waits on stdin and never returns without it.
+// `stdio: ignore` on stdin matters: the CLI waits on it and never returns.
+//
+// The two `--dangerously-*` flags are curia's own, copied from the codex
+// `template` in `config/routing.yaml`. They are fidelity rather than
+// convenience, and the `reread` case cannot run without them: codex sandboxes a
+// nested `exec_command` with bwrap, an agent container has no unprivileged user
+// namespaces, and every read comes back as a bwrap error instead of a file.
 function codex(args, { cfg, ws }) {
   return new Promise((resolve) => {
     const p = spawn('codex', [
       'exec', '--skip-git-repo-check',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--dangerously-bypass-hook-trust',
       '-c', 'model_providers.fake.name=fake',
       '-c', `model_providers.fake.base_url=http://127.0.0.1:${PORT}/v1`,
       '-c', 'model_providers.fake.wire_api=responses',
@@ -163,6 +199,12 @@ function readings(body) {
   const parts = items.flatMap((m) => (m.content ?? []).map((c) => ({ role: m.role, text: c.text ?? '' })))
   const catalog = parts.find((p) => p.text.startsWith('<skills_instructions>'))?.text ?? ''
   const line = catalog.split('\n').find((l) => l.startsWith('- wayfinder:') || l.startsWith('- curia-wayfinder:')) ?? ''
+  // A tool result is the OTHER way a skill body reaches the input, and it is the
+  // one a mention cannot cause: the model reads the file itself. Counted apart
+  // from `<skill>` blocks, because the two arrive by different doors and only
+  // one of them is curia's to stop.
+  const outputs = items.filter((i) => i?.type === 'custom_tool_call_output')
+  const readChars = outputs.reduce((a, o) => a + JSON.stringify(o.output ?? '').length, 0)
   return {
     items: items.length,
     users: items.filter((m) => m.role === 'user').length,
@@ -170,29 +212,37 @@ function readings(body) {
     body: parts.filter((p) => p.text.startsWith('<skill>')).reduce((a, p) => a + p.text.length, 0),
     catalog: catalog.length,
     entry: line.length,
-    chars: parts.reduce((a, p) => a + p.text.length, 0),
+    reads: outputs.length,
+    readChars,
+    chars: parts.reduce((a, p) => a + p.text.length, 0) + readChars,
   }
 }
 
-function table(name, requests) {
+function table(name, requests, { turnOf = null } = {}) {
   console.log(`\n### ${name}`)
-  console.log('\n| turn | input items | user msgs | `<skill>` blocks | body chars | catalog chars | wayfinder entry | input chars |')
-  console.log('|---|---|---|---|---|---|---|---|')
+  console.log('\n| turn | input items | `<skill>` blocks | body chars | catalog chars | entry | file reads | read chars | input chars |')
+  console.log('|---|---|---|---|---|---|---|---|---|')
   requests.forEach((b, i) => {
     const r = readings(b)
-    console.log(`| ${i + 1} | ${r.items} | ${r.users} | ${r.blocks} | ${r.body} | ${r.catalog} | ${r.entry || '—'} | ${r.chars} |`)
+    const label = turnOf ? turnOf[i] : i + 1
+    console.log(`| ${label} | ${r.items} | ${r.blocks} | ${r.body} | ${r.catalog} | ${r.entry || '—'} | ${r.reads} | ${r.readChars} | ${r.chars} |`)
   })
 }
 
-async function turns(name, dir, seeded, prompts) {
+async function turns(name, dir, seeded, prompts, { reads = [] } = {}) {
   const requests = []
-  const server = await serveModel(dir, requests)
+  const turnOf = []
+  const server = await serveModel(dir, requests, reads)
   for (const [i, prompt] of prompts.entries()) {
+    const before = requests.length
     const { code, out } = await codex(i === 0 ? [prompt] : ['resume', '--last', prompt], seeded)
     if (code !== 0) console.error(`turn ${i + 1} exited ${code}\n${out.slice(-1200)}`)
+    // One turn can cost several requests once the model reads files, so the
+    // table labels a row by the TURN it belongs to rather than by its position.
+    for (let k = before; k < requests.length; k += 1) turnOf.push(`${i + 1}`)
   }
   await new Promise((r) => server.close(r))
-  table(`${name} — prompts: ${prompts.map((p) => JSON.stringify(p)).join(', ')}`, requests)
+  table(`${name} — prompts: ${prompts.map((p) => JSON.stringify(p)).join(', ')}`, requests, { turnOf })
   return requests
 }
 
@@ -237,6 +287,34 @@ const CASES = {
     const seeded = seed(dir)
     writePointer(seeded.cfg)
     await turns('pointer', dir, seeded, ['$wayfinder hello', 'turn two, no mention'])
+  },
+
+  // What curia SHIPS after #399: pointers written by `seedConfigDir`, and a
+  // spawn prompt that types no sigil. Nothing is hand-built here, so a
+  // regression in the daemon shows up as a number in this table.
+  async shipped() {
+    const dir = path.join(ROOT, 'shipped')
+    const seeded = seed(dir)
+    const listed = fs.readdirSync(path.join(seeded.cfg, 'skills')).filter((d) => d.startsWith('curia-'))
+    console.log(`\npointers curia wrote: ${listed.join(', ') || '(none)'}`)
+    console.log(`prompt.md first line: ${JSON.stringify(fs.readFileSync(path.join(seeded.cfg, 'prompt.md'), 'utf8').split('\n')[0])}`)
+    await turns('shipped', dir, seeded, ['resolve the ticket in prompt.md', 'turn two', 'turn three'])
+  },
+
+  // The worst case, and the one the stub cannot settle by watching: codex tells
+  // the model to read a skill's `SKILL.md` completely every time it uses the
+  // skill, and it also tells it not to carry a skill across turns. A model that
+  // obeys both literally re-reads on every turn. This scripts exactly that, so
+  // the cost is measured rather than guessed — with the pointer, and then with
+  // the whole wayfinder skill for comparison.
+  async reread() {
+    for (const [label, file] of [['pointer', 'curia-wayfinder'], ['full skill', 'wayfinder']]) {
+      const dir = path.join(ROOT, `reread-${file}`)
+      const seeded = seed(dir)
+      const target = path.join(seeded.cfg, 'skills', file, 'SKILL.md')
+      await turns(`reread every turn — ${label} (${fs.statSync(target).size} bytes)`, dir, seeded,
+        ['turn one', 'turn two', 'turn three'], { reads: [target] })
+    }
   },
 
   // Is there a supported lever in `config.toml` today? The control is what makes


### PR DESCRIPTION
Ticket: alp82/curia#399 — [A stable way to arm the wayfinder skill on codex](https://github.com/alp82/curia/issues/399)

Arms the wayfinder skill on codex through a pointer curia owns, and stops typing the `$wayfinder` mention.

**The mechanism.** `seedConfigDir` writes `<cfgDir>/skills/curia-<name>/SKILL.md` for each skill codex hides from its own catalog (`wayfinder` and `implement`). The pointer carries the real skill's own description, names the installed file, and restates none of it. Codex lists a skill with no manifest by default, so no vendored byte is patched. Hidden-ness is read from upstream's manifest, so a release that lists a skill stops its pointer with no edit here.

**The mention goes.** `$wayfinder` was the only thing that pasted the 11,867-character skill body into a codex session, and it pasted it as conversation, which codex treats as stale after its turn. The prose now names the skill so nothing dangles on the lane with no sigil. The claude lane keeps `/wayfinder`.

**Measured, credential-free, on the pinned codex 0.146.0** (`docs/live-checks/399-codex-skill-arming.md`, probe committed beside it):
- A listed skill never pastes its body: zero skill blocks on every turn.
- `config.toml` has no additive lever, with a control. `enabled` is also required — an entry without it stops codex at startup, and curia writes these entries.
- Shipped seed: 623 characters of catalog per turn, turn one down from 46,682 to 34,825.
- Worst case measured rather than guessed: a model that re-reads every turn costs 999 characters for the pointer and 12,299 for the whole skill, and it stacks. The pointer carries a read-once rule for that reason.

**One bug caught by the live render:** `implement` writes a quoted description, so splicing a sentence onto it made invalid YAML — and codex drops a skill with unparseable frontmatter from its catalog in silence. Frontmatter is parsed and re-emitted as quoted scalars now, with a regression test.

`CONTEXT.md` gains **Skill pointer** and its **Spawn prompt** entry is corrected. Suite 2238 pass.

---

Dispatched by the curia daemon — session `curia-399`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `903d39a` A skill pointer arms wayfinder on codex, and the mention goes away
- `9a06c65` Live check 399: a listed skill pastes no body, and curia can own one