### PR TITLE
The deploy creates the overseer's bind sources before docker can (alp82/curia#474)

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -14,6 +14,11 @@ HOST="${CURIA_DEPLOY_HOST:-alp@coinmatica.net}"
 ssh "$HOST" 'set -euo pipefail
 cd ~/curia
 git pull --ff-only
+# The overseer bind-mount sources, before compose can create them as root
+# (alp82/curia#474). The path comes from the committed config, so the two
+# stay one fact.
+WORK=$(awk "/^ *workspace_root:/ {print \$2; exit}" config/curia.yaml)
+mkdir -p "$WORK/cfg/curia-overseer" "$WORK/overseer/repos"
 # --force-recreate: code runs from the repo mount, so a code-only deploy
 # changes no image layer, and without the flag compose leaves the old
 # daemon running (#270).

--- a/daemon/src/deploy.mjs
+++ b/daemon/src/deploy.mjs
@@ -46,7 +46,7 @@ const short = (sha) => String(sha).slice(0, 7)
 // lives in deploy.log, not in docker), and named — the fixed name is the
 // concurrency guard: a second deploy while one is in flight fails the run
 // with a name conflict instead of racing it.
-export function helperRunArgs({ repoRoot, dataDir, home, uid, gid }) {
+export function helperRunArgs({ repoRoot, dataDir, home, uid, gid, workRoot }) {
   return [
     'run', '-d', '--rm', '--name', 'curia-deploy',
     // host network: the health check curls the daemon on host loopback
@@ -57,6 +57,10 @@ export function helperRunArgs({ repoRoot, dataDir, home, uid, gid }) {
     // same-path principle: the checkout and the data dir mount where they live
     '-v', `${repoRoot}:${repoRoot}`,
     '-v', `${dataDir}:${dataDir}`,
+    // the workspace, so the script can pre-create the overseer's bind-mount
+    // sources as uid 1000 — dockerd creates a missing source as root, and the
+    // overseer then cannot write its own trees (alp82/curia#474)
+    '-v', `${workRoot}:${workRoot}`,
     // git over https via gh's credential helper, same mounts the daemon has
     '-v', `${home}/.config/gh:${home}/.config/gh`,
     '-v', `${home}/.gitconfig:${home}/.gitconfig:ro`,
@@ -69,9 +73,10 @@ export function helperRunArgs({ repoRoot, dataDir, home, uid, gid }) {
 }
 
 export class SelfDeploy {
-  constructor({ repoRoot, dataDir, reduction, log = console.log, exec = execFileP, port = 4271, home = process.env.HOME ?? '/home/alp', dockerSocket = '/var/run/docker.sock' }) {
+  constructor({ repoRoot, dataDir, workRoot, reduction, log = console.log, exec = execFileP, port = 4271, home = process.env.HOME ?? '/home/alp', dockerSocket = '/var/run/docker.sock' }) {
     this.repoRoot = repoRoot
     this.dataDir = dataDir
+    this.workRoot = workRoot
     this.reduction = reduction
     this.log = log
     this.exec = exec
@@ -150,10 +155,10 @@ export class SelfDeploy {
     const args = [
       ...helperRunArgs({
         repoRoot: this.repoRoot, dataDir: this.dataDir, home: this.home,
-        uid: process.getuid?.() ?? 1000, gid,
+        uid: process.getuid?.() ?? 1000, gid, workRoot: this.workRoot,
       }),
-      // script argv: prev next repoRoot markerFile logFile port
-      prev, next, this.repoRoot, this.markerPath, this.logPath, String(this.port),
+      // script argv: prev next repoRoot markerFile logFile port workRoot
+      prev, next, this.repoRoot, this.markerPath, this.logPath, String(this.port), this.workRoot,
     ]
     try {
       await this.exec('docker', args, { timeout: 60_000 })

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1177,7 +1177,10 @@ dispatcher.identityProxy = identityProxy // #151: reconcile publishes the proxy,
 
 // The self-deploy seam (#270): the verb orders, a sibling container executes,
 // resolvePending() below announces whichever outcome the sibling wrote.
-const selfDeploy = new SelfDeploy({ repoRoot: path.dirname(ROOT), dataDir: DATA, reduction, log, port: PORT })
+const selfDeploy = new SelfDeploy({
+  repoRoot: path.dirname(ROOT), dataDir: DATA, reduction, log, port: PORT,
+  workRoot: curiaConfig.dispatch.workspace_root,
+})
 
 const router = new CommandRouter({ dispatcher, attach: attachApi, deploy: selfDeploy, log })
 

--- a/daemon/test/deploy.test.mjs
+++ b/daemon/test/deploy.test.mjs
@@ -62,7 +62,7 @@ function build(opts = {}) {
   const reduction = fakeStore()
   const { exec, docker, git } = fakeExec(opts)
   const deploy = new SelfDeploy({
-    repoRoot: '/home/alp/curia', dataDir, reduction, exec,
+    repoRoot: '/home/alp/curia', dataDir, workRoot: '/home/alp/curia-work', reduction, exec,
     log: () => {}, port: 4271, home: '/home/alp', dockerSocket: sock,
   })
   return { deploy, reduction, docker, git, dataDir }
@@ -150,8 +150,8 @@ describe('the daemon half: preflight and hand-off', () => {
     // the script runs from a container-local copy: the sibling's own merge
     // rewrites the checkout copy mid-run
     assert.ok(args.some((a) => a.includes('cp /home/alp/curia/deploy/self-deploy.sh /tmp/')))
-    // script argv: prev next repoRoot markerFile logFile port
-    assert.deepEqual(args.slice(-6), [PREV, NEXT, '/home/alp/curia', deploy.markerPath, deploy.logPath, '4271'])
+    // script argv: prev next repoRoot markerFile logFile port workRoot
+    assert.deepEqual(args.slice(-7), [PREV, NEXT, '/home/alp/curia', deploy.markerPath, deploy.logPath, '4271', '/home/alp/curia-work'])
   })
 
   test('a second deploy while one is in flight is refused by the marker', async () => {
@@ -240,6 +240,17 @@ describe('the sibling script holds the deploy rule', () => {
     for (const l of ups) assert.match(l, /up -d --build --force-recreate --no-deps daemon dashboard overseer$/)
   })
 
+  // alp82/curia#474: dockerd creates a missing bind-mount source as root:root,
+  // and the overseer (uid 1000) then cannot write its own trees. The sibling
+  // creates both sources before every compose up — the rollback one included.
+  test('the overseer bind-mount sources are created before every compose up', () => {
+    const lines = code.split('\n')
+    const mkdir = lines.findIndex((l) => /mkdir -p "\$WORK\/cfg\/curia-overseer" "\$WORK\/overseer\/repos"/.test(l))
+    const up = lines.findIndex((l) => /compose .*up/.test(l))
+    assert.ok(mkdir !== -1, 'the pre-create line is missing')
+    assert.ok(mkdir < up, 'the pre-create must run before the compose up')
+  })
+
   test('the script never touches tmux or ttyd', () => {
     assert.doesNotMatch(code, /tmux|ttyd/)
   })
@@ -252,12 +263,13 @@ describe('the sibling script holds the deploy rule', () => {
 
 describe('helperRunArgs', () => {
   test('mounts what the sibling needs and nothing writable it does not', () => {
-    const args = helperRunArgs({ repoRoot: '/r', dataDir: '/r/daemon/data', home: '/h', uid: 1000, gid: 998 })
+    const args = helperRunArgs({ repoRoot: '/r', dataDir: '/r/daemon/data', home: '/h', uid: 1000, gid: 998, workRoot: '/w' })
     const mounts = args.filter((a, i) => args[i - 1] === '-v')
     assert.deepEqual(mounts, [
       '/var/run/docker.sock:/var/run/docker.sock',
       '/r:/r',
       '/r/daemon/data:/r/daemon/data',
+      '/w:/w',
       '/h/.config/gh:/h/.config/gh',
       '/h/.gitconfig:/h/.gitconfig:ro',
     ])

--- a/deploy/self-deploy.sh
+++ b/deploy/self-deploy.sh
@@ -17,9 +17,9 @@
 # and a recreated tmux service kills every live agent (wayfinder #132 in
 # compose clothes). deploy.test.mjs pins this file to the rule.
 #
-# argv: prev next repoRoot markerFile logFile port
+# argv: prev next repoRoot markerFile logFile port workRoot
 set -uo pipefail
-PREV=$1 NEXT=$2 REPO=$3 MARKER=$4 LOG=$5 PORT=$6
+PREV=$1 NEXT=$2 REPO=$3 MARKER=$4 LOG=$5 PORT=$6 WORK=${7:-}
 exec >>"$LOG" 2>&1
 
 say() { echo "[self-deploy $(date -u +%FT%TZ)] $*"; }
@@ -38,6 +38,13 @@ mark() {
 # nothing to do and leaves the OLD daemon running — a deploy that lands
 # without deploying (observed on the #270 drill).
 recreate() {
+  # The overseer's bind-mount sources must exist BEFORE compose creates the
+  # container: dockerd creates a missing source as root:root, and the overseer
+  # runs as 1000:1000, so its first turn then dies on EACCES (alp82/curia#474).
+  # This container runs as uid 1000 with the workspace mounted, so the
+  # directories it creates carry the right owner. $WORK can only be empty on a
+  # hand run that left the argument off — the daemon always passes it.
+  [ -n "$WORK" ] && mkdir -p "$WORK/cfg/curia-overseer" "$WORK/overseer/repos"
   docker compose -f "$REPO/deploy/compose.yaml" up -d --build --force-recreate --no-deps daemon dashboard overseer
 }
 


### PR DESCRIPTION
Closes alp82/curia#474.

## The failure

The 2026-08-16 deploy created the overseer container on a box where its two bind-mount source directories did not exist. dockerd creates a missing source as `root:root`, the overseer runs as `1000:1000`, and every turn died at `fs.mkdirSync(home)` in `daemon/src/overseerturn.mjs`:

```
EACCES: permission denied, mkdir '/home/alp/curia-work/cfg/curia-overseer/home'
```

The box was repaired by hand with a one-shot root chown. This change prevents the next fresh box from repeating it.

## The fix

Both deploy paths create `<workspace_root>/cfg/curia-overseer` and `<workspace_root>/overseer/repos` before their `docker compose up`:

- **Self-deploy**: `helperRunArgs` mounts the workspace into the sibling, the daemon passes the workspace root as a seventh argv entry, and `recreate()` runs `mkdir -p` first. The rollback recreate goes through the same function, so it is covered too. The sibling runs as uid 1000, so the directories carry the right owner.
- **`bin/deploy.sh`**: the same `mkdir -p` on the box, with the path read from the committed `config/curia.yaml` instead of a second copy of it.
- **`deploy.test.mjs`**: pins the new mount, the new argv shape, and that the pre-create line precedes every compose up in the script.

Suite 2525 pass, 0 fail, 0 cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFTdJmGa8cMhTgqxwKrXBy