### PR TITLE
The codex seed refuses an access token that already expired

### DIFF
--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -568,6 +568,23 @@ function writeSecretFile(file, data) {
   fs.chmodSync(file, 0o600) // the mode applies only on create; a reused config dir already has one
 }
 
+// When the codex access token expires, in epoch milliseconds — or null when the
+// file does not answer the question. The token is a JWT, so the expiry is the
+// `exp` claim in its payload, read without verification: the daemon is not the
+// audience, it only needs the clock value the server stamped. Null on ANY
+// parse failure, on purpose: the #351 refusal below must stand on a measured
+// expiry, and a credential file this parser cannot read proves nothing about
+// the token's lifetime.
+function codexAccessTokenExpiry(authJson) {
+  try {
+    const token = JSON.parse(authJson)?.tokens?.access_token
+    const payload = JSON.parse(Buffer.from(String(token).split('.')[1], 'base64url').toString('utf8'))
+    return Number.isFinite(payload.exp) ? payload.exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
 const HARNESS = {
   claude: {
     // The CLI's global-memory file, and the ONLY per-session channel either
@@ -762,6 +779,19 @@ const HARNESS = {
     // runs as uid 1000 and owns the file, so it could chmod it back. What it
     // buys is that an ordinary in-place refresh FAILS rather than silently
     // rotating the host away.
+    //
+    // AND THE COPY MUST NOT START EXPIRED (#351). The 0400 bit blocks the
+    // write-back, not the refresh: a refresh is a network call, and the server
+    // rotates the refresh token the moment it succeeds. A copy whose access
+    // token is already expired refreshes on first use, the rotated credential
+    // lives only in process memory, and the next re-read presents the old
+    // refresh token — which the server refuses as already used. That strands
+    // the agent AND the host store, because both hold the same spent token.
+    // So an expired host token refuses the dispatch here, loudly and before
+    // any claim work is lost. The bound this buys is one access-token
+    // lifetime: an agent that outlives a fresh token still dies on the same
+    // sequence, and only the API-key shape (ADR-0007's, for the claude lane)
+    // removes the lineage entirely.
     seed: (cfgDir, _wtPath, { sandboxed = false } = {}) => {
       const dest = path.join(cfgDir, 'auth.json')
       const host = path.join(os.homedir(), '.codex', 'auth.json')
@@ -773,7 +803,12 @@ const HARNESS = {
       if (!fs.existsSync(host)) {
         throw new Error(`no codex credential for the container: ${host} does not exist, and a sandboxed codex agent cannot reach the host store — run \`codex login\` on this box`)
       }
-      fs.copyFileSync(host, dest)
+      const raw = fs.readFileSync(host, 'utf8')
+      const expiry = codexAccessTokenExpiry(raw)
+      if (expiry !== null && expiry <= Date.now()) {
+        throw new Error(`refusing to seed the codex credential into the container: the host access token expired ${new Date(expiry).toISOString()}. A copy that starts expired refreshes at once, the server rotates the refresh token, and the read-only copy cannot store the rotation — that strands the host store too (#351) — run \`codex login\` on this box first`)
+      }
+      fs.writeFileSync(dest, raw)
       fs.chmodSync(dest, 0o400)
     },
 

--- a/daemon/test/workspace.test.mjs
+++ b/daemon/test/workspace.test.mjs
@@ -593,6 +593,63 @@ describe('the codex agent harness (#39)', () => {
     }))
   })
 
+  // #351: the 0400 bit blocks the write-back, not the refresh. A copy whose
+  // access token is already expired refreshes on first use, the server rotates
+  // the refresh token, and the rotation cannot land in the read-only file — so
+  // the agent AND the host store end on a spent token. The seed refuses that
+  // dispatch instead. The access token is a JWT, so the tests build one with a
+  // real `exp` claim and nothing else.
+  describe('an expired codex access token refuses the seed (#351)', () => {
+    const jwt = (payload) => `h.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.s`
+    const authWith = (accessToken) => JSON.stringify({ tokens: { access_token: accessToken, refresh_token: 'r' } })
+    const hostAuth = (home, content) => {
+      fs.mkdirSync(path.join(home, '.codex'), { recursive: true })
+      fs.writeFileSync(path.join(home, '.codex', 'auth.json'), content)
+    }
+    const nowS = Math.floor(Date.now() / 1000)
+
+    test('an expired token refuses the dispatch, naming the expiry and the remedy', () => withHome((home) => {
+      hostAuth(home, authWith(jwt({ exp: nowS - 3600 })))
+      const { cfgDir, wtPath } = dirs(25)
+      assert.throws(
+        () => seedConfigDir(cfgDir, wtPath, null, 'codex', { sandboxed: true }),
+        /access token expired .*codex login/s,
+      )
+      assert.equal(fs.existsSync(path.join(cfgDir, 'auth.json')), false, 'no copy lands on a refusal')
+    }))
+
+    test('a live token seeds as before', () => withHome((home) => {
+      const content = authWith(jwt({ exp: nowS + 3600 }))
+      hostAuth(home, content)
+      const { cfgDir, wtPath } = dirs(26)
+      seedConfigDir(cfgDir, wtPath, null, 'codex', { sandboxed: true })
+      const dest = path.join(cfgDir, 'auth.json')
+      assert.equal(fs.readFileSync(dest, 'utf8'), content)
+      assert.equal(fs.lstatSync(dest).mode & 0o777, 0o400)
+    }))
+
+    test('a token this parser cannot read proves nothing — the seed proceeds', () => withHome((home) => {
+      hostAuth(home, authWith('not-a-jwt'))
+      const { cfgDir, wtPath } = dirs(27)
+      seedConfigDir(cfgDir, wtPath, null, 'codex', { sandboxed: true })
+      assert.equal(fs.existsSync(path.join(cfgDir, 'auth.json')), true)
+    }))
+
+    test('an exp claim that is not a number proves nothing either', () => withHome((home) => {
+      hostAuth(home, authWith(jwt({ exp: 'soon' })))
+      const { cfgDir, wtPath } = dirs(28)
+      seedConfigDir(cfgDir, wtPath, null, 'codex', { sandboxed: true })
+      assert.equal(fs.existsSync(path.join(cfgDir, 'auth.json')), true)
+    }))
+
+    test('the bare path never refuses — the host process refreshes its own store in place', () => withHome((home) => {
+      hostAuth(home, authWith(jwt({ exp: nowS - 3600 })))
+      const { cfgDir, wtPath } = dirs(29)
+      seedConfigDir(cfgDir, wtPath, null, 'codex')
+      assert.equal(fs.lstatSync(path.join(cfgDir, 'auth.json')).isSymbolicLink(), true)
+    }))
+  })
+
   // #171: CODEX_HOME does not bound skills. The pinned codex also reads
   // `$HOME/.agents/skills`, with no config key to turn the root off, so the
   // harness writes one disable entry per host skill the seed did not install.


### PR DESCRIPTION
Closes #351.

## What changed

The sandboxed codex `seed` in `daemon/src/workspace.mjs` now reads the expiry from the host access token's JWT `exp` claim. When the token has already expired, the seed throws instead of copying, and the dispatch fails before any claim work is lost. The refusal names the expiry and the remedy: `codex login` on the box.

## Why this direction

The issue listed three directions. This lands the first one:

- The 0400 bit blocks the write-back, not the refresh. A copy that starts expired refreshes on first use, the server rotates the refresh token, and the rotation cannot land in the read-only file. Both lineages end on the same spent token.
- A refusal at seed time is loud and cheap. It closes the observed case (curia-318, Aug 13).
- The write-back direction needs a last-writer story across concurrent agents, and codex writes are truncate-in-place. The API-key direction needs an operations change on the box. Both stay open in #351's terms; the issue can stay open or spawn a follow-up if the long-lived-agent case matters in practice.

## Bounds

- A token the parser cannot read proves nothing and seeds as before. The refusal stands only on a measured expiry.
- The bound this buys is one access-token lifetime. An agent that outlives a fresh token still dies on the same sequence.
- The bare (non-sandboxed) path never refuses: the host process refreshes its own store in place.

## Tests

Five new tests in `daemon/test/workspace.test.mjs` (expired refuses, live seeds, unreadable token seeds, non-numeric `exp` seeds, bare path unchanged). Full daemon suite: 2684 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMmgg87Yg6jXWACL6sUb2J