### PR TITLE
Typed report_result (alp82/curia#419)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -340,6 +340,10 @@ _Avoid_: strict lint, soft lint.
 The optional code-block table or ASCII diagram on a card. At most 42 columns by 20 lines, which is the phone limit from #414. That sits under `CODE_BLOCK_LIMIT`, so a typed visual passes the block cap the lint already ships (#432). curia writes the fence, never the agent. A visual earns its space by removing prose (#415).
 _Avoid_: diagram, figure.
 
+**Ending report**:
+What `report_result` puts in the thread, in the agent's own voice, as the first of the ending's two messages (#253, #419). It is typed: `headline` says what the work came to in one line, `summary` says what changed, and a `visual` and a `detail` are the agent's judgment. curia lays the parts out and appends the pull-request link. The same headline leads the resolution comment curia writes, and it becomes the gist of the map pointer. A cross-check reviewer's report is a verdict instead, and #421 types that surface.
+_Avoid_: final summary, result message.
+
 **Lint gate**:
 The voice check on agent prose that reaches a human, and the rejection that enforces it (#416, #438). The daemon lints against `daemon/assets/voice.md` and refuses the call with the lint message. The agent rewrites its own text and calls again. The daemon never rewrites it. Three rejections is the cap, and the daemon counts them, because an agent miscounts its own. See [ADR-0005](docs/adr/0005-escalation-contract.md).
 _Avoid_: voice gate, prose check.

--- a/daemon/src/card.mjs
+++ b/daemon/src/card.mjs
@@ -17,7 +17,7 @@
 // instructions stay in the bridge, because they are the answer surface rather
 // than the question.
 
-import { unfence } from './lint.mjs'
+import { unfence, isTypedResult } from './lint.mjs'
 
 // A. B. C. up to Z, then the number. 26 options or more is the numbered-list
 // band anyway (#414), where the letters have stopped helping.
@@ -93,6 +93,35 @@ export function composeReviewBody(payload = {}) {
   if (has(payload.visual)) parts.push(visualBlock(payload.visual))
   if (has(payload.detail)) parts.push(`Details: ||${String(payload.detail).trim()}||`)
   return parts.join('\n\n')
+}
+
+// The ending report the thread reads (#419, ADR-0019). It is the FIRST of the
+// ending's two messages (#253): the agent's own voice states what the work came
+// to, and curia's receipt follows it.
+//
+// The parts read top down as the operator's eye does. The headline says what the
+// work came to, the visual shows it, the summary says what changed, and the
+// spoiler holds the facts a reader may want and nobody needs.
+export function composeResultBody(payload = {}) {
+  const parts = []
+  if (has(payload.headline)) parts.push(`**${String(payload.headline).trim()}**`)
+  if (has(payload.visual)) parts.push(visualBlock(payload.visual))
+  if (has(payload.summary)) parts.push(String(payload.summary).trim())
+  if (has(payload.detail)) parts.push(`Details: ||${String(payload.detail).trim()}||`)
+  return parts.join('\n\n')
+}
+
+// The whole post, status and all. The STATUS leads, because it is the one thing
+// the operator reads this message for.
+//
+// An untyped report keeps the one-line shape the thread has read since #253: the
+// status, a colon, and the summary. Until the flip (#422) both shapes are live,
+// and a one-line report must not grow a paragraph break it never had.
+export function composeResultReport(status, payload = {}) {
+  const head = `✅ reports **${status}**`
+  const body = composeResultBody(payload)
+  if (!body) return head
+  return isTypedResult(payload) ? `${head}\n\n${body}` : `${head}: ${body}`
 }
 
 // The ✅ All as recommended button, DERIVED (ADR-0019). It renders when every

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -52,7 +52,7 @@ import {
   verdictComment, judgementComment, verdictNote, verdictCarrier,
 } from './resolve.mjs'
 import { smallPrint } from './messaging.mjs'
-import { outstanding, stopReason, reviewGateText, classifyReviewAnswer, REVIEW_KIND, dutyLines } from './lifecycle.mjs'
+import { outstanding, stopReason, reviewGateText, classifyReviewAnswer, REVIEW_KIND, RESULT_KIND, dutyLines } from './lifecycle.mjs'
 import { CONFIRM_KIND, CROSS_CHECK_LABEL, VERDICT_LABEL } from './reduction.mjs'
 import {
   probeTtyd, assertServe, serveOff, CHAT_HANDLE_RE, isChatHandle, nextChatHandle,
@@ -81,6 +81,11 @@ const SESSION_RE = new RegExp(`^curia-(\\d+|${CHAT_HANDLE_RE.source.replace(/^\^
 // wider list explicitly.
 const REVIEW_SESSION_RE = /^curia-review-(\d+)$/
 export const reviewSessionFor = (n) => `curia-review-${n}`
+
+// Which tool a lint rejection came from (#418, #419). The gate keeps its own
+// kind and so does the ending report, and every other kind is an `ask_human`.
+// The Stop hook names the tool, because the model has to make the call again.
+const TOOL_FOR_KIND = { [REVIEW_KIND]: 'request_review', [RESULT_KIND]: 'report_result' }
 
 // The label a CHARTING dispatch needs (#160): `map curia#<n>` on a map's own
 // issue spawns an agent that updates the map, not one that resolves a ticket
@@ -1915,6 +1920,15 @@ export class Dispatcher {
     return REVIEW_SESSION_RE.test(String(agentName ?? ''))
   }
 
+  // The same predicate, readable from outside, and journalling nothing (#419).
+  // `toolRefusal` answers the same question but writes a refusal line, which is
+  // wrong for a caller that only wants to know which SHAPE a call carries. The
+  // report lint asks it: a reviewer's `report_result` summary is the verdict,
+  // and #421 types that surface.
+  isReviewerSession(agentName) {
+    return this.#isReviewer(agentName)
+  }
+
   // The refusal a reviewer gets for every tool but `notify` and `report_result`.
   // Returns null for anyone else, so a caller can put one line in front of a
   // tool and change nothing for a builder. index.mjs uses it for `ask_human`
@@ -3450,8 +3464,10 @@ export class Dispatcher {
       return {
         decision: 'block',
         reason: [
-          `curia REFUSED your last \`${held.kind === REVIEW_KIND ? 'request_review' : 'ask_human'}\` call, and you did not read the refusal.`,
-          'Nothing was asked and nobody saw it. These are the faults:',
+          `curia REFUSED your last \`${TOOL_FOR_KIND[held.kind] ?? 'ask_human'}\` call, and you did not read the refusal.`,
+          held.kind === RESULT_KIND
+            ? 'This ticket has reported nothing and nobody saw it. These are the faults:'
+            : 'Nothing was asked and nobody saw it. These are the faults:',
           '',
           ...held.faults.map((f) => `• ${f}`),
           '',
@@ -3459,10 +3475,12 @@ export class Dispatcher {
         ].join('\n'),
       }
     }
-    // The review gate is a step of the ENDING, so the checklist below already
-    // holds an agent that never opened one. Only `ask_human` has no such step,
-    // which is the hole this send exists to close.
-    if (held.kind === REVIEW_KIND || !this.deps.sendFlagged) {
+    // The review gate and the ending report are both STEPS OF THE ENDING, so the
+    // checklist below already holds an agent that never completed one. Only
+    // `ask_human` has no such step, which is the hole this send exists to close.
+    // A report is also the wrong thing to send this way: `sendFlagged` opens an
+    // ESCALATION, and a report asks nobody anything (#419).
+    if (held.kind === REVIEW_KIND || held.kind === RESULT_KIND || !this.deps.sendFlagged) {
       this.reduction.clearLintRejections(agentName, held.kind)
       return null
     }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -38,7 +38,7 @@ import { loadCuriaConfig, loadRoutingConfig, overrideSummary } from './config.mj
 import { PROBE_MARK, PROBE_PATH, GUEST_DAEMON_HOST, GUEST_WT, dockerGateway, probeSideChannel } from './sandbox.mjs'
 import { Cooling, providerOf } from './routing.mjs'
 import { Dispatcher } from './dispatch.mjs'
-import { REVIEW_KIND } from './lifecycle.mjs'
+import { REVIEW_KIND, RESULT_KIND } from './lifecycle.mjs'
 import { sameDigest } from './diffdigest.mjs'
 import { CommandRouter } from './commands.mjs'
 import { SelfDeploy } from './deploy.mjs'
@@ -64,12 +64,15 @@ import { LIVE_PATHS, DISPATCH_KEYS, liveSettings, liveDiff, frozenDifference } f
 import { TimelineSurface } from './timeline.mjs'
 import { IdentityProxy, identityRefusal, hostsForPorts, tailnetSelf } from './identity.mjs'
 import { detectHarness } from './transcript.mjs'
-import { promptTitle, elapsedLabel, speakerName } from './messaging.mjs'
+import { promptTitle, elapsedLabel, speakerName, smallPrint } from './messaging.mjs'
 import {
   TYPED_FLOOR, isTyped, floorFaults, hasText, lintAskHuman, lintRequestReview, reviewFloorFaults,
+  lintResult, resultFloorFaults,
 } from './lint.mjs'
-import { composeCard, composeReviewBody, optionLabels, derivedRecommended } from './card.mjs'
-import { LintGate } from './lintgate.mjs'
+import {
+  composeCard, composeReviewBody, composeResultReport, optionLabels, derivedRecommended,
+} from './card.mjs'
+import { LintGate, flaggedResultText } from './lintgate.mjs'
 import { StatusLine } from './statusline.mjs'
 import { remainingRenderRetries } from './renderretry.mjs'
 import { AccountUsage, ModelWindows, agentMeters, ctxOnWire, consoleConversationsOnWire } from './usage.mjs'
@@ -1503,14 +1506,58 @@ function buildMcpServer(agent, ticket) {
   // after 300s of silence (#34).
   server.tool(
     'report_result',
-    'Deliver the structured resolution for the ticket. Call exactly once, when the work is done and you have run the resolve protocol from your standing orders. curia verifies the resolution, repairs anything missing, and pushes your branch as a pull request; the reply tells you what it did.',
+    'Deliver the structured resolution for the ticket. Call exactly once, when the work is done and you have run the resolve protocol from your standing orders. curia verifies the resolution, repairs anything missing, and pushes your branch as a pull request; the reply tells you what it did.'
+    + ' `headline` says what the work came to in one line, and it leads the report the thread reads.'
+    + ' READ WHAT THIS CALL RETURNS. Curia lints your words and refuses the call when they break a rule, and the refusal names the rule and quotes the text. Rewrite the named field and call again.',
     {
+      // The two MACHINE fields keep their zod types. They are not prose, no
+      // grade reads them, and an agent that loses one to -32602 is still held
+      // at the ending by the Stop hook, which is the backstop a question never
+      // had (#438). `summary` moves off zod for the reason the gate's did.
       ticket: z.string(),
       status: z.enum(['resolved', 'blocked', 'aborted']),
-      summary: z.string(),
+      // #419, ADR-0019: the typed fields. `summary` is Grade B block prose, and
+      // the headline, the detail and the visual are what #415's card-4 shape
+      // gives an ending report.
+      summary: z.string().optional().describe('What the work came to, in plain words, at most 600 characters. The thread reads this, and curia records it on the ticket.'),
+      headline: z.string().optional().describe('What the work came to, in one line, at most 150 characters. No markdown and no link.'),
+      detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters.'),
+      visual: z.string().optional().describe('A table or an ASCII diagram, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+      // ADR-0019 rule 3: a free record. No surface renders it and no lint reads
+      // it, so it stays the one field an agent may shape for itself.
       details: z.record(z.string(), z.any()).optional(),
     },
     async (result, extra) => {
+      // The lint gate, BEFORE the park and before anything persists (#419). A
+      // refused report has reported nothing: no journal line, no results file
+      // and no word in the thread, so the agent rewrites and calls again.
+      // Linting after the cross-check park would make an agent wait hours for a
+      // rejection it could have read at once.
+      //
+      // The cross-check REVIEWER is exempt. Its `report_result` summary is the
+      // VERDICT, which ADR-0019 lists as a surface of its own with its own
+      // fields, and #421 types it. Holding a verdict to the report's shape here
+      // would half-type a surface another ticket owns, and a verdict runs to as
+      // many findings as the diff earns.
+      let flags = null
+      let flagNote = null
+      if (!dispatcher.isReviewerSession(agent)) {
+        const floor = resultFloorFaults(result)
+        const verdict = lintGate.judge({
+          agent, kind: RESULT_KIND, faults: [...floor, ...lintResult(result)],
+          schema: floor.length > 0, prompt: result.summary ?? null, payload: result,
+          // A report always carries something a human can read: the status. So
+          // the cap always ends in a flagged send, and the dead end a textless
+          // question gets has no counterpart here. An ending that reaches the
+          // thread flagged beats an ending that reaches it never.
+          hasText: true,
+        })
+        if (verdict.reject) return { content: [{ type: 'text', text: verdict.reject }] }
+        flags = verdict.flags ?? null
+        // The gate's own flagged line speaks of a card and of an operator about
+        // to answer. A report has neither, so the report says its own words.
+        flagNote = flags ? flaggedResultText(flags) : null
+      }
       // #258: a cross-check still reading PARKS this call, exactly as it parks
       // the gate. The keepalive starts first, because the park lasts as long as
       // a reviewer takes and the client aborts an MCP call after 300s of silence
@@ -1541,6 +1588,10 @@ function buildMcpServer(agent, ticket) {
       const disagrees = reported !== null && reported !== bound
       const rec = reduction.journal('result', {
         agent, ...result, ticket: bound, ...(disagrees ? { reported_ticket: reported } : {}),
+        // A flagged send rides the record too (#419). The escalation record has
+        // carried `lint_flags` since #418, and the report is the other text the
+        // lint can let through unfixed.
+        ...(flags ? { lint_flags: flags } : {}),
       })
       fs.writeFileSync(path.join(DATA, 'results', `${agent}.json`), JSON.stringify(rec, null, 2))
       // Route by that same bound ticket: an agent-supplied id may be
@@ -1552,14 +1603,30 @@ function buildMcpServer(agent, ticket) {
       // unfurl — the receipt that follows wraps every url in <>. A summary that
       // already names the link keeps its own wording; two copies of one link in
       // one message is the same defect at a smaller scale.
+      // #419: `composeResultReport` lays the report out. The agent writes the
+      // parts and curia lays them out, which is the same rule the card follows
+      // (ADR-0002 at the level of one message).
       if (bridge) {
         const pr = dispatcher.pullRequestUrlFor(agent)
-        const tail = pr && !result.summary.includes(pr) ? `\n🔗 ${pr}` : ''
-        bridge.notify(bound, `✅ reports **${result.status}**: ${result.summary}${tail}`, { as: speaker }).catch(() => {})
+        const tail = pr && !String(result.summary ?? '').includes(pr) ? `\n🔗 ${pr}` : ''
+        bridge.notify(bound, `${composeResultReport(result.status, result)}${tail}`, { as: speaker }).catch(() => {})
+        // A flagged send is CURIA's fact about the agent's text, so it is curia
+        // that says it (ADR-0013). It rides a second message in the bot voice,
+        // under the report it is about, rather than inside the agent's own.
+        if (flags?.length) {
+          bridge.notify(bound, smallPrint([
+            `⚠️ curia sent this report after ${flags.length} lint fault(s) the agent did not fix:`,
+            ...flags,
+          ].join('\n'))).catch(() => {})
+        }
       }
       const stopKeepAlive = startKeepAlive(extra, `${agent}/result`)
       try {
-        return { content: [{ type: 'text', text: await dispatcher.onResult(agent, result) }, ...drainNotes()] }
+        const text = await dispatcher.onResult(agent, result)
+        // The flagged line rides the result the agent is already waiting on
+        // (#416), so nothing about the send is silent.
+        const note = flagNote ? [{ type: 'text', text: flagNote }] : []
+        return { content: [...note, { type: 'text', text }, ...drainNotes()] }
       } finally {
         stopKeepAlive()
       }

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -30,6 +30,13 @@
 // hand-rolled ask_human.
 export const REVIEW_KIND = 'review-gate'
 
+// The lint gate's key for `report_result` (#419). It is not an escalation kind
+// and it opens no record: it keys the rejection count apart from a question's
+// and the gate's, on the agent-and-kind pair supersession already uses (#336).
+// A rejected report and a rejected question must not spend each other's three
+// attempts.
+export const RESULT_KIND = 'report-result'
+
 export const ENDING = [
   {
     key: 'commit',

--- a/daemon/src/lint.mjs
+++ b/daemon/src/lint.mjs
@@ -261,6 +261,45 @@ export function hasText(payload = {}) {
     || (payload.options ?? []).some((o) => present(typeof o === 'object' ? o?.label : o))
 }
 
+// ---- the ending report (#419) -------------------------------------------------
+//
+// `report_result` takes `ticket` and `status` for the machine, and `headline`
+// plus `summary` for the human. The two machine fields keep their zod types,
+// because they are not prose and the ending checklist already holds an agent
+// that never reported.
+//
+// `details` is a free record and no lint reads it (ADR-0019 rule 3). It is
+// machine-facing and no surface renders it.
+
+// Whether a report carries a typed field at all. The report differs from a card
+// here: `summary` is linted either way, because it shipped before this ticket
+// and it is the text the thread has always read. This tells curia which SHAPE to
+// render, not whether to lint.
+export function isTypedResult(payload = {}) {
+  return present(payload.headline) || present(payload.detail) || present(payload.visual)
+}
+
+// The report's floor. `summary` was required by the schema before this ticket,
+// so it is required now, flip or no flip — the same rule as the gate's, and for
+// the same reason (#438: moving a check off zod decides which layer refuses the
+// call, never whether a silent report lands). Only the `headline` waits for the
+// flip (#422), because it is the field this ticket adds.
+export function resultFloorFaults(payload = {}, { typedFloor = TYPED_FLOOR } = {}) {
+  const faults = []
+  if (typedFloor && !present(payload.headline)) faults.push('headline: missing. Say what the work came to in one line.')
+  if (!present(payload.summary)) faults.push('summary: missing. Say what you did and what it came to.')
+  return faults
+}
+
+export function lintResult(payload = {}) {
+  const faults = []
+  if (present(payload.headline)) faults.push(...gradeA('headline', payload.headline, CAPS.headline))
+  if (present(payload.detail)) faults.push(...gradeA('detail', payload.detail, CAPS.detail))
+  if (present(payload.visual)) faults.push(...lintVisual(payload.visual))
+  if (present(payload.summary)) faults.push(...gradeB('summary', payload.summary))
+  return faults
+}
+
 // The gate's floor, in two halves.
 //
 // `summary` and `charting` were REQUIRED by the schema before this ticket, so

--- a/daemon/src/lintgate.mjs
+++ b/daemon/src/lintgate.mjs
@@ -53,6 +53,16 @@ export function flaggedText(faults) {
     + ' Do not call again about this question. It is with them now, and this call is waiting for their answer.'
 }
 
+// The same cap, on the ending report (#419). The words differ because the
+// surface does: a report asks nothing, so nobody is waiting on an answer to it.
+// It is the last call of the ticket, and saying "do not call again" is what
+// stops an agent from spending its ending on the lint.
+export function flaggedResultText(faults) {
+  return `⚠️ curia sent your report as it stands, flagged with ${faults.length} lint fault(s) you did not fix.`
+    + ' The operator sees the faults in the thread, under the report.'
+    + ' Do not call `report_result` again. The ticket has ended and this report is on the record.'
+}
+
 // A schema fault at the cap with nothing to send. This is the one refusal that
 // is final, and it says what would have made it sendable.
 export function deadEndText(faults) {

--- a/daemon/src/resolve.mjs
+++ b/daemon/src/resolve.mjs
@@ -120,14 +120,28 @@ export function insertMapPointer(body, line) {
   return out.join('\n')
 }
 
+// What the report SAID, for a record curia writes from it (#419, ADR-0019).
+//
+// The report is typed now: a `headline` says what the work came to in one line
+// and the `summary` says what changed. A record that printed only the summary
+// would drop the headline, and losing no information is the requirement the
+// whole #413 map serves. An untyped report has no headline and reads exactly as
+// it did before this ticket.
+export function reportProse(result) {
+  const headline = String(result?.headline ?? '').trim()
+  const summary = String(result?.summary ?? '').trim()
+  if (!headline && !summary) return '(no summary)'
+  return [headline && `**${headline}**`, summary].filter(Boolean).join('\n\n')
+}
+
 export function fallbackResolutionComment(result) {
   return [
     '## Resolution (recorded by curia)',
     '',
-    result.summary ?? '(no summary)',
+    reportProse(result),
     '',
     `_The agent reported **${result.status}** but posted no resolution comment of its own; curia`,
-    'recorded its `report_result` summary verbatim rather than let the ticket close silently._',
+    'recorded its `report_result` text verbatim rather than let the ticket close silently._',
   ].join('\n')
 }
 
@@ -135,7 +149,7 @@ export function nonCleanComment({ agent, result, released }) {
   return machine([
     `⚠️ curia: agent \`${agent}\` stopped with status **${result.status}** and did **not** resolve this ticket.`,
     '',
-    result.summary ?? '(no summary)',
+    reportProse(result),
     '',
     released
       ? '_The ticket stays open and its claim has been released, so it returns to the frontier. Nothing was pushed._'
@@ -169,7 +183,7 @@ export function chartingComment({ agent, model, instruction, result, landing = n
     `## ${clean ? 'Charting' : `Charting — **${result.status}**`} (curia session \`${agent}\`)`,
     '',
     ...(instruction ? ['The operator asked for:', '', `> ${instruction}`, ''] : ['Dispatched with no instruction.', '']),
-    result.summary ?? '(no summary)',
+    reportProse(result),
     '',
     ...(landed
       ? [
@@ -423,7 +437,12 @@ export async function resolveAndLand({
             journal('map_pointer_present', { repo, map: parent, ticket, line: existing })
             return { state: 'present', number: parent }
           }
-          const line = pointerLine({ title, url, gist: result.summary })
+          // The HEADLINE is the gist when the report carries one (#419). The
+          // map's Decisions-so-far is an index — one line per closed ticket —
+          // and a headline is that line already. Without one the summary is
+          // flattened to one line, which is what this did before the field
+          // existed.
+          const line = pointerLine({ title, url, gist: result.headline || result.summary })
           const next = insertMapPointer(fresh.body, line)
           if (!next) {
             journal('map_pointer_failed', { repo, map: parent, ticket, line, reason: 'no "## Decisions so far" section' })

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -1944,7 +1944,10 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '- `request_review` — the one gate, and it judges the FINDINGS. curia shows the human the pull',
     '  request and the map, and blocks until they approve or reject. **You never write a link yourself.**',
     '  A rejection comes back as their own words: fix, commit, `open_pull_request` again, ask again.',
-    '- `report_result` — exactly once, at the very end. Its summary becomes curia\'s comment on the map.',
+    // #419, ADR-0019: the report is typed too. The headline is the line the
+    // thread reads first, and the map pointer takes it as the gist.
+    '- `report_result` — exactly once, at the very end. `headline` says what the session came to in one',
+    '  line, and `summary` says what you charted. Both become curia\'s comment on the map.',
     '- `publish_preview` belongs to a ticket dispatch. A research note is read as a diff, so there is',
     '  nothing here to preview.',
   ] : [
@@ -1965,7 +1968,8 @@ export function writePrompt(cfgDir, issue, { repo, wtPath, mapNumber = null, typ
     '  curia composes all three from its own records, which is what makes them evidence rather than your',
     '  account of your own work. If the preview link points at the wrong page, fix it where it is made —',
     '  call `publish_preview` again with the right path — not by pasting a URL into your summary.',
-    '- `report_result` — exactly once, at the very end.',
+    '- `report_result` — exactly once, at the very end. `headline` says what the work came to in one',
+    '  line, and `summary` says what changed. curia lints both, and it lays the report out itself.',
   ]
 
   // #165, ADR-0010: the gate's third button. The builder is told this at spawn

--- a/daemon/test/card.test.mjs
+++ b/daemon/test/card.test.mjs
@@ -3,7 +3,9 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { composeCard, composeReviewBody, visualBlock, optionLabels } from '../src/card.mjs'
+import {
+  composeCard, composeReviewBody, composeResultBody, composeResultReport, visualBlock, optionLabels,
+} from '../src/card.mjs'
 import { lintReply, CHUNK_LIMIT } from '../src/messaging.mjs'
 
 const CHOICE = {
@@ -144,5 +146,44 @@ describe('composeReviewBody', () => {
 
   test('an untyped gate composes nothing', () => {
     assert.equal(composeReviewBody({}), '')
+  })
+})
+
+describe('composeResultReport: the ending report (#419)', () => {
+  const REPORT = {
+    status: 'resolved',
+    headline: 'The ending report is typed, and curia lays it out.',
+    summary: 'The report takes a headline, a summary, a detail and a visual.',
+    detail: 'The composer is daemon/src/card.mjs.',
+    visual: 'headline  150\nsummary   600',
+  }
+
+  test('the parts read top down: headline, visual, summary, spoiler', () => {
+    assert.equal(composeResultBody(REPORT), [
+      '**The ending report is typed, and curia lays it out.**',
+      '```\nheadline  150\nsummary   600\n```',
+      'The report takes a headline, a summary, a detail and a visual.',
+      'Details: ||The composer is daemon/src/card.mjs.||',
+    ].join('\n\n'))
+  })
+
+  test('the status leads, because it is what the operator reads this message for', () => {
+    const post = composeResultReport('resolved', REPORT)
+    assert.equal(post.split('\n')[0], '✅ reports **resolved**')
+    assert.ok(post.includes(composeResultBody(REPORT)))
+  })
+
+  test('an untyped report keeps the one line the thread has read since #253', () => {
+    assert.equal(composeResultReport('blocked', { summary: 'the token was missing' }),
+      '✅ reports **blocked**: the token was missing')
+  })
+
+  test('a report with no prose at all is still a status', () => {
+    assert.equal(composeResultReport('aborted', {}), '✅ reports **aborted**')
+  })
+
+  test('curia writes the fence, so an agent that fenced its visual is not fenced twice', () => {
+    const body = composeResultBody({ visual: '```\na\nb\n```' })
+    assert.equal(body, '```\na\nb\n```')
   })
 })

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -4006,6 +4006,44 @@ describe('the Stop hook enforces the ending (#54 item 4)', () => {
     assert.match(decision.reason, /request_review/, 'the ordinary checklist asks for the gate instead')
   })
 
+  test('the reviewer is nameable without writing a refusal line (#419)', () => {
+    // The report lint asks which SHAPE a call carries. `toolRefusal` answers the
+    // same question and journals a refusal, which is the wrong record for it.
+    const d = makeDispatcher({})
+    assert.equal(d.isReviewerSession('curia-review-42'), true)
+    assert.equal(d.isReviewerSession('curia-42'), false)
+    assert.ok(!typesOf().includes('reviewer_tool_refused'))
+  })
+
+  test('a rejected REPORT falls through the same way, and opens no card (#419)', async () => {
+    // `sendFlagged` opens an escalation, and a report asks nobody anything. The
+    // ending checklist already holds an agent that has not reported.
+    journalTo([{ type: 'dispatch_claimed', ticket: '42', repo: 'o/r', agent: 'curia-42' }])
+    const sent = []
+    const d = makeDispatcher({
+      lintRejection: () => rejected({ kind: 'report-result', stop_blocks: 1 }),
+      sendFlagged: (agent, h) => { sent.push(h); return { id: 'esc-9' } },
+    })
+    liveAgent(d)
+
+    const decision = await d.onStopHook('curia-42', {})
+
+    assert.equal(sent.length, 0, 'a report is never sent as a question')
+    assert.equal(decision.decision, 'block')
+    assert.match(decision.reason, /report_result/, 'the ordinary checklist asks for the report instead')
+  })
+
+  test('the first block on a rejected report names report_result and says nothing reported (#419)', async () => {
+    const d = makeDispatcher({ lintRejection: () => rejected({ kind: 'report-result' }) })
+    liveAgent(d)
+
+    const decision = await d.onStopHook('curia-42', {})
+
+    assert.equal(decision.decision, 'block')
+    assert.match(decision.reason, /curia REFUSED your last `report_result` call/)
+    assert.match(decision.reason, /This ticket has reported nothing/)
+  })
+
   test('#47 stays first: a turn that ends on an open escalation is a block, never a stop-block', async () => {
     const d = makeDispatcher({ hasSession: async () => true })
     liveAgent(d)

--- a/daemon/test/lint.test.mjs
+++ b/daemon/test/lint.test.mjs
@@ -7,6 +7,7 @@ import {
   CAPS, VISUAL_COLUMNS, VISUAL_LINES, SENTENCE_WORDS,
   gradeA, gradeB, lintVisual, unfence, isTyped, floorFaults, lintAskHuman,
   lintRequestReview, reviewFloorFaults, hasText,
+  isTypedResult, lintResult, resultFloorFaults,
 } from '../src/lint.mjs'
 
 const names = (faults) => faults.join(' | ')
@@ -278,5 +279,63 @@ describe('lintRequestReview', () => {
     assert.match(names(reviewFloorFaults({ headline: 'h' })), /charting: missing/)
     assert.deepEqual(reviewFloorFaults({ summary: 's', charting: 'none' }), [],
       'only the headline waits for the flip, because only the headline is new')
+  })
+})
+
+describe('lintResult: the ending report (#419)', () => {
+  const REPORT = {
+    ticket: '419',
+    status: 'resolved',
+    headline: 'The ending report is typed, and the lint reads its named fields.',
+    summary: 'The report takes a headline, a summary, a detail and a visual. Curia lays them out.',
+    detail: 'The lint module is daemon/src/lint.mjs and the composer is daemon/src/card.mjs.',
+    visual: 'headline  one line, 150\nsummary   block prose, 600',
+  }
+
+  test('a typed report passes every grade', () => {
+    assert.deepEqual(lintResult(REPORT), [])
+  })
+
+  test('the headline is grade A, so a link in it is refused', () => {
+    assert.match(names(lintResult({ ...REPORT, headline: 'see https://example.com' })), /headline: a link/)
+  })
+
+  test('the summary is grade B, so it keeps its sentences and loses its em-dash', () => {
+    assert.deepEqual(lintResult({ summary: 'One thing changed. Then a second thing changed.' }), [])
+    assert.match(names(lintResult({ summary: 'One thing changed — and then another.' })), /summary: an em-dash/)
+  })
+
+  test('a summary over the block cap is refused rather than cut', () => {
+    const faults = lintResult({ summary: 'x'.repeat(CAPS.block + 1) })
+    assert.match(names(faults), new RegExp(`summary: 601 characters over the ${CAPS.block} cap`))
+    assert.match(names(faults), /never cuts it/)
+  })
+
+  test('the visual keeps its geometry check and no grade', () => {
+    assert.match(names(lintResult({ visual: 'x'.repeat(VISUAL_COLUMNS + 1) })), /visual: 43 columns/)
+    assert.deepEqual(lintResult({ visual: 'a; b — c' }), [], 'a diagram is not prose')
+  })
+
+  test('`details` is a free record: ADR-0019 rule 3, and no lint reads it', () => {
+    assert.deepEqual(lintResult({ ...REPORT, details: { note: "it's a machine field — and it stays one" } }), [])
+  })
+
+  test('the floor is the summary now, and the headline waits for the flip', () => {
+    assert.deepEqual(resultFloorFaults({ summary: 's' }), [],
+      'only the headline waits for #422, because only the headline is new')
+    assert.match(names(resultFloorFaults({ headline: 'h' })), /summary: missing/)
+    assert.match(names(resultFloorFaults({ summary: 's' }, { typedFloor: true })), /headline: missing/)
+    assert.deepEqual(resultFloorFaults({ headline: 'h', summary: 's' }, { typedFloor: true }), [])
+  })
+
+  test('isTypedResult reads the SHAPE, and a bare summary is the old one', () => {
+    assert.equal(isTypedResult({ summary: 'what changed' }), false)
+    assert.equal(isTypedResult({ headline: 'h' }), true)
+    assert.equal(isTypedResult({ detail: 'd' }), true)
+    assert.equal(isTypedResult({ visual: 'v' }), true)
+  })
+
+  test('a report carrying a summary has text, so the cap ends in a flagged send', () => {
+    assert.equal(hasText({ status: 'resolved', summary: 'what changed' }), true)
   })
 })

--- a/daemon/test/lintgate.test.mjs
+++ b/daemon/test/lintgate.test.mjs
@@ -15,7 +15,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { Reduction } from '../src/reduction.mjs'
-import { LintGate, REJECTION_CAP } from '../src/lintgate.mjs'
+import { LintGate, REJECTION_CAP, flaggedResultText } from '../src/lintgate.mjs'
 import { DiscordBridge } from '../src/bridge.mjs'
 import { composeCard } from '../src/card.mjs'
 
@@ -177,5 +177,36 @@ describe('the flagged card', () => {
     assert.match(msg.content, /Pick one; then move on/, 'the text the operator judges is the text that failed')
     assert.match(msg.content, /-# ⚠️ curia sent this after 1 lint fault/)
     assert.match(msg.content, /-# headline: a semicolon/)
+  })
+})
+
+describe('the ending report at the cap (#419)', () => {
+  test('the flagged line speaks of a report, not of a question waiting on an answer', () => {
+    const note = flaggedResultText(['summary: an em-dash. Write two sentences, or use a normal dash.'])
+    assert.match(note, /sent your report as it stands/)
+    assert.match(note, /flagged with 1 lint fault/)
+    assert.match(note, /Do not call `report_result` again/)
+    assert.doesNotMatch(note, /waiting for their answer/, 'nobody answers a report')
+  })
+
+  test('a report always has text, so its cap ends in a flagged send and never a dead end', () => {
+    const reduction = new Reduction(tmp())
+    const gate = new LintGate({ reduction })
+    const judge = () => gate.judge({
+      agent: 'curia-419', kind: 'report-result', faults: ['summary: missing.'], schema: true, hasText: true,
+    })
+    for (let i = 0; i < REJECTION_CAP; i += 1) judge()
+    const r = judge()
+    assert.equal(r.ok, true)
+    assert.equal(r.refuse, undefined, 'an ending that reaches the thread flagged beats one that reaches it never')
+  })
+
+  test('a rejected report spends its own three attempts, not the one a question spends', () => {
+    const reduction = new Reduction(tmp())
+    const gate = new LintGate({ reduction })
+    gate.judge({ agent: 'curia-419', kind: 'report-result', faults: ['a'] })
+    gate.judge({ agent: 'curia-419', kind: 'report-result', faults: ['a'] })
+    assert.equal(reduction.lintRejections('curia-419', 'report-result'), 2)
+    assert.equal(reduction.lintRejections('curia-419', 'free-text'), 0)
   })
 })

--- a/daemon/test/resolve.test.mjs
+++ b/daemon/test/resolve.test.mjs
@@ -11,7 +11,7 @@ import { test, describe, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   sectionBounds, pointerLine, mapPointerFor, insertMapPointer,
-  fallbackResolutionComment, nonCleanComment, prBody, resolveAndLand, summariseOutcome,
+  fallbackResolutionComment, nonCleanComment, reportProse, prBody, resolveAndLand, summariseOutcome,
   landBranch, prLinkComment, DECISIONS_HEADING, MACHINE_MARKER,
 } from '../src/resolve.mjs'
 
@@ -137,6 +137,21 @@ describe('comment bodies', () => {
     assert.ok(nonCleanComment({ agent: 'curia-42', result: { status: 'blocked' }, released: true }).startsWith(MACHINE_MARKER))
     assert.ok(!fallbackResolutionComment({ summary: 's' }).includes(MACHINE_MARKER),
       'the fallback IS the resolution — marking it would make a later dispatch re-post one')
+  })
+
+  // #419, ADR-0019: the report is typed now, and a record curia writes from it
+  // must carry every part the agent typed. Losing no information is the
+  // requirement the whole #413 map serves.
+  test('a typed report keeps its headline in the records curia writes', () => {
+    const result = { status: 'resolved', headline: 'The report is typed.', summary: 'Two fields, one record.' }
+    assert.equal(reportProse(result), '**The report is typed.**\n\nTwo fields, one record.')
+    assert.match(fallbackResolutionComment(result), /\*\*The report is typed\.\*\*/)
+    assert.match(nonCleanComment({ agent: 'curia-42', result, released: true }), /\*\*The report is typed\.\*\*/)
+  })
+
+  test('an untyped report reads exactly as it did before the headline existed', () => {
+    assert.equal(reportProse({ summary: 'did the thing' }), 'did the thing')
+    assert.equal(reportProse({}), '(no summary)')
   })
 
   test('the pull-request link comment says what was pushed and where', () => {
@@ -290,6 +305,23 @@ describe('resolveAndLand: repairs', () => {
     assert.ok(journalled.some((e) => e.type === 'map_pointer_appended' && /issues\/42/.test(e.line)),
       'the line stays replayable from the journal even when the map lost it')
     assert.match(summariseOutcome(out), /NOT verified/)
+  })
+
+  test('the map pointer takes the HEADLINE as its gist when the report carries one (#419)', async () => {
+    // Decisions-so-far is an index, one line per closed ticket. A headline is
+    // that line already, where a summary has to be flattened into one.
+    const h = fixture({
+      result: { status: 'resolved', headline: 'The gist, in one line.', summary: 'First sentence.\nSecond sentence.' },
+      issues: {
+        42: { ...TICKET, parent_issue_url: 'https://api.github.com/repos/o/r/issues/1' },
+        1: { ...MAP_ISSUE },
+      },
+      overrides: { issueComments: async () => [{ user: { login: 'me' }, created_at: '2026-07-25T10:00:00Z' }] },
+    })
+    await h.run()
+
+    const appended = journalled.find((e) => e.type === 'map_pointer_appended')
+    assert.match(appended.line, /^- \[a ticket\]\(https:\/\/github\.com\/o\/r\/issues\/42\) — The gist, in one line\.$/)
   })
 
   test('a map with no Decisions-so-far section is not guessed at', async () => {

--- a/daemon/test/typedreport.test.mjs
+++ b/daemon/test/typedreport.test.mjs
@@ -1,0 +1,170 @@
+// The typed ending report on the wire (#419, ADR-0019).
+//
+// The composers and the grades are unit-tested next door (card.test.mjs,
+// lint.test.mjs). What only a real boot can answer is whether the MCP tool
+// really carries the new fields and really refuses a report whose words break a
+// rule: the schema is zod, the refusal is a tool RESULT rather than a throw, and
+// #416 measured that carriage dying in silence on codex.
+//
+// Two cases, and the second is the one that guards another ticket's surface. A
+// reviewer's `report_result` summary IS the verdict, which ADR-0019 lists as a
+// surface of its own and #421 types. It must reach the daemon untouched here.
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { TOKEN_HEADER, mintAgentToken } from '../src/agenttoken.mjs'
+import { freePort, waitForBoot, watchDaemon } from './fixtures/real-boot.mjs'
+import { seedSkillsRoot, skillsYaml } from './fixtures/skills.mjs'
+import { sandboxYaml } from './fixtures/sandbox.mjs'
+import { journalEvents } from './fixtures/journal.mjs'
+
+const DIR = path.dirname(fileURLToPath(import.meta.url))
+const DAEMON = path.join(DIR, '..', 'src', 'index.mjs')
+
+function request(port, method, urlPath) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, method, path: urlPath }, (res) => {
+      let data = ''
+      res.on('data', (c) => { data += c })
+      res.on('end', () => resolve({ status: res.statusCode, body: data }))
+    })
+    req.once('error', reject)
+    req.end()
+  })
+}
+
+describe('report_result carries the typed fields and the lint gate (#419, real boot)', () => {
+  let tmp, child, port, watch
+
+  const call = async (agent, ticket, args) => {
+    const token = mintAgentToken(path.join(tmp, 'data'), agent)
+    const client = new Client({ name: 'curia-419-test', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp?agent=${agent}&ticket=${ticket}`),
+      { requestInit: { headers: { [TOKEN_HEADER]: token } } },
+    )
+    await client.connect(transport)
+    try {
+      const r = await client.callTool({ name: 'report_result', arguments: args }, undefined, { timeout: 30_000 })
+      return r.content.map((c) => c.text ?? '').join('\n')
+    } finally {
+      await client.close().catch(() => {})
+    }
+  }
+
+  before(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-419-test-'))
+    const cfgDir = path.join(tmp, 'config')
+    const shim = path.join(tmp, 'shim')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    fs.mkdirSync(shim, { recursive: true })
+    for (const bin of ['gh', 'tmux', 'tailscale']) {
+      const p = path.join(shim, bin)
+      fs.writeFileSync(p, '#!/bin/sh\nexit 1\n')
+      fs.chmodSync(p, 0o755)
+    }
+    const [daemonPort, ttydPort, servePort, proxyPort] = [await freePort(), await freePort(), await freePort(), await freePort()]
+    port = daemonPort
+    fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
+      'watch:',
+      '  - repo: example/fixture',
+      '    mode: ready-for-agent',
+      'dispatch:',
+      '  auto_dispatch: false',
+      '  max_concurrent: 1',
+      '  poll_interval_s: 60',
+      `  workspace_root: ${path.join(tmp, 'work')}`,
+      '  ready_timeout_s: 5',
+      '  confirm_ttl_h: 1',
+      'attach:',
+      `  ttyd_port: ${ttydPort}`,
+      `  serve_port: ${servePort}`,
+      'identity:',
+      '  allow: [tester@example.com]',
+      `  proxy_port: ${proxyPort}`,
+      ...skillsYaml(seedSkillsRoot(tmp)),
+      ...sandboxYaml(),
+      '',
+    ].join('\n'))
+    fs.writeFileSync(path.join(cfgDir, 'routing.yaml'), [
+      'defaults:',
+      '  untyped: sonnet',
+      'models:',
+      '  sonnet: { provider: anthropic, harness: claude }',
+      'harnesses:',
+      '  claude:',
+      '    template: claude --model {model} "$(cat {prompt_file})"',
+      "    ready: '⏵⏵|bypass permissions'",
+      '    tool_channel_grace_s: 15',
+      '',
+    ].join('\n'))
+    child = spawn(process.execPath, [DAEMON], {
+      env: {
+        ...process.env,
+        PORT: String(port),
+        CURIA_CONFIG_DIR: cfgDir,
+        CURIA_DATA_DIR: path.join(tmp, 'data'),
+        PATH: `${shim}:${process.env.PATH}`,
+        DISCORD_BOT_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    watch = watchDaemon(child)
+    await waitForBoot(watch, async () => {
+      try {
+        return (await request(port, 'GET', '/state')).status === 200
+      } catch { return false }
+    }, 'the /state route')
+  })
+
+  after(async () => {
+    await new Promise((resolve) => {
+      if (!child || child.exitCode !== null) return resolve()
+      child.once('exit', resolve)
+      child.kill('SIGKILL')
+    })
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  test('a report whose words break a rule is refused, and the refusal names the field', async () => {
+    const text = await call('curia-419', '419', {
+      ticket: '419',
+      status: 'resolved',
+      headline: 'The report is typed; the lint reads it',
+      summary: 'The gate refuses the call and the agent rewrites its own text.',
+    })
+
+    assert.match(text, /curia refused this call/)
+    assert.match(text, /attempt 1 of 3/)
+    assert.match(text, /headline: a semicolon/)
+    assert.match(text, /Keep every option and every constraint/)
+    const events = journalEvents(path.join(tmp, 'data'))
+    assert.ok(events.some((e) => e.type === 'lint_rejected' && e.kind === 'report-result'),
+      'the rejection is counted under the report, not under a question')
+    assert.ok(!events.some((e) => e.type === 'result'),
+      'a refused report reported nothing: no journal line, no results file, no word in the thread')
+    assert.ok(!fs.existsSync(path.join(tmp, 'data', 'results', 'curia-419.json')))
+  })
+
+  test("a reviewer's verdict reaches the daemon untouched: that surface is #421's", async () => {
+    // An em-dash and a bare list, which the report's own grades would refuse.
+    const text = await call('curia-review-419', '419', {
+      ticket: '419',
+      status: 'resolved',
+      summary: 'VERDICT: concerns\n- daemon/src/lint.mjs:1 — the cap is a ceiling, not a target',
+    })
+
+    assert.doesNotMatch(text, /curia refused this call/)
+    const events = journalEvents(path.join(tmp, 'data'))
+    assert.ok(events.some((e) => e.type === 'result' && e.agent === 'curia-review-419'))
+    assert.ok(!events.some((e) => e.type === 'lint_rejected' && e.agent === 'curia-review-419'))
+  })
+})


### PR DESCRIPTION
Ticket: alp82/curia#419 — [Typed report_result](https://github.com/alp82/curia/issues/419)

Typed report_result per ADR-0019, plus the ending report the thread reads (#419).

The lint reads named fields on the report: headline and detail at Grade A, summary at Grade B, and the visual keeps its geometry check. `summary` stays required because the schema required it before this ticket. Only the headline waits for the flip (#422).

`composeResultReport` lays the report out — status, headline, visual, summary, spoiler. An untyped report keeps the one line the thread has read since #253.

The gate runs before the cross-check park, so a refused report costs no wait and persists nothing. A report always carries a status, so its cap ends in a flagged send. The Stop hook names `report_result` and never sends a report as a question.

The headline also rides the records curia writes from the report, and the map pointer takes it as its gist.

The cross-check reviewer is exempt: its summary is the verdict, and #421 types that surface.

Tests: 2457 pass, 0 fail.

---

Dispatched by the curia daemon — session `curia-419`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `f81e621` Typed report_result, and the ending report the thread reads (#419)