### PR TITLE
Query every global search source through one interface (alp82/curia#693)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -585,6 +585,12 @@ _Avoid_: browser thread (there is no Discord thread behind it, and there is more
 **Spent number**:
 A browser conversation number that is used up. The daemon journals every key it mints, and it never mints one twice, so a delete spends that number for good. This is the one rule that separates a conversation number from a **Chat handle**: an agent is torn down whole and its index comes back, and a conversation is memory, so a reused number would wake the deleted conversation's own transcript. A delete forgets the key and leaves the file on disk. See [#333](https://github.com/alp82/curia/issues/333).
 
+**Global search**:
+One query over the four indexed sources: the GitHub facts, the decisions a map records under `## Decisions so far`, the journal, and the local chat transcripts. Discord thread bodies stay out of the first index, because Discord is the alert surface and its text is a copy of what the journal and the transcripts already hold. The lens button in every screen header opens it. See [#589](https://github.com/alp82/curia/issues/589) and `daemon/src/search.mjs`.
+
+**Landing target**:
+Where a search result opens, as typed data rather than a URL. A ticket hit and a chat hit land on `chat`, a map hit on `maps`, a journal hit on `feed`, and a decision hit on `github`, at its resolution comment. The query names the surface and its key, and the screen does the routing.
+
 **Preview**:
 A tailnet HTTPS link to an agent's running dev server. The daemon allocates the public port and composes the link.
 

--- a/daemon/src/questions.mjs
+++ b/daemon/src/questions.mjs
@@ -235,6 +235,7 @@ export class Questions {
     this.db = db
     this.stmts = {}
     this.mapSnapshotStmts = new Map()
+    this.searchStmts = new Map()
     for (const [name, sql] of Object.entries(SQL)) this.stmts[name] = db.prepare(sql)
   }
 
@@ -424,5 +425,39 @@ select w.ticket,
       })
       // An opener with no agent names nobody, and a keystroke needs a pane.
       .filter((park) => park.agent && park.ticket)
+  }
+
+  // The global search's journal source (#693). Every event whose verbatim line
+  // holds all of the operator's terms, newest first.
+  //
+  // This is the one question that is deliberately proportional to history, like
+  // question 12: a substring search over `body` has no index to ride, and an
+  // FTS table would be a second copy of the record ADR-0017 keeps in one place.
+  // The `limit` bounds the answer, and the lens asks it once per keystroke
+  // burst rather than once per tick.
+  //
+  // `like` is case-insensitive for ASCII in SQLite, which is what the operator
+  // types. `escape` keeps a `%` or a `_` in a term as a literal character.
+  searchEvents(query, { limit = 40 } = {}) {
+    const terms = String(query ?? '').toLowerCase().split(/\s+/).filter(Boolean)
+    if (!terms.length) return []
+    let stmt = this.searchStmts.get(terms.length)
+    if (!stmt) {
+      const where = terms.map((_, index) => `body like :q${index} escape '\\'`).join(' and ')
+      stmt = this.db.prepare(`
+select id, ts, type, ticket, repo, body from events
+ where ${where}
+ order by id desc limit :limit`)
+      this.searchStmts.set(terms.length, stmt)
+    }
+    const params = { limit: Number(limit) || 40 }
+    terms.forEach((term, index) => {
+      params[`q${index}`] = `%${term.replace(/[\\%_]/g, (c) => `\\${c}`)}%`
+    })
+    try {
+      return stmt.all(params)
+    } catch (e) {
+      throw new Error(`events journal is unreadable: ${e.message}`)
+    }
   }
 }

