### PR TITLE
A kill aimed at the harness process tree is refused inside the container

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -49,8 +49,8 @@ import { readDiffDigest, readFileHunks, digestLine, sliceFromPatch, capText } fr
 import { transcriptReset, holdVerdict, hottestPct, WARM_PCT } from './usage.mjs'
 import { mintAgentToken, forgetAgentToken, sweepAgentTokens } from './agenttoken.mjs'
 import {
-  GUEST_WT, GUEST_CFG, GUEST_DAEMON_HOST, ENV_FILE, PORTS_PER_AGENT,
-  allocatePorts, containerPorts, dockerRunCmd, listContainers, modelCredential, stopContainer,
+  GUEST_WT, GUEST_CFG, GUEST_DAEMON_HOST, GUEST_GUARD_ENV, ENV_FILE, PORTS_PER_AGENT,
+  allocatePorts, containerPorts, dockerRunCmd, listContainers, modelCredential, seedKillGuard, stopContainer,
   writeEnvFile,
 } from './sandbox.mjs'
 import {
@@ -1616,6 +1616,10 @@ export class Dispatcher {
     // skipped because it commits nothing at all: ADR-0010 gives it a detached
     // head and no branch.
     if (!reviewer) await this.#authorAsBot(wtPath, ghToken, session)
+    // The kill guard (#385) rides the same mount as the env file: a signal the
+    // agent aims at its own harness process tree is refused inside the
+    // container, whatever verb resolved the pid.
+    seedKillGuard(cfgDir)
     const envFile = writeEnvFile(path.join(cfgDir, ENV_FILE), {
       ...agentEnv(GUEST_CFG, harness, { sandboxed: true }),
       // The PATH to the credential above, and no credential in it (#389). It is
@@ -1628,6 +1632,10 @@ export class Dispatcher {
       // the agent cannot write.
       HOME: '/home/agent',
       TERM: 'xterm-256color',
+      // Every non-interactive bash sources the kill guard's PATH prepend and
+      // builtin shadow (#385). Login shells read /etc/profile.d instead — the
+      // agent image carries the same lines there.
+      BASH_ENV: GUEST_GUARD_ENV,
     })
     const shellCmd = dockerRunCmd({
       name: session, ticket, image: image.ref, cfgDir, wtPath, envFile, spawnCmd, ports, sandbox,

--- a/daemon/src/sandbox.mjs
+++ b/daemon/src/sandbox.mjs
@@ -340,6 +340,151 @@ export function writeEnvFile(file, env) {
   return file
 }
 
+// ---- the kill guard (#385) -------------------------------------------------------
+
+// An agent's own kill can end its harness. The container shares one pid
+// namespace, one uid owns every process in it, and the harness sits at the top
+// of the agent's own ancestor chain — so `ps | grep | xargs kill` with a
+// pattern from the ticket text resolved pid 7 and SIGTERM'd the session
+// mid-ticket (curia-314). A harness-side guard covers single verbs; this one
+// covers the effect: any exec'd `kill`/`pkill` whose resolved target is an
+// ancestor of the killing process is aimed at the harness tree, and it is
+// refused with the reason, whatever verb carried it.
+//
+// Ignoring SIGTERM instead was measured and does not hold: the claude CLI
+// installs its own SIGTERM handler, which overrides an inherited SIG_IGN
+// disposition, and the process exits 143 anyway.
+//
+// Delivery is the /cfg mount, not the image: the image digest covers only the
+// Dockerfile bytes, so a COPYed script would drift silently, and a mounted
+// guard is testable in this suite with plain bash. Three files under
+// `<cfgDir>/bin`:
+//
+//   kill    — refuses a target pid (or process group) in its own ancestor set
+//   pkill   — resolves the pattern with pgrep FIRST and refuses on a collision
+//   bashenv.sh — sourced via BASH_ENV by every non-interactive bash: prepends
+//     /cfg/bin to PATH and shadows the `kill` BUILTIN with the guard
+//
+// `bash -lc` (the codex tool shell) reads /etc/profile instead of BASH_ENV, so
+// the agent image carries the same two lines in /etc/profile.d (Dockerfile).
+// The whole guard is a bound against accident, not against the agent: the
+// mount is writable and `command kill` bypasses a shell function. What it buys
+// is that the observed pattern-kill fails loudly instead of ending the session.
+//
+// A signal of 0 always passes: `kill -0` is the standard liveness probe, and
+// refusing it would break scripts that only ask.
+
+export const GUEST_GUARD_ENV = `${GUEST_CFG}/bin/bashenv.sh`
+
+const GUARD_ANCESTORS = `ancestors=" "
+p=$$
+while [ "\${p:-0}" -gt 0 ] 2>/dev/null; do
+  ancestors="\$ancestors\$p "
+  pp=""
+  while read -r k v _; do
+    if [ "\$k" = "PPid:" ]; then pp=\$v; break; fi
+  done < "/proc/\$p/status" || break
+  p=\$pp
+done 2>/dev/null`
+
+const GUARD_KILL = `#!/bin/bash
+# curia kill guard (#385) — see daemon/src/sandbox.mjs
+set -u
+real=/bin/kill
+[ -x "\$real" ] || real=/usr/bin/kill
+${GUARD_ANCESTORS}
+probe=false
+expect_sig=false
+opts_done=false
+targets=()
+for a in "\$@"; do
+  if \$expect_sig; then expect_sig=false; [ "\$a" = 0 ] && probe=true; continue; fi
+  if ! \$opts_done; then
+    case "\$a" in
+      --) opts_done=true; continue ;;
+      -l|-l*|-L|--list*|--table) exec "\$real" "\$@" ;;
+      -0) probe=true; continue ;;
+      -s|--signal) expect_sig=true; continue ;;
+      --signal=0) probe=true; continue ;;
+      -[0-9]*|-[A-Za-z]*|--*) continue ;;
+    esac
+  fi
+  targets+=("\$a")
+done
+if ! \$probe; then
+  for t in \${targets[@]+"\${targets[@]}"}; do
+    n=\${t#-}
+    case "\$n" in ''|*[!0-9]*) continue ;; esac
+    if [ "\$n" = 1 ]; then
+      echo "curia: refusing \\\`kill \$t\\\`: that reaches the container's init, and the agent harness dies with it — killing your own harness ends this session (#385)" >&2
+      exit 1
+    fi
+    case "\$ancestors" in *" \$n "*)
+      echo "curia: refusing \\\`kill \$t\\\`: pid \$n is this command's own ancestor — the agent harness process tree. Killing it ends this session (#385)" >&2
+      exit 1 ;;
+    esac
+  done
+fi
+exec "\$real" "\$@"
+`
+
+const GUARD_PKILL = `#!/bin/bash
+# curia pkill guard (#385) — see daemon/src/sandbox.mjs
+set -u
+real=/usr/bin/pkill
+pgrep_bin=/usr/bin/pgrep
+${GUARD_ANCESTORS}
+probe=false
+skip=false
+res=()
+for a in "\$@"; do
+  if \$skip; then skip=false; [ "\$a" = 0 ] && probe=true; continue; fi
+  case "\$a" in
+    --signal) skip=true; continue ;;
+    --signal=*) [ "\${a#--signal=}" = 0 ] && probe=true; continue ;;
+    -0) probe=true; continue ;;
+    -[0-9]*|-SIG[A-Z]*|-[A-Z]*) continue ;;
+  esac
+  res+=("\$a")
+done
+pids=\$("\$pgrep_bin" \${res[@]+"\${res[@]}"} 2>/dev/null) || exec "\$real" "\$@"
+if ! \$probe; then
+  for t in \$pids; do
+    case "\$ancestors" in *" \$t "*)
+      echo "curia: refusing this pkill: the pattern resolves to pid \$t, this command's own ancestor — the agent harness process tree. Killing it ends this session (#385). Narrow the pattern (a [b]racketed first letter keeps it out of your own command line) or name the pid." >&2
+      exit 1 ;;
+    esac
+  done
+fi
+exec "\$real" "\$@"
+`
+
+const GUARD_BASHENV = `# curia kill guard (#385) — sourced by every non-interactive bash (BASH_ENV).
+# Login shells read /etc/profile.d/curia-kill-guard.sh instead (agent image).
+if [ -d ${GUEST_CFG}/bin ]; then
+  case ":\$PATH:" in *":${GUEST_CFG}/bin:"*) ;; *) export PATH="${GUEST_CFG}/bin:\$PATH" ;; esac
+fi
+if [ -x ${GUEST_CFG}/bin/kill ]; then kill() { ${GUEST_CFG}/bin/kill "\$@"; }; fi
+`
+
+// Written on every dispatch, like the env file beside it: the config dir is
+// reused across dispatches and across the cross-harness respawn, and the guard
+// must be the current one, not whatever the last daemon version left.
+export function seedKillGuard(cfgDir) {
+  const bin = path.join(cfgDir, 'bin')
+  fs.mkdirSync(bin, { recursive: true })
+  for (const [name, content, mode] of [
+    ['kill', GUARD_KILL, 0o755],
+    ['pkill', GUARD_PKILL, 0o755],
+    ['bashenv.sh', GUARD_BASHENV, 0o644],
+  ]) {
+    const file = path.join(bin, name)
+    fs.writeFileSync(file, content, { mode })
+    fs.chmodSync(file, mode) // the mode applies only on create; the dir is reused
+  }
+  return bin
+}
+
 // ---- the command the pane runs ---------------------------------------------------
 
 // The `docker run` line, as one shell command for tmux.newSession.

--- a/daemon/test/sandbox.test.mjs
+++ b/daemon/test/sandbox.test.mjs
@@ -16,10 +16,12 @@ import path from 'node:path'
 
 import { Dispatcher } from '../src/dispatch.mjs'
 import { loadCuriaConfig, loadRoutingConfig } from '../src/config.mjs'
+import { spawn, spawnSync } from 'node:child_process'
+
 import {
-  GUEST_CFG, GUEST_WT, GUEST_DAEMON_HOST, PORTS_PER_AGENT, PROBE_MARK, PROBE_PATH,
+  GUEST_CFG, GUEST_WT, GUEST_DAEMON_HOST, GUEST_GUARD_ENV, PORTS_PER_AGENT, PROBE_MARK, PROBE_PATH,
   allocatePorts, containerPorts, dockerGateway, dockerRunCmd, modelCredential,
-  probeSideChannel, sourceAddressFor, stopContainer, writeEnvFile,
+  probeSideChannel, seedKillGuard, sourceAddressFor, stopContainer, writeEnvFile,
 } from '../src/sandbox.mjs'
 import { installSkills, seedConfigDir, agentEnv, writePrompt as realWritePrompt } from '../src/workspace.mjs'
 import { journalDouble } from './fixtures/journal.mjs'
@@ -106,6 +108,87 @@ describe('the docker run line (#156)', () => {
 
   test('the container runs as the uid that owns the mounts', () => {
     assert.match(line(), /--user 1000:1000/)
+  })
+})
+
+// ---- the kill guard (#385) -----------------------------------------------------
+
+// The guard scripts run under the REAL bash here, against this test process's
+// own ancestor chain — which is exactly the shape they exist for: the node
+// process running this suite stands in for the harness, and a guard that let a
+// refused signal through would kill the suite itself.
+describe('the kill guard (#385)', () => {
+  const guardBin = () => seedKillGuard(path.join(tmp, 'cfg', 'curia-9'))
+
+  // Runs the guard from INSIDE a child bash, the way an agent's tool command
+  // would: the guard's ancestors are then that bash and this node process.
+  const inWrapper = (script, bin) => spawnSync('bash', ['-c', script, '_', bin], { encoding: 'utf8' })
+
+  test('the seed writes two executable shims and the BASH_ENV file', () => {
+    const bin = guardBin()
+    for (const name of ['kill', 'pkill']) {
+      assert.ok(fs.statSync(path.join(bin, name)).mode & 0o100, `${name} must be executable`)
+    }
+    const env = fs.readFileSync(path.join(bin, 'bashenv.sh'), 'utf8')
+    assert.match(env, /PATH="\/cfg\/bin:\$PATH"/)
+    assert.match(env, /kill\(\) \{ \/cfg\/bin\/kill "\$@"; \}/)
+  })
+
+  test('a kill aimed at an ancestor is refused, whatever signal it carries', () => {
+    const bin = path.join(guardBin(), 'kill')
+    for (const argv of ['-TERM $PPID', '-9 $PPID', '$PPID', '-s KILL $PPID']) {
+      const r = inWrapper(`"$1" ${argv}`, bin)
+      assert.equal(r.status, 1, `\`kill ${argv}\` must be refused`)
+      assert.match(r.stderr, /own ancestor.*#385/s)
+    }
+  })
+
+  test('a kill aimed at pid 1 is refused — that is the container init', () => {
+    const r = inWrapper('"$1" -TERM 1', path.join(guardBin(), 'kill'))
+    assert.equal(r.status, 1)
+    assert.match(r.stderr, /init/)
+  })
+
+  test('signal 0 is a liveness probe and always passes', () => {
+    const bin = path.join(guardBin(), 'kill')
+    for (const argv of ['-0 $PPID', '-s 0 $PPID']) {
+      const r = inWrapper(`"$1" ${argv}`, bin)
+      assert.equal(r.status, 0, `\`kill ${argv}\` is a probe, not a signal`)
+    }
+  })
+
+  test('an ordinary kill of a non-ancestor passes through and lands', async () => {
+    const child = spawn('sleep', ['30'])
+    await new Promise((res) => setTimeout(res, 50))
+    const r = spawnSync(path.join(guardBin(), 'kill'), [String(child.pid)], { encoding: 'utf8' })
+    assert.equal(r.status, 0, r.stderr)
+    const signal = await new Promise((res) => child.on('exit', (_c, s) => res(s)))
+    assert.equal(signal, 'SIGTERM')
+  })
+
+  test('a pkill whose pattern resolves to an ancestor is refused and says how to narrow it', () => {
+    // the nonce sits in the wrapper bash's own command line, which is the
+    // observed shape: the ticket text names the harness's prompt too
+    const r = inWrapper('"$1" -f guardnonce_c0ffee', path.join(guardBin(), 'pkill'))
+    assert.equal(r.status, 1)
+    assert.match(r.stderr, /resolves to pid \d+.*own ancestor/s)
+    assert.match(r.stderr, /racketed/)
+  })
+
+  test('a pkill that resolves only to a non-ancestor passes through and lands', async () => {
+    // assembled at runtime so the pattern text sits in NO ancestor's argv
+    const nonce = `${86000 + Math.floor(Math.random() * 999)}.31`
+    const child = spawn('sleep', [nonce])
+    await new Promise((res) => setTimeout(res, 50))
+    const r = spawnSync(path.join(guardBin(), 'pkill'), ['-f', `slee[p] ${nonce}`], { encoding: 'utf8' })
+    assert.equal(r.status, 0, r.stderr)
+    const signal = await new Promise((res) => child.on('exit', (_c, s) => res(s)))
+    assert.equal(signal, 'SIGTERM')
+  })
+
+  test('the BASH_ENV path the env file names is the file the seed writes', () => {
+    assert.equal(GUEST_GUARD_ENV, `${GUEST_CFG}/bin/bashenv.sh`)
+    assert.ok(fs.existsSync(path.join(guardBin(), 'bashenv.sh')))
   })
 })
 
@@ -648,6 +731,17 @@ describe('a sandboxed dispatch (#156)', () => {
     assert.match(env, /GH_CONFIG_DIR=\/cfg\/gh/)
     assert.doesNotMatch(env, /GH_TOKEN=/)
     assert.ok(!spawns[0].shellCmd.includes('sk-test'), 'the credential reached the command line')
+  })
+
+  test('the dispatch seeds the kill guard and points BASH_ENV at it (#385)', async () => {
+    const { d } = makeDispatcher()
+    await d.start('42', { repo: 'o/r' })
+    const cfg = path.join(tmp, 'work', 'cfg', 'curia-42')
+    const env = fs.readFileSync(path.join(cfg, 'container.env'), 'utf8')
+    assert.match(env, /BASH_ENV=\/cfg\/bin\/bashenv\.sh/)
+    for (const name of ['kill', 'pkill', 'bashenv.sh']) {
+      assert.ok(fs.existsSync(path.join(cfg, 'bin', name)), `${name} must be seeded beside the env file`)
+    }
   })
 
   test('the workspace is a private clone, never a worktree of a shared base', async () => {

--- a/deploy/agent/Dockerfile
+++ b/deploy/agent/Dockerfile
@@ -135,6 +135,19 @@ RUN set -eux; \
     mkdir -p /cache/npm /cache/playwright-browsers /workspace; \
     chown -R agent:agent /cache /workspace
 
+# The kill guard's login-shell half (#385). The guard itself is written by the
+# daemon into the mounted config dir (`/cfg/bin`, see daemon/src/sandbox.mjs):
+# BASH_ENV covers every non-interactive bash, but `bash -lc` — the codex tool
+# shell — reads /etc/profile instead of BASH_ENV, so the same two lines land in
+# profile.d. Both are guarded on the mount, so the image still works with no
+# /cfg at all (the daemon's own test suite runs in here, #231/#409). Written
+# inline rather than COPYed, so the build context stays empty of content and
+# the guard rides the image digest with the rest of the Dockerfile.
+RUN printf '%s\n' \
+      'if [ -d /cfg/bin ]; then case ":$PATH:" in *":/cfg/bin:"*) ;; *) PATH="/cfg/bin:$PATH" ;; esac; fi' \
+      'if [ -x /cfg/bin/kill ]; then kill() { /cfg/bin/kill "$@"; }; fi' \
+      > /etc/profile.d/curia-kill-guard.sh
+
 # Both CLIs check for a newer self on start. The image IS the pin, and an
 # updated CLI inside a container that dies with its ticket is a download the
 # next agent repeats.


### PR DESCRIPTION
Closes #385.

## What changed

The daemon seeds a kill guard into each agent's mounted config dir (`/cfg/bin`, `seedKillGuard` in `daemon/src/sandbox.mjs`):

- `kill` walks its own ancestor chain through `/proc` and refuses a target pid or process group in that chain — which is the harness process tree, whatever verb resolved the pid. Pid 1 (the container init) is refused too. Signal 0 always passes, because `kill -0` is the standard liveness probe.
- `pkill` resolves its pattern with `pgrep` first and refuses on a collision, naming the colliding pid and how to narrow the pattern (a `[b]racketed` first letter keeps it out of the command's own line).
- `bashenv.sh`, sourced through `BASH_ENV` by every non-interactive bash, prepends `/cfg/bin` to `PATH` and shadows the `kill` builtin. `bash -lc` (the codex tool shell) reads `/etc/profile` instead of `BASH_ENV`, so the agent image carries the same two lines in `/etc/profile.d` — written inline in the Dockerfile, so the guard rides the image digest and the build context stays empty of content.

## Why not the SIGTERM direction

Measured on this box before writing the guard: the claude CLI installs its own SIGTERM handler (`process.on("SIGTERM", …)` in the bundle, signal mask confirmed with `ps -o caught`). A registered handler overrides an inherited SIG_IGN disposition, and a `trap '' TERM`-wrapped claude still exits on SIGTERM. So the issue's second direction does not hold for the claude harness, and the first direction — match on the resolved target pids — is what this lands, at the container level where an exec'd `kill`/`pkill` actually runs.

## Bounds

The guard is a bound against accident, not against the agent: the mount is writable, and `command kill` bypasses a shell function. The observed incident (`ps aux | grep | awk | xargs -r kill` in curia-314) execs `kill` from PATH and is caught. #386's dead-harness sweep is the containment for whatever still gets through.

## Tests

Nine new tests in `daemon/test/sandbox.test.mjs`. The guard scripts run under real bash against the test process's own ancestor chain: refusals for `-TERM`, `-9`, `-s KILL`, plain pid, and pid 1; pass-through for probes, ordinary kills, and a pkill that resolves only to a non-ancestor. A dispatch-level test pins `BASH_ENV` in the env file and the seeded files. Full daemon suite: 2688 pass, 0 fail.

The Dockerfile edit changes the image digest, so the first dispatch after deploy rebuilds the agent image (about four minutes, said in-thread as usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMmgg87Yg6jXWACL6sUb2J