### PR TITLE
Run exact commands through one checked interface (alp82/curia#692)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -259,6 +259,13 @@ The expiry half is a PAT-only fact and it dies holder by holder as [ADR-0018](do
 `tickets`, `next`, `status`, `start`, `map`, `cancel`, `resume`, `attach`, `review`. The whole command surface, identical over Discord and REST. Each verb has one meaning. `start` works a thing, and `map` updates a map.
 _Avoid_: the five verbs (the pre-#81 count, wrong since `next`, `resume` and `review` joined).
 
+**Typed command**:
+A top-level message in the command channel that the parser accepts as a whole line. It runs on the router before any model turn: no conversation thread, and no overseer session. A line the parser refuses, and a line that only starts with a verb, are both prose, and prose opens a conversation. See [ADR-0022](docs/adr/0022-the-overseers-command-understanding.md) and [#692](https://github.com/alp82/curia/issues/692).
+_Avoid_: slash command (that names the Discord manifest, which is another transport onto the same router).
+
+**The map tools**:
+The two tools the overseer reaches the `map` verb through. `map_update` requires an existing map's number. `map_new` has no number field at all and requires the operator's brief. Both compose the same `map` router text, so the grammar, the slash surface and the operator's usage catalogue don't change. The test of which shape to use is a schema rather than prompt prose, so the wrong shape is not a call the model can make. See [ADR-0022](docs/adr/0022-the-overseers-command-understanding.md) and [#692](https://github.com/alp82/curia/issues/692).
+
 **Resume**:
 A fresh agent on a ticket whose agent is gone. It inherits the surviving worktree, the model of the last spawn, which the journal states, and the inherited exchange (#374). It never inherits the conversation. A live agent refuses it: `cancel <n>` is the way to end one.
 

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -25,6 +25,7 @@ import {
   StringSelectMenuBuilder,
 } from 'discord.js'
 import { isChatHandle } from './attach.mjs'
+import { parseCommand } from './commands.mjs'
 import { safeLeaf } from './attachments.mjs'
 import { REVIEW_KIND, CROSS_CHECK_ANSWER, ALL_AS_RECOMMENDED } from './lifecycle.mjs'
 import { CONFIRM_KIND } from './reduction.mjs'
@@ -1836,6 +1837,23 @@ export class DiscordBridge {
     if (!this.authorized(m.author.id)) return
     // Top-level prose in #curia always opens a fresh conversation thread (#89).
     if (m.channel.id === this.channel.id) {
+      // #692, ADR-0022: a typed verb runs BEFORE a model turn. When the whole
+      // trimmed line parses, it is a command the operator wrote, not prose for
+      // the overseer to interpret. It runs on the router, in the channel, with
+      // no thread and no session behind it.
+      //
+      // The reference incident is three `status` lines in four minutes: three
+      // threads named "status", three model sessions, and three paraphrases of
+      // an answer the router already had. Interpretation is for prose.
+      //
+      // The whole line has to parse. A partial match is prose that starts with
+      // a verb ("status of the landing page map?"), and that is a question.
+      const typed = m.content?.trim() ?? ''
+      if (typed && this.handlers.command && parseCommand(typed)) {
+        const reply = await this.handlers.command(typed, m.author.id, { threadId: null })
+        await this.#sendChunked(m.channel, { content: reply ?? `relayed: \`${typed}\`` })
+        return
+      }
       if (!this.handlers.overseerTurn) return
       const thread = await m.startThread({ name: m.content.slice(0, 80) || 'overseer', autoArchiveDuration: 10080 })
       await this.#addWatchers(thread)

--- a/daemon/src/commands.mjs
+++ b/daemon/src/commands.mjs
@@ -35,7 +35,7 @@ const REPOISH_RE = /^[\w./-]+$/
 // the FIRST WORD is the repo when it IS a watched repo's name — `map curia
 // chart the dashboard` — and is the first word of the sentence when it is not.
 // The ruling needs the watch list, so the parser only marks the candidate and
-// the router decides (see #chartNew). The match is exact there, never the
+// the router decides (see `newMapPlan`). The match is exact there, never the
 // substring match `tickets cur` takes: a fragment rule would eat the first word
 // of any sentence that happens to sit inside a repo name.
 //
@@ -148,7 +148,7 @@ function parseIssueRef(cmd, rest, { instruction: takesInstruction = false } = {}
 // names both shapes rather than a session that opens with a blank question.
 //
 // The repo token is optional, and the ROUTER fills it in when exactly one repo
-// is watched (see #newMapRepo). #255: with the `--` retired, this parser cannot
+// is watched (see `newMapPlan`). #255: with the `--` retired, this parser cannot
 // tell a repo from the first word of the sentence — that needs the watch list —
 // so it marks ONE candidate as `repoWord` and hands the ruling to the router.
 // A bare number is never the candidate: `map 147 x` is the OTHER shape, and a
@@ -178,6 +178,39 @@ function parseNewMap(rest) {
   if (!instruction && !cmd.repoWord) return null
   cmd.instruction = instruction
   return cmd
+}
+
+// The new-map RULING (#241, made a pure function by #692). The parser marks one
+// candidate word and stops, because only the watch list says whether that word
+// names a repo or opens the operator's sentence. This decides, and it takes the
+// watch list as an argument rather than reaching into the router, so the seam
+// the overseer's `map_new` tool composes into can be round-tripped in a test
+// with no dispatcher and no Discord in the loop.
+//
+// The match is EXACT, on the full name or the part after the slash, never the
+// substring match `tickets cur` takes: a fragment rule would eat the first word
+// of every sentence that sits inside a repo name.
+//
+// One watched repo means there is no question to ask, and asking it anyway
+// would put a token in the way of the shortest form of the command. Two or
+// more, and curia refuses rather than picking the first: a map is a standing
+// artifact, and one charted into the wrong repo is a manual move.
+export function newMapPlan(cmd, watched = []) {
+  const word = cmd.repoWord
+  const named = word
+    ? watched.find((r) => {
+      const w = word.toLowerCase()
+      return r.toLowerCase() === w || r.slice(r.indexOf('/') + 1).toLowerCase() === w
+    }) ?? null
+    : null
+  // A word that names no repo is the first word of the brief, so it goes back
+  // in front of the sentence it was taken from.
+  const instruction = named ? cmd.instruction : [word, cmd.instruction].filter(Boolean).join(' ')
+  if (!instruction) return { error: `❌ \`map ${word}\` names a repo and nothing to chart.\n${MAP_SHAPES}` }
+  if (named) return { repo: named, instruction }
+  if (watched.length === 1) return { repo: watched[0], instruction }
+  if (!watched.length) return { error: '❌ no repo is on the watch list, so there is nowhere to chart a new map' }
+  return { error: `❌ ${watched.length} repos are watched, so a new map needs one named first: ${watched.map((r) => `\`map ${r} …\``).join(' or ')}` }
 }
 
 // 'tickets [repo]' | 'next [repo]' | 'status'
@@ -395,43 +428,16 @@ export class CommandRouter {
     return this.#matchRepo(cmd.repoArg)
   }
 
-  // A NEW-map dispatch (#241), and the ruling #255 moved here: whether the
-  // first word is a repo or the first word of the brief. The parser cannot
-  // know — only the watch list says — so it hands over a candidate and this
-  // decides. The match is EXACT, on the full name or the part after the slash,
-  // never the substring match `tickets cur` takes: a fragment rule would eat
-  // the first word of every sentence that sits inside a repo name.
+  // A NEW-map dispatch (#241). The ruling that reads the parser's repo
+  // candidate is `newMapPlan`, which #692 lifted out of this class so the
+  // round-trip test can reach it with no dispatcher in the loop. What is left
+  // here is the dispatch itself.
   async #chartNew(cmd, { userId, threadId }) {
-    const named = this.#namedRepo(cmd.repoWord)
-    const instruction = named ? cmd.instruction : [cmd.repoWord, cmd.instruction].filter(Boolean).join(' ')
-    if (!instruction) return `❌ \`map ${cmd.repoWord}\` names a repo and nothing to chart.\n${MAP_SHAPES}`
-    const target = named ? { repo: named } : this.#newMapRepo()
-    if (target.error) return target.error
+    const plan = newMapPlan(cmd, (this.dispatcher.config?.watch ?? []).map((w) => w.repo))
+    if (plan.error) return plan.error
     return await this.dispatcher.chartNew({
-      repo: target.repo, model: cmd.model, instruction, by: userId, threadId,
+      repo: plan.repo, model: cmd.model, instruction: plan.instruction, by: userId, threadId,
     })
-  }
-
-  // The watched repo a word NAMES, or null when it names none. `alp82/curia`
-  // and `curia` both name it; `cur` does not.
-  #namedRepo(word) {
-    if (!word) return null
-    const w = word.toLowerCase()
-    return (this.dispatcher.config?.watch ?? [])
-      .map((x) => x.repo)
-      .find((r) => r.toLowerCase() === w || r.slice(r.indexOf('/') + 1).toLowerCase() === w) ?? null
-  }
-
-  // The repo a NEW-map dispatch runs against when the operator named none
-  // (#241). One watched repo means there is no question to ask, and asking it
-  // anyway would put a token in the way of the shortest form of the command.
-  // Two or more, and curia refuses rather than picking the first — a map is a
-  // standing artifact, and one charted into the wrong repo is a manual move.
-  #newMapRepo() {
-    const watched = (this.dispatcher.config?.watch ?? []).map((w) => w.repo)
-    if (watched.length === 1) return { repo: watched[0] }
-    if (!watched.length) return { error: '❌ no repo is on the watch list, so there is nowhere to chart a new map' }
-    return { error: `❌ ${watched.length} repos are watched, so a new map needs one named first: ${watched.map((r) => `\`map ${r} …\``).join(' or ')}` }
   }
 
   // #81: a repo argument matches on any unambiguous substring of a watched

--- a/daemon/src/overseerclient.mjs
+++ b/daemon/src/overseerclient.mjs
@@ -16,7 +16,7 @@
 //   1. `OverseerTurns` — the per-turn registry. It mints the secret the
 //      container's model presents, and it holds what a verb call needs to know:
 //      which thread to route to, and how to narrate.
-//   2. `buildVerbMcpServer` — the eight verbs as an HTTP MCP server, which is
+//   2. `buildVerbMcpServer` — the verb catalogue as an HTTP MCP server, which is
 //      the daemon's own side channel. The handlers are the catalogue's, so a
 //      call composes canonical text HERE and posts it to `/command`.
 //   3. `OverseerClient` — what the bridge and the Chat screen call. It kept
@@ -44,7 +44,7 @@ import {
   OVERSEER_CONTAINER_MODEL, overseerConfigDirFor,
 } from './overseerturn.mjs'
 
-// The eight verbs, served over HTTP MCP. One server per request, like the agent
+// The verb catalogue, served over HTTP MCP. One server per request, like the agent
 // surface: the transport is stateless, and the per-turn context is closed over
 // by `command` before this is ever called.
 export function buildVerbMcpServer(command) {

--- a/daemon/src/overseerprompt.mjs
+++ b/daemon/src/overseerprompt.mjs
@@ -42,19 +42,23 @@ const BASE_PROMPT = `You are the curia overseer. Curia is a personal orchestrati
 You speak with one operator, in one Discord thread, in short Discord markdown. You act only through the curia tools. The daemon executes every effect.
 
 What you do:
-- Translate the operator's prose into the verbs: tickets, next, status, start, map, cancel, resume, attach.
+- Translate the operator's prose into the verbs: tickets, next, status, start, map_update, map_new, cancel, resume, attach.
 - Answer reasoning questions from tool output ("what should I start next?" — call tickets, then recommend one, with a one-line reason).
 - Report tool replies faithfully. Do not invent agents, tickets, or states.
+
+What a tool reply is, and what it is not:
+- Copy every id. Take each ticket, map, and session id character by character from a tool reply of THIS turn. Never retype one from memory, and never carry one over from an earlier turn. A wrong digit names another ticket.
+- An id you cannot find in this turn's tool replies is one you do not have. Call \`tickets\` or \`status\` and read it there.
+- Quote every refusal. When the daemon refuses a line your tool call composed, repeat the refusal word for word, then say what you will do next. Do not paraphrase it, and do not name a cause the refusal did not name. "Ticket 91 does not exist" is a cause you invented if the refusal said something else.
 
 Vocabulary the operator uses:
 - A "map" is a wayfinder map: a GitHub issue whose child tickets chart one effort. The operator names maps by topic ("the landing page map"). The \`tickets\` output groups tickets under their map's header line ("map #109 **The curia landing page**").
 - A map named in prose resolves to that map's header, never to repo-wide order: "continue with <map>" means \`start\` the FIRST ticket listed under that map's header. A repo can hold several maps — picking the repo's first takeable when the operator named a map dispatches the wrong ticket.
 - When a phrase names no repo or map you know, call \`tickets\` with no filter and match the phrase against the headers that come back before saying you cannot.
-- Two verbs take a map's own number, and they mean different things. \`start\` WORKS the map: it dispatches the map's next takeable ticket. \`map\` UPDATES the map: a charting agent edits the map itself.
-- Use \`map\` when the operator asks to CHANGE a map ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words. Do not rewrite it and do not summarize it.
+- Two verbs take a map's own number, and they mean different things. \`start\` WORKS the map: it dispatches the map's next takeable ticket. \`map_update\` UPDATES the map: a charting agent edits the map itself.
+- Use \`map_update\` when the operator asks to CHANGE a map that already exists ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words. Do not rewrite it and do not summarize it.
 - Use \`start\` when the operator asks to work the map ("continue with <map>", "start the landing page map"). Either the map's own number or the ticket number listed under its header does this.
-- Use \`map\` with NO ticket when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". There is no number to give, and asking them for one is wrong — the whole point is that the map does not exist. Put their words in \`instruction\`, unchanged: it is the whole brief the charting agent settles the destination from. Add \`repo\` only when more than one repo is watched.
-- The test between the two shapes is whether the map EXISTS. A map you can name from \`tickets\` output takes its number. A map the operator is asking you to bring into being takes no number.
+- Use \`map_new\` when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". The tool takes no number, so do not ask the operator for one. Put their words in \`instruction\`, unchanged: it is the whole brief the charting agent settles the destination from. Add \`repo\` only when more than one repo is watched.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run \`tickets\` or \`status\` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/src/overseerturn.mjs
+++ b/daemon/src/overseerturn.mjs
@@ -14,7 +14,7 @@
 //
 // WHY THE VERBS TAKE THE MCP SIDE CHANNEL. See `overseerverbs.mjs`: a route
 // that took canonical text would hand the container the whole router, and a
-// tool call hands it eight verbs with validated arguments. The daemon composes
+// tool call hands it the verb catalogue with validated arguments. The daemon composes
 // the canonical text on its own side, so `/command` still receives text the
 // daemon wrote. Every effect crosses that seam, the daemon executes it, and the
 // ✅/❌ confirm on `cancel` survives untouched.
@@ -62,7 +62,7 @@ export const OVERSEER_MCP_PATH = '/overseer/mcp'
 export const MCP_SERVER_NAME = 'curia'
 
 // Sonnet 5, as ADR-0014 decides. Haiku answered the in-daemon host's mapping
-// from prose to eight verbs, and this posture reads code and diffs.
+// from prose to the verbs, and this posture reads code and diffs.
 export const OVERSEER_CONTAINER_MODEL = 'claude-sonnet-5'
 
 // The in-daemon host capped a turn at 12 assistant turns, and that was sized

--- a/daemon/src/overseerverbs.mjs
+++ b/daemon/src/overseerverbs.mjs
@@ -1,11 +1,11 @@
-// The overseer's eight verbs, one catalogue (#314).
+// The overseer's verb catalogue (#314), nine tools since #692.
 //
 // The catalogue moved out of `overseer.mjs` for the reason the standing orders
 // moved into `overseerprompt.mjs`: it outlives that file. The in-daemon host
 // serves these verbs as an IN-PROCESS SDK server, because the model runs in the
 // daemon. The container cannot, because the model is on the other side of the
-// boundary, so the daemon serves the same eight over HTTP MCP and the container
-// connects to them as a client (#314). #315 deletes the in-process adapter and
+// boundary, so the daemon serves the same catalogue over HTTP MCP and the
+// container connects to it as a client (#314). #315 deletes the in-process adapter and
 // this catalogue stays.
 //
 // WHY THE MODEL REACHES THE SEAM THROUGH MCP RATHER THAN POSTING TEXT. The
@@ -14,13 +14,15 @@
 // because the seam parses text and the router knows verbs no tool here names —
 // `deploy`, `restart`, everything a slash verb can say. A tool call cannot. The
 // daemon composes the canonical text itself, from arguments the MCP layer has
-// validated against the schemas below, so the container reaches these eight
-// verbs and nothing else. The transport is the containment, which is what makes
+// validated against the schemas below, so the container reaches these verbs
+// and nothing else. The transport is the containment, which is what makes
 // it worth the extra hop.
 //
 // `canonicalFor` is the whole tool → router contract, and it is pure: one
-// string builder rather than eight inline template literals, so the mapping is
-// testable with no model and no transport in the loop.
+// string builder rather than a template literal inline in every tool, so the
+// mapping is testable with no model and no transport in the loop. #692 pins it
+// against `parseCommand` with a generated case for every verb and every
+// combination of its optional arguments.
 
 import { z } from 'zod'
 
@@ -35,13 +37,28 @@ export function canonicalFor(verb, args = {}) {
     // instruction: `start` no longer charts, so it carries no sentence.
     case 'start':
       return `start ${args.repo ? `${args.repo}#` : ''}${args.ticket}${args.model ? ` model=${args.model}` : ''}`
-    case 'map': {
+    // #692, ADR-0022: two tools, one router verb. `map_update` requires the map
+    // number and `map_new` has no number field at all, so the shape the model
+    // could get wrong is now the shape it cannot call. Both compose `map`, so
+    // the router and the slash surface never learn that the tool split.
+    //
+    // The legacy `map` name still composes, because `canonicalFor` is a pure
+    // string builder that other callers reach for, and the shape it picks is
+    // the one the arguments name: a ticket means an update.
+    case 'map':
+    case 'map_update':
+    case 'map_new': {
+      // A ticket handed to `map_new` is DROPPED rather than composed, the way
+      // a hallucinated `harness=` is dropped on `start`. The new-map shape has
+      // no number to carry, and a number smuggled through the wrong tool would
+      // compose an update the operator never asked for.
+      const ticket = verb === 'map_new' ? null : args.ticket
       // #241: with no map number this is the NEW-map shape, where the repo is a
       // bare token rather than the `repo#n` qualifier — there is no `n` to
       // qualify. The instruction is mandatory there, and a call that omits it
       // composes a bare `map`, which the router refuses by naming both shapes.
-      let text = args.ticket
-        ? `map ${args.repo ? `${args.repo}#` : ''}${args.ticket}`
+      let text = ticket
+        ? `map ${args.repo ? `${args.repo}#` : ''}${ticket}`
         : `map${args.repo ? ` ${args.repo}` : ''}`
       if (args.model) text += ` model=${args.model}`
       // The instruction (#160, moved here by #221) rides LAST, because it is
@@ -105,16 +122,33 @@ export const VERB_SPECS = [
     description: 'Claim a ticket and dispatch an agent to WORK it. Use the repo field when the ticket number alone is ambiguous. Given a MAP number, this dispatches that map\'s next takeable ticket — it does NOT update the map; the map tool does that.',
     args: { ticket: ticketArg, repo: repoArg, model: modelArg },
   },
+  // #692, ADR-0022: the map tool is two tools. The exists-test used to be prose
+  // in the standing orders ("the test between the two shapes is whether the map
+  // EXISTS"), and prose is what an A-class incident argues with. It is a schema
+  // now: `map_update` cannot be called without a number, and `map_new` has no
+  // number field to fill in. Both compose the `map` router verb, so the router,
+  // the slash surface and the operator's usage catalogue don't change.
+  //
+  // The header-resolution rule stays prose in `overseerprompt.mjs`, because
+  // deciding which map the operator's phrase names needs the model's judgment.
   {
-    verb: 'map',
-    description: 'Dispatch a charting agent. WITH a map number it UPDATES that map: add tickets, graduate fog, change scope, fix what the map says. WITHOUT one it charts a NEW map: the agent settles the destination and the scope with the operator, then creates the `wayfinder:map` issue itself — use that form when the operator asks for a map that does not exist yet ("make a map for the next feature"), and put their words in the instruction. It never closes the map either way, and the only tickets it closes are the research ones it burned down itself.',
+    verb: 'map_update',
+    description: 'Dispatch a charting agent to UPDATE an EXISTING map, by its own issue number: add tickets, graduate fog, change scope, fix what the map says. It never closes the map, and the only tickets it closes are the research ones it burned down itself. To chart a map that does not exist yet, use map_new.',
     args: {
-      ticket: ticketArg.optional(),
-      // #255: with a map number the repo is any unambiguous part of the name,
-      // as everywhere else. With NO number the repo rides in front of a plain
-      // sentence, so only the repo's OWN name is read as one.
-      repo: z.string().optional().describe('repo qualifier — any unambiguous part of a watched repo name, but with no map number it must be the repo\'s own name'),
-      instruction: z.string().optional().describe('What the operator wants, in their own words. On an existing map: what should change ("update the landing page map so that X") — leave it out and the agent asks. On a NEW map it is REQUIRED: it is the whole brief the agent chooses a destination from.'),
+      ticket: ticketArg.describe('the EXISTING map\'s issue number, digits only — never a sentence'),
+      repo: repoArg,
+      instruction: z.string().optional().describe('What should change, in the operator\'s own words ("update the landing page map so that X"). Leave it out and the agent asks.'),
+      model: modelArg,
+    },
+  },
+  {
+    verb: 'map_new',
+    description: 'Dispatch a charting agent to chart a NEW map from the operator\'s brief. The agent settles the destination and the scope with the operator, then creates the `wayfinder:map` issue itself. Use this when the operator asks for a map that does not exist yet ("make a map for the next feature"). There is no map number, so do not ask for one. To change a map that already exists, use map_update.',
+    args: {
+      // #255: with no map number the repo rides in front of a plain sentence,
+      // so only the repo's OWN name is read as one.
+      repo: z.string().optional().describe('repo qualifier — with no map number it must be the repo\'s own name. Add it only when more than one repo is watched.'),
+      instruction: z.string().describe('The whole brief, in the operator\'s own words. It is what the agent chooses a destination and a scope from, so pass their sentence unchanged.'),
       model: modelArg,
     },
   },

--- a/daemon/test/fixtures/overseer-prompt-no-shell.txt
+++ b/daemon/test/fixtures/overseer-prompt-no-shell.txt
@@ -3,19 +3,23 @@ You are the curia overseer. Curia is a personal orchestration daemon: it watches
 You speak with one operator, in one Discord thread, in short Discord markdown. You act only through the curia tools. The daemon executes every effect.
 
 What you do:
-- Translate the operator's prose into the verbs: tickets, next, status, start, map, cancel, resume, attach.
+- Translate the operator's prose into the verbs: tickets, next, status, start, map_update, map_new, cancel, resume, attach.
 - Answer reasoning questions from tool output ("what should I start next?" — call tickets, then recommend one, with a one-line reason).
 - Report tool replies faithfully. Do not invent agents, tickets, or states.
+
+What a tool reply is, and what it is not:
+- Copy every id. Take each ticket, map, and session id character by character from a tool reply of THIS turn. Never retype one from memory, and never carry one over from an earlier turn. A wrong digit names another ticket.
+- An id you cannot find in this turn's tool replies is one you do not have. Call `tickets` or `status` and read it there.
+- Quote every refusal. When the daemon refuses a line your tool call composed, repeat the refusal word for word, then say what you will do next. Do not paraphrase it, and do not name a cause the refusal did not name. "Ticket 91 does not exist" is a cause you invented if the refusal said something else.
 
 Vocabulary the operator uses:
 - A "map" is a wayfinder map: a GitHub issue whose child tickets chart one effort. The operator names maps by topic ("the landing page map"). The `tickets` output groups tickets under their map's header line ("map #109 **The curia landing page**").
 - A map named in prose resolves to that map's header, never to repo-wide order: "continue with <map>" means `start` the FIRST ticket listed under that map's header. A repo can hold several maps — picking the repo's first takeable when the operator named a map dispatches the wrong ticket.
 - When a phrase names no repo or map you know, call `tickets` with no filter and match the phrase against the headers that come back before saying you cannot.
-- Two verbs take a map's own number, and they mean different things. `start` WORKS the map: it dispatches the map's next takeable ticket. `map` UPDATES the map: a charting agent edits the map itself.
-- Use `map` when the operator asks to CHANGE a map ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the `instruction` field, in their own words. Do not rewrite it and do not summarize it.
+- Two verbs take a map's own number, and they mean different things. `start` WORKS the map: it dispatches the map's next takeable ticket. `map_update` UPDATES the map: a charting agent edits the map itself.
+- Use `map_update` when the operator asks to CHANGE a map that already exists ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the `instruction` field, in their own words. Do not rewrite it and do not summarize it.
 - Use `start` when the operator asks to work the map ("continue with <map>", "start the landing page map"). Either the map's own number or the ticket number listed under its header does this.
-- Use `map` with NO ticket when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". There is no number to give, and asking them for one is wrong — the whole point is that the map does not exist. Put their words in `instruction`, unchanged: it is the whole brief the charting agent settles the destination from. Add `repo` only when more than one repo is watched.
-- The test between the two shapes is whether the map EXISTS. A map you can name from `tickets` output takes its number. A map the operator is asking you to bring into being takes no number.
+- Use `map_new` when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". The tool takes no number, so do not ask the operator for one. Put their words in `instruction`, unchanged: it is the whole brief the charting agent settles the destination from. Add `repo` only when more than one repo is watched.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run `tickets` or `status` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/test/overseerprompt.test.mjs
+++ b/daemon/test/overseerprompt.test.mjs
@@ -31,10 +31,11 @@ describe('the standing orders, with no shell (#328)', () => {
   // than a prompt. The fixture was taken from the shipped code BEFORE the move,
   // and it stays the record of what the no-shell posture says.
   //
-  // ONE BLOCK HAS MOVED SINCE, deliberately: the writing rules, when #133's
-  // voice went from Simplified Technical English to the Google developer
-  // documentation style. The fixture was regenerated for that and nothing
-  // else, so every other line is still the pre-move text.
+  // TWO CHANGES HAVE LANDED SINCE, both deliberate. First the writing rules,
+  // when #133's voice went from Simplified Technical English to the Google
+  // developer documentation style. Then #692 (ADR-0022) added the tool-reply
+  // section and split the map verb in two. The fixture was regenerated for
+  // each, and for nothing else.
   test('it is byte for byte the text the in-daemon host always sent', () => {
     assert.equal(`${buildSystemPrompt()}\n`, fs.readFileSync(FIXTURE, 'utf8'))
   })
@@ -243,5 +244,39 @@ describe('the tool list agrees with the text (#328)', () => {
   test('the lists are copies, so a caller cannot edit the next caller list', () => {
     toolsFor().allowed.push('Bash')
     assert.ok(!ALLOWED_TOOLS.includes('Bash'))
+  })
+})
+
+// The two standing orders #692 added, from ADR-0022. Both come from measured
+// incidents, and both are prompt tests for the reason the new-map phrase test
+// is one: a rule the text does not carry is a rule the model never follows.
+describe('what a tool reply is, and what it is not (#692, ADR-0022)', () => {
+  // The overseer paraphrased a router refusal into "Ticket 91 does not exist",
+  // a cause the refusal never named. The refusal is the daemon's own words
+  // about the daemon's own state, and the model repeats them.
+  test('a refusal is quoted word for word, and its cause is never invented', () => {
+    for (const text of [SYSTEM_PROMPT, shellPrompt()]) {
+      assert.match(text, /Quote every refusal/)
+      assert.match(text, /word for word/)
+      assert.match(text, /do not name a cause the refusal did not name/)
+    }
+  })
+
+  // The overseer retyped the ids in a `tickets` summary and named other
+  // tickets. Every id it says has to come from a tool reply of THIS turn.
+  test('ids are copied from this turn\'s tool replies, never retyped', () => {
+    for (const text of [SYSTEM_PROMPT, shellPrompt()]) {
+      assert.match(text, /Copy every id/)
+      assert.match(text, /character by character/)
+      assert.match(text, /Never retype one from memory/)
+    }
+  })
+
+  // The order sits in front of the vocabulary and the never-list, because it
+  // governs every answer the model writes rather than one verb.
+  test('the order comes before the vocabulary the verbs are chosen with', () => {
+    assert.ok(
+      SYSTEM_PROMPT.indexOf('Copy every id') < SYSTEM_PROMPT.indexOf('Vocabulary the operator uses:'),
+    )
   })
 })

--- a/daemon/test/overseerturn.test.mjs
+++ b/daemon/test/overseerturn.test.mjs
@@ -114,8 +114,11 @@ function storeDouble({ sessions = {}, notes = [], conversations = ['console-1'] 
 }
 
 describe('the verb catalogue serves both transports (#314)', () => {
-  test('one catalogue, eight verbs, in one order', () => {
-    assert.deepEqual(VERB_TOOLS, ['tickets', 'next', 'status', 'start', 'map', 'cancel', 'resume', 'attach'])
+  // #692 (ADR-0022) made the map tool two tools, so the catalogue is nine.
+  // Both compose the one `map` router verb, which is why the grammar, the slash
+  // surface and the operator's usage catalogue stayed where they were.
+  test('one catalogue, nine verbs, in one order', () => {
+    assert.deepEqual(VERB_TOOLS, ['tickets', 'next', 'status', 'start', 'map_update', 'map_new', 'cancel', 'resume', 'attach'])
     for (const spec of VERB_SPECS) {
       assert.ok(spec.description.length > 40, `${spec.verb} needs a description the model can act on`)
       assert.equal(typeof spec.args, 'object')
@@ -126,7 +129,7 @@ describe('the verb catalogue serves both transports (#314)', () => {
     assert.equal(canonicalFor('start', { ticket: '314', repo: 'curia' }), 'start curia#314')
   })
 
-  test('the HTTP transport publishes the same eight, with the same schemas', async () => {
+  test('the HTTP transport publishes the same nine, with the same schemas', async () => {
     const posted = []
     const mcp = buildVerbMcpServer(async (text) => { posted.push(text); return `ran ${text}` })
     const client = new Client({ name: 'test', version: '0' })

--- a/daemon/test/overseerverbs.test.mjs
+++ b/daemon/test/overseerverbs.test.mjs
@@ -6,8 +6,8 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseCommand } from '../src/commands.mjs'
-import { canonicalFor, verbHandlers } from '../src/overseerverbs.mjs'
+import { parseCommand, newMapPlan } from '../src/commands.mjs'
+import { canonicalFor, verbHandlers, VERB_SPECS, VERB_TOOLS } from '../src/overseerverbs.mjs'
 import { buildSystemPrompt, ALLOWED_TOOLS } from '../src/overseerprompt.mjs'
 
 // The posture that runs since the cutover (#315): the container holds a shell.
@@ -143,5 +143,172 @@ describe('verbHandlers', () => {
     const handlers = verbHandlers(async () => { throw new Error('daemon answered 500') })
     const status = handlers.find((h) => h.verb === 'status')
     await assert.rejects(() => status.handler({}), /daemon answered 500/)
+  })
+})
+
+// ---- the round trip (#692, ADR-0022) ----------------------------------------
+//
+// The A-class incidents behind ADR-0022 came from hand-maintained agreement:
+// `canonicalFor` and `parseCommand` are two halves of one seam, and only `map`
+// and `start` had spot checks. This suite GENERATES a case for every verb in
+// the catalogue and every combination of its optional arguments, composes each
+// one, parses the text back, and asserts the verb and the fields survived.
+//
+// A verb added to the catalogue with no sample here fails the coverage test
+// rather than going untested, and a field added to a verb fails the same way.
+describe('the command round trip, generated (#692)', () => {
+  // One watched repo, so the new-map shape's repo ruling has a sole repo to
+  // fall back to. `newMapPlan` is that ruling, and the test calls it for the
+  // same reason the router does: the parser marks a candidate word and only
+  // the watch list says whether it names a repo.
+  const WATCHED = ['alp82/curia']
+
+  // One sample per field name. The values are deliberately awkward: the repo
+  // is the slashed form the ambiguity refusals recommend, and the instruction
+  // carries a retired `--` inside it, which is the token #255 stopped writing
+  // and never stopped reading.
+  const SAMPLE = {
+    ticket: '147',
+    repo: 'alp82/curia',
+    model: 'opus',
+    instruction: 'chart the fog -- all of it',
+  }
+
+  // The verbs whose ticket field also takes "all". Both shapes are a separate
+  // case, because `all` names every agent and the composition drops arguments
+  // around it.
+  const BULK = { cancel: ['147', 'all'], resume: ['147', 'all'] }
+
+  const subsets = (keys) => keys.reduce(
+    (acc, k) => [...acc, ...acc.map((s) => [...s, k])],
+    [[]],
+  )
+
+  // What the seam DELIBERATELY drops on the way out. A drop is not a round-trip
+  // failure: it is the catalogue refusing to compose text the router would
+  // refuse, and it belongs in the expectation rather than in an exception.
+  const dropped = (verb, args) => {
+    // #177: `resume all` takes no model. One model over every surviving
+    // worktree would overwrite each ticket's own inherited model.
+    if (verb === 'resume' && args.ticket === 'all') return ['model']
+    return []
+  }
+
+  const cases = []
+  for (const spec of VERB_SPECS) {
+    const keys = Object.keys(spec.args)
+    const optional = keys.filter((k) => spec.args[k].isOptional())
+    const required = keys.filter((k) => !optional.includes(k))
+    for (const k of keys) {
+      assert.ok(k in SAMPLE, `the round trip has no sample value for \`${spec.verb}.${k}\``)
+    }
+    const tickets = BULK[spec.verb] ?? [SAMPLE.ticket]
+    for (const ticket of tickets) {
+      for (const chosen of subsets(optional)) {
+        const args = {}
+        for (const k of required) args[k] = k === 'ticket' ? ticket : SAMPLE[k]
+        for (const k of chosen) args[k] = k === 'ticket' ? ticket : SAMPLE[k]
+        cases.push({ verb: spec.verb, args })
+      }
+    }
+  }
+
+  test('every verb in the catalogue gets generated cases', () => {
+    assert.deepEqual([...new Set(cases.map((c) => c.verb))], [...VERB_TOOLS])
+    // The count is stated so a silently emptied powerset cannot pass as
+    // coverage: 9 verbs, 28 argument combinations.
+    assert.equal(cases.length, 28)
+  })
+
+  for (const { verb, args } of cases) {
+    const label = `${verb}(${Object.entries(args).map(([k, v]) => `${k}=${v}`).join(', ') || 'no arguments'})`
+    test(`${label} composes and parses back`, () => {
+      const text = canonicalFor(verb, args)
+      const cmd = parseCommand(text)
+      assert.ok(cmd, `\`${text}\` is text the router refuses`)
+
+      // The router verb. Both map tools compose the one `map` verb, which is
+      // the whole point of splitting the tool rather than the grammar.
+      const routerVerb = verb.startsWith('map') ? 'map' : verb
+      assert.equal(cmd.verb, routerVerb)
+
+      // The new-map shape hands its repo ruling to the router, so the fields
+      // are read after that ruling rather than off the raw parse.
+      const isNewMap = routerVerb === 'map' && !cmd.ticket
+      const plan = isNewMap ? newMapPlan(cmd, WATCHED) : null
+      assert.ok(!plan?.error, `the new-map ruling refused \`${text}\`: ${plan?.error}`)
+
+      const got = {
+        ticket: cmd.all ? 'all' : cmd.ticket,
+        repo: plan ? plan.repo : (cmd.repo ?? cmd.repoArg),
+        model: cmd.model,
+        instruction: plan ? plan.instruction : cmd.instruction,
+      }
+      const gone = dropped(verb, args)
+      for (const field of ['ticket', 'repo', 'model', 'instruction']) {
+        // `map_new` composes no number, so the ticket field is absent by
+        // design and the powerset never offers it one.
+        const want = gone.includes(field) ? undefined : args[field]
+        // The new-map shape with no repo named falls back to the sole watched
+        // repo, and that fallback is the router's answer, not a lost field.
+        if (field === 'repo' && isNewMap && want === undefined) {
+          assert.equal(got.repo, WATCHED[0])
+          continue
+        }
+        assert.equal(got[field], want, `\`${text}\` lost or changed \`${field}\``)
+      }
+    })
+  }
+})
+
+// ---- the map tool is two tools (#692, ADR-0022) -----------------------------
+//
+// The exists-test used to be prose in the standing orders: "the test between
+// the two shapes is whether the map EXISTS". A model argued with that prose and
+// called the update shape for a map that did not exist yet. It is a schema now,
+// so the wrong shape is not a call the model can make.
+describe('the map tool is two tools (#692)', () => {
+  const spec = (verb) => VERB_SPECS.find((s) => s.verb === verb)
+
+  test('map_update requires a map number, and map_new has no number field', () => {
+    assert.ok(!spec('map_update').args.ticket.isOptional(), 'map_update can be called with no map')
+    assert.ok(!('ticket' in spec('map_new').args), 'map_new publishes a number field to fill in')
+  })
+
+  test('map_new requires the brief, because there is nothing to ask about', () => {
+    assert.ok(!spec('map_new').args.instruction.isOptional())
+    // On an existing map a missing sentence has a safe meaning: the agent asks
+    // what should change. That asymmetry is deliberate (#241).
+    assert.ok(spec('map_update').args.instruction.isOptional())
+  })
+
+  test('both tools compose the one map router verb', () => {
+    assert.equal(
+      canonicalFor('map_update', { ticket: '147', instruction: 'add a ticket' }),
+      'map 147 add a ticket',
+    )
+    assert.equal(
+      canonicalFor('map_new', { repo: 'alp82/curia', instruction: 'chart the next feature' }),
+      'map alp82/curia chart the next feature',
+    )
+    for (const text of ['map 147 add a ticket', 'map alp82/curia chart the next feature']) {
+      assert.equal(parseCommand(text).verb, 'map')
+    }
+  })
+
+  // A number smuggled through the new-map tool is DROPPED rather than composed,
+  // the same treatment a hallucinated `harness=` gets on `start`. Composing it
+  // would update a map the operator never named.
+  test('a ticket handed to map_new is dropped, never composed into the text', () => {
+    assert.equal(
+      canonicalFor('map_new', { ticket: '147', instruction: 'chart the next feature' }),
+      'map chart the next feature',
+    )
+  })
+
+  test('the standing orders name both tools and neither the retired one', () => {
+    assert.match(PROMPT, /map_update/)
+    assert.match(PROMPT, /map_new/)
+    assert.ok(!/`map`/.test(PROMPT), 'the standing orders still name a `map` tool that no longer exists')
   })
 })

--- a/daemon/test/typedcommand.test.mjs
+++ b/daemon/test/typedcommand.test.mjs
@@ -1,0 +1,114 @@
+// The typed verb runs BEFORE a model turn (#692, ADR-0022).
+//
+// A top-level line in #curia used to be prose by definition: it opened a
+// thread, started a session, and the model then composed the same verb the
+// operator had already typed. The reference incident is three `status` lines in
+// four minutes, which cost three threads named "status" and three model
+// sessions to answer a question the router answers for free.
+//
+// The rule is the whole line. When `parseCommand` accepts the trimmed message,
+// it is a command; anything else is prose, and prose still opens a conversation.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { DiscordBridge } from '../src/bridge.mjs'
+
+// One #curia channel, one operator, and a record of everything the bridge did
+// with the message. `overseerTurn` records the calls it should never receive.
+function harness() {
+  const sent = []
+  const commands = []
+  const turns = []
+  const threads = []
+  const bridge = new DiscordBridge({
+    token: 'x',
+    allowedUsers: ['operator'],
+    dataDir: '/tmp',
+    handlers: {
+      command: async (text, userId, opts) => {
+        commands.push({ text, userId, opts })
+        return `⚙️ ran ${text}`
+      },
+      overseerTurn: async (threadId, prompt) => { turns.push({ threadId, prompt }) },
+      findOpenForThread: () => null,
+    },
+    log: () => {},
+  })
+  bridge.channel = { id: 'curia-channel' }
+
+  const message = (content) => ({
+    author: { bot: false, id: 'operator' },
+    channel: {
+      id: 'curia-channel',
+      send: async (payload) => { sent.push(payload); return { id: 'sent-1' } },
+    },
+    content,
+    startThread: async ({ name }) => {
+      threads.push(name)
+      return { id: 'thread-1', sendTyping: async () => {}, send: async () => ({ id: 'm' }) }
+    },
+  })
+
+  return { bridge, message, sent, commands, turns, threads }
+}
+
+describe('a fully parsed top-level command runs without a conversation (#692)', () => {
+  test('a typed verb reaches the router, and no thread and no session open', async () => {
+    const h = harness()
+    await h.bridge.handleMessage(h.message('status'))
+
+    assert.deepEqual(h.commands.map((c) => c.text), ['status'])
+    assert.equal(h.commands[0].userId, 'operator')
+    assert.deepEqual(h.turns, [], 'a typed verb opened an overseer session')
+    assert.deepEqual(h.threads, [], 'a typed verb opened a thread')
+    assert.deepEqual(h.sent.map((p) => p.content), ['⚙️ ran status'])
+  })
+
+  // The router's own reply is the answer. The operator sees it in #curia, where
+  // they typed the command, with no thread between them and it.
+  test('the router reply lands in the channel the command was typed in', async () => {
+    const h = harness()
+    await h.bridge.handleMessage(h.message('  tickets alp82/curia  '))
+
+    assert.deepEqual(h.commands.map((c) => c.text), ['tickets alp82/curia'])
+    assert.deepEqual(h.sent.map((p) => p.content), ['⚙️ ran tickets alp82/curia'])
+  })
+
+  // A top-level command carries no thread, the way a top-level slash command
+  // carries none. There is nothing for `start` to bind.
+  test('a typed verb binds no thread', async () => {
+    const h = harness()
+    await h.bridge.handleMessage(h.message('start 147'))
+    assert.deepEqual(h.commands[0].opts, { threadId: null })
+  })
+
+  // The whole line has to parse. A line that STARTS with a verb and goes on in
+  // prose is a question, and a question is what the overseer is for.
+  test('prose that starts with a verb still opens a conversation', async () => {
+    const h = harness()
+    await h.bridge.handleMessage(h.message('status of the landing page map?'))
+
+    assert.deepEqual(h.commands, [], 'prose reached the router')
+    assert.deepEqual(h.turns.map((t) => t.prompt), ['status of the landing page map?'])
+    assert.deepEqual(h.threads, ['status of the landing page map?'])
+  })
+
+  test('a line the parser refuses is prose, not a refusal', async () => {
+    const h = harness()
+    await h.bridge.handleMessage(h.message('map'))
+
+    assert.deepEqual(h.commands, [])
+    assert.deepEqual(h.turns.length, 1)
+  })
+
+  // Both map shapes are typed commands, so the operator's shortest route to a
+  // charting agent needs no model in it either.
+  test('both map shapes run typed', async () => {
+    for (const line of ['map 147 add a ticket for the sidecar', 'map curia chart the next feature']) {
+      const h = harness()
+      await h.bridge.handleMessage(h.message(line))
+      assert.deepEqual(h.commands.map((c) => c.text), [line], `\`${line}\` did not run typed`)
+      assert.deepEqual(h.turns, [])
+    }
+  })
+})


### PR DESCRIPTION
Closes part of the Atlas map: implements [alp82/curia#692](https://github.com/alp82/curia/issues/692), on map [#685](https://github.com/alp82/curia/issues/685), spec [#684](https://github.com/alp82/curia/issues/684).

[ADR-0022](https://github.com/alp82/curia/blob/main/docs/adr/0022-the-overseers-command-understanding.md) named four decisions that never landed in code. This branch lands them.

## A typed verb runs before a model turn

A top-level line in the command channel goes through `parseCommand` first. When the whole trimmed line parses, it runs on the router: no thread, no overseer session, and no model paraphrase of an answer the router already had. The reference incident is three `status` lines in four minutes, which cost three threads named "status" and three sessions.

The rule is the whole line. Prose still opens a conversation, and so does a line that only starts with a verb ("status of the landing page map?").

## The round trip is generated

`canonicalFor` and `parseCommand` are two halves of one seam, and only `map` and `start` had spot checks. A generated suite now composes a case for every verb in the catalogue and every combination of its optional arguments, 28 in all, parses each one back, and asserts the verb and the fields survived. A verb or a field added to the catalogue with no sample fails the coverage test rather than going untested.

Two deliberate drops are expectations rather than exceptions: `resume all` drops a model override, and `map_new` drops a ticket number.

## The map tool is two tools

`map_update` requires an existing map's number. `map_new` has no number field at all and requires the operator's brief. Both compose the same `map` router text, so the grammar, the slash surface and the operator's usage catalogue don't change. The test of which shape to use moved from prompt prose into the schemas, so the wrong shape is not a call the model can make. The header-resolution rule stays prose, because it needs the model's judgment.

## The standing orders gain two rules

A refusal is quoted word for word, and the overseer never names a cause the refusal did not name. Every ticket, map, and session id is copied character by character from a tool reply of this turn, never retyped from memory.

## Also here

`newMapPlan` is the new-map repo ruling, lifted out of `CommandRouter` as a pure function that takes the watch list. The round trip needs it: the parser marks a candidate word and only the watch list says whether that word names a repo.

`CONTEXT.md` gains **Typed command** and **The map tools**.

## Testing

`npm test` in `daemon/`: 3211 pass, 0 fail, 0 cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