--- a/daemon/src/search.mjs
+++ b/daemon/src/search.mjs
@@ -1,0 +1,400 @@
+// The global search query (#693, decided in #589).
+//
+// One request searches every source Atlas can land on: the GitHub facts
+// (tickets and maps), the decisions a map records under `## Decisions so far`,
+// the journal, and the local chat transcripts. The lens overlay in every screen
+// header calls this once, and the rows it draws come back already typed.
+//
+// Four rules come out of the decision on #589, and this module keeps them.
+//
+//   - **One request, four sources.** The caller passes a query and the
+//     adapters. A source that throws contributes no rows and names itself in
+//     `failures`, so a dead transcript directory can't blank the ticket hits.
+//   - **Discord thread bodies stay out of the first index.** There is no Discord
+//     adapter here, and `SEARCH_SOURCES` is the whole list. Discord is the alert
+//     surface; its thread text is a copy of what the journal and the transcripts
+//     already hold.
+//   - **Every row names where it lands.** `landing` is a typed target, never a
+//     URL the caller has to parse. A ticket hit and a chat hit land in Chat, a
+//     map hit lands on Maps, a journal hit lands on the Feed, and a decision
+//     lands on its resolution comment on GitHub.
+//   - **Every row states its age and its attention state.** `age_ms` is measured
+//     against the `now` the caller passes, so the age of a reading is the
+//     caller's clock and not this module's. `attention` is `needs_you` for an
+//     item on the operator's list, `closed` for finished work, and `open`
+//     otherwise.
+//
+// Everything here is pure given its adapters. `test/search.test.mjs` drives it
+// with local GitHub, journal, and transcript adapters, and nothing in this file
+// reaches the network or the disk.
+
+import { normalizeEvent } from './journal.mjs'
+import { DECISIONS_HEADING, sectionBounds } from './resolve.mjs'
+import { readActiveMessages } from './transcript.mjs'
+
+// The five kinds a row can carry, in the order the lens ranks them when two
+// rows are equally recent.
+export const SEARCH_KINDS = ['ticket', 'map', 'decision', 'journal', 'chat']
+
+// The four sources of the first index. Discord is deliberately absent.
+export const SEARCH_SOURCES = ['github', 'decisions', 'journal', 'transcripts']
+
+// The three attention states a row can carry. `needs_you` is the amber word the
+// row shows instead of its kind.
+export const ATTENTION_STATES = ['needs_you', 'open', 'closed']
+
+// How much text a snippet carries, and how far ahead of the first hit it starts.
+const SNIPPET_WIDTH = 180
+const SNIPPET_LEAD = 40
+
+// How many rows one request returns when the caller names no limit.
+const DEFAULT_LIMIT = 40
+
+// The transcript items that hold operator-readable words. `think` is left out:
+// a hit inside a model's reasoning isn't a line the operator remembers writing
+// or reading.
+const CHAT_ITEM_KINDS = new Set(['prompt', 'say', 'note', 'queued'])
+
+// Who said a transcript item, in the words the row shows.
+const CHAT_SPEAKERS = { prompt: 'operator', queued: 'operator', note: 'curia', say: 'agent' }
+
+// The journal fields that are bookkeeping rather than words. They stay out of
+// the searchable text so that a query for "result" doesn't match every row's
+// own type twice.
+const JOURNAL_SKIP_KEYS = new Set(['ts', 'type', 'epoch'])
+
+// The terms a query means: every whitespace-separated word, lowercased. A row
+// matches when its text holds all of them, in any order and any position.
+export function queryTerms(query) {
+  return String(query ?? '').toLowerCase().split(/\s+/).filter(Boolean)
+}
+
+// Where the first term lands in this text, or -1 when any term is missing.
+// The index is what centers the snippet, so it's the earliest hit of any term
+// and not of the first one the operator typed.
+export function matchIndex(terms, text) {
+  if (!terms.length) return -1
+  const hay = String(text ?? '').toLowerCase()
+  let first = -1
+  for (const term of terms) {
+    const at = hay.indexOf(term)
+    if (at === -1) return -1
+    if (first === -1 || at < first) first = at
+  }
+  return first
+}
+
+// One readable line around the first hit. Whitespace collapses first, so a
+// snippet out of a JSON body or a wrapped issue body reads as prose.
+export function snippetAround(text, terms, { width = SNIPPET_WIDTH } = {}) {
+  const flat = String(text ?? '').replace(/\s+/g, ' ').trim()
+  if (!flat) return ''
+  const at = matchIndex(terms, flat)
+  let start = at <= SNIPPET_LEAD ? 0 : at - SNIPPET_LEAD
+  if (start > 0) {
+    const space = flat.indexOf(' ', start)
+    if (space !== -1 && space - start < 20) start = space + 1
+  }
+  const cut = flat.slice(start, start + width)
+  return `${start > 0 ? '…' : ''}${cut}${start + width < flat.length ? '…' : ''}`
+}
+
+// The typed landing target for a row. The caller renders the word; the surface
+// and its key are what Atlas routes on.
+export function landingFor(kind, fact) {
+  switch (kind) {
+    case 'ticket':
+    case 'chat':
+      return { surface: 'chat', repo: fact.repo, ticket: fact.ticket }
+    case 'map':
+      return { surface: 'maps', repo: fact.repo, map: fact.map }
+    case 'journal':
+      return { surface: 'feed', event: fact.event }
+    case 'decision':
+      return { surface: 'github', url: fact.url }
+    default:
+      throw new Error(`no landing target for search kind "${kind}"`)
+  }
+}
+
+const keyOf = (repo, ticket) => (ticket == null ? null : `${repo ?? ''}#${ticket}`)
+
+function attentionOf({ repo, ticket, state }, needsYou) {
+  const key = keyOf(repo, ticket)
+  if (key && needsYou.has(key)) return 'needs_you'
+  return state === 'closed' ? 'closed' : 'open'
+}
+
+function ageOf(at, now) {
+  const stamp = Date.parse(at ?? '')
+  if (!Number.isFinite(stamp)) return null
+  return Math.max(0, now - stamp)
+}
+
+function labelsOf(issue) {
+  return (issue.labels ?? []).map((label) => (typeof label === 'string' ? label : label.name))
+}
+
+function isMap(issue) {
+  return labelsOf(issue).includes('wayfinder:map')
+}
+
+function issueUrl(repo, number, issue) {
+  return issue?.html_url ?? `https://github.com/${repo}/issues/${number}`
+}
+
+// A row, in the one shape every source returns.
+function row({ kind, repo, ref, title, snippet, at, attention, landing, extra = {} }, now) {
+  return {
+    kind,
+    repo: repo ?? null,
+    ref: ref ?? null,
+    title: title ?? '',
+    snippet,
+    at: at ?? null,
+    age_ms: ageOf(at, now),
+    attention,
+    landing,
+    ...extra,
+  }
+}
+
+// The GitHub facts: every open and recently closed issue the adapter hands over.
+// A `wayfinder:map` issue becomes a map row, and everything else a ticket row.
+function githubRows(issues, { repo, terms, needsYou, now }) {
+  const rows = []
+  for (const issue of issues) {
+    const title = issue.title ?? ''
+    const body = issue.body ?? ''
+    // The title and the body are one text for matching, so a query whose terms
+    // are split between the two still finds the issue.
+    if (matchIndex(terms, `${title}\n${body}`) === -1) continue
+    const kind = isMap(issue) ? 'map' : 'ticket'
+    const fact = kind === 'map'
+      ? { repo, map: issue.number }
+      : { repo, ticket: issue.number }
+    rows.push(row({
+      kind,
+      repo,
+      ref: `#${issue.number}`,
+      title,
+      snippet: snippetAround(body || title, terms),
+      at: issue.updated_at ?? null,
+      attention: attentionOf({ repo, ticket: issue.number, state: issue.state }, needsYou),
+      landing: landingFor(kind, fact),
+      extra: { url: issueUrl(repo, issue.number, issue) },
+    }, now))
+  }
+  return rows
+}
+
+// One pointer line under `## Decisions so far`. The link is the ticket that
+// decided it, which is where its resolution comment lives.
+export function decisionPointers(body) {
+  const section = sectionBounds(body, DECISIONS_HEADING)
+  if (!section) return []
+  const out = []
+  for (const line of section.lines.slice(section.start + 1, section.end)) {
+    const m = line.match(/^\s*[-*+]\s+\[([^\]]*)\]\(([^)]+)\)\s*(?:[-–—:]\s*)?(.*)$/)
+    if (!m) continue
+    const url = m[2].trim()
+    const number = Number(url.match(/\/issues\/(\d+)/)?.[1] ?? NaN)
+    out.push({
+      title: m[1].trim(),
+      url,
+      gist: m[3].trim(),
+      ticket: Number.isInteger(number) ? number : null,
+    })
+  }
+  return out
+}
+
+function decisionRows(maps, { repo, terms, now }) {
+  const rows = []
+  for (const map of maps) {
+    for (const pointer of decisionPointers(map.body)) {
+      const text = `${pointer.title} ${pointer.gist}`
+      if (matchIndex(terms, text) === -1) continue
+      rows.push(row({
+        kind: 'decision',
+        repo,
+        ref: pointer.ticket == null ? null : `#${pointer.ticket}`,
+        title: pointer.title,
+        snippet: snippetAround(pointer.gist || pointer.title, terms),
+        at: map.updated_at ?? null,
+        // A decision is settled work. It never carries the amber word.
+        attention: 'closed',
+        landing: landingFor('decision', { url: pointer.url }),
+        extra: { map: map.number, url: pointer.url },
+      }, now))
+    }
+  }
+  return rows
+}
+
+// What a journal row offers the query: the words in the line, without the
+// bookkeeping keys. The body is verbatim (ADR-0017), so `normalizeEvent` is
+// what translates a pre-#184 line before the operator reads it.
+export function journalText(body) {
+  let event
+  try { event = normalizeEvent(JSON.parse(body)) } catch { return '' }
+  if (!event || typeof event !== 'object') return ''
+  const parts = []
+  const walk = (value) => {
+    if (typeof value === 'string') parts.push(value)
+    else if (typeof value === 'number' || typeof value === 'boolean') parts.push(String(value))
+    else if (Array.isArray(value)) value.forEach(walk)
+    else if (value && typeof value === 'object') {
+      for (const [key, inner] of Object.entries(value)) {
+        if (!JOURNAL_SKIP_KEYS.has(key)) walk(inner)
+      }
+    }
+  }
+  walk(event)
+  return parts.join(' ')
+}
+
+function journalRows(events, { terms, needsYou, now }) {
+  const rows = []
+  for (const event of events) {
+    const parsed = (() => {
+      try { return normalizeEvent(JSON.parse(event.body ?? '')) ?? {} } catch { return {} }
+    })()
+    const text = journalText(event.body)
+    const type = event.type ?? parsed.type ?? ''
+    if (matchIndex(terms, `${type} ${text}`) === -1) continue
+    const ticket = event.ticket == null ? null : Number(event.ticket)
+    const repo = event.repo ?? parsed.repo ?? null
+    rows.push(row({
+      kind: 'journal',
+      repo,
+      ref: ticket == null ? null : `#${ticket}`,
+      title: event.title ?? (ticket == null ? type : `${type} on #${ticket}`),
+      snippet: snippetAround(text, terms),
+      at: event.ts ?? parsed.ts ?? null,
+      attention: attentionOf({ repo, ticket, state: 'open' }, needsYou),
+      landing: landingFor('journal', { event: event.id }),
+      extra: { type },
+    }, now))
+  }
+  return rows
+}
+
+// One conversation, one row at most. A transcript that matches in several
+// messages lands on its latest matching message, because that's the one the
+// operator scrolls to.
+function chatRows(conversations, { terms, needsYou, now }) {
+  const rows = []
+  for (const conversation of conversations) {
+    const { items } = readActiveMessages(conversation.harness, conversation.lines ?? [])
+    let best = null
+    for (const item of items) {
+      if (!CHAT_ITEM_KINDS.has(item.kind)) continue
+      if (matchIndex(terms, item.text ?? '') === -1) continue
+      const at = Date.parse(item.at ?? '')
+      const bestAt = best ? Date.parse(best.at ?? '') : NaN
+      if (!best || !Number.isFinite(bestAt) || (Number.isFinite(at) && at >= bestAt)) best = item
+    }
+    if (!best) continue
+    const ticket = conversation.ticket ?? null
+    rows.push(row({
+      kind: 'chat',
+      repo: conversation.repo ?? null,
+      ref: ticket == null ? null : `#${ticket}`,
+      title: conversation.title ?? conversation.session ?? '',
+      snippet: snippetAround(best.text, terms),
+      at: best.at ?? null,
+      attention: attentionOf({ repo: conversation.repo, ticket, state: 'open' }, needsYou),
+      landing: landingFor('chat', { repo: conversation.repo ?? null, ticket }),
+      extra: { session: conversation.session ?? null, speaker: CHAT_SPEAKERS[best.kind] ?? 'agent' },
+    }, now))
+  }
+  return rows
+}
+
+// Newest first. A row with no stamp sorts last, and two rows of the same age
+// fall back to the kind order the lens draws.
+function rank(a, b) {
+  const at = (rowValue) => (Number.isFinite(Date.parse(rowValue.at ?? '')) ? Date.parse(rowValue.at) : -Infinity)
+  const byAge = at(b) - at(a)
+  if (byAge !== 0) return byAge
+  return SEARCH_KINDS.indexOf(a.kind) - SEARCH_KINDS.indexOf(b.kind)
+}
+
+// One request over every indexed source.
+//
+// The adapters:
+//
+//   - `github.searchIssues(repo, query)` returns the issues of one repo, each
+//     with `number`, `title`, `body`, `state`, `labels`, and `updated_at`.
+//   - `github.repoMaps(repo)` returns the maps whose bodies hold the decisions.
+//   - `journal.searchEvents(query, { limit })` returns journal rows, each with
+//     `id`, `ts`, `type`, `ticket`, `repo`, and the verbatim `body`.
+//   - `transcripts.conversations()` returns the local chat transcripts, each
+//     with `harness`, `lines`, and the ticket the conversation belongs to.
+//
+// `needsYou` is the operator's attention list, as `repo#number` keys. `now` is
+// the clock every age is measured against.
+export async function searchAll({
+  query,
+  repos = [],
+  github = null,
+  journal = null,
+  transcripts = null,
+  needsYou = [],
+  now = Date.now(),
+  limit = DEFAULT_LIMIT,
+} = {}) {
+  const terms = queryTerms(query)
+  const attention = new Set(needsYou)
+  const failures = []
+  const rows = []
+
+  const gather = async (source, read) => {
+    try { rows.push(...(await read())) } catch (error) {
+      failures.push({ source, reason: error.message })
+    }
+  }
+
+  if (!terms.length) {
+    return { query: String(query ?? ''), computed_at: new Date(now).toISOString(), results: [], failures, truncated: false }
+  }
+
+  for (const repo of repos) {
+    if (github?.searchIssues) {
+      await gather('github', async () => githubRows(
+        await github.searchIssues(repo, query),
+        { repo, terms, needsYou: attention, now },
+      ))
+    }
+    if (github?.repoMaps) {
+      await gather('decisions', async () => decisionRows(
+        await github.repoMaps(repo),
+        { repo, terms, now },
+      ))
+    }
+  }
+
+  if (journal?.searchEvents) {
+    await gather('journal', async () => journalRows(
+      await journal.searchEvents(query, { limit }),
+      { terms, needsYou: attention, now },
+    ))
+  }
+
+  if (transcripts?.conversations) {
+    await gather('transcripts', async () => chatRows(
+      await transcripts.conversations(),
+      { terms, needsYou: attention, now },
+    ))
+  }
+
+  rows.sort(rank)
+  return {
+    query: String(query),
+    computed_at: new Date(now).toISOString(),
+    results: rows.slice(0, limit),
+    failures,
+    truncated: rows.length > limit,
+  }
+}

