### PR TITLE
The liveness sweep reads the exit marker, so a dead harness under a live pane is a death

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -5458,7 +5458,13 @@ export class Dispatcher {
       } catch {
         continue
       }
-      if (present) continue
+      if (present) {
+        // A live session is not yet a live agent (#386): the pane outlives the
+        // harness command, so a session that still answers may be a bare shell
+        // over a dead harness. The exit marker in the pane settles it.
+        await this.#sweepDeadHarness(w).catch((e) => this.log(`dead-harness sweep for ${w.session} failed:`, e.message))
+        continue
+      }
       // re-judge after the await: a teardown or replacement that started while
       // tmux was being asked makes this absence an ordered one after all
       if (this.agents.get(w.session) !== w || this.orderedKills.has(w.session)) continue
@@ -5466,8 +5472,57 @@ export class Dispatcher {
     }
   }
 
-  async #onAgentDied(w) {
+  // #386: the harness command dies, the pane survives as a bare bash shell,
+  // and every liveness read off `tmux ls` keeps saying "ready". The exit
+  // marker (#169) is already printed into that pane; before this sweep,
+  // nothing looked at it after readiness — the observed cost was a thread
+  // that went silent for a day, an operator message typed into the dead shell
+  // (which executed two of its words), and a `resume` that refused with
+  // "already running".
+  //
+  // On a hit the session is KILLED, not kept: the dead shell is an input the
+  // daemon would keep typing into, so removing it is what makes the queued-
+  // word refusal and the `resume` guard both come out right — and unlike the
+  // cancel-then-resume detour this leaves the worktree in place, so the
+  // resumed agent inherits the uncommitted work instead of losing it. The
+  // pane's evidence rides the notify as an excerpt before the kill takes it.
+  //
+  // Two states are somebody else's: 'spawning' belongs to the pre-ready
+  // watchdog (#169 reports the same marker there), and 'failed' is a session
+  // deliberately kept for post-mortem — sweeping it would break that promise.
+  // An adoption record carries no marker and is skipped by the first guard;
+  // its deaths still land through the session-gone half above.
+  async #sweepDeadHarness(w) {
+    if (!w.exitMarker) return
+    if (w.state === 'spawning' || w.state === 'failed') return
+    let pane
+    try {
+      pane = await this.deps.capturePane(w.session)
+    } catch {
+      return // an unreadable pane proves nothing — next pass asks again
+    }
+    const tail = paneTail(pane)
+    const status = parseExitMarker(tail, w.exitMarker)
+    if (status === null) return
+    // re-judge after the await, as the session-gone half does
+    if (this.agents.get(w.session) !== w || this.orderedKills.has(w.session)) return
+    const excerpt = paneExcerpt(tail, w.exitMarker)
+    await this.deps.killSession(w.session).catch((e) => this.log(`dead-shell kill for ${w.session} failed:`, e.message))
+    await this.#onAgentDied(w, { status, excerpt })
+  }
+
+  // `status`/`excerpt` arrive from the dead-harness half of the sweep (#386):
+  // the harness command's exit status off the pane marker, and the pane lines
+  // above it. The session-gone half has neither — the pane died with its
+  // evidence.
+  async #onAgentDied(w, { status = null, excerpt = '' } = {}) {
     const { session, ticket, repo } = w
+    // How the death reads in the thread: measured when the marker gave one,
+    // and the old wording when only the absence is known.
+    const cause = status !== null
+      ? `'s **${w.harness}** command exited with status ${status} and left the pane as a dead shell — curia killed it`
+      : ' is gone without a teardown order'
+    const tail = excerpt ? `\n\`\`\`\n${excerpt}\n\`\`\`` : ''
     // A dead session WITH a recorded result is a finishing agent whose Stop
     // hook never landed — the normal close, not a death. onAgentDone already
     // handles exactly that shape.
