### PR TITLE
The stranded map gets an alarm, and the close ending says why the map stays open

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -20,6 +20,7 @@ import { setTimeout as sleepFor } from 'node:timers/promises'
 import {
   repoMaps, mapFrontier, flatFrontier, fetchIssue, claim, unclaim, blockedByOf,
   selectLane, frontierForRepo, filterTakeable, agentOnlyChainCount, directUnblocks, commentIssue, closeIssue, setIssueBody, issueComments,
+  strandedMaps, strandedMapLine,
   parentNumberOf, hasLabel, findPullRequest, createPullRequest, setPullRequestBody,
   deleteRemoteBranch, pullRequestDiff, approvePullRequest,
 } from './github.mjs'
@@ -342,11 +343,15 @@ export class Dispatcher {
   // escalation and returns its record; lapseEscalation closes one as lapsed
   // (journal + message edit); confirmNote posts a line next to a record's
   // buttons; overseerNote journals a synthetic line for a thread's session.
-  constructor({ config, routing, reduction, notify, openConfirm, lapseEscalation, confirmNote, overseerNote, askReview, cancelEscalation, threads, log = console.log, cooling, readings, dataDir, daemonPort, previews, attachLinks, channelName, minter, deps }) {
+  constructor({ config, routing, reduction, notify, announce, openConfirm, lapseEscalation, confirmNote, overseerNote, askReview, cancelEscalation, threads, log = console.log, cooling, readings, dataDir, daemonPort, previews, attachLinks, channelName, minter, deps }) {
     this.config = config
     this.routing = routing
     this.reduction = reduction
     this.notify = notify
+    // The plain channel line (#485), injected by index.mjs the way the
+    // backup's announce is (#436): false when there is no bridge yet, so an
+    // alarm that could not be said stands and re-says.
+    this.announce = announce ?? (async () => false)
     this.openConfirm = openConfirm ?? (() => null)
     this.lapseEscalation = lapseEscalation ?? ((id, reason) => this.reduction.lapse?.(id, reason))
     this.confirmNote = confirmNote ?? (() => {})
@@ -629,6 +634,10 @@ export class Dispatcher {
     } else if (lane === 'flat') {
       flatItems = await this.deps.flatFrontier(entry.repo)
     }
+    // The stranded-map watch (#485) rides the read that already holds every
+    // map and its children. `ready-for-agent` mode never reads maps, so it
+    // neither raises nor clears.
+    if (mode !== 'ready-for-agent') await this.#watchStrandedMaps(entry.repo, maps, mapItems)
     const numbers = frontierForRepo({ mode, maps, mapItems, flatItems })
     // Map membership rides every item (#120): the tickets view groups by map,
     // and the overseer resolves "the <topic> map" against these headers instead
@@ -678,6 +687,48 @@ export class Dispatcher {
           })),
         }
       }),
+    }
+  }
+
+  // The stranded-map watch (#485): an open, non-deferred map whose children
+  // are all closed. No dispatch ever fires on it again, so this is the one
+  // place that can say so — #316 sat that way for days. Edge-triggered off the
+  // journal like the backup alarm (#436): said once when it is news, standing
+  // until the map closes, defers, or gains an open child, each of which clears
+  // it here. It never throws — a watch must not cost the frontier its read.
+  async #watchStrandedMaps(repo, maps, mapItems) {
+    try {
+      const stranded = strandedMaps(maps, mapItems)
+      const now = new Set(stranded.map((m) => m.number))
+      for (const s of this.reduction.standingStrandedMaps?.() ?? []) {
+        if (s.repo === repo && !now.has(s.map)) {
+          this.reduction.journal('map_stranded_cleared', { repo, map: s.map })
+        }
+      }
+      for (const m of stranded) {
+        const entry = this.reduction.strandedMap?.(repo, m.number)
+        if (entry?.said) continue
+        const said = await this.#sayChannel(strandedMapLine(repo, m))
+        // First sighting journals whatever happened. After that, only the say
+        // that finally lands journals — the standing entry already states the
+        // fact, and a tick is too often to restate it.
+        if (!entry || said) this.reduction.journal('map_stranded', { repo, map: m.number, title: m.title, said })
+      }
+    } catch (e) {
+      this.log(`the stranded-map watch failed (${e.message}) — the frontier read stands`)
+    }
+  }
+
+  // The one place `said` is decided, exactly as the backup's #say (#436): a
+  // missing bridge and a failing send are the same answer — the operator did
+  // not read it — so the alarm stands unsaid and re-says on a later pass.
+  async #sayChannel(text) {
+    try {
+      const res = await this.announce(text)
+      return res !== false
+    } catch (e) {
+      this.log(`a channel line did not reach Discord (${e.message}) — it stands until it does`)
+      return false
     }
   }
 

