### PR TITLE
Teardown sees uncommitted work (#649)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -260,7 +260,7 @@ _Avoid_: the five verbs (the pre-#81 count, wrong since `next`, `resume` and `re
 A fresh agent on a ticket whose agent is gone. It inherits the surviving worktree, the model of the last spawn, which the journal states, and the inherited exchange (#374). It never inherits the conversation. A live agent refuses it: `cancel <n>` is the way to end one.
 
 **Cancel**:
-The one act that ends a running agent. It kills the session, removes the worktree and releases the GitHub claim. It closes every open question of that agent, and the ticket goes back to the frontier. The word has one place: `cancel <n>` in the command channel. No button on a question ends anything.
+The one act that ends a running agent. It kills the session, captures anything in the clone that exists nowhere else onto a **salvage branch**, removes the worktree and releases the GitHub claim. A capture curia cannot make keeps the worktree instead, and the line says so - the session and the claim end either way, because that is what was ordered. It closes every open question of that agent, and the ticket goes back to the frontier. The word has one place: `cancel <n>` in the command channel. No button on a question ends anything.
 
 ### Agents
 
@@ -536,13 +536,13 @@ How many times the Stop hook may refuse one agent's stop (`stop_nudge_budget`).
 The daemon's push of `curia/<n>` and the open or update of the one pull request per ticket. Agents never push.
 
 **Workspace lease**:
-The hold on a worktree and branch until the pull request is positively merged. Every uncertain case keeps the workspace.
+The hold on a worktree and branch until the pull request is positively merged. Every uncertain case keeps the workspace. What is merged has landed, so anything still uncommitted at the end of the lease is captured onto a **salvage branch** before the worktree goes.
 
 **Local-only work**:
 Work that exists in no place but one private clone. Two kinds, and they stay two named predicates rather than one widened one: **unpushed commits**, which `hasUnpushedCommits` answers from `git rev-list --count`, and **uncommitted changes**, which `hasUncommittedChanges` answers from `git status --porcelain`. Untracked files count as work; the repo's `.gitignore` and the clone's own `.git/info/exclude` are what separate work from noise. The distinction is load-bearing because the cross-check callers ask about the pushed tip only, and a dirty tree is no reason to refuse a cross-check. Every guard curia had before [#649](https://github.com/alp82/curia/issues/649) read the first kind and was blind to the second. See [ADR-0028](docs/adr/0028-local-only-work-is-salvaged-before-a-clone-dies.md).
 
 **Salvage branch**:
-Where local-only work goes before curia destroys the clone holding it: `curia/<n>-salvage-<stamp>`, committed by curia and pushed. It accumulates and never overwrites, because a salvage that destroys the previous salvage is the same loss one level up. Cancel and the workspace lease capture one and then proceed; the orphan sweep keeps the clone instead; `start <n>` refuses over a surviving clone and names `resume <n>`. A push that fails keeps the clone and says so. Nothing deletes a salvage branch. It is a branch on the tracker rather than a patch on the box because a patch is what nobody reads. See [ADR-0028](docs/adr/0028-local-only-work-is-salvaged-before-a-clone-dies.md) and [#649](https://github.com/alp82/curia/issues/649).
+Where local-only work goes before curia destroys the clone holding it: `curia/<n>-salvage-<stamp>`, committed by curia and pushed. It accumulates and never overwrites, because a salvage that destroys the previous salvage is the same loss one level up. Cancel and the workspace lease capture one and then proceed; the orphan sweep keeps the clone instead; `start <n>` and `map <n>` both refuse over a surviving clone and name `resume <n>`. A push that fails keeps the clone and says so. Nothing deletes a salvage branch. It is a branch on the tracker rather than a patch on the box because a patch is what nobody reads. See [ADR-0028](docs/adr/0028-local-only-work-is-salvaged-before-a-clone-dies.md) and [#649](https://github.com/alp82/curia/issues/649).
 
 **Repair**:
 The daemon's completion of resolve-protocol steps the agent missed, recorded as repairs.

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -34,7 +34,7 @@ import {
   removeConfigDir, removeCredentials, createReviewCheckout, reviewPathFor, writeReviewPrompt,
   seedConfigDir, writeConnectionSettings, writePrompt, worktreePathFor, cfgDirFor,
   branchFor, defaultBranchOf, commitsOnBranch, changedFilesOnBranch, uncommittedFiles,
-  pushBranch, hasUnpushedWork, agentEnv, setGitIdentity,
+  pushBranch, hasUnpushedCommits, hasUncommittedChanges, salvageLocalOnlyWork, agentEnv, setGitIdentity,
   untrustedProjectConfig, plantedSkills,
 } from './workspace.mjs'
 // the agent's minted GitHub credential (#389, ADR-0018)
@@ -231,7 +231,9 @@ const DEFAULT_DEPS = {
   // the gate press as a real GitHub approval (#391) — the one call here that
   // keeps the operator's own login
   approvePullRequest,
-  defaultBranchOf, commitsOnBranch, changedFilesOnBranch, uncommittedFiles, pushBranch, hasUnpushedWork,
+  defaultBranchOf, commitsOnBranch, changedFilesOnBranch, uncommittedFiles, pushBranch, hasUnpushedCommits,
+  // local-only work, and where it goes before a clone dies (#649, ADR-0028)
+  hasUncommittedChanges, salvageLocalOnlyWork,
   // the diff digest (#355) — the numbers at the gate, the hunks on demand
   readDiffDigest, readFileHunks,
 }
@@ -942,6 +944,23 @@ export class Dispatcher {
       if (!reuse && hasLabel(issue, MAP_LABEL)) {
         return await this.#startNextOfMap(theRepo, n, issue, { model, by, threadId })
       }
+      // #649: `createPrivateClone` opens with an unconditional `rmSync`, so a
+      // start over a surviving clone takes every uncommitted file in it. #376
+      // already taught the auto loop to check this exact path and RESUME
+      // instead; the operator's verb gets the same rule in the shape `start`
+      // uses for every other anomaly — refuse, and name the way out. Refusing
+      // costs no salvage branch, because the teardown does not have to happen.
+      //
+      // Checked before the assignee and blocker anomalies: those are cleared on
+      // GitHub, and this one is not — telling the operator to go clear a label
+      // would be advice that does not reach the thing standing in the way.
+      const survivingClone = worktreePathFor(this.root, theRepo, n)
+      if (!reuse && fs.existsSync(survivingClone)) {
+        this.reduction.journal('start_refused_over_clone', {
+          repo: theRepo, ticket: n, agent: session, by: by ?? 'unknown', path: survivingClone, verb: 'start',
+        })
+        return `❌ ${theRepo}#${n} still has a clone on disk from an earlier agent — \`start\` recreates it from origin and would take every uncommitted file with it. \`resume ${n}\` inherits it instead; \`cancel ${n}\` ends it, capturing anything that exists nowhere else.`
+      }
       const anomalies = []
       const assignees = (issue.assignees ?? []).map((a) => a.login)
       if (assignees.length) anomalies.push(`already assigned to ${assignees.join(', ')}`)
@@ -1050,6 +1069,20 @@ export class Dispatcher {
       if (issue.state !== 'open') return `❌ ${theRepo}#${n} is ${issue.state} — a closed map is not charted; reopen it first`
       if (!hasLabel(issue, MAP_LABEL)) {
         return `❌ ${theRepo}#${n} is not a \`${MAP_LABEL}\` issue — \`map\` updates a map, and \`start ${n}\` is how a ticket gets worked`
+      }
+      // #649: the same refusal `start` carries, for the same reason. A charting
+      // clone is a private clone, `createPrivateClone` opens with an
+      // unconditional `rmSync`, and a charting session that died mid-turn never
+      // reached the Stop hook that would have had it commit its findings. The
+      // sharpest case is a clone cancel deliberately KEPT because its salvage
+      // failed: without this, the next `map <n>` destroys the one copy curia had
+      // just refused to destroy.
+      const survivingClone = worktreePathFor(this.root, theRepo, n)
+      if (!reuse && fs.existsSync(survivingClone)) {
+        this.reduction.journal('start_refused_over_clone', {
+          repo: theRepo, ticket: n, agent: session, by: by ?? 'unknown', path: survivingClone, verb: 'map',
+        })
+        return `❌ ${theRepo}#${n} still has a charting clone on disk from an earlier agent — \`map\` recreates it from origin and would take every uncommitted file with it. \`resume ${n}\` inherits it instead; \`cancel ${n}\` ends it, capturing anything that exists nowhere else.`
       }
       return (await this.#dispatch(theRepo, n, issue, { model, instruction, by, reuse, threadId, charting: true })) ?? this.#exhaustedReply()
     } finally {
@@ -2341,7 +2374,7 @@ export class Dispatcher {
     const wtPath = builder?.wtPath ?? worktreePathFor(this.root, repo, ticket)
     if (!fs.existsSync(wtPath)) return null
     try {
-      const unpushed = await this.deps.hasUnpushedWork(wtPath, branchFor(ticket), await this.deps.defaultBranchOf(wtPath))
+      const unpushed = await this.deps.hasUnpushedCommits(wtPath, branchFor(ticket), await this.deps.defaultBranchOf(wtPath))
       if (!unpushed) return null
       return `❌ #${ticket} holds commits that are on no remote, and a reviewer reads the PUSHED tip — the verdict would be about a different diff than the pull request shows. Have the builder call \`open_pull_request\`, then ask again.`
     } catch (e) {
@@ -5168,6 +5201,25 @@ export class Dispatcher {
     }
   }
 
+  // The one capture both destroying paths run (#649, ADR-0028). It never throws:
+  // it hands back the branch it captured onto, or the reason it could not, and
+  // each caller decides what a failure buys. Cancel keeps the clone; the lease
+  // keeps the whole workspace. `teardown` names which path asked, so the journal
+  // can tell a cancel's capture from a lease's.
+  async #captureLocalOnlyWork({ wtPath, repo, ticket, agent, teardown }) {
+    try {
+      const captured = await this.deps.salvageLocalOnlyWork(wtPath, repo, ticket)
+      if (!captured.salvaged) return { branch: null, error: null }
+      this.reduction.journal('work_salvaged', {
+        repo, ticket, agent, path: wtPath, branch: captured.branch, sha: captured.sha, teardown,
+      })
+      return { branch: captured.branch, error: null }
+    } catch (e) {
+      this.reduction.journal('salvage_failed', { repo, ticket, agent, path: wtPath, teardown, error: e.message })
+      return { branch: null, error: e.message }
+    }
+  }
+
   // Merge ends the workspace lease (#54 item 7), replacing "worktree, branch and
   // claim kept for review" — the review is over by now.
   //
@@ -5210,6 +5262,27 @@ export class Dispatcher {
       }
     }
 
+    // #649: the pull request is merged, so anything still dirty in there is by
+    // definition NOT what landed — and it exists in no other place. Capture it,
+    // then proceed. Keeping the clone instead would leak disk on the common
+    // happy ending forever, with no sweep able to take it: the orphan sweep
+    // would find it dirty and keep it too.
+    //
+    // A capture that FAILED keeps the workspace. ADR-0028 sanctions a keep only
+    // for cancel, and argues against keeping HERE because a kept clone leaks
+    // disk with no sweep able to take it. That argument is about keeping as a
+    // POLICY on a dirty tree, and this is the failure case the same ADR rules on
+    // one section later: destroying the only copy because a network call failed
+    // is the bug it closes. It is also the rule every other branch of this
+    // function already runs on. The leak is real and accepted: it costs one
+    // clone per failed capture, and the alternative costs the work.
+    const capture = await this.#captureLocalOnlyWork({ wtPath, repo, ticket, agent: agentName, teardown: 'lease' })
+    if (capture.error) {
+      this.reduction.journal('lease_kept', { repo, ticket, agent: agentName, branch, reason: `local-only work could not be captured: ${capture.error}` })
+      return `⚠️ worktree KEPT — ${pr ? `${pr.url} is merged, but ` : ''}the clone holds work that exists nowhere else and curia could not capture it (${capture.error})`
+    }
+    const salvageBranch = capture.branch
+
     let removed = false
     try {
       await this.deps.removeWorkspace(wtPath)
@@ -5226,8 +5299,11 @@ export class Dispatcher {
         branchNote = `, remote \`${branch}\` still there (${e.message})`
       }
     }
-    this.reduction.journal('lease_released', { repo, ticket, agent: agentName, branch, merged: Boolean(pr), worktree_removed: removed })
-    return `${pr ? `${pr.url} is merged` : 'no code was produced'} — ${removed ? 'worktree removed' : 'worktree removal FAILED'}${branchNote}`
+    this.reduction.journal('lease_released', {
+      repo, ticket, agent: agentName, branch, merged: Boolean(pr), worktree_removed: removed, salvage: salvageBranch,
+    })
+    const salvageNote = salvageBranch ? `, and work that existed nowhere else was captured on \`${salvageBranch}\` first` : ''
+    return `${pr ? `${pr.url} is merged` : 'no code was produced'} — ${removed ? 'worktree removed' : 'worktree removal FAILED'}${branchNote}${salvageNote}`
   }
 
   // ---- cancel --------------------------------------------------------------------
@@ -5774,8 +5850,33 @@ export class Dispatcher {
     const chartedMap = charting && isChatHandle(ticket) ? this.#chartedMap(session, ticket, w) : null
     let released = false
     let failure = null
+    // #649: the operator ordered a teardown and the teardown happens — curia's
+    // job at an ordered ending is not to argue with the order, it is to not lose
+    // the work silently. So the clone's local-only work is CAPTURED first, and
+    // only a capture that FAILED holds the removal back: destroying the only
+    // copy because a network call failed is the exact bug ADR-0028 closes, and
+    // it would arrive under a line announcing a successful teardown.
+    let salvageBranch = null
+    let salvageFailure = null
+    // Whether the clone is actually gone, rather than whether curia tried. The
+    // removal's own failure used to be swallowed under a line saying "worktree
+    // removed", which is the same lie in a second place.
+    let cloneRemoved = false
     if (w) {
-      await this.deps.removeWorkspace(w.wtPath).catch((e) => this.log(`workspace removal for ${session} failed:`, e.message))
+      const capture = await this.#captureLocalOnlyWork({
+        wtPath: w.wtPath, repo: w.repo, ticket, agent: session, teardown: 'cancel',
+      })
+      salvageBranch = capture.branch
+      salvageFailure = capture.error
+      if (salvageFailure) {
+        this.log(`salvage for ${session} failed (${salvageFailure}) — the clone at ${w.wtPath} is KEPT`)
+      } else {
+        cloneRemoved = await this.deps.removeWorkspace(w.wtPath).then(() => true)
+          .catch((e) => { this.log(`workspace removal for ${session} failed:`, e.message); return false })
+      }
+      // The session dies and the claim is released either way. The agent ending
+      // is what was ordered; the clone is the only thing an unreadable salvage
+      // buys a stay for.
       if (!charting) {
         try {
           await this.deps.unclaim(w.repo, ticket, this.claimLogin())
@@ -5799,17 +5900,28 @@ export class Dispatcher {
     // status's recent-cancelled view reads this event; the unclaim events
     // above cannot carry it because an untracked cancel writes none.
     this.reduction.journal('agent_cancelled', { repo: w?.repo, ticket, agent: session, by: by ?? 'unknown', tracked: Boolean(w) })
+    // "worktree removed" is a lie the moment a capture failed and the clone
+    // stands, so the word is built from what actually happened (#649).
+    const removal = cloneRemoved ? 'removed' : 'KEPT'
     const chartTail = isChatHandle(ticket)
       ? (chartedMap
-        ? `, checkout removed — nothing was claimed, and the map it created (${w?.repo ? `${w.repo}#` : '#'}${chartedMap}) STANDS`
-        : ', checkout removed — nothing was claimed, and it had created no map yet, so the tracker is untouched')
-      : ', checkout removed — the map was never claimed, and whatever the agent already wrote to it STANDS'
+        ? `, checkout ${removal} — nothing was claimed, and the map it created (${w?.repo ? `${w.repo}#` : '#'}${chartedMap}) STANDS`
+        : `, checkout ${removal} — nothing was claimed, and it had created no map yet, so the tracker is untouched`)
+      : `, checkout ${removal} — the map was never claimed, and whatever the agent already wrote to it STANDS`
     const tail = w
       ? (charting
         ? chartTail
-        : released ? ', worktree removed, ticket re-frontiered' : ', worktree removed — but the claim release FAILED: the issue is still assigned; reconcile will retry')
+        : released ? `, worktree ${removal}, ticket re-frontiered` : `, worktree ${removal} — but the claim release FAILED: the issue is still assigned; reconcile will retry`)
       : ' (was untracked; GitHub claim untouched)'
-    const msg = `⚰️ \`${session}\` cancelled — session killed${tail}${reviewerLine ? `\n${reviewerLine}` : ''}`
+    // A salvage branch nobody is told about is a patch nobody reads (ADR-0028),
+    // so cancel names it. A failed capture says all three things at once: the
+    // session is gone, the claim moved, and the clone is still on the box.
+    const salvageLine = salvageBranch
+      ? `\n💾 the clone held work that existed nowhere else — curia captured it on \`${salvageBranch}\` before removing it. Nothing deletes that branch.`
+      : salvageFailure
+        ? `\n⚠️ the clone is KEPT at \`${w?.wtPath}\` — curia could not capture the local-only work in it (${salvageFailure}), and it will not destroy the only copy.`
+        : ''
+    const msg = `⚰️ \`${session}\` cancelled — session killed${tail}${salvageLine}${reviewerLine ? `\n${reviewerLine}` : ''}`
     this.notify(ticket, msg)
     // the agent is positively gone ⇒ any OTHER open confirm on it lapses (#94)
     this.lapseConfirmsFor(session, `\`${session}\` was cancelled`)
@@ -7025,16 +7137,31 @@ export class Dispatcher {
   // worktree (loudly); and "cannot tell" is not "nothing there" — an
   // indeterminate check keeps it too, the same evidence rule the rest of
   // reconcile runs on.
+  //
+  // #649 widened it from commits to LOCAL-ONLY WORK. A tree an agent edited for
+  // hours and never committed exists in no other place either, and nothing here
+  // established anything or ordered anything — so it gets the same answer the
+  // commits get. This path never captures: rubble is cheaper than a salvage
+  // branch spent on a teardown nobody asked for.
   async #sweepWorktree(repo, n, session) {
     const wt = worktreePathFor(this.root, repo, n)
-    let unpushed = true
+    let keep = true
     let why = 'it holds commits that exist nowhere else'
     try {
-      unpushed = await this.deps.hasUnpushedWork(wt, branchFor(n), await this.deps.defaultBranchOf(wt))
+      keep = await this.deps.hasUnpushedCommits(wt, branchFor(n), await this.deps.defaultBranchOf(wt))
     } catch (e) {
       why = `curia could not tell whether it holds unlanded commits (${e.message})`
     }
-    if (unpushed) {
+    if (!keep) {
+      try {
+        keep = await this.deps.hasUncommittedChanges(wt)
+        if (keep) why = 'it holds uncommitted changes that exist nowhere else'
+      } catch (e) {
+        keep = true
+        why = `curia could not tell whether it holds uncommitted changes (${e.message})`
+      }
+    }
+    if (keep) {
       this.reduction.journal('orphan_worktree_kept', { agent: session, ticket: n, repo, path: wt, reason: why })
       this.log(`reconcile: kept orphan worktree ${wt} — ${why}`)
       return

--- a/daemon/src/resolve.mjs
+++ b/daemon/src/resolve.mjs
@@ -504,7 +504,7 @@ export async function resolveAndLand({
           journal('resolved_unmerged', { repo, ticket, agent, branch, url: pr.url, pr_state: pr.state })
           // push whatever is not on the remote yet, so nothing lives only in a
           // worktree the human may now discard
-          if (await deps.hasUnpushedWork(wtPath, branch, defaultBranch).catch(() => true)) {
+          if (await deps.hasUnpushedCommits(wtPath, branch, defaultBranch).catch(() => true)) {
             const sha = await deps.pushBranch(wtPath, repo, branch)
             journal('branch_pushed', { repo, ticket, agent, branch, sha, commits: commits.length, reason: 'unmerged at resolve' })
           }

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -31,6 +31,9 @@ import { codexAccessTokenExpiry } from './credentials.mjs'
 // the daemon's own minted credential (#390, ADR-0018) — every clone, fetch and
 // push below reaches GitHub as `curia-sh[bot]` rather than as the operator
 import { daemonGhEnv } from './daemongh.mjs'
+// the salvage branch's stamp (#649). One stamp shape for the whole daemon: UTC,
+// colons folded to hyphens, sorting in write order.
+import { stampFor } from './backup.mjs'
 
 // The mandatory communication rules (#133): a curia-owned copy of the
 // operator's STE writing standard, seeded into every config dir as the CLI's
@@ -201,7 +204,7 @@ export async function uncommittedFiles(wtPath) {
 // token keeps the host login, which is exactly what this line did before.
 //
 // Pushing an explicit URL does not move refs/remotes/origin/*, and
-// hasUnpushedWork() — which decides whether the orphan sweep is allowed to
+// hasUnpushedCommits() — which decides whether the orphan sweep is allowed to
 // destroy a worktree — reads exactly that ref. So the tracking ref is updated
 // here, to the sha that was actually pushed and nothing else.
 export async function pushBranch(wtPath, repo, branch) {
@@ -215,12 +218,25 @@ export async function pushBranch(wtPath, repo, branch) {
   return sha
 }
 
+// ---- local-only work, in its two kinds (#649, ADR-0028) ---------------------
+//
+// Work that exists in no place but this clone. It is the union of two facts,
+// and they stay TWO predicates rather than one widened one: the cross-check
+// callers ask about the pushed tip, and a dirty tree is no reason to refuse a
+// cross-check or to trigger a repair push. A single vague predicate would have
+// changed behavior at call sites that never asked for it.
+//
+// Both throw when they cannot tell, and every caller reads "unknown" as "keep".
+
 // Does this worktree hold commits that exist nowhere else? Before #41 a
 // worktree held only a local commit nobody depended on, so the orphan sweep
 // could force-remove it freely. Now the daemon is expected to land that work,
 // and a sweep that fires between the commit and the push would destroy the only
 // copy. Throws when it cannot tell — callers must read "unknown" as "keep".
-export async function hasUnpushedWork(wtPath, branch, defaultBranch) {
+//
+// Named `hasUnpushedCommits` since #649, because after it there is a second
+// question this must not be mistaken for.
+export async function hasUnpushedCommits(wtPath, branch, defaultBranch) {
   let ref = `origin/${defaultBranch}`
   try {
     await git(wtPath, ['rev-parse', '--verify', `refs/remotes/origin/${branch}`])
@@ -228,6 +244,96 @@ export async function hasUnpushedWork(wtPath, branch, defaultBranch) {
   } catch { /* never pushed: measure against the default branch instead */ }
   const { stdout } = await git(wtPath, ['rev-list', '--count', `${ref}..HEAD`])
   return Number(stdout.trim()) > 0
+}
+
+// The other kind: a tree an agent has been editing and has not committed. Built
+// on `uncommittedFiles` rather than on a second `git status` call, so the two
+// can never disagree about what counts — untracked files included, and the
+// repo's `.gitignore` plus the clone's own `.git/info/exclude` are what separate
+// work from noise.
+export async function hasUncommittedChanges(wtPath) {
+  return (await uncommittedFiles(wtPath)).length > 0
+}
+
+// Who a salvage commit says it is. NOT the clone's own identity, which is the
+// ticket owner's or the app bot's and belongs to commits an agent chose to
+// make: a machine commit of a tree nobody reviewed, under the owner's name,
+// would be a lie about who wrote it. A constant rather than a read of the app's
+// bot user, because this runs on the path that must not fail for a network
+// reason — the whole point of the salvage is that it happens.
+const SALVAGE_AUTHOR = { name: 'curia', email: 'curia@users.noreply.github.com' }
+
+// Where local-only work goes. The stamp is `backup.mjs`'s — UTC, colons folded
+// to hyphens, sorting in write order — and it is what makes the branch
+// ACCUMULATE rather than overwrite: one ticket can be salvaged more than once,
+// and a salvage that destroys the previous salvage is the same silent loss one
+// level up.
+export function salvageBranchFor(n, at) {
+  return `curia/${n}-salvage-${stampFor(at)}`
+}
+
+// Capture everything this clone holds that exists nowhere else, then hand back
+// the branch it landed on (#649, ADR-0028).
+//
+// `git add -A` and a commit, never `git diff HEAD`: the diff form silently drops
+// untracked files, honors no ignore rules of its own, and produces a text blob
+// where a ref is wanted. Pushing HEAD carries any unpushed commits along in the
+// same act, which closes cancel's second silent loss for free.
+//
+// It goes to GitHub rather than to a patch under the workspace root because
+// ADR-0001 says GitHub is the only durable state home — and because nobody
+// reads a patch. A branch on the tracker is findable later, by the person who
+// saw the alarm, with no knowledge that an archive directory exists.
+//
+// The push runs on `daemonGhEnv`, the daemon's OWN token, so it cannot race a
+// cancel path that has already forgotten the agent's credential.
+//
+// `{ salvaged: false }` when there is nothing to capture — including a clone
+// that is already gone, which is not a loss and must not read as one. It THROWS
+// on every other failure, and every caller reads a throw as "keep the clone":
+// destroying the only copy because a network call failed is the exact bug this
+// closes.
+//
+// A push that fails leaves the COMMIT behind in the kept clone, and that is the
+// right direction rather than a leak: the work is now committed instead of
+// loose, the ticket branch reads as holding unpushed commits, and every keep
+// rule downstream already answers that correctly.
+//
+// `remote` is the seam `checkoutTicketBranch`'s `env` is: the real caller passes
+// none and the push goes to GitHub, and the suite drives a local bare origin.
+export async function salvageLocalOnlyWork(wtPath, repo, n, { at = Date.now(), remote = null } = {}) {
+  const nothing = { salvaged: false, branch: null, sha: null }
+  if (!fs.existsSync(wtPath)) return nothing
+  if (!repo) throw new Error('curia could not tell which repo this clone belongs to, so it has nowhere to push a salvage')
+  const branch = branchFor(n)
+  const dirty = await hasUncommittedChanges(wtPath)
+  if (!dirty && !await hasUnpushedCommits(wtPath, branch, await defaultBranchOf(wtPath))) return nothing
+  if (dirty) {
+    await git(wtPath, ['add', '-A'])
+    // `--no-verify`: a salvage must not run whatever hooks the repo or the
+    // agent installed. It is curia's own act, not a commit the agent is making.
+    await git(wtPath, [
+      '-c', `user.name=${SALVAGE_AUTHOR.name}`,
+      '-c', `user.email=${SALVAGE_AUTHOR.email}`,
+      'commit', '--no-verify', '-m', salvageMessage(branch),
+    ])
+  }
+  const { stdout } = await git(wtPath, ['rev-parse', 'HEAD'])
+  const sha = stdout.trim()
+  const salvage = salvageBranchFor(n, at)
+  await git(wtPath, [
+    '-c', 'credential.helper=!gh auth git-credential',
+    'push', remote ?? `https://github.com/${repo}.git`, `${sha}:refs/heads/${salvage}`,
+  ], { timeout: CLONE_TIMEOUT_MS, env: await daemonGhEnv(repo) })
+  return { salvaged: true, branch: salvage, sha }
+}
+
+function salvageMessage(branch) {
+  return `Salvage local-only work from ${branch}\n\n`
+    + 'Committed by curia, not by the agent whose clone this was, and not '
+    + 'reviewed by anyone. The clone was about to be destroyed and this is '
+    + 'everything in it that existed nowhere else.\n\n'
+    + 'See ADR-0028 and alp82/curia#649.\n'
 }
 
 // Branch is kept deliberately (salvage; re-frontier is the recovery).

--- a/daemon/test/crosscheck.test.mjs
+++ b/daemon/test/crosscheck.test.mjs
@@ -146,7 +146,11 @@ function makeDispatcher(deps = {}, { askReview } = {}) {
     defaultBranchOf: async () => 'main',
     commitsOnBranch: async () => [],
     pushBranch: async () => 'abc1234',
-    hasUnpushedWork: async () => false,
+    hasUnpushedCommits: async () => false,
+    // #649: nothing local-only, and no salvage. A test that is about the salvage
+    // passes its own — the real ones reach a real clone on disk.
+    hasUncommittedChanges: async () => false,
+    salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
     setPullRequestBody: async () => {},
     // #389: a spawn authors the worktree as the bot, so it reaches git. Inert
     // here — dispatch.test.mjs owns the identity itself.

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -110,6 +110,15 @@ const workingMinter = () => ({
 })
 
 // Deps default to inert doubles; each test overrides only what it asserts on.
+// #649: `start` REFUSES over a clone still on disk, because createPrivateClone
+// opens with an unconditional rmSync. Every real ending removes the clone, so a
+// test simulating "the agent is gone" has to remove it too — otherwise the
+// second start is refused rather than dispatched, and the test is measuring the
+// refusal instead of what it came for.
+function cloneGone(ticket, repo = 'o/r') {
+  fs.rmSync(path.join(tmp, 'work', 'repos', repo.replace('/', '__'), 'wt', String(ticket)), { recursive: true, force: true })
+}
+
 function makeDispatcher(deps = {}, {
   watch = [{ repo: 'o/r', mode: 'auto' }], readyTimeoutS = 45, routing = ROUTING,
   skills = null, stopNudgeBudget = 3,
@@ -267,7 +276,11 @@ function makeDispatcher(deps = {}, {
     defaultBranchOf: async () => 'main',
     commitsOnBranch: async () => [],
     pushBranch: async () => 'abc1234',
-    hasUnpushedWork: async () => false,
+    hasUnpushedCommits: async () => false,
+    // #649: nothing local-only, and no salvage. A test that is about the salvage
+    // passes its own — the real ones reach a real clone on disk.
+    hasUncommittedChanges: async () => false,
+    salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
     setPullRequestBody: async () => {},
     deleteRemoteBranch: async () => ({ deleted: true }),
   }
@@ -345,6 +358,7 @@ describe('in-flight admission guard (criterion 3)', () => {
     const d = makeDispatcher({ claim: async () => { claims += 1 } })
     await d.start('42', { repo: 'o/r' })
     d.agents.delete('curia-42') // simulate the agent having gone away
+    cloneGone('42')
     const again = await d.start('42', { repo: 'o/r' })
     assert.match(again, /dispatched/)
     assert.equal(claims, 2)
@@ -947,7 +961,7 @@ describe('reconcile epoch scoping (criterion 7)', () => {
       killSession: async () => {},
       removeWorkspace: async () => {},
       removeConfigDir: () => {},
-      hasUnpushedWork: async () => false,
+      hasUnpushedCommits: async () => false,
     })
 
     await d.reconcile({ boot: false })
@@ -965,7 +979,7 @@ describe('reconcile epoch scoping (criterion 7)', () => {
       killSession: async () => {},
       removeWorkspace: async () => {},
       removeConfigDir: () => {},
-      hasUnpushedWork: async () => false,
+      hasUnpushedCommits: async () => false,
     })
 
     await d.reconcile({ boot: false })
@@ -1660,6 +1674,7 @@ describe('the claim assigns dispatch.claim_login (#390)', () => {
     await d.start('42', { repo: 'o/r' })
     d.config.dispatch.claim_login = 'someone-else'
     d.agents.delete('curia-42')
+    cloneGone('42')
     await d.start('42', { repo: 'o/r' })
 
     assert.deepEqual(assigned, ['alp82', 'someone-else'])
@@ -3823,7 +3838,7 @@ describe('the orphan sweep cannot destroy unlanded work (#41)', () => {
       killSession: async () => {},
       removeWorkspace: async () => {},
       removeConfigDir: () => { throw new Error('ENOTEMPTY, Directory not empty') },
-      hasUnpushedWork: async () => false,
+      hasUnpushedCommits: async () => false,
     })
     let surfacesAsserted = false
     d.timeline = { assert: async () => { surfacesAsserted = true; return { verified: true } } }
@@ -3843,7 +3858,7 @@ describe('the orphan sweep cannot destroy unlanded work (#41)', () => {
       killSession: async (n) => destroyed.push(`kill:${n}`),
       removeWorkspace: async (wt) => destroyed.push(`workspace:${wt}`),
       removeConfigDir: () => {},
-      hasUnpushedWork: async () => true,
+      hasUnpushedCommits: async () => true,
     })
 
     await d.reconcile({ boot: false })
@@ -3862,7 +3877,7 @@ describe('the orphan sweep cannot destroy unlanded work (#41)', () => {
       killSession: async () => {},
       removeWorkspace: async (wt) => destroyed.push(wt),
       removeConfigDir: () => {},
-      hasUnpushedWork: async () => { throw new Error('git exploded') },
+      hasUnpushedCommits: async () => { throw new Error('git exploded') },
     })
 
     await d.reconcile({ boot: false })
@@ -3880,7 +3895,7 @@ describe('the orphan sweep cannot destroy unlanded work (#41)', () => {
       killSession: async (n) => destroyed.push(`kill:${n}`),
       removeWorkspace: async (wt) => destroyed.push(`workspace:${wt}`),
       removeConfigDir: (dir) => destroyed.push(`cfg:${path.basename(dir)}`),
-      hasUnpushedWork: async () => false,
+      hasUnpushedCommits: async () => false,
     })
 
     await d.reconcile({ boot: false })
@@ -3927,6 +3942,7 @@ describe('the spawn prompt names the parent map (#41)', () => {
     assert.equal(prompt.mapNumber, null)
 
     prompt = null
+    cloneGone('42')
     const d2 = makeDispatcher({
       fetchIssue: async (repo, n) => {
         if (String(n) === '1') throw new Error('HTTP 502')
@@ -5763,6 +5779,7 @@ describe('agent-liveness sweep (#138)', () => {
     await d.start('42', { repo: 'o/r' })
     await d.deps.killSession('curia-42')
     d.agents.delete('curia-42')
+    cloneGone('42')
     await d.start('42', { repo: 'o/r' })
     state.assigned = true
 
@@ -6808,5 +6825,236 @@ describe('a re-authentication session is invisible to every sweep (#642)', () =>
     await d.reconcile({ boot: false })
 
     assert.deepEqual(swept, ['curia-77'], 'the dead agent is swept and the live login is not')
+  })
+})
+
+// #649, ADR-0028. Three paths destroyed a private clone without ever asking
+// what was in it. Two of them now CAPTURE first, one KEEPS, and `start` refuses
+// rather than clone over one. The salvage itself is git plumbing and is driven
+// against a real clone in workspace.test.mjs; what these cases pin is which path
+// does which, and what the operator is told.
+describe('teardown sees uncommitted work (#649)', () => {
+  const salvaged = (branch) => async () => ({ salvaged: true, branch, sha: 'deadbee' })
+  const cannotSalvage = (why) => async () => { throw new Error(why) }
+  const tracked = (d) => d.agents.set('curia-42', {
+    repo: 'o/r', ticket: '42', session: 'curia-42', wtPath: '/w/42', cfgDir: '/c/curia-42', state: 'ready',
+  })
+
+  describe('cancel captures, then proceeds', () => {
+    test('the work is captured before the clone goes, and the line names the branch', async () => {
+      const acts = []
+      const d = makeDispatcher({
+        salvageLocalOnlyWork: async (wt, repo, n) => {
+          acts.push(`salvage:${wt}`)
+          return { salvaged: true, branch: `curia/${n}-salvage-2026-08-24T03-04-05Z`, sha: 'deadbee' }
+        },
+        removeWorkspace: async (wt) => acts.push(`workspace:${wt}`),
+        unclaim: async () => acts.push('unclaim'),
+        killSession: async () => acts.push('kill'),
+        removeConfigDir: () => {},
+      })
+      tracked(d)
+
+      const reply = await d.cancel('42', { by: 'test' })
+
+      assert.deepEqual(acts, ['kill', 'salvage:/w/42', 'workspace:/w/42', 'unclaim'],
+        'the capture has to happen BEFORE the removal, or it captures nothing')
+      assert.match(reply, /worktree removed, ticket re-frontiered/)
+      assert.match(reply, /curia\/42-salvage-2026-08-24T03-04-05Z/,
+        'a salvage branch nobody is told about is a patch nobody reads')
+      assert.ok(events.some((e) => e.type === 'work_salvaged'
+        && e.teardown === 'cancel' && e.branch === 'curia/42-salvage-2026-08-24T03-04-05Z' && e.ticket === '42'))
+    })
+
+    test('a clone holding nothing local-only is removed with no branch spent and nothing said', async () => {
+      const d = makeDispatcher({ removeConfigDir: () => {} })
+      tracked(d)
+
+      const reply = await d.cancel('42', { by: 'test' })
+
+      assert.match(reply, /worktree removed, ticket re-frontiered/)
+      assert.ok(!/salvage/.test(reply), 'nothing was captured, so there is nothing to name')
+      assert.ok(!typesOf().includes('work_salvaged'))
+    })
+
+    test('a capture curia could not make KEEPS the clone, and the line says all three', async () => {
+      const acts = []
+      const d = makeDispatcher({
+        salvageLocalOnlyWork: cannotSalvage('HTTP 502 from github.com'),
+        removeWorkspace: async (wt) => acts.push(`workspace:${wt}`),
+        unclaim: async () => acts.push('unclaim'),
+        killSession: async () => acts.push('kill'),
+        removeConfigDir: () => {},
+      })
+      tracked(d)
+
+      const reply = await d.cancel('42', { by: 'test' })
+
+      assert.deepEqual(acts, ['kill', 'unclaim'], 'the only copy survives a network failure')
+      // the session is gone, the claim moved, and the clone is still on the box
+      assert.match(reply, /cancelled — session killed/)
+      assert.match(reply, /ticket re-frontiered/)
+      assert.match(reply, /clone is KEPT at `\/w\/42`/)
+      assert.match(reply, /HTTP 502 from github\.com/)
+      assert.ok(events.some((e) => e.type === 'salvage_failed' && e.teardown === 'cancel' && /502/.test(e.error)))
+      assert.ok(events.some((e) => e.type === 'dispatch_unclaimed'), 'the agent ends either way — that is what was ordered')
+    })
+
+    test('a charting session is salvaged by the same mechanism, with no special case', async () => {
+      const salvages = []
+      const d = makeDispatcher({
+        salvageLocalOnlyWork: async (wt, repo, n) => {
+          salvages.push(n)
+          return { salvaged: true, branch: `curia/${n}-salvage-2026-08-24T03-04-05Z`, sha: 'deadbee' }
+        },
+        unclaim: async () => { throw new Error('a charting dispatch has no claim to release') },
+        removeConfigDir: () => {},
+      })
+      d.agents.set('curia-chat-1', {
+        repo: 'o/r', ticket: 'chat-1', session: 'curia-chat-1', wtPath: '/w/chat-1',
+        cfgDir: '/c/curia-chat-1', state: 'ready', charting: true,
+      })
+
+      const reply = await d.cancel('chat-1', { by: 'test' })
+
+      assert.deepEqual(salvages, ['chat-1'])
+      assert.match(reply, /curia\/chat-1-salvage-2026-08-24T03-04-05Z/)
+      assert.match(reply, /checkout removed/)
+    })
+  })
+
+  describe('the merge path captures, then proceeds', () => {
+    const liveAgent = (d) => d.agents.set('curia-42', {
+      repo: 'o/r', ticket: '42', session: 'curia-42', wtPath: '/w/42', cfgDir: '/c/curia-42',
+      state: 'ready', instance: 'curia-42@1',
+    })
+    const withResult = () => fs.writeFileSync(path.join(tmp, 'data', 'results', 'curia-42.json'), '{"status":"resolved"}')
+
+    test('what is still dirty at a merge is not what landed, so it is captured and the clone still goes', async () => {
+      const acts = []
+      const d = makeDispatcher({
+        findPullRequest: async () => ({ number: 7, url: 'https://x/pull/7', state: 'MERGED' }),
+        salvageLocalOnlyWork: async () => { acts.push('salvage'); return salvaged('curia/42-salvage-2026-08-24T03-04-05Z')() },
+        removeWorkspace: async () => acts.push('rm'),
+      })
+      liveAgent(d)
+      withResult()
+
+      await d.onAgentDone('curia-42')
+
+      assert.deepEqual(acts, ['salvage', 'rm'])
+      assert.match(notifies.at(-1).message, /captured on `curia\/42-salvage-2026-08-24T03-04-05Z` first/)
+      assert.ok(events.some((e) => e.type === 'work_salvaged' && e.teardown === 'lease'))
+      assert.ok(events.some((e) => e.type === 'lease_released' && e.salvage === 'curia/42-salvage-2026-08-24T03-04-05Z'))
+    })
+
+    test('a capture it cannot make keeps the workspace, the way every other branch here does', async () => {
+      let removed = false
+      const d = makeDispatcher({
+        findPullRequest: async () => ({ number: 7, url: 'https://x/pull/7', state: 'MERGED' }),
+        salvageLocalOnlyWork: cannotSalvage('git is wedged'),
+        removeWorkspace: async () => { removed = true },
+      })
+      liveAgent(d)
+      withResult()
+
+      await d.onAgentDone('curia-42')
+
+      assert.equal(removed, false)
+      assert.ok(events.some((e) => e.type === 'lease_kept' && /could not be captured.*wedged/.test(e.reason)))
+      assert.match(notifies.at(-1).message, /worktree KEPT/)
+    })
+  })
+
+  describe('the orphan sweep keeps', () => {
+    // Nothing is established and nobody ordered anything, so a dirty tree gets
+    // the same answer its commits already get — and it costs no salvage branch.
+    const orphan = (deps) => {
+      fs.writeFileSync(path.join(tmp, 'data', 'events.jsonl'),
+        JSON.stringify({ type: 'dispatch_claimed', repo: 'o/r', ticket: '42', agent: 'curia-42' }) + '\n')
+      return makeDispatcher({
+        listSessions: async () => ['curia-42'],
+        fetchIssue: async () => ({ ...OPEN_ISSUE, state: 'closed', assignees: [] }),
+        killSession: async () => {},
+        removeConfigDir: () => {},
+        hasUnpushedCommits: async () => false,
+        ...deps,
+      })
+    }
+
+    test('a tree with uncommitted work keeps its clone, and nothing is pushed for it', async () => {
+      const destroyed = []
+      const d = orphan({
+        hasUncommittedChanges: async () => true,
+        removeWorkspace: async (wt) => destroyed.push(wt),
+        salvageLocalOnlyWork: async () => { throw new Error('the sweep must never capture — rubble is cheaper') },
+      })
+
+      await d.reconcile({ boot: false })
+
+      assert.deepEqual(destroyed, [])
+      assert.ok(events.some((e) => e.type === 'orphan_worktree_kept'
+        && /uncommitted changes that exist nowhere else/.test(e.reason)))
+    })
+
+    test('an unreadable dirty check keeps it too — "cannot tell" is not "nothing there"', async () => {
+      const destroyed = []
+      const d = orphan({
+        hasUncommittedChanges: async () => { throw new Error('git exploded') },
+        removeWorkspace: async (wt) => destroyed.push(wt),
+      })
+
+      await d.reconcile({ boot: false })
+
+      assert.deepEqual(destroyed, [])
+      assert.ok(events.some((e) => e.type === 'orphan_worktree_kept'
+        && /could not tell whether it holds uncommitted changes \(git exploded\)/.test(e.reason)))
+    })
+  })
+
+  describe('start refuses over a surviving clone', () => {
+    test('the refusal names `resume`, spends no salvage branch, and claims nothing', async () => {
+      const acts = []
+      const d = makeDispatcher({
+        claim: async () => acts.push('claim'),
+        createPrivateClone: async () => { throw new Error('createPrivateClone opens with an unconditional rmSync') },
+        salvageLocalOnlyWork: async () => { throw new Error('a refusal costs no salvage branch') },
+      })
+      fakePrivateClone(path.join(tmp, 'work'), 'o/r', '42')
+
+      const reply = await d.start('42', { repo: 'o/r', by: 'test' })
+
+      assert.match(reply, /^❌/)
+      assert.match(reply, /still has a clone on disk/)
+      assert.match(reply, /`resume 42` inherits it instead/)
+      assert.deepEqual(acts, [], 'a refused start claims nothing')
+      assert.ok(events.some((e) => e.type === 'start_refused_over_clone' && e.ticket === '42' && e.by === 'test'))
+    })
+
+    test('`map <n>` refuses over a charting clone for the same reason', async () => {
+      const d = makeDispatcher({
+        fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:map' }] }),
+        createPrivateClone: async () => { throw new Error('createPrivateClone opens with an unconditional rmSync') },
+      })
+      fakePrivateClone(path.join(tmp, 'work'), 'o/r', '42')
+
+      const reply = await d.chart('42', { repo: 'o/r', instruction: 'chart it', by: 'test' })
+
+      assert.match(reply, /still has a charting clone on disk/)
+      assert.match(reply, /`resume 42` inherits it instead/)
+      assert.ok(events.some((e) => e.type === 'start_refused_over_clone' && e.verb === 'map'),
+        'the one curia KEPT because a salvage failed must not die to the next map dispatch')
+    })
+
+    test('a resume is exempt — inheriting the clone is the whole point of it', async () => {
+      const wt = fakePrivateClone(path.join(tmp, 'work'), 'o/r', '42')
+      const d = makeDispatcher({
+        createPrivateClone: async () => { throw new Error('a resume must never reach the clone') },
+      })
+
+      await d.start('42', { repo: 'o/r', reuse: true })
+
+      assert.equal(d.agents.get('curia-42')?.wtPath, wt)
+    })
   })
 })

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -164,7 +164,11 @@ function makeDispatcher(deps = {}, { issue = MAP_ISSUE, routing = ROUTING } = {}
     defaultBranchOf: async () => 'main',
     commitsOnBranch: async () => [],
     pushBranch: async () => { calls.push('pushBranch'); return 'abc1234' },
-    hasUnpushedWork: async () => false,
+    hasUnpushedCommits: async () => false,
+    // #649: nothing local-only, and no salvage. A test that is about the salvage
+    // passes its own — the real ones reach a real clone on disk.
+    hasUncommittedChanges: async () => false,
+    salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
     setPullRequestBody: async () => {},
     // #389: a spawn authors the worktree as the bot, so it reaches git. Inert
     // here — dispatch.test.mjs owns the identity itself.
@@ -469,6 +473,10 @@ describe('the charting checklist', () => {
     // ending, so the fixture states the channel the real path would have.
     const chartLive = async (deps) => {
       const d = makeDispatcher(deps)
+      // #649: `map <n>` refuses over a clone still on disk, so the second
+      // dispatch here needs the first one's clone gone — which is what every
+      // real ending does to it.
+      fs.rmSync(path.join(tmp, 'work', 'repos', 'o__r', 'wt', '147'), { recursive: true, force: true })
       await d.chart('147')
       d.agents.get('curia-147').mcpSeenAt = Date.now()
       return d

--- a/daemon/test/resolve.test.mjs
+++ b/daemon/test/resolve.test.mjs
@@ -181,7 +181,11 @@ function fixture({ issues, overrides = {}, result = { status: 'resolved', summar
     defaultBranchOf: async () => 'main',
     commitsOnBranch: async () => [{ sha: 'abc1234', subject: 'do it' }],
     pushBranch: async (wt, repo, branch) => { calls.push({ op: 'push', branch }); return 'abc1234' },
-    hasUnpushedWork: async () => false,
+    hasUnpushedCommits: async () => false,
+    // #649: nothing local-only, and no salvage. A test that is about the salvage
+    // passes its own — the real ones reach a real clone on disk.
+    hasUncommittedChanges: async () => false,
+    salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
     // the happy path since #54: the agent merged what a human approved
     findPullRequest: async () => ({ number: 7, url: 'https://github.com/o/r/pull/7', state: 'MERGED' }),
     createPullRequest: async (repo, opts) => { calls.push({ op: 'pr', ...opts }); return 'https://github.com/o/r/pull/7' },
@@ -434,7 +438,7 @@ describe('resolveAndLand: is the code IN', () => {
       overrides: {
         ...withComment,
         findPullRequest: async () => ({ number: 7, url: 'u', state: 'OPEN' }),
-        hasUnpushedWork: async () => true,
+        hasUnpushedCommits: async () => true,
       },
     })
     await h.run()

--- a/daemon/test/reviewer.test.mjs
+++ b/daemon/test/reviewer.test.mjs
@@ -161,7 +161,11 @@ function makeDispatcher(deps = {}, { routing = ROUTING, minter = workingMinter()
     defaultBranchOf: async () => 'main',
     commitsOnBranch: async () => [],
     pushBranch: async () => 'abc1234',
-    hasUnpushedWork: async () => false,
+    hasUnpushedCommits: async () => false,
+    // #649: nothing local-only, and no salvage. A test that is about the salvage
+    // passes its own — the real ones reach a real clone on disk.
+    hasUncommittedChanges: async () => false,
+    salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
     setPullRequestBody: async () => {},
     // #389: a spawn authors the worktree as the bot, so it reaches git. Inert
     // here — dispatch.test.mjs owns the identity itself.
@@ -464,7 +468,7 @@ describe('Dispatcher.crossCheck (#164)', () => {
     fs.mkdirSync(wt, { recursive: true })
     const spawned = []
     const d = makeDispatcher({
-      hasUnpushedWork: async () => true,
+      hasUnpushedCommits: async () => true,
       newSession: async (o) => spawned.push(o.name),
     })
     withBuilder(d, { wtPath: wt })
@@ -478,7 +482,7 @@ describe('Dispatcher.crossCheck (#164)', () => {
   test('an indeterminate unpushed check refuses too — the evidence rule', async () => {
     const wt = path.join(tmp, 'work', 'repos', 'o__r', 'wt', '42')
     fs.mkdirSync(wt, { recursive: true })
-    const d = makeDispatcher({ hasUnpushedWork: async () => { throw new Error('git is wedged') } })
+    const d = makeDispatcher({ hasUnpushedCommits: async () => { throw new Error('git is wedged') } })
     withBuilder(d, { wtPath: wt })
     assert.match(await d.crossCheck('42'), /could not tell whether #42 holds unpushed commits/)
   })

--- a/daemon/test/sandbox.test.mjs
+++ b/daemon/test/sandbox.test.mjs
@@ -578,7 +578,11 @@ function makeDispatcher(deps = {}, { routing = SANDBOXED_ROUTING, sandbox = PINS
     assertServe: async () => {},
     serveOff: async () => {},
     defaultBranchOf: async () => 'main',
-    hasUnpushedWork: async () => false,
+    hasUnpushedCommits: async () => false,
+    // #649: nothing local-only, and no salvage. A test that is about the salvage
+    // passes its own — the real ones reach a real clone on disk.
+    hasUncommittedChanges: async () => false,
+    salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
     findPullRequest: async () => null,
     ensureAgentImage: async () => ({ ref: 'curia-agent:test', built: false }),
     assertSideChannel: async () => '10.0.1.1',

--- a/daemon/test/threads.test.mjs
+++ b/daemon/test/threads.test.mjs
@@ -1075,7 +1075,11 @@ function makeDispatcher(deps = {}, { confirm = async () => true, bound = [] } = 
       createPullRequest: async () => 'url', setPullRequestBody: async () => {},
       deleteRemoteBranch: async () => ({ deleted: true }),
       defaultBranchOf: async () => 'main', commitsOnBranch: async () => [],
-      pushBranch: async () => 'abc', hasUnpushedWork: async () => false,
+      pushBranch: async () => 'abc', hasUnpushedCommits: async () => false,
+      // #649: nothing local-only, and no salvage. A test that is about the salvage
+      // passes its own — the real ones reach a real clone on disk.
+      hasUncommittedChanges: async () => false,
+      salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
       ...deps,
     },
   })

--- a/daemon/test/workspace.test.mjs
+++ b/daemon/test/workspace.test.mjs
@@ -1,5 +1,5 @@
 // #53: an agent shares the host credential store instead of snapshotting it.
-import { test, describe, before, after } from 'node:test'
+import { test, describe, before, beforeEach, after } from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -11,6 +11,8 @@ import {
   seedConfigDir, agentEnv, retiredAgentTokenKeys, hostStorageDir, installSkills, defaultSkillsRoot, DEFAULT_SKILLS,
   writeConnectionSettings, removeCredentials, untrustedProjectConfig, plantedSkills, MCP_SERVER_NAME,
   checkoutTicketBranch, remoteBranchExists, defaultBranchOf,
+  // #649, ADR-0028
+  hasUncommittedChanges, hasUnpushedCommits, salvageBranchFor, salvageLocalOnlyWork,
 } from '../src/workspace.mjs'
 
 describe('per-agent config dir (#53)', () => {
@@ -900,5 +902,152 @@ describe('the codex agent harness (#39)', () => {
     assert.deepEqual(plantedSkills(wtPath, 'claude', undefined), [])
     // the directory exists but holds no SKILL.md, so no harness loads it
     assert.deepEqual(plantedSkills(wtPath, 'claude', ['wayfinder']), [])
+  })
+})
+
+// ---- local-only work, and the salvage that carries it out (#649, ADR-0028) --
+//
+// Every guard curia owned before this counted COMMITS. A tree an agent edited
+// for six hours and never committed was invisible to all of them, and three
+// teardown paths destroyed the clone holding it. These drive the real git, on a
+// real local origin, because the whole mechanism is git plumbing and a double of
+// it would be a second opinion about what `add -A` picks up.
+describe('local-only work and its salvage (#649)', () => {
+  let tmp, origin, wt
+  const git = (cwd, ...args) => execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+  const branchesOnOrigin = () => git(origin, 'for-each-ref', '--format=%(refname:short)', 'refs/heads/')
+    .split('\n').map((l) => l.trim()).filter(Boolean)
+
+  // A FRESH clone per test: a salvage commits and pushes, so a shared fixture
+  // would have each case reading the last one's leftovers.
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-salvage-'))
+    origin = path.join(tmp, 'origin.git')
+    const seed = path.join(tmp, 'seed')
+    execFileSync('git', ['init', '--bare', '-b', 'main', origin])
+    execFileSync('git', ['clone', origin, seed])
+    fs.writeFileSync(path.join(seed, 'README.md'), 'base\n')
+    fs.writeFileSync(path.join(seed, '.gitignore'), 'noise.log\n')
+    git(seed, 'add', '.')
+    git(seed, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', 'base')
+    git(seed, 'push', 'origin', 'main')
+
+    wt = path.join(tmp, 'repos', 'o__r', 'wt', '42')
+    fs.mkdirSync(path.dirname(wt), { recursive: true })
+    execFileSync('git', ['clone', origin, wt])
+    git(wt, 'remote', 'set-head', 'origin', 'main')
+    // what `createPrivateClone` writes: the agent's own git identity, and the
+    // exclude file that hides curia's plumbing from the agent's commits
+    git(wt, 'config', 'user.name', 'Ticket Owner')
+    git(wt, 'config', 'user.email', 'owner@example.com')
+    fs.appendFileSync(path.join(wt, '.git', 'info', 'exclude'), '\n.mcp.json\n.claude/\n.curia-prompt.md\n')
+    git(wt, 'checkout', '-B', 'curia/42', 'origin/main')
+  })
+  after(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
+
+  test('the branch name carries a sortable UTC stamp, and every salvage gets its own', () => {
+    assert.equal(salvageBranchFor(42, Date.parse('2026-08-24T10:11:12.345Z')), 'curia/42-salvage-2026-08-24T10-11-12Z')
+    assert.equal(salvageBranchFor('chat-1', Date.parse('2026-08-24T10:11:12Z')), 'curia/chat-1-salvage-2026-08-24T10-11-12Z')
+  })
+
+  test('hasUncommittedChanges counts untracked files and ignores what the two ignore files hide', async () => {
+    assert.equal(await hasUncommittedChanges(wt), false)
+
+    // both ignore rules: the repo's .gitignore, and the clone's own exclude
+    fs.writeFileSync(path.join(wt, 'noise.log'), 'chatter\n')
+    fs.writeFileSync(path.join(wt, '.curia-prompt.md'), 'the prompt\n')
+    assert.equal(await hasUncommittedChanges(wt), false, 'ignored files are noise, not work')
+
+    fs.writeFileSync(path.join(wt, 'findings.md'), 'six hours of it\n')
+    assert.equal(await hasUncommittedChanges(wt), true, 'an untracked file an agent wrote IS work')
+  })
+
+  test('an unreadable clone throws rather than reading as clean', async () => {
+    await assert.rejects(() => hasUncommittedChanges(path.join(tmp, 'not-a-repo')),
+      'callers read a throw as "keep" — a swallowed error would read as "nothing there"')
+  })
+
+  test('a clone with nothing local-only is not salvaged, and no branch is spent on it', async () => {
+    const out = await salvageLocalOnlyWork(wt, 'o/r', '42', { remote: origin })
+
+    assert.deepEqual(out, { salvaged: false, branch: null, sha: null })
+    assert.deepEqual(branchesOnOrigin(), ['main'])
+  })
+
+  test('a clone that is already gone is not a loss and must not read as one', async () => {
+    assert.deepEqual(
+      await salvageLocalOnlyWork(path.join(tmp, 'never-existed'), 'o/r', '42', { remote: origin }),
+      { salvaged: false, branch: null, sha: null },
+    )
+  })
+
+  test('an uncommitted tree is committed and pushed, untracked files and all, authored by curia', async () => {
+    fs.writeFileSync(path.join(wt, 'README.md'), 'edited\n')
+    fs.mkdirSync(path.join(wt, 'docs', 'research'), { recursive: true })
+    fs.writeFileSync(path.join(wt, 'docs', 'research', 'note.md'), 'never added\n')
+    fs.writeFileSync(path.join(wt, 'noise.log'), 'chatter\n')
+    fs.writeFileSync(path.join(wt, '.curia-prompt.md'), 'the prompt\n')
+
+    const out = await salvageLocalOnlyWork(wt, 'o/r', '42', { at: Date.parse('2026-08-24T03:04:05Z'), remote: origin })
+
+    assert.equal(out.salvaged, true)
+    assert.equal(out.branch, 'curia/42-salvage-2026-08-24T03-04-05Z')
+    assert.ok(branchesOnOrigin().includes(out.branch), 'the work is on the tracker, not in a patch on the box')
+
+    const files = git(origin, 'ls-tree', '-r', '--name-only', out.branch).split('\n').filter(Boolean)
+    assert.ok(files.includes('docs/research/note.md'), '`git diff HEAD` would have dropped this one')
+    assert.ok(!files.includes('noise.log'), '.gitignore separates work from noise')
+    assert.ok(!files.includes('.curia-prompt.md'), 'and so does the clone\'s own exclude file')
+    assert.match(git(origin, 'show', `${out.branch}:README.md`), /edited/)
+
+    // the clone carries the ticket owner's identity, and a machine commit of a
+    // tree nobody reviewed must not read as theirs
+    assert.equal(git(origin, 'log', '-1', '--format=%an', out.branch).trim(), 'curia')
+    assert.equal(git(origin, 'log', '-1', '--format=%cn', out.branch).trim(), 'curia')
+  })
+
+  test('a local-only COMMIT rides along, with no dirty tree to trigger the capture', async () => {
+    fs.writeFileSync(path.join(wt, 'work.txt'), 'committed and never pushed\n')
+    git(wt, 'add', '.')
+    git(wt, 'commit', '-m', 'the agent\'s own commit')
+
+    assert.equal(await hasUncommittedChanges(wt), false)
+    assert.equal(await hasUnpushedCommits(wt, 'curia/42', 'main'), true)
+
+    const out = await salvageLocalOnlyWork(wt, 'o/r', '42', { at: Date.parse('2026-08-24T03:04:05Z'), remote: origin })
+
+    assert.equal(out.salvaged, true)
+    // the agent's own commit, under the agent's own name — pushing HEAD carries
+    // it rather than re-authoring it
+    assert.equal(git(origin, 'log', '-1', '--format=%s', out.branch).trim(), 'the agent\'s own commit')
+    assert.equal(git(origin, 'log', '-1', '--format=%an', out.branch).trim(), 'Ticket Owner')
+  })
+
+  test('salvage accumulates: a second one never overwrites the first', async () => {
+    fs.writeFileSync(path.join(wt, 'first.md'), 'one\n')
+    const one = await salvageLocalOnlyWork(wt, 'o/r', '42', { at: Date.parse('2026-08-24T03:04:05Z'), remote: origin })
+    fs.writeFileSync(path.join(wt, 'second.md'), 'two\n')
+    const two = await salvageLocalOnlyWork(wt, 'o/r', '42', { at: Date.parse('2026-08-24T04:05:06Z'), remote: origin })
+
+    assert.notEqual(one.branch, two.branch)
+    const heads = branchesOnOrigin()
+    assert.ok(heads.includes(one.branch) && heads.includes(two.branch),
+      'a salvage that destroys the previous salvage is the same silent loss one level up')
+    assert.ok(!git(origin, 'ls-tree', '-r', '--name-only', one.branch).includes('second.md'))
+    assert.ok(git(origin, 'ls-tree', '-r', '--name-only', two.branch).includes('first.md'))
+  })
+
+  test('a push that fails throws, so the caller keeps the clone', async () => {
+    fs.writeFileSync(path.join(wt, 'findings.md'), 'six hours of it\n')
+
+    await assert.rejects(
+      () => salvageLocalOnlyWork(wt, 'o/r', '42', { remote: path.join(tmp, 'no-such-origin.git') }),
+      'destroying the only copy because a push failed is the bug this closes',
+    )
+  })
+
+  test('a clone whose repo curia cannot name has nowhere to push, and says so', async () => {
+    fs.writeFileSync(path.join(wt, 'findings.md'), 'six hours of it\n')
+    await assert.rejects(() => salvageLocalOnlyWork(wt, null, '42'), /nowhere to push/)
   })
 })

--- a/docs/adr/0028-local-only-work-is-salvaged-before-a-clone-dies.md
+++ b/docs/adr/0028-local-only-work-is-salvaged-before-a-clone-dies.md
@@ -1,6 +1,6 @@
 # ADR-0028: Local-only work is salvaged before a clone dies
 
-**Status**: accepted (2026-08). Decided, not built.
+**Status**: accepted (2026-08). Built, by [#649](https://github.com/alp82/curia/issues/649).
 **Provenance**: [Teardown sees uncommitted work (#649)](https://github.com/alp82/curia/issues/649), charted from the credential incident recorded in [#641](https://github.com/alp82/curia/issues/641). Extends [ADR-0001](0001-github-is-the-only-durable-state-home.md) to the agent's working tree.
 
 ## Context
@@ -49,7 +49,7 @@ The commit is authored by curia. The clone carries the ticket owner's git identi
 - **Cancel captures, then proceeds.** A teardown was ordered and the teardown happens. Curia's job at an ordered ending is not to argue with the order, it is to not lose the work silently.
 - **The workspace lease captures, then proceeds.** The pull request is merged, so anything still dirty is by definition not what landed. Keeping the clone instead would leak disk on the common happy ending, forever, with no sweep able to take it: the orphan sweep would find it dirty and keep it too.
 - **The orphan sweep keeps.** Nothing is established and nobody ordered anything. This is the same evidence rule it already runs for commits, where "cannot tell" means keep.
-- **`start <n>` refuses.** `createPrivateClone` opens with an unconditional `rmSync`, and #376 already taught the tick's auto loop to check the path and resume rather than start. The operator's verb gets the same rule in the shape `start` already uses for every other anomaly: refuse, and name the way out, which is `resume <n>`. No salvage branch is spent on a teardown that does not have to happen.
+- **`start <n>` refuses**, and so does `map <n>`, which is the charting verb's copy of the same dispatch. `createPrivateClone` opens with an unconditional `rmSync`, and #376 already taught the tick's auto loop to check the path and resume rather than start. The operator's verb gets the same rule in the shape `start` already uses for every other anomaly: refuse, and name the way out, which is `resume <n>`. No salvage branch is spent on a teardown that does not have to happen.
 - **The review checkout is untouched.** It is a detached HEAD at a pushed sha and holds nothing that exists nowhere else.
 
 ### A failed capture keeps the clone
@@ -65,7 +65,7 @@ A keep stays journal-only, which is what `orphan_worktree_kept` and `lease_kept`
 ## Consequences
 
 - Salvage branches accumulate in watched repos and nothing deletes them. This is accepted: a salvage branch is a few kilobytes and is the record of a loss, so the person who wants it gone deletes it. Retention would pull in a durable-salvage story - browsing, restoring, expiring - that #649 ruled out of scope.
-- The rename of `hasUnpushedWork` touches `dispatch.mjs:2344`, `dispatch.mjs:7033`, and `resolve.mjs:507`. None of them changes behavior. The rename is the point: those three ask about the pushed tip, and after this ADR there is a second question they must not be mistaken for.
+- The rename of `hasUnpushedWork` touches three call sites. Two of them - the cross-check guard in `dispatch.mjs` and the repair push in `resolve.mjs` - do not change behavior, and the rename is the point: they ask about the pushed tip, and after this ADR there is a second question they must not be mistaken for. The third is the orphan sweep, which decision 4 above deliberately widens to the second question as well.
 - Curia becomes a committer in watched repos, on branches no human asked for. The commit author makes that visible rather than hiding it under the ticket owner's name.
 - ADR-0001's reach extends from tracker state to the agent's working tree. The claim it makes is unchanged: there is one durable home, and it is not this box.
 - The #297 Stop hook nudge for charting sessions stays. It is better to have the agent commit its own findings with its own message than to have curia salvage them under a machine one. The salvage is the floor, not the replacement.


### PR DESCRIPTION
Closes #649. Builds [ADR-0028](docs/adr/0028-local-only-work-is-salvaged-before-a-clone-dies.md).

Every guard curia owned against losing an agent's work counted commits. A working tree an agent had been editing for hours and never committed was invisible to all of them, and three teardown paths destroyed the private clone holding it.

## The two predicates

`hasUnpushedWork` is now `hasUnpushedCommits`, and `hasUncommittedChanges` stands beside it. They stay apart because the cross-check callers ask about the pushed tip, and a dirty tree is no reason to refuse a cross-check.

## The capture

`salvageLocalOnlyWork` stages the tree with `git add -A`, commits it as curia rather than as the ticket owner, and pushes HEAD to `curia/<n>-salvage-<stamp>`. Untracked files ride along, which `git diff HEAD` would have dropped. Unpushed commits ride along too, which closes cancel's second silent loss in the same act. The branch accumulates, and nothing deletes it.

## What each path does

| Path | Before | Now |
|---|---|---|
| cancel | destroyed the clone unguarded | captures, then proceeds; the line names the branch |
| workspace lease | destroyed on a merged PR | captures, then proceeds |
| orphan sweep | counted commits only | keeps a dirty clone, journal-only |
| `start <n>` | cloned over whatever stood | refuses, and names `resume <n>` |
| `map <n>` | same hole, for charting clones | refuses the same way |
| review checkout | detached HEAD at a pushed sha | untouched |

A capture curia cannot make keeps the clone. Cancel still kills the session and releases the claim, and says all three things.

## Two departures from the chart, both deliberate

- **The lease keeps on a failed capture.** ADR-0028 §4 argues against keeping there because a kept clone leaks disk with no sweep able to take it. That argument is about keeping as a policy on a dirty tree; this is the failure case §5 rules on, and it is the rule every other branch of `#endWorkspaceLease` already runs on. The leak costs one clone per failed capture; the alternative costs the work.
- **`map <n>` refuses too.** The issue's decision names only `start <n>`, but its scope names charting-session clones, and `chart` carries `start`'s dispatch shape verbatim. Without it, a clone cancel deliberately KEPT after a failed salvage dies to the next charting dispatch.

## Tests

`npm test` in `daemon/`: 2958 pass, 0 fail, 0 cancelled. New coverage drives the real git against a local bare origin for the salvage itself, and the dispatcher doubles for which path does which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX1uNq5wqpGBgR2992VUmd