@@ -5480,15 +5535,17 @@ export class Dispatcher {
     // reviewer over this checkout.
     if (w.reviewer) {
       this.agents.delete(session)
-      this.reduction.journal('agent_died', { repo, ticket, agent: session, kind: 'reviewer' })
+      this.reduction.journal('agent_died', { repo, ticket, agent: session, kind: 'reviewer', ...(status !== null && { status }) })
       this.lapseConfirmsFor(session, `\`${session}\` died`)
       this.deps.removeCredentials(w.cfgDir ?? cfgDirFor(this.root, session))
       this.log(`liveness sweep: reviewer ${session} is gone with no teardown order`)
-      this.notify(ticket, `⚰️ \`${session}\` is gone without a teardown order and left NO verdict — nothing about #${ticket} changed. Ask for the cross-check again to start a fresh reviewer.`)
+      this.notify(ticket, status !== null
+        ? `⚰️ \`${session}\`${cause}. It left NO verdict — nothing about #${ticket} changed. Ask for the cross-check again to start a fresh reviewer.${tail}`
+        : `⚰️ \`${session}\` is gone without a teardown order and left NO verdict — nothing about #${ticket} changed. Ask for the cross-check again to start a fresh reviewer.`)
       return
     }
     this.agents.delete(session)
-    this.reduction.journal('agent_died', { repo, ticket, agent: session })
+    this.reduction.journal('agent_died', { repo, ticket, agent: session, ...(status !== null && { status }) })
     this.log(`liveness sweep: ${session} is gone with no teardown order`)
 
     // The surface half of item 19: the agent's open questions STAY open and
@@ -5541,7 +5598,7 @@ export class Dispatcher {
     const escLine = open.length
       ? ` ${open.length} open question(s) — ${open.map((r) => `**${r.id}**`).join(', ')} — stay answerable: an answer there is recorded and handed to the resumed agent.`
       : ''
-    this.notify(ticket, `⚰️ \`${session}\` is gone without a teardown order — ${claimLine}.${escLine} \`resume ${ticket}\` starts a fresh agent on the surviving worktree`)
+    this.notify(ticket, `⚰️ \`${session}\`${cause} — ${claimLine}.${escLine} \`resume ${ticket}\` starts a fresh agent on the surviving worktree${tail}`)
   }
 
   // ---- reconcile -----------------------------------------------------------------

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -5591,6 +5591,111 @@ describe('agent-liveness sweep (#138)', () => {
   })
 })
 
+// #386: the harness command dies, the pane survives as a bare bash shell, and
+// `tmux ls` keeps answering "live". The exit marker is already printed into
+// that pane; the sweep now reads it after readiness. Observed cost before
+// this: a thread silent for a day, an operator message typed into the dead
+// shell, and a `resume` refused with "already running".
+describe('a dead harness under a live pane is a death (#386)', () => {
+  const READY = '⏵⏵ bypass permissions on'
+  const deadPane = (marker, status = 143) => [
+    'some tool output',
+    `[curia] the harness command exited — ${marker} ${status}`,
+    'agent@curia-42:/workspace$',
+  ].join('\n')
+
+  // A dispatcher whose agent reaches the composer, and whose pane the test can
+  // flip to the dead shell afterwards. The session stays "live" in tmux the
+  // whole time — that is the #386 shape.
+  function makeStranded(deps = {}) {
+    // `live` flips at spawn: start() must see no session, the sweep must see
+    // one — the pane that outlives its harness answers `tmux ls` either way.
+    const state = { assigned: false, dead: false, live: false, marker: null, kills: [], removed: [] }
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, assignees: state.assigned ? [{ login: 'me' }] : [] }),
+      hasSession: async () => state.live,
+      newSession: async (opts) => { state.live = true; state.marker = opts.exitMarker },
+      capturePane: async () => (state.dead ? deadPane(state.marker) : READY),
+      killSession: async (name) => { state.kills.push(name) },
+      removeWorkspace: async (p) => { state.removed.push(p) },
+      ...deps,
+    })
+    return { d, state }
+  }
+  const readyAt = (d, session = 'curia-42') => waitFor(() => d.agents.get(session)?.state === 'ready')
+
+  test('the exit marker flips the agent to dead: journalled with the status, pane killed, worktree kept', async () => {
+    const { d, state } = makeStranded()
+    await d.start('42', { repo: 'o/r' })
+    await readyAt(d)
+    state.assigned = true
+    state.dead = true
+
+    await d.livenessSweep()
+
+    const died = events.find((e) => e.type === 'agent_died')
+    assert.ok(died, 'the death reaches the journal')
+    assert.equal(died.status, 143)
+    assert.ok(state.kills.includes('curia-42'), 'the dead shell is killed — it is an input surface, not an agent')
+    assert.deepEqual(state.removed, [], 'the worktree survives for the resume — cancel-then-resume lost it (#386)')
+    assert.ok(!d.agents.has('curia-42'), 'the record is dropped, so queued words refuse and `resume` is takeable')
+    const n = notifies.find((x) => /exited with status 143/.test(x.message))
+    assert.ok(n, 'the thread hears the death, not silence')
+    assert.match(n.message, /`resume 42`/)
+    assert.match(n.message, /some tool output/, 'the pane evidence rides the notify — the kill took the pane')
+  })
+
+  test('a live composer is left alone — the marker is the evidence, not the sweep pass', async () => {
+    const { d } = makeStranded()
+    await d.start('42', { repo: 'o/r' })
+    await readyAt(d)
+
+    await d.livenessSweep()
+
+    assert.ok(!events.some((e) => e.type === 'agent_died'))
+    assert.ok(d.agents.has('curia-42'))
+  })
+
+  test('a session kept for post-mortem is not swept — that pane was promised to a human', async () => {
+    const { d, state } = makeStranded()
+    await d.start('42', { repo: 'o/r' })
+    await readyAt(d)
+    d.agents.get('curia-42').state = 'failed'
+    state.dead = true
+
+    await d.livenessSweep()
+
+    assert.ok(!events.some((e) => e.type === 'agent_died'))
+    assert.deepEqual(state.kills, [], 'the kept session must survive the sweep')
+    assert.ok(d.agents.has('curia-42'))
+  })
+
+  test('a spawning agent belongs to the watchdog — the sweep does not race it', async () => {
+    const { d, state } = makeStranded({
+      // never reaches the composer: the pane shows the death from the start
+      capturePane: async () => (state.marker ? deadPane(state.marker) : ''),
+    })
+    await d.start('42', { repo: 'o/r' })
+
+    await d.livenessSweep()
+
+    assert.ok(!events.some((e) => e.type === 'agent_died'), 'the pre-ready death is #169 material, not #386')
+  })
+
+  test('an unreadable pane proves nothing — the next pass asks again', async () => {
+    const { d, state } = makeStranded()
+    await d.start('42', { repo: 'o/r' })
+    await readyAt(d)
+    d.deps.capturePane = async () => { throw new Error('tmux wedged') }
+    state.dead = true
+
+    await d.livenessSweep()
+
+    assert.ok(!events.some((e) => e.type === 'agent_died'))
+    assert.ok(d.agents.has('curia-42'))
+  })
+})
+
 // The stranded-map watch (#485). An open, non-deferred map whose children are
 // all closed gets no dispatch ever again, so the frontier read is the one place
 // that can say so. The alarm is edge-triggered off the journal like the backup