--- a/daemon/src/github.mjs
+++ b/daemon/src/github.mjs
@@ -297,6 +297,27 @@ export function selectLane(maps, mode = 'auto') {
   return { lane: 'map', maps: active.map((m) => m.number) }
 }
 
+// The stranded map (#485): open, not deferred, with at least one child and
+// every child closed. No dispatch ever fires on it again — no open child
+// remains — so without a watch nobody would ever say so (#316 sat that way
+// for days). At least one child, because a new-map session creates the map
+// moments before its first tickets, and that window must not alarm.
+export function strandedMaps(maps = [], mapItems = {}) {
+  return maps
+    .filter((m) => m.state === 'open' && !(m.labels ?? []).some((l) => l.name === 'wayfinder:deferred'))
+    .filter((m) => {
+      const children = mapItems[m.number] ?? []
+      return children.length > 0 && children.every((c) => c.state === 'closed')
+    })
+    .map((m) => ({ number: m.number, title: m.title ?? '' }))
+}
+
+// CuriaBot's line for one stranded map. It names the acts that end it, the way
+// the backup lines do (#436): close the map, or graduate what the fog holds.
+export function strandedMapLine(repo, { number, title }) {
+  return `⚠️ map ${repo}#${number} “${title}” has no open ticket left, but it is still open. Close it with a verdict comment, or graduate what stands under Not yet specified.`
+}
+
 // The HITL-free chain count (#81's tickets view): how many open tickets an
 // agent could work through with no human in the loop — takeable now, or
 // unblocked purely by chains of other HITL-free tickets. `research` and `task`

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -982,6 +982,10 @@ const dispatcher = new Dispatcher({
   routing: routingConfig,
   reduction,
   notify: notifyThread,
+  // #485: the plain channel line for the stranded-map alarm. `bridge` is read
+  // per call for the reason the backup's announce reads it per call — it is
+  // null at boot and the wedge watchdog replaces it whole.
+  announce: (text) => (bridge ? bridge.announce(text).then(() => true) : false),
   openConfirm,
   lapseEscalation,
   // a confirm outcome lands next to its own buttons, whatever thread they are in

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -103,6 +103,11 @@ export const ENDING = [
         // session exercises none past its steps — so the checklist says it.
         'If your close left the map with no open child and nothing under Not yet specified, close the',
         'map itself with a verdict comment: the way is walked, and no one else is dispatched to say so.',
+        // The other emptied ending (#485): no open child, but the fog still
+        // holds patches. The agent must not close then, and it must not stay
+        // silent either — #316 stranded exactly there.
+        'If no open child remains but Not yet specified still holds patches, leave the map open and say',
+        'so in your report_result summary: the map cannot close until that fog is graduated or ruled.',
       ]
       : [
         `Then resolve the ticket on the tracker with \`gh\`: post the resolution as a comment on ${repo}#{n},`,

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -145,6 +145,7 @@ export class Reduction {
     this.turnStarts = new Map() // conversation key -> when its last turn started (#388)
     this.lintRejects = new Map() // `<agent>|<kind>` -> the rejections the lint gate still holds (#418)
     this.backupAlarm = null // the journal-backup failure that still stands, or null (#436)
+    this.mapAlarms = new Map() // "repo#map" -> the stranded-map alarm that still stands (#485)
     this.seq = 0
     this.noteSeq = 0
     this.rebuild()
@@ -312,6 +313,14 @@ export class Reduction {
     // it. A dump that lands clears it, because the fact it stated is gone.
     if (ev.type === 'journal_backup_failed') this.backupAlarm = { ...ev, at: ev.ts ?? null }
     if (ev.type === 'journal_backup') this.backupAlarm = null
+
+    // The stranded-map alarm (#485). A reduction for the reason the backup's is
+    // one: it must not be re-said at every boot or every frontier pass. The
+    // clearing event is explicit, because the fact that ends it — the map
+    // closed, deferred, or gained an open child — lives on GitHub, and the
+    // frontier read is what observes it.
+    if (ev.type === 'map_stranded') this.mapAlarms.set(`${ev.repo}#${ev.map}`, { ...ev, at: ev.ts ?? null })
+    if (ev.type === 'map_stranded_cleared') this.mapAlarms.delete(`${ev.repo}#${ev.map}`)
 
     if (ev.type === 'token_warned' || ev.type === 'token_cleared') {
       const key = ev.fault === 'expiring'
@@ -1211,6 +1220,19 @@ export class Reduction {
   // reads this to decide whether a failure is news, and a boot inherits it.
   standingBackupAlarm() {
     return this.backupAlarm ? { ...this.backupAlarm } : null
+  }
+
+  // Every stranded-map alarm that still stands (#485). The frontier read
+  // clears the ones whose fact is gone, and a boot inherits the rest.
+  standingStrandedMaps() {
+    return [...this.mapAlarms.values()].map((a) => ({ ...a }))
+  }
+
+  // The stranded-map alarm standing for one map, or null (#485). The frontier
+  // read consults this to decide whether a reading is news.
+  strandedMap(repo, map) {
+    const a = this.mapAlarms.get(`${repo}#${map}`)
+    return a ? { ...a } : null
   }
 
   // The pull request an agent's CURRENT dispatch pushed, or null (#289). This

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -160,6 +160,10 @@ function makeDispatcher(deps = {}, {
     // #377, for the same reason: the cooling the dispatcher seeds itself from
     // at construction is the real reduction over the real journal.
     armedCoolings: () => journal.armedCoolings(),
+    // #485: the stranded-map alarm is the real reduction's, for the reason the
+    // backup's is — it must stand across passes and across a deploy.
+    standingStrandedMaps: () => journal.standingStrandedMaps(),
+    strandedMap: (repo, map) => journal.strandedMap(repo, map),
     openEscalations: () => escalations.filter((r) => r.status === 'open'),
     // #374: the real reduction over the real journal. A test seeds `esc_open`
     // and `esc_answer` through `journal` above, and the exchange the prompt
@@ -5566,5 +5570,113 @@ describe('agent-liveness sweep (#138)', () => {
     const d = makeDispatcher()
     const { recent } = await d.status()
     assert.deepEqual(recent, [{ kind: 'died', repo: 'o/r', ticket: '7' }])
+  })
+})
+
+// The stranded-map watch (#485). An open, non-deferred map whose children are
+// all closed gets no dispatch ever again, so the frontier read is the one place
+// that can say so. The alarm is edge-triggered off the journal like the backup
+// alarm (#436): said once, standing until the map closes, defers, or gains an
+// open child.
+describe('the stranded-map watch (#485)', () => {
+  const map = (n, { state = 'open', labels = [] } = {}) => ({
+    number: n, state, title: 'The journal becomes a queryable store',
+    labels: [{ name: 'wayfinder:map' }, ...labels.map((name) => ({ name }))],
+  })
+  const closedChild = (n) => ({ number: n, state: 'closed', assignees: [], labels: [{ name: 'wayfinder:task' }] })
+  const openChild = (n) => ({
+    number: n, state: 'open', assignees: [], labels: [{ name: 'wayfinder:task' }],
+    issue_dependencies_summary: { blocked_by: 0 },
+  })
+
+  test('an all-closed map is said once, journalled, and the second pass is quiet', async () => {
+    const says = []
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316)],
+      mapFrontier: async () => [closedChild(1), closedChild(2)],
+    })
+    d.announce = async (text) => { says.push(text); return true }
+
+    await d.frontier()
+    assert.equal(says.length, 1)
+    assert.match(says[0], /#316/)
+    assert.match(says[0], /no open ticket left/)
+    const ev = events.find((e) => e.type === 'map_stranded')
+    assert.equal(ev.repo, 'o/r')
+    assert.equal(ev.map, 316)
+    assert.equal(ev.said, true)
+
+    await d.frontier()
+    assert.equal(says.length, 1, 'a standing alarm is not re-said')
+    assert.equal(events.filter((e) => e.type === 'map_stranded').length, 1)
+  })
+
+  test('an open child, an empty map, and a deferred map raise nothing', async () => {
+    const says = []
+    let maps = [map(316)]
+    let children = [closedChild(1), openChild(2)]
+    const d = makeDispatcher({
+      repoMaps: async () => maps,
+      mapFrontier: async () => children,
+    })
+    d.announce = async (text) => { says.push(text); return true }
+
+    await d.frontier()
+    children = []
+    await d.frontier()
+    maps = [map(316, { labels: ['wayfinder:deferred'] })]
+    children = [closedChild(1)]
+    await d.frontier()
+
+    assert.equal(says.length, 0)
+    assert.ok(!events.some((e) => e.type === 'map_stranded'))
+  })
+
+  test('the alarm clears when a child reopens, and again when the map closes', async () => {
+    let maps = [map(316)]
+    let children = [closedChild(1)]
+    const says = []
+    const d = makeDispatcher({
+      repoMaps: async () => maps,
+      mapFrontier: async () => children,
+    })
+    d.announce = async (text) => { says.push(text); return true }
+
+    await d.frontier()
+    assert.equal(says.length, 1)
+
+    children = [closedChild(1), openChild(2)]
+    await d.frontier()
+    assert.ok(events.some((e) => e.type === 'map_stranded_cleared' && e.map === 316))
+
+    // it re-strands and is news again
+    children = [closedChild(1), closedChild(2)]
+    await d.frontier()
+    assert.equal(says.length, 2)
+
+    maps = [map(316, { state: 'closed' })]
+    await d.frontier()
+    assert.equal(events.filter((e) => e.type === 'map_stranded_cleared').length, 2)
+  })
+
+  test('an alarm the bridge could not carry stands unsaid and re-says when it returns', async () => {
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316)],
+      mapFrontier: async () => [closedChild(1)],
+    })
+    // the constructor default announce is the no-bridge answer: false
+
+    await d.frontier()
+    assert.equal(events.find((e) => e.type === 'map_stranded').said, false)
+
+    await d.frontier()
+    assert.equal(events.filter((e) => e.type === 'map_stranded').length, 1,
+      'a standing unsaid alarm does not journal every pass')
+
+    const says = []
+    d.announce = async (text) => { says.push(text); return true }
+    await d.frontier()
+    assert.equal(says.length, 1)
+    assert.equal(events.filter((e) => e.type === 'map_stranded').at(-1).said, true)
   })
 })

--- a/daemon/test/frontier.test.mjs
+++ b/daemon/test/frontier.test.mjs
@@ -48,7 +48,7 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { filterTakeable, selectLane, frontierForRepo, agentOnlyChainCount, probeRepoToken, tokenExpiryDays } from '../src/github.mjs'
+import { filterTakeable, selectLane, frontierForRepo, agentOnlyChainCount, probeRepoToken, tokenExpiryDays, strandedMaps, strandedMapLine } from '../src/github.mjs'
 
 // Small fixture builder -- keeps the field-notes ground truth readable below.
 // assignees/labels use the real gh shape: arrays of objects, not strings.
@@ -359,5 +359,44 @@ describe('the agent token boot probe (#155)', () => {
     for (const bad of [null, undefined, '', 'sometime soon']) {
       assert.equal(tokenExpiryDays(bad, now), null)
     }
+  })
+})
+
+// The stranded map (#485): open, not deferred, at least one child, every child
+// closed. #316 sat that way for days — all fifteen tickets closed, the map
+// open, and no dispatch left to notice.
+describe('strandedMaps (#485)', () => {
+  const map = (n, { state = 'open', labels = [] } = {}) => ({
+    number: n, state, title: `Map ${n}`,
+    labels: [{ name: 'wayfinder:map' }, ...labels.map((name) => ({ name }))],
+  })
+  const child = (state) => ({ number: 9, state, labels: [], assignees: [] })
+
+  test('an open map whose children are all closed is stranded', () => {
+    const out = strandedMaps([map(316)], { 316: [child('closed'), child('closed')] })
+    assert.deepEqual(out, [{ number: 316, title: 'Map 316' }])
+  })
+
+  test('an open child keeps the map off the list', () => {
+    assert.deepEqual(strandedMaps([map(316)], { 316: [child('closed'), child('open')] }), [])
+  })
+
+  test('a map with no children yet is not stranded — the new-map window must not alarm', () => {
+    assert.deepEqual(strandedMaps([map(316)], { 316: [] }), [])
+    assert.deepEqual(strandedMaps([map(316)], {}), [])
+  })
+
+  test('closed and deferred maps are never stranded', () => {
+    const maps = [map(1, { state: 'closed' }), map(2, { labels: ['wayfinder:deferred'] })]
+    const items = { 1: [child('closed')], 2: [child('closed')] }
+    assert.deepEqual(strandedMaps(maps, items), [])
+  })
+
+  test('the line names the map and both acts that end it', () => {
+    const line = strandedMapLine('o/r', { number: 316, title: 'The journal becomes a queryable store' })
+    assert.match(line, /o\/r#316/)
+    assert.match(line, /no open ticket left/)
+    assert.match(line, /Close it with a verdict comment/)
+    assert.match(line, /Not yet specified/)
   })
 })


### PR DESCRIPTION
Closes #485.

Map #316 sat open for days after its last ticket closed, because its fog still held a patch and no role owned that state. This change gives the state two owners.

**The daemon detects a stranded map.** A stranded map is open, not deferred, with at least one child and every child closed. `strandedMaps` in `github.mjs` is the pure rule, and the watch rides `#repoFrontier`, the read that already holds every map and its children. On detection, CuriaBot says one plain channel line: close the map with a verdict comment, or graduate what stands under Not yet specified. The alarm follows the journal-backup pattern (#436): `map_stranded` / `map_stranded_cleared` fold to a standing entry in the reduction, the line is said once when it is news, an unsaid alarm re-says when the bridge returns, and the alarm clears when the map closes, defers, or gains an open child. A map with no children yet never alarms, so the new-map charting window stays quiet. The `Dispatcher` gains an `announce` seam, wired in `index.mjs` the way the backup's is.

**The close ending states the other emptied case.** The `lifecycle.mjs` resolve prose covered one ending: no open child and an empty fog, close the map. It now also covers the ending #316 hit: no open child but patches still under Not yet specified. The agent leaves the map open and says so in its `report_result` summary, so the thread explains the state instead of going silent.

The suite is green: 2629 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vQ9HhTjH2kaMueAna5wDL