--- a/daemon/test/search.test.mjs
+++ b/daemon/test/search.test.mjs
@@ -1,0 +1,532 @@
+// The global search query (#693).
+//
+// Every source here is a local adapter: an object with the same method the
+// daemon's GitHub, journal, and transcript modules expose. Nothing in this file
+// reaches the network, the `gh` CLI, or a transcript directory, so the suite
+// proves the query and not the plumbing.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  ATTENTION_STATES,
+  SEARCH_KINDS,
+  SEARCH_SOURCES,
+  decisionPointers,
+  journalText,
+  landingFor,
+  matchIndex,
+  searchAll,
+  snippetAround,
+} from '../src/search.mjs'
+import { Questions } from '../src/questions.mjs'
+import { Journal } from '../src/journal.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const NOW = Date.parse('2026-08-25T12:00:00.000Z')
+
+const issue = (number, title, {
+  body = '', state = 'open', labels = [], updatedAt = '2026-08-25T11:00:00.000Z',
+} = {}) => ({
+  number,
+  title,
+  body,
+  state,
+  updated_at: updatedAt,
+  labels: labels.map((name) => ({ name })),
+})
+
+const MAP_BODY = `## Destination
+
+Decide the operator surfaces.
+
+## Decisions so far
+
+- [The maps screen](https://github.com/o/r/issues/522) - One band per map: walked, in flight, takeable, blocked, fog, with counts.
+- [The embedded terminal](https://github.com/o/r/issues/537) - ttyd behind the identity proxy, with touch keys on phones.
+
+## Not yet specified
+
+- The search index.
+`
+
+const line = (event) => JSON.stringify(event)
+
+const journalEvents = [
+  {
+    id: 41,
+    ts: '2026-08-25T10:00:00.000Z',
+    type: 'review_answered',
+    ticket: '588',
+    repo: 'o/r',
+    body: line({
+      ts: '2026-08-25T10:00:00.000Z',
+      type: 'review_answered',
+      ticket: '588',
+      repo: 'o/r',
+      approved: true,
+      note: 'the frontier visual is approved',
+    }),
+  },
+  {
+    id: 42,
+    ts: '2026-08-25T09:00:00.000Z',
+    type: 'agent_spawned',
+    ticket: '589',
+    repo: 'o/r',
+    body: line({
+      ts: '2026-08-25T09:00:00.000Z',
+      type: 'worker_spawned',
+      ticket: '589',
+      repo: 'o/r',
+      worker: 'curia-589',
+      backend: 'claude',
+      note: 'started on the terminal work',
+    }),
+  },
+]
+
+const claudeLine = (uuid, parentUuid, event) => JSON.stringify({ uuid, parentUuid, ...event })
+
+const transcript = [
+  claudeLine('a', null, {
+    type: 'user',
+    timestamp: '2026-08-25T08:00:00.000Z',
+    message: { content: 'Does the embedded terminal survive a restart?' },
+  }),
+  claudeLine('b', 'a', {
+    type: 'assistant',
+    timestamp: '2026-08-25T08:01:00.000Z',
+    message: { content: [{ type: 'text', text: 'The terminal reconnects through the identity proxy.' }] },
+  }),
+]
+
+const adapters = ({ issues = [], maps = [], events = journalEvents, conversations = [] } = {}) => ({
+  github: {
+    searchIssues: async () => issues,
+    repoMaps: async () => maps,
+  },
+  journal: { searchEvents: async () => events },
+  transcripts: { conversations: async () => conversations },
+})
+
+const conversation = () => ({
+  repo: 'o/r',
+  ticket: 537,
+  session: 'curia-537',
+  title: 'The embedded terminal',
+  harness: 'claude',
+  lines: transcript,
+})
+
+test('one request searches tickets, maps, decisions, journal entries, and chat transcripts', async () => {
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({
+      issues: [
+        issue(537, 'The embedded terminal', { body: 'ttyd behind the identity proxy.' }),
+        issue(511, 'The UX map', { body: 'The terminal retires its own address.', labels: ['wayfinder:map'] }),
+      ],
+      maps: [{ number: 511, body: MAP_BODY, updated_at: '2026-08-25T07:00:00.000Z' }],
+      conversations: [conversation()],
+    }),
+  })
+
+  assert.deepEqual([...new Set(results.map((row) => row.kind))].sort(), [
+    'chat', 'decision', 'journal', 'map', 'ticket',
+  ])
+})
+
+test('every result names its kind, title, snippet, age, attention state, and landing target', async () => {
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    needsYou: ['o/r#537'],
+    ...adapters({
+      issues: [issue(537, 'The embedded terminal', { body: 'ttyd behind the identity proxy, with touch keys.' })],
+    }),
+  })
+
+  const [row] = results
+  assert.equal(row.kind, 'ticket')
+  assert.equal(row.title, 'The embedded terminal')
+  assert.match(row.snippet, /identity proxy/)
+  assert.equal(row.age_ms, 60 * 60 * 1000)
+  assert.equal(row.attention, 'needs_you')
+  assert.deepEqual(row.landing, { surface: 'chat', repo: 'o/r', ticket: 537 })
+  for (const key of ['kind', 'title', 'snippet', 'age_ms', 'attention', 'landing']) {
+    assert.ok(key in row, `a result carries ${key}`)
+  }
+})
+
+test('a result with no stamp reports a null age rather than a wrong one', async () => {
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({ issues: [issue(537, 'The embedded terminal', { updatedAt: null })], events: [] }),
+  })
+
+  assert.equal(results[0].age_ms, null)
+})
+
+test('each kind lands on the surface the decision on #589 gave it', async () => {
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({
+      issues: [
+        issue(537, 'The embedded terminal'),
+        issue(511, 'The UX map', { body: 'the terminal', labels: ['wayfinder:map'] }),
+      ],
+      maps: [{ number: 511, body: MAP_BODY }],
+      conversations: [conversation()],
+    }),
+  })
+
+  const landings = Object.fromEntries(results.map((row) => [row.kind, row.landing]))
+  assert.deepEqual(landings.ticket, { surface: 'chat', repo: 'o/r', ticket: 537 })
+  assert.deepEqual(landings.chat, { surface: 'chat', repo: 'o/r', ticket: 537 })
+  assert.deepEqual(landings.map, { surface: 'maps', repo: 'o/r', map: 511 })
+  assert.deepEqual(landings.journal, { surface: 'feed', event: 42 })
+  assert.deepEqual(landings.decision, { surface: 'github', url: 'https://github.com/o/r/issues/537' })
+})
+
+test('the first index holds no Discord source', async () => {
+  assert.deepEqual(SEARCH_SOURCES, ['github', 'decisions', 'journal', 'transcripts'])
+  assert.ok(!SEARCH_SOURCES.includes('discord'))
+  assert.ok(!SEARCH_KINDS.includes('discord'))
+
+  let asked = false
+  const discord = { threads: async () => { asked = true; return [] } }
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    discord,
+    ...adapters({ issues: [issue(537, 'The embedded terminal')] }),
+  })
+
+  assert.equal(asked, false, 'the query never reads a Discord thread body')
+  assert.ok(results.length > 0)
+})
+
+test('a map issue is a map row and an ordinary issue is a ticket row', async () => {
+  const { results } = await searchAll({
+    query: 'surfaces',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({
+      issues: [
+        issue(511, 'The UX map of the surfaces', { labels: ['wayfinder:map'] }),
+        issue(560, 'The navigation of the surfaces', { labels: ['wayfinder:task'] }),
+      ],
+      events: [],
+    }),
+  })
+
+  // Both rows carry the same stamp, so the tie falls back to the kind order.
+  assert.deepEqual(results.map((row) => [row.kind, row.ref]), [['ticket', '#560'], ['map', '#511']])
+})
+
+test('a closed ticket reports the closed attention state and an open one reports open', async () => {
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({
+      issues: [
+        issue(537, 'The embedded terminal', { state: 'closed', updatedAt: '2026-08-25T11:00:00.000Z' }),
+        issue(538, 'The terminal keys', { state: 'open', updatedAt: '2026-08-25T10:30:00.000Z' }),
+      ],
+      events: [],
+    }),
+  })
+
+  assert.deepEqual(results.map((row) => row.attention), ['closed', 'open'])
+  for (const row of results) assert.ok(ATTENTION_STATES.includes(row.attention))
+})
+
+test('a decision row comes out of the map pointer and lands on its resolution comment', async () => {
+  const { results } = await searchAll({
+    query: 'walked',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({ maps: [{ number: 511, body: MAP_BODY }], events: [] }),
+  })
+
+  assert.equal(results.length, 1)
+  assert.equal(results[0].kind, 'decision')
+  assert.equal(results[0].title, 'The maps screen')
+  assert.equal(results[0].attention, 'closed')
+  assert.deepEqual(results[0].landing, { surface: 'github', url: 'https://github.com/o/r/issues/522' })
+})
+
+test('a journal hit reads the verbatim line in today\'s spelling', async () => {
+  const { results } = await searchAll({
+    query: 'started',
+    repos: [],
+    now: NOW,
+    ...adapters(),
+  })
+
+  assert.equal(results.length, 1)
+  assert.equal(results[0].kind, 'journal')
+  assert.equal(results[0].title, 'agent_spawned on #589')
+  assert.match(results[0].snippet, /started on the terminal work/)
+  assert.deepEqual(results[0].landing, { surface: 'feed', event: 42 })
+})
+
+test('a chat hit names the speaker and lands on the ticket\'s chat thread', async () => {
+  const { results } = await searchAll({
+    query: 'reconnects',
+    repos: [],
+    now: NOW,
+    ...adapters({ events: [], conversations: [conversation()] }),
+  })
+
+  assert.equal(results.length, 1)
+  assert.equal(results[0].kind, 'chat')
+  assert.equal(results[0].title, 'The embedded terminal')
+  assert.equal(results[0].speaker, 'agent')
+  assert.match(results[0].snippet, /identity proxy/)
+  assert.deepEqual(results[0].landing, { surface: 'chat', repo: 'o/r', ticket: 537 })
+})
+
+test('an operator turn in a transcript is a chat hit with the operator as its speaker', async () => {
+  const { results } = await searchAll({
+    query: 'survive a restart',
+    repos: [],
+    now: NOW,
+    ...adapters({ events: [], conversations: [conversation()] }),
+  })
+
+  assert.equal(results.length, 1)
+  assert.equal(results[0].speaker, 'operator')
+})
+
+test('one conversation returns one row, on its latest matching message', async () => {
+  const later = {
+    ...conversation(),
+    lines: [
+      ...transcript,
+      claudeLine('c', 'b', {
+        type: 'assistant',
+        timestamp: '2026-08-25T08:05:00.000Z',
+        message: { content: [{ type: 'text', text: 'The terminal is embedded now.' }] },
+      }),
+    ],
+  }
+
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: [],
+    now: NOW,
+    ...adapters({ events: [], conversations: [later] }),
+  })
+
+  assert.equal(results.length, 1)
+  assert.equal(results[0].at, '2026-08-25T08:05:00.000Z')
+})
+
+test('the results come back newest first', async () => {
+  const { results } = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({
+      issues: [issue(537, 'The embedded terminal', { updatedAt: '2026-08-25T11:00:00.000Z' })],
+      conversations: [conversation()],
+    }),
+  })
+
+  const stamps = results.map((row) => Date.parse(row.at))
+  assert.deepEqual(stamps, [...stamps].sort((a, b) => b - a))
+})
+
+test('a query needs every term, in any order', async () => {
+  const { results } = await searchAll({
+    query: 'identity terminal',
+    repos: ['o/r'],
+    now: NOW,
+    ...adapters({
+      issues: [
+        issue(537, 'The embedded terminal', { body: 'ttyd behind the identity proxy.' }),
+        issue(538, 'The terminal keys', { body: 'touch keys on phones.' }),
+      ],
+      events: [],
+    }),
+  })
+
+  assert.deepEqual(results.map((row) => row.ref), ['#537'])
+})
+
+test('an empty query returns no rows rather than everything', async () => {
+  const answer = await searchAll({ query: '   ', repos: ['o/r'], now: NOW, ...adapters() })
+
+  assert.deepEqual(answer.results, [])
+  assert.deepEqual(answer.failures, [])
+})
+
+test('a source that throws names itself and leaves the other sources standing', async () => {
+  const answer = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    github: {
+      searchIssues: async () => [issue(537, 'The embedded terminal')],
+      repoMaps: async () => { throw new Error('gh is not logged in') },
+    },
+    journal: { searchEvents: async () => { throw new Error('events journal is unreadable') } },
+    transcripts: { conversations: async () => [] },
+  })
+
+  assert.deepEqual(answer.results.map((row) => row.kind), ['ticket'])
+  assert.deepEqual(answer.failures, [
+    { source: 'decisions', reason: 'gh is not logged in' },
+    { source: 'journal', reason: 'events journal is unreadable' },
+  ])
+})
+
+test('the limit bounds the answer and says the rows were cut', async () => {
+  const issues = Array.from({ length: 5 }, (_, index) => issue(600 + index, `The terminal ${index}`, {
+    updatedAt: `2026-08-25T1${index}:00:00.000Z`,
+  }))
+  const answer = await searchAll({
+    query: 'terminal',
+    repos: ['o/r'],
+    now: NOW,
+    limit: 2,
+    ...adapters({ issues, events: [] }),
+  })
+
+  assert.equal(answer.results.length, 2)
+  assert.equal(answer.truncated, true)
+})
+
+test('the snippet centers on the first hit and marks what it cut', () => {
+  const text = `${'a word '.repeat(30)}the identity proxy ${'b word '.repeat(30)}`
+  const snippet = snippetAround(text, ['identity'])
+
+  assert.match(snippet, /^…/)
+  assert.match(snippet, /identity proxy/)
+  assert.match(snippet, /…$/)
+})
+
+test('matchIndex reports the earliest hit of any term', () => {
+  assert.equal(matchIndex(['proxy', 'ttyd'], 'ttyd behind the proxy'), 0)
+  assert.equal(matchIndex(['proxy', 'nope'], 'ttyd behind the proxy'), -1)
+  assert.equal(matchIndex([], 'anything'), -1)
+})
+
+test('landingFor refuses a kind it has no surface for', () => {
+  assert.throws(() => landingFor('discord', {}), /no landing target for search kind "discord"/)
+})
+
+test('decisionPointers reads the title, the link, and the gist of every pointer', () => {
+  assert.deepEqual(decisionPointers(MAP_BODY), [
+    {
+      title: 'The maps screen',
+      url: 'https://github.com/o/r/issues/522',
+      gist: 'One band per map: walked, in flight, takeable, blocked, fog, with counts.',
+      ticket: 522,
+    },
+    {
+      title: 'The embedded terminal',
+      url: 'https://github.com/o/r/issues/537',
+      gist: 'ttyd behind the identity proxy, with touch keys on phones.',
+      ticket: 537,
+    },
+  ])
+})
+
+test('decisionPointers reads a pointer written with the em dash the resolve path writes', () => {
+  const body = '## Decisions so far\n\n- [The one voice](https://github.com/o/r/issues/13) — one voice per fact.\n'
+
+  assert.deepEqual(decisionPointers(body), [
+    { title: 'The one voice', url: 'https://github.com/o/r/issues/13', gist: 'one voice per fact.', ticket: 13 },
+  ])
+})
+
+test('a map with no Decisions so far section contributes no decision rows', () => {
+  assert.deepEqual(decisionPointers('## Destination\n\nSomething.\n'), [])
+})
+
+test('journalText drops the bookkeeping keys and keeps the words', () => {
+  const text = journalText(JSON.stringify({
+    ts: '2026-08-25T09:00:00.000Z',
+    type: 'result',
+    epoch: 12,
+    ticket: '589',
+    headline: 'the terminal is embedded',
+  }))
+
+  assert.ok(!text.includes('2026-08-25T09:00:00.000Z'))
+  assert.match(text, /the terminal is embedded/)
+  assert.match(text, /589/)
+})
+
+test('journalText survives a line that is not JSON', () => {
+  assert.equal(journalText('not json at all'), '')
+})
+
+// The journal adapter the daemon actually passes: the indexed question over the
+// real `node:sqlite` store. The rest of this file uses a local adapter, so this
+// is the one test that opens a database.
+test('the journal question answers the query over the real store', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-search-'))
+  const journal = new Journal(path.join(dir, 'events.db'))
+  try {
+    journal.append(line({
+      ts: '2026-08-25T09:00:00.000Z', type: 'worker_spawned', ticket: '589', repo: 'o/r', worker: 'curia-589',
+      note: 'the embedded terminal starts',
+    }))
+    journal.append(line({
+      ts: '2026-08-25T09:30:00.000Z', type: 'result', ticket: '590', repo: 'o/r', headline: 'the maps screen ships',
+    }))
+    const questions = new Questions(journal.db)
+
+    const rows = questions.searchEvents('embedded TERMINAL')
+    assert.equal(rows.length, 1)
+    assert.equal(rows[0].ticket, '589')
+    assert.equal(rows[0].type, 'agent_spawned')
+
+    assert.deepEqual(questions.searchEvents('   '), [])
+    assert.equal(questions.searchEvents('e', { limit: 1 }).length, 1)
+    // A `%` in a term is a literal character, not a wildcard.
+    assert.deepEqual(questions.searchEvents('%terminal%'), [])
+  } finally {
+    journal.close()
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('the real journal question feeds the query as its journal adapter', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-search-'))
+  const journal = new Journal(path.join(dir, 'events.db'))
+  try {
+    journal.append(line({
+      ts: '2026-08-25T09:00:00.000Z', type: 'worker_spawned', ticket: '589', repo: 'o/r', worker: 'curia-589',
+      note: 'the embedded terminal starts',
+    }))
+    const questions = new Questions(journal.db)
+
+    const { results } = await searchAll({
+      query: 'embedded terminal',
+      now: NOW,
+      journal: { searchEvents: (query, opts) => questions.searchEvents(query, opts) },
+    })
+
+    assert.deepEqual(results.map((row) => [row.kind, row.title, row.landing.surface]), [
+      ['journal', 'agent_spawned on #589', 'feed'],
+    ])
+  } finally {
+    journal.close()
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Closes part of [Build the Atlas operator experience](https://github.com/alp82/curia/issues/685). Implements [alp82/curia#693](https://github.com/alp82/curia/issues/693).

## What this adds

`daemon/src/search.mjs` is the one query module behind the global search decided on [#589](https://github.com/alp82/curia/issues/589). `searchAll` takes a query and the adapters, asks every indexed source, and returns one row shape.

| Source | Kind | Lands on |
| --- | --- | --- |
| GitHub issues | `ticket` | `chat` |
| GitHub issues labeled `wayfinder:map` | `map` | `maps` |
| A map's `## Decisions so far` pointers | `decision` | `github`, at the resolution comment |
| The journal | `journal` | `feed` |
| Local chat transcripts | `chat` | `chat` |

Every row carries the kind, the title, a snippet around the first hit, `age_ms` against the caller's clock, an attention state of `needs_you`, `open`, or `closed`, and a typed `landing` target. The landing is data, not a URL the screen has to parse.

`Questions.searchEvents` is the journal adapter the daemon passes: every event whose verbatim line holds all of the operator's terms, newest first. It's proportional to history on purpose. A substring search over `body` has no index to ride, and an FTS table would be a second copy of the record ADR-0017 keeps in one place.

## Discord stays out of the first index

There is no Discord adapter, and `SEARCH_SOURCES` is the whole list. A test asserts a Discord adapter handed to `searchAll` is never read.

## Failures

A source that throws contributes no rows and names itself in `failures`. A dead transcript directory can't blank the ticket hits.

## Tests

`daemon/test/search.test.mjs` drives the query with local adapters for GitHub, the journal, and the transcripts, so it proves the query and not the plumbing. Two tests open a real `node:sqlite` journal to check the question the daemon actually asks.

The complete daemon suite passes: 3195 tests, 0 failures, 0 cancelled.

## Left out

Rendering the lens overlay and its routes stays with [#713](https://github.com/alp82/curia/issues/713). Nothing wires this module to the sidecar yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