### PR DESCRIPTION
Closes #386.

## What changed

`livenessSweep` in `daemon/src/dispatch.mjs` grew a second half. The existing half asks tmux whether the session exists. The new half (`#sweepDeadHarness`) captures the pane of every live tracked session and parses the per-spawn exit marker that `wrapShellCmd` already prints. On a hit:

1. The session is killed. The dead shell is an input surface — the observed incident typed an operator message into it and executed two stray words — so it goes before anything is announced. The pane's evidence is captured first and rides the notify as an excerpt.
2. `agent_died` is journalled with the exit status, and the thread hears `⚰️ curia-314's **claude** command exited with status 143 and left the pane as a dead shell — curia killed it — … `resume 314` starts a fresh agent on the surviving worktree`.
3. The record is dropped through the existing `#onAgentDied` path, so the claim decision, escalations, confirms, notes and credentials all settle the same way a vanished session settles today.

## What this fixes structurally

- Queued thread words now refuse with the resume hint instead of queueing forever (`noteDisposition` sees no record), and the interrupt path refuses instead of typing into bash.
- `resume` passes all three of its guards — no record, no in-flight dispatch, no tmux session — and inherits the surviving worktree. The cancel-then-resume detour, which removed the worktree right before the resume that wanted it, is no longer the only path after a harness death.

## Scope bounds

- `spawning` agents stay with the pre-ready watchdog (#169 reports the same marker there).
- `failed` records are sessions deliberately kept for post-mortem; the sweep does not touch them.
- Adoption records carry no marker, so a post-restart agent's harness death is only caught by the session-gone half. Stamping a marker across adoption would need the pane's history and is out of scope here.

## Tests

Five new tests in `daemon/test/dispatch.test.mjs`: the death (journal status, pane killed, worktree kept, record dropped, notify with excerpt and resume hint), and the four non-events (live composer, kept post-mortem session, spawning agent, unreadable pane). Full daemon suite: 2684 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMmgg87Yg6jXWACL6sUb2J