### PR TITLE
The Atlas drawer names the Credentials screen (alp82/curia#661)

### DIFF
--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -260,7 +260,10 @@ describe('the Atlas frame (#686)', () => {
     assert.ok(drawer)
     assert.deepEqual(
       [...drawer.matchAll(/<span class="nav-label">([^<]+)<\/span>/g)].map((match) => match[1]),
-      ['Home', 'Maps', 'Agents', 'Feed', 'Chat', 'Settings'],
+      // Credentials sits between Chat and Settings (#661). It landed while the
+      // Atlas frame was in review, so the two agreed on every screen but this
+      // one until they met on `main`.
+      ['Home', 'Maps', 'Agents', 'Feed', 'Chat', 'Credentials', 'Settings'],
     )
   })
 


### PR DESCRIPTION
`main` is red at one test after [#672](https://github.com/alp82/curia/pull/672) and [#730](https://github.com/alp82/curia/pull/730) merged an hour apart. Neither is wrong: #730 pinned the drawer's screen order while #672 was in review, and #672 adds Credentials between Chat and Settings. Git merged both clean, because they never touched the same line.

The page is right and the expectation is stale, so this fixes the expectation.

The notch bar is untouched. Credentials is not one of its four tabs by #661's own decision - the pointer on Home and the Discord alarm are the ways in on a phone.

`npm test` green at 3123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5