### PR TITLE
Convert and adopt a GitHub App manifest (alp82/curia#694)

### DIFF
--- a/daemon/src/appsetup.mjs
+++ b/daemon/src/appsetup.mjs
@@ -1,0 +1,319 @@
+// Creating curia's GitHub App from Atlas (#694, building the spec at #684).
+//
+// docs/github-app.md is a seven-step checklist a human does by hand, and every
+// step of it is a place to get one field wrong. GitHub's app-manifest flow
+// replaces the first three: curia states the app it wants as JSON, the operator
+// presses one button on github.com, and GitHub hands back a temporary code that
+// converts ONCE into the app id, the slug and the private key.
+//
+// WHAT THIS MODULE OWNS is the daemon's half of that flow, and the reason the
+// daemon owns it at all is the key. The conversion response carries curia's one
+// durable secret in its body. The sidecar holds no secret (#263) and a browser
+// must hold this one least of all — so the browser carries the manifest TO
+// GitHub and carries `code` and `state` BACK, and the conversion itself happens
+// here, on the daemon, where the key can go straight to a 0600 file.
+//
+//   browser ── manifest form ──> github.com
+//   github.com ── ?code&state ──> sidecar ──> daemon POST /app/convert
+//   daemon ── POST /app-manifests/<code>/conversions ──> GitHub
+//   daemon ── writes .curia-app.pem + two env keys ──> adopts in process
+//
+// THE STATE IS THE WHOLE GATE. A conversion code arrives on a plain redirect,
+// which anything can forge, so the daemon mints the state that goes out with
+// the manifest and refuses any code that comes back without one it minted. A
+// state is single use and short lived, which is what makes the replay of a
+// captured redirect a refusal rather than a second conversion.
+//
+// ADOPTION IS IN PROCESS. Writing the key and the env keys alone would leave a
+// running daemon with no app until its next restart, and the restart is the
+// step this ticket exists to delete. So a stored key is handed to the caller's
+// `adopt`, which rewires the live minter.
+
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  APP_ID_KEY, APP_KEY_FILE_KEY, DEFAULT_KEY_FILE, TokenMinter,
+} from './githubapp.mjs'
+
+// ---- the manifest ----------------------------------------------------------
+
+// The five repository permissions of docs/github-app.md step 2, and nothing
+// else. The write set the agents mint (contents, issues, pull requests) plus the
+// two the overseer reads through (commit statuses, metadata), because a minted
+// token may scope DOWN from the installation and never up: an app created
+// without `statuses` would 422 the first read token the overseer asked for.
+//
+// WORKFLOWS IS DELIBERATELY ABSENT, for the reason githubapp.mjs states at
+// WRITE_PERMISSIONS: an app that can write `.github/workflows/` is a path from
+// a ticket's text to whatever secrets the next CI run holds.
+export const MANIFEST_PERMISSIONS = Object.freeze({
+  contents: 'write',
+  issues: 'write',
+  pull_requests: 'write',
+  statuses: 'read',
+  metadata: 'read',
+})
+
+// Curia polls. It listens for no webhook, so it subscribes to no event — and an
+// app with no events needs no webhook endpoint to be reachable from GitHub at
+// all. `active: false` is how the manifest says that; the url is required
+// alongside it and is never called.
+export const MANIFEST_EVENTS = Object.freeze([])
+
+export const HOMEPAGE_URL = 'https://github.com/alp82/curia'
+
+// Where the browser posts the manifest. `?state=` is appended by the caller.
+export const MANIFEST_ACTION = 'https://github.com/settings/apps/new'
+
+// The app must be installable on an ORGANIZATION as well as on the operator's
+// own user, which is what `public: true` buys — docs/github-app.md step 1 says
+// why: "Only on this account" leaves an org off the Install App page entirely.
+export function buildManifest({ name, redirectUrl }) {
+  const appName = String(name ?? '').trim()
+  if (!appName) throw refuse('a GitHub App needs a name, and it must be free across the whole of GitHub')
+  const redirect = String(redirectUrl ?? '').trim()
+  if (!/^https:\/\/[^\s"']+$/.test(redirect)) {
+    throw refuse(`"${redirect}" is not an https redirect url — GitHub sends the conversion code back to it`)
+  }
+  return {
+    name: appName,
+    url: HOMEPAGE_URL,
+    redirect_url: redirect,
+    public: true,
+    default_permissions: { ...MANIFEST_PERMISSIONS },
+    default_events: [...MANIFEST_EVENTS],
+    hook_attributes: { url: HOMEPAGE_URL, active: false },
+  }
+}
+
+// ---- the env file ----------------------------------------------------------
+
+// `daemon/.env.daemon` holds the Discord token beside these two keys, so the
+// write is an UPSERT of two lines rather than a rewrite of the file: a setup
+// run that dropped the bot token would take the box off Discord.
+//
+// Pure, so the one thing worth pinning — that every other line survives, in
+// order — is pinned without a filesystem.
+export function upsertEnv(text, entries) {
+  const lines = String(text ?? '').split('\n')
+  const left = new Map(Object.entries(entries))
+  const out = lines.map((line) => {
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line)
+    if (!m || !left.has(m[1])) return line
+    const key = m[1]
+    const value = left.get(key)
+    left.delete(key)
+    return `${key}=${value}`
+  })
+  while (out.length && out[out.length - 1].trim() === '') out.pop()
+  for (const [key, value] of left) out.push(`${key}=${value}`)
+  return `${out.join('\n')}\n`
+}
+
+// ---- refusals --------------------------------------------------------------
+
+// The sidecar's own vocabulary (#265): a refusal is something the operator can
+// see and fix, and it answers 409 rather than reading as this process failing.
+const refuse = (msg) => Object.assign(new Error(msg), { refusal: true })
+
+// What a browser may send back. The code is GitHub's, and it is composed into a
+// URL here, so its shape is named rather than trusted.
+export const CODE_RE = /^[A-Za-z0-9_-]{1,255}$/
+export const STATE_RE = /^[0-9a-f]{64}$/
+
+// ---- the flow --------------------------------------------------------------
+
+const API = 'https://api.github.com'
+const API_VERSION = '2022-11-28'
+const CONVERT_TIMEOUT_MS = 20_000
+
+// How long a started setup stays convertible. The operator's own trip through
+// github.com — name the app, press create, press install — is minutes, and a
+// state that outlived the tab it was minted for is a forged redirect's window.
+export const STATE_TTL_MS = 30 * 60 * 1000
+
+// How many starts are remembered at once. A person presses the button twice
+// when the first tab got lost; nobody presses it eight times, and an unbounded
+// map is a way for a refused-but-admitted caller to grow the daemon's heap.
+export const MAX_PENDING = 8
+
+export class AppSetup {
+  // `<state>` → { at, used }. `used` is set BEFORE the conversion call, which
+  // is what makes replay a refusal even while the first conversion is still in
+  // flight.
+  #pending = new Map()
+
+  constructor({
+    daemonRoot = '.',
+    envFile = null,
+    keyFile = DEFAULT_KEY_FILE,
+    fetchImpl = globalThis.fetch,
+    now = Date.now,
+    log = () => {},
+    adopt = null,
+  } = {}) {
+    this.daemonRoot = daemonRoot
+    this.envFile = envFile ?? path.join(daemonRoot, '.env.daemon')
+    this.keyFile = path.resolve(daemonRoot, keyFile)
+    this.fetchImpl = fetchImpl
+    this.now = now
+    this.log = log
+    this.adopt = adopt
+  }
+
+  // The operator opens the setup screen. The daemon mints the state and states
+  // the manifest; the page posts BOTH to github.com as a form, because a
+  // manifest travels as a form field and never as a call curia makes.
+  begin({ name, redirectUrl }) {
+    const manifest = buildManifest({ name, redirectUrl })
+    this.#sweep()
+    if (this.#pending.size >= MAX_PENDING) {
+      throw refuse(`${MAX_PENDING} GitHub App setups are already open — finish one, or wait for them to lapse`)
+    }
+    const state = crypto.randomBytes(32).toString('hex')
+    this.#pending.set(state, { at: this.now(), used: false })
+    this.log(`GitHub App setup started for "${manifest.name}", redirecting to ${manifest.redirect_url}`)
+    return { state, action: `${MANIFEST_ACTION}?state=${state}`, manifest }
+  }
+
+  #sweep() {
+    for (const [state, rec] of this.#pending) {
+      if (this.now() - rec.at > STATE_TTL_MS) this.#pending.delete(state)
+    }
+  }
+
+  // Everything the browser is allowed to learn about the setup: the facts that
+  // are already public on the app's own settings page. The conversion response
+  // never leaves this method, and the pem never leaves this file.
+  static publicFacts(app, { keyFile }) {
+    const slug = String(app?.slug ?? '').trim()
+    return {
+      ok: true,
+      app_id: String(app.id),
+      slug,
+      name: app?.name ?? null,
+      bot_login: slug ? `${slug}[bot]` : null,
+      html_url: app?.html_url ?? null,
+      install_url: slug ? `https://github.com/apps/${slug}/installations/new` : null,
+      key_file: keyFile,
+    }
+  }
+
+  // The one conversion. `code` and `state` are the only two things that cross
+  // from the browser, and this is the only place either is read.
+  async convert({ code, state }) {
+    const stateValue = String(state ?? '').trim()
+    const codeValue = String(code ?? '').trim()
+    if (!STATE_RE.test(stateValue)) throw refuse('that GitHub App setup carries no state curia minted, so curia did not start it')
+    if (!CODE_RE.test(codeValue)) throw refuse('GitHub sent no usable conversion code back — start the setup again')
+    this.#sweep()
+    const rec = this.#pending.get(stateValue)
+    if (!rec) throw refuse('that GitHub App setup did not start on this box, or it lapsed — start it again from Atlas')
+    // Single use, and consumed BEFORE the network call: a redirect replayed
+    // while the first conversion is still in flight must not convert twice.
+    if (rec.used) throw refuse('that GitHub App setup was already converted — a conversion code is good exactly once')
+    rec.used = true
+
+    const app = await this.#convertOnGitHub(codeValue)
+    const key = this.#readKey(app)
+    this.#store(app, key)
+    this.#adopt(app, key)
+    return AppSetup.publicFacts(app, { keyFile: this.keyFile })
+  }
+
+  async #convertOnGitHub(code) {
+    let res
+    try {
+      res = await this.fetchImpl(`${API}/app-manifests/${encodeURIComponent(code)}/conversions`, {
+        method: 'POST',
+        headers: {
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': API_VERSION,
+          'user-agent': 'curia',
+        },
+        signal: AbortSignal.timeout(CONVERT_TIMEOUT_MS),
+      })
+    } catch (e) {
+      throw refuse(`curia could not reach GitHub to convert the app manifest (${e.message}) — start the setup again`)
+    }
+    const text = await res.text()
+    let payload = null
+    try {
+      payload = text ? JSON.parse(text) : null
+    } catch { /* a non-JSON body leaves the status as the whole answer */ }
+    if (!res.ok) {
+      const detail = payload?.message ? `: ${payload.message}` : ''
+      // 404 is what an expired or already-converted code answers, and it is the
+      // operator's own sentence rather than a status nobody can place.
+      if (res.status === 404) {
+        throw refuse('GitHub does not know that conversion code — it is good for one hour and for one conversion. Start the setup again')
+      }
+      throw refuse(`GitHub answered HTTP ${res.status} to the app manifest conversion${detail}`)
+    }
+    if (!payload?.id || !payload?.pem) {
+      throw refuse('GitHub converted the manifest without an app id and a private key, so there is nothing to store')
+    }
+    return payload
+  }
+
+  // The pem, as a key object rather than as text — the same check boot makes
+  // (githubapp.mjs readPrivateKey), run BEFORE anything is written: a key that
+  // will not parse must refuse here and not at the first mint.
+  #readKey(app) {
+    try {
+      return crypto.createPrivateKey(app.pem)
+    } catch (e) {
+      throw refuse(`GitHub's converted app carries a private key curia cannot read (${e.message})`)
+    }
+  }
+
+  // The key file and the two env keys. NOT a refusal when it fails: a full disk
+  // or a read-only mount is this box failing, and the operator's next act is on
+  // the box rather than on the page. The sentence names the file either way,
+  // because the conversion is spent and the key is gone with it.
+  #store(app, key) {
+    try {
+      fs.writeFileSync(this.keyFile, app.pem, { mode: 0o600 })
+      fs.chmodSync(this.keyFile, 0o600)
+    } catch (e) {
+      throw new Error(`the GitHub App was created, but curia could not store its private key at ${this.keyFile} (${e.message}) — the key is gone with the conversion, so delete the app on GitHub and run the setup again`)
+    }
+    try {
+      const before = fs.existsSync(this.envFile) ? fs.readFileSync(this.envFile, 'utf8') : ''
+      fs.writeFileSync(this.envFile, upsertEnv(before, {
+        [APP_ID_KEY]: String(app.id),
+        [APP_KEY_FILE_KEY]: path.relative(this.daemonRoot, this.keyFile) || this.keyFile,
+      }), { mode: 0o600 })
+      fs.chmodSync(this.envFile, 0o600)
+    } catch (e) {
+      // The key is on disk and the env file is not, which is the half-configured
+      // state githubapp.mjs refuses a boot on. Say both halves.
+      throw new Error(`the GitHub App's key is stored at ${this.keyFile}, but curia could not write ${APP_ID_KEY} and ${APP_KEY_FILE_KEY} into ${this.envFile} (${e.message}) — add those two keys by hand before the next restart`)
+    }
+    // Nothing here logs the pem, and nothing ever should: this line is the only
+    // trace the setup leaves in journalctl.
+    this.log(`GitHub App ${app.id} (${app.slug}) created — key stored at ${this.keyFile}, ${APP_ID_KEY} written to ${this.envFile}`)
+    void key
+  }
+
+  // In process, so the operator's next act is the install and not a restart.
+  // A caller with no `adopt` stores and says so; the app is live at the next
+  // boot either way, which is what makes the failure here worth a log and not a
+  // refusal of a setup that already succeeded.
+  #adopt(app, key) {
+    if (!this.adopt) return
+    try {
+      this.adopt({ appId: String(app.id), key, keyFile: this.keyFile, slug: app.slug ?? null })
+    } catch (e) {
+      this.log(`WARNING: the GitHub App is stored but this daemon could not adopt it in process (${e.message}) — restart the daemon`)
+    }
+  }
+}
+
+// The minter one adoption produces. Here rather than in index.mjs so that the
+// setup's own tests can prove a converted app becomes a minting one.
+export function minterForAdopted({ appId, key, keyFile, fetchImpl = globalThis.fetch, now = Date.now, log = () => {} }) {
+  return new TokenMinter({ appId, key, keyFile, fetchImpl, now, log })
+}

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -235,6 +235,14 @@ const VERB_FILE_RE = /^\d{1,4}$/
 // reply the button shows — this only keeps a browser from writing the rest of
 // the line.
 const VERB_PROVIDER_RE = /^[a-z0-9][a-z0-9-]*$/
+// The GitHub App setup (#694). A name GitHub will slugify, and the two fields
+// GitHub redirects back with. Checked here for the reason every field above is:
+// this surface composes the daemon call, so it names the shape it will send —
+// and `code` is composed into a URL on the daemon side.
+const APP_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9 ._-]{0,33}$/
+const APP_CODE_RE = /^[A-Za-z0-9_-]{1,255}$/
+const APP_STATE_RE = /^[0-9a-f]{64}$/
+
 export const MAX_WORDS = 4000
 
 // Why an answer did not land (#266). The reduction refuses in ONE WORD — `unknown`,
@@ -866,6 +874,42 @@ export class DashboardSurface {
       // deletes one, and both are composed here out of a shape this file names:
       // `new` sends no field at all, and `delete` sends one key this side
       // validates before the daemon validates it again.
+      // The GitHub App setup (#694), in two presses.
+      //
+      // THE SIDECAR RELAYS CODE AND STATE, and that is the whole of its part.
+      // It holds no secret (#263) and this flow's secret is curia's only
+      // durable one, so the conversion happens on the daemon and what comes
+      // back here is the app's public facts. The manifest and the state go OUT
+      // to the browser because the browser is what posts them to github.com;
+      // the private key never travels this way at all.
+      if (url.pathname === '/api/appsetup/begin') {
+        return this.#write(res, async () => {
+          const b = await this.#body(req)
+          const name = field(b.name, APP_NAME_RE, 'a GitHub App name')
+          // The redirect is THIS surface's own address, composed from curia's
+          // own records (#68) rather than from anything the browser said:
+          // GitHub sends the conversion code to it, and a browser-named
+          // redirect would be a way to send that code somewhere else.
+          const redirect = await this.link()
+          const out = await this.#daemon({
+            method: 'POST', path: '/app/setup', body: { name, redirect_url: redirect }, accept: [200, 409],
+          })
+          if (out.ok === false) throw refuse(out.error)
+          return out
+        })
+      }
+      if (url.pathname === '/api/appsetup/convert') {
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const code = field(b.code, APP_CODE_RE, 'a GitHub conversion code')
+          const state = field(b.state, APP_STATE_RE, 'a setup state curia minted')
+          const out = await this.#daemon({
+            method: 'POST', path: '/app/convert', body: { code, state }, accept: [200, 409, 500],
+          })
+          if (out.ok === false) throw refuse(out.error)
+          return out
+        })
+      }
       if (url.pathname === '/api/console/new') {
         return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/console/new' }))
       }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -49,6 +49,7 @@ import { OVERSEER_MCP_PATH } from './overseerturn.mjs'
 import { hasSession } from './tmux.mjs'
 import { retiredAgentTokenKeys } from './workspace.mjs'
 import { APP_ID_KEY, APP_KEY_FILE_KEY, minterFrom } from './githubapp.mjs'
+import { AppSetup, minterForAdopted } from './appsetup.mjs'
 import { CodexCredentialBroker, AnthropicCredentialStore, anthropicStoreFile } from './credentials.mjs'
 import {
   OVERSEER_ENV_FILE, overseerEnvPath, loadOverseerEnv, daemonOnlyKeys, retiredTokenKeys,
@@ -259,7 +260,9 @@ function checkWatchedCredentials() {
 // nobody can place. NO app is a different thing and stays legal: a box can watch
 // and read before its operator finishes the checklist, and the refusal it gets
 // at the first dispatch names the step that was missed.
-const appMinter = minterFrom({ daemonRoot: ROOT, log })
+// `let`, because #694 adopts a converted app in process: the setup flow puts a
+// new minter here and hands it to the dispatcher without a restart.
+let appMinter = minterFrom({ daemonRoot: ROOT, log })
 if (!appMinter) {
   log(`no GitHub App configured — set ${APP_ID_KEY} and ${APP_KEY_FILE_KEY} in daemon/.env.daemon (docs/github-app.md). No agent can be dispatched until it is`)
 } else {
@@ -2417,6 +2420,25 @@ function consoleOnWire() {
   })
 }
 
+// The GitHub App setup (#694, building the spec at #684).
+//
+// The daemon owns the conversion because the conversion response carries the
+// private key, and neither the sidecar nor the browser may hold it. Adoption is
+// in process: the minter this file holds is replaced, the dispatcher is handed
+// the new one, and the installation read runs again — so the operator's next
+// act is installing the app rather than restarting the box.
+const appSetup = new AppSetup({
+  daemonRoot: ROOT,
+  log,
+  adopt: ({ appId, key, keyFile }) => {
+    appMinter = minterForAdopted({ appId, key, keyFile, log })
+    dispatcher.minter = appMinter
+    reduction.journal('github_app_adopted', { app_id: appId })
+    log(`GitHub App ${appId} adopted in process — key at ${keyFile}`)
+    checkAppInstallations()
+  },
+})
+
 async function handleRequest(req, res, { fromContainer = false } = {}) {
   const url = new URL(req.url, `http://127.0.0.1:${PORT}`)
   const json = (code, obj) => {
@@ -2776,6 +2798,34 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   // live object reference — `this.config.dispatch`, `this.config.watch`,
   // `resolveModel(this.routing, …)`, `isActive(this.routing, …)`. Only
   // `poll_interval_s` is captured, by the interval `startAutoLoop` arms.
+  // ---- the GitHub App setup (#694) ---------------------------------------
+  //
+  // Two routes, and between them the browser learns a manifest and a state and
+  // nothing else. The conversion response never crosses back: what the second
+  // route answers is the set of facts already public on the app's own settings
+  // page, plus where to install it.
+  if (url.pathname === '/app/setup' && req.method === 'POST') {
+    const body = await readBody(req).catch(() => ({}))
+    try {
+      return json(200, appSetup.begin({ name: body?.name, redirectUrl: body?.redirect_url }))
+    } catch (e) {
+      if (e?.refusal) return json(409, { ok: false, error: e.message })
+      throw e
+    }
+  }
+  if (url.pathname === '/app/convert' && req.method === 'POST') {
+    const body = await readBody(req).catch(() => ({}))
+    try {
+      return json(200, await appSetup.convert({ code: body?.code, state: body?.state }))
+    } catch (e) {
+      reduction.journal('github_app_setup_failed', { error: e.message, refusal: Boolean(e?.refusal) })
+      log(`the GitHub App setup failed: ${e.message}`)
+      // A refusal is the operator's own to fix and reads as one; anything else
+      // is this box failing, and it answers 500 so the two never read the same.
+      return json(e?.refusal ? 409 : 500, { ok: false, error: e.message })
+    }
+  }
+
   if (url.pathname === '/reload' && req.method === 'POST') {
     const body = await readBody(req).catch(() => ({}))
     const by = named(body?.by)

--- a/daemon/test/appsetup.test.mjs
+++ b/daemon/test/appsetup.test.mjs
@@ -1,0 +1,452 @@
+// Creating curia's GitHub App from Atlas (#694, building the spec at #684).
+//
+// Four things are worth pinning, and they are the four the ticket names: the
+// manifest asks for the five repository permissions and no events; the state
+// gate converts once and refuses a replay or a code curia never started; the
+// key and the two env keys reach disk or the failure says so; and the browser
+// learns none of it — the sidecar relays `code` and `state` and gets the app's
+// public facts back, never the conversion response.
+
+import { test, describe, before, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  AppSetup, buildManifest, upsertEnv, minterForAdopted,
+  MANIFEST_PERMISSIONS, MANIFEST_ACTION, STATE_TTL_MS, MAX_PENDING, STATE_RE,
+} from '../src/appsetup.mjs'
+import { APP_ID_KEY, APP_KEY_FILE_KEY, appConfigFrom } from '../src/githubapp.mjs'
+import { DashboardSurface, DEFAULT_DASHBOARD_INDEX } from '../src/dashboard.mjs'
+import { serveHosts, LOGIN_HEADER } from '../src/identity.mjs'
+
+const REDIRECT = 'https://box.tail1234.ts.net:8445/'
+
+let PEM
+before(() => {
+  PEM = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+    .privateKey.export({ type: 'pkcs1', format: 'pem' })
+})
+
+// What GitHub answers a conversion with. The pem is the whole reason this flow
+// lives on the daemon, so every test that has one asserts where it did NOT go.
+const conversion = () => ({
+  id: 4610603,
+  slug: 'curia-sh',
+  name: 'curia.sh',
+  html_url: 'https://github.com/apps/curia-sh',
+  pem: PEM,
+  client_secret: 'not-a-real-secret',
+})
+
+describe('the manifest (#694)', () => {
+  test('it asks for the five repository permissions of the checklist, and no more', () => {
+    const m = buildManifest({ name: 'curia.sh', redirectUrl: REDIRECT })
+    assert.deepEqual(m.default_permissions, {
+      contents: 'write', issues: 'write', pull_requests: 'write', statuses: 'read', metadata: 'read',
+    })
+    assert.equal(Object.keys(m.default_permissions).length, 5)
+    // ADR-0018's one absence: an app that writes `.github/workflows/` lets any
+    // agent rewrite CI, and the PATs it replaced could not do it either.
+    assert.equal(m.default_permissions.workflows, undefined)
+  })
+
+  test('it subscribes to no events and activates no webhook — curia polls', () => {
+    const m = buildManifest({ name: 'curia.sh', redirectUrl: REDIRECT })
+    assert.deepEqual(m.default_events, [])
+    assert.equal(m.hook_attributes.active, false)
+  })
+
+  test('it is installable on any account, because one owner is an organization', () => {
+    assert.equal(buildManifest({ name: 'curia.sh', redirectUrl: REDIRECT }).public, true)
+  })
+
+  test('a redirect that is not https refuses — the conversion code lands on it', () => {
+    assert.throws(() => buildManifest({ name: 'curia.sh', redirectUrl: 'http://box/' }), /not an https redirect url/)
+    assert.throws(() => buildManifest({ name: 'curia.sh', redirectUrl: '' }), /not an https redirect url/)
+  })
+
+  test('an app with no name refuses', () => {
+    assert.throws(() => buildManifest({ name: '  ', redirectUrl: REDIRECT }), /needs a name/)
+  })
+})
+
+describe('the env file upsert (#694)', () => {
+  test('every other line survives, in order — the Discord token lives here too', () => {
+    const before = 'DISCORD_TOKEN=abc\n# a comment\nCURIA_GH_APP_ID=1\n'
+    const after = upsertEnv(before, { [APP_ID_KEY]: '7', [APP_KEY_FILE_KEY]: '.curia-app.pem' })
+    assert.equal(after, 'DISCORD_TOKEN=abc\n# a comment\nCURIA_GH_APP_ID=7\nCURIA_GH_APP_KEY_FILE=.curia-app.pem\n')
+  })
+
+  test('an empty file becomes the two keys and nothing else', () => {
+    assert.equal(upsertEnv('', { A: '1' }), 'A=1\n')
+  })
+})
+
+describe('the conversion (#694)', () => {
+  let dir
+  let calls
+  let answer
+  let adopted
+  let setup
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-appsetup-'))
+    calls = []
+    answer = () => ({ ok: true, status: 201, body: conversion() })
+    adopted = []
+    setup = makeSetup({})
+  })
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  function makeSetup(over) {
+    return new AppSetup({
+      daemonRoot: dir,
+      log: () => {},
+      adopt: (a) => adopted.push(a),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, method: init?.method })
+        const a = answer()
+        return { ok: a.ok, status: a.status, text: async () => JSON.stringify(a.body) }
+      },
+      ...over,
+    })
+  }
+
+  const start = (s = setup) => s.begin({ name: 'curia.sh', redirectUrl: REDIRECT })
+
+  test('a start mints a single-use state and points the form at GitHub', () => {
+    const { state, action, manifest } = start()
+    assert.match(state, STATE_RE)
+    assert.equal(action, `${MANIFEST_ACTION}?state=${state}`)
+    assert.equal(manifest.redirect_url, REDIRECT)
+  })
+
+  // ---- success -------------------------------------------------------------
+
+  test('a converted manifest stores the key at 0600, writes both env keys, and adopts in process', async () => {
+    const { state } = start()
+    const out = await setup.convert({ code: 'gh-code-1', state })
+
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].url, 'https://api.github.com/app-manifests/gh-code-1/conversions')
+    assert.equal(calls[0].method, 'POST')
+
+    const keyFile = path.join(dir, '.curia-app.pem')
+    assert.equal(fs.readFileSync(keyFile, 'utf8'), PEM)
+    assert.equal(fs.statSync(keyFile).mode & 0o777, 0o600, 'curia\'s one durable secret is not world-readable')
+
+    const env = fs.readFileSync(path.join(dir, '.env.daemon'), 'utf8')
+    assert.match(env, new RegExp(`^${APP_ID_KEY}=4610603$`, 'm'))
+    assert.match(env, new RegExp(`^${APP_KEY_FILE_KEY}=.curia-app.pem$`, 'm'))
+    // The two keys the next boot reads, read the way the next boot reads them.
+    const cfg = appConfigFrom({ [APP_ID_KEY]: '4610603', [APP_KEY_FILE_KEY]: '.curia-app.pem' }, dir)
+    assert.equal(cfg.keyFile, keyFile)
+
+    // In process, so the operator's next act is the install and not a restart.
+    assert.equal(adopted.length, 1)
+    assert.equal(adopted[0].appId, '4610603')
+    assert.equal(minterForAdopted(adopted[0]).appId, '4610603')
+
+    // What the browser is allowed to learn: the app's own settings page, and
+    // where to install it. Nothing from the conversion body.
+    assert.deepEqual(out, {
+      ok: true,
+      app_id: '4610603',
+      slug: 'curia-sh',
+      name: 'curia.sh',
+      bot_login: 'curia-sh[bot]',
+      html_url: 'https://github.com/apps/curia-sh',
+      install_url: 'https://github.com/apps/curia-sh/installations/new',
+      key_file: keyFile,
+    })
+    assert.doesNotMatch(JSON.stringify(out), /PRIVATE KEY|client_secret/)
+  })
+
+  // ---- replay --------------------------------------------------------------
+
+  test('the same state converts once — a replayed redirect is refused and asks GitHub nothing', async () => {
+    const { state } = start()
+    await setup.convert({ code: 'gh-code-1', state })
+    await assert.rejects(
+      setup.convert({ code: 'gh-code-1', state }),
+      (e) => e.refusal === true && /already converted/.test(e.message))
+    assert.equal(calls.length, 1, 'a replay must not reach GitHub at all')
+    assert.equal(adopted.length, 1)
+  })
+
+  test('a replay that arrives while the first conversion is still in flight is refused too', async () => {
+    let release
+    answer = () => ({ ok: true, status: 201, body: conversion() })
+    const slow = makeSetup({
+      fetchImpl: async (url, init) => {
+        calls.push({ url, method: init?.method })
+        await new Promise((r) => { release = r })
+        return { ok: true, status: 201, text: async () => JSON.stringify(conversion()) }
+      },
+    })
+    const { state } = start(slow)
+    const first = slow.convert({ code: 'gh-code-1', state })
+    await assert.rejects(slow.convert({ code: 'gh-code-1', state }), /already converted/)
+    release()
+    await first
+    assert.equal(calls.length, 1)
+  })
+
+  // ---- bad state -----------------------------------------------------------
+
+  test('a code with a state curia never minted is refused before any call', async () => {
+    start()
+    const forged = 'f'.repeat(64)
+    await assert.rejects(
+      setup.convert({ code: 'gh-code-1', state: forged }),
+      (e) => e.refusal === true && /did not start on this box/.test(e.message))
+    assert.equal(calls.length, 0)
+  })
+
+  test('a code with no state at all is refused — a plain redirect is forgeable', async () => {
+    await assert.rejects(setup.convert({ code: 'gh-code-1', state: '' }), /no state curia minted/)
+    await assert.rejects(setup.convert({ code: 'gh-code-1', state: 'nope' }), /no state curia minted/)
+    assert.equal(calls.length, 0)
+  })
+
+  test('a state that lapsed is a state curia no longer holds', async () => {
+    let clock = 1_000
+    const aged = makeSetup({ now: () => clock })
+    const { state } = start(aged)
+    clock += STATE_TTL_MS + 1
+    await assert.rejects(aged.convert({ code: 'gh-code-1', state }), /or it lapsed/)
+    assert.equal(calls.length, 0)
+  })
+
+  test('a state good for a code GitHub no longer knows says so in the operator\'s words', async () => {
+    const { state } = start()
+    answer = () => ({ ok: false, status: 404, body: { message: 'Not Found' } })
+    await assert.rejects(
+      setup.convert({ code: 'gh-code-1', state }),
+      (e) => e.refusal === true && /good for one hour and for one conversion/.test(e.message))
+    assert.equal(adopted.length, 0)
+  })
+
+  test('open setups are bounded', () => {
+    for (let i = 0; i < MAX_PENDING; i += 1) start()
+    assert.throws(() => start(), /are already open/)
+  })
+
+  // ---- failed storage ------------------------------------------------------
+
+  test('a key that cannot be stored refuses the setup, adopts nothing, and names the file', async () => {
+    const blocked = makeSetup({ keyFile: path.join(dir, 'no-such-dir', 'app.pem') })
+    const { state } = start(blocked)
+    await assert.rejects(
+      blocked.convert({ code: 'gh-code-1', state }),
+      (e) => !e.refusal && /could not store its private key at .*no-such-dir/.test(e.message)
+        && /delete the app on GitHub/.test(e.message))
+    assert.equal(adopted.length, 0, 'a daemon must not run on an app whose key it could not keep')
+  })
+
+  test('an env file that cannot be written names both halves — the key is on disk and the keys are not', async () => {
+    const blocked = makeSetup({ envFile: path.join(dir, 'no-such-dir', '.env.daemon') })
+    const { state } = start(blocked)
+    await assert.rejects(
+      blocked.convert({ code: 'gh-code-1', state }),
+      (e) => !e.refusal && new RegExp(`key is stored at .*\\.curia-app\\.pem.*${APP_ID_KEY}`, 's').test(e.message))
+    assert.equal(adopted.length, 0)
+  })
+
+  test('a conversion carrying no key stores nothing', async () => {
+    const { state } = start()
+    answer = () => ({ ok: true, status: 201, body: { id: 7, slug: 'x' } })
+    await assert.rejects(setup.convert({ code: 'gh-code-1', state }), /nothing to store/)
+    assert.equal(fs.existsSync(path.join(dir, '.curia-app.pem')), false)
+  })
+
+  test('a private key GitHub sent that curia cannot read is refused before anything is written', async () => {
+    const { state } = start()
+    answer = () => ({ ok: true, status: 201, body: { ...conversion(), pem: 'not a pem' } })
+    await assert.rejects(setup.convert({ code: 'gh-code-1', state }), /cannot read/)
+    assert.equal(fs.existsSync(path.join(dir, '.curia-app.pem')), false)
+    assert.equal(adopted.length, 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// the relay (#694)
+// ---------------------------------------------------------------------------
+//
+// A real sidecar in front of a real AppSetup, with a fake GitHub behind it. The
+// one thing being proved is the boundary: what crosses the browser wire in each
+// direction, and what does not.
+
+describe('the sidecar relays code and state, and nothing else (#694)', () => {
+  const SERVE_PORT = 8445
+  const ALLOW = ['alp@example.com']
+  const HOST = 'box.tail1234.ts.net:8445'
+  const served = (extra = {}) => ({ host: HOST, [LOGIN_HEADER]: 'alp@example.com', ...extra })
+  const writes = (extra = {}) => served({
+    origin: `https://${HOST}`, 'content-type': 'application/json', ...extra,
+  })
+
+  let dir
+  let surface
+  let daemon
+  let setup
+  let bodies
+  let ghCalls
+
+  function req(port, p, { headers = {}, method = 'GET', body = null } = {}) {
+    return new Promise((resolve, reject) => {
+      const r = http.request({ host: '127.0.0.1', port, path: p, method, headers, setHost: false }, (res) => {
+        let buf = ''
+        res.on('data', (d) => { buf += d })
+        res.on('end', () => resolve({ status: res.statusCode, text: buf }))
+      })
+      r.on('error', reject)
+      if (body !== null) r.write(typeof body === 'string' ? body : JSON.stringify(body))
+      r.end()
+    })
+  }
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-appsetup-relay-'))
+    bodies = []
+    ghCalls = []
+    setup = new AppSetup({
+      daemonRoot: dir,
+      log: () => {},
+      fetchImpl: async (url) => {
+        ghCalls.push(url)
+        return { ok: true, status: 201, text: async () => JSON.stringify(conversion()) }
+      },
+    })
+    // A stand-in daemon holding the real flow, so the conversion is proved to
+    // happen on the far side of the browser's wire.
+    daemon = http.createServer(async (r, res) => {
+      let raw = ''
+      for await (const c of r) raw += c
+      const body = raw ? JSON.parse(raw) : {}
+      bodies.push({ url: r.url, body })
+      res.writeHead(200, { 'content-type': 'application/json' })
+      try {
+        if (r.url === '/app/setup') return res.end(JSON.stringify(setup.begin({ name: body.name, redirectUrl: body.redirect_url })))
+        if (r.url === '/app/convert') return res.end(JSON.stringify(await setup.convert(body)))
+      } catch (e) {
+        return res.end(JSON.stringify({ ok: false, error: e.message }))
+      }
+      res.end(JSON.stringify({ ok: true }))
+    })
+    await new Promise((done) => daemon.listen(0, '127.0.0.1', done))
+
+    surface = new DashboardSurface({
+      port: 0,
+      servePort: SERVE_PORT,
+      index: DEFAULT_DASHBOARD_INDEX,
+      allow: ALLOW,
+      pollIntervalS: 5,
+      daemonPort: daemon.address().port,
+      log: () => {},
+      deps: {
+        fetchOverview: async () => ({ daemon: { port: 4271 }, agents: [] }),
+        assertServe: async () => {},
+        serveOff: async () => {},
+        attachBase: async () => 'box.tail1234.ts.net',
+        tailnetSelf: async () => ({ dnsName: 'box.tail1234.ts.net', ips: ['100.98.118.33'] }),
+      },
+    })
+    await surface.start()
+    await surface.resolveHosts()
+    assert.deepEqual([...surface.hosts].sort(), [...serveHosts({ dnsName: 'box.tail1234.ts.net.', ips: ['100.98.118.33'], servePort: SERVE_PORT })].sort())
+  })
+
+  afterEach(() => {
+    surface?.stop()
+    daemon?.close()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function begin() {
+    const res = await req(surface.port, '/api/appsetup/begin', {
+      method: 'POST', headers: writes(), body: { name: 'curia.sh' },
+    })
+    assert.equal(res.status, 200)
+    return JSON.parse(res.text)
+  }
+
+  test('the start hands the browser a manifest and a state, and names the redirect itself', async () => {
+    const out = await begin()
+    assert.match(out.state, STATE_RE)
+    assert.deepEqual(out.manifest.default_permissions, { ...MANIFEST_PERMISSIONS })
+    // The redirect is composed from curia's own records, never from the body.
+    assert.equal(bodies[0].body.redirect_url, 'https://box.tail1234.ts.net:8445/')
+    assert.equal(out.manifest.redirect_url, 'https://box.tail1234.ts.net:8445/')
+  })
+
+  test('a browser-named redirect is not a field this surface forwards', async () => {
+    await req(surface.port, '/api/appsetup/begin', {
+      method: 'POST', headers: writes(), body: { name: 'curia.sh', redirect_url: 'https://evil.example.com/' },
+    })
+    assert.equal(bodies[0].body.redirect_url, 'https://box.tail1234.ts.net:8445/')
+  })
+
+  test('the convert relays exactly code and state, and the browser gets no key back', async () => {
+    const { state } = await begin()
+    const res = await req(surface.port, '/api/appsetup/convert', {
+      method: 'POST', headers: writes(), body: { code: 'gh-code-1', state, extra: 'ignored' },
+    })
+    assert.equal(res.status, 200)
+    assert.equal(ghCalls.length, 1)
+    assert.deepEqual(Object.keys(bodies[1].body).sort(), ['code', 'state'])
+
+    // The one assertion this ticket exists for.
+    assert.doesNotMatch(res.text, /PRIVATE KEY|client_secret/)
+    const out = JSON.parse(res.text)
+    assert.equal(out.pem, undefined)
+    assert.equal(out.bot_login, 'curia-sh[bot]')
+    assert.equal(out.install_url, 'https://github.com/apps/curia-sh/installations/new')
+    // And the key went where the daemon put it, which is not on this wire.
+    assert.equal(fs.readFileSync(path.join(dir, '.curia-app.pem'), 'utf8'), PEM)
+  })
+
+  test('a replayed convert answers the refusal, not a second conversion', async () => {
+    const { state } = await begin()
+    await req(surface.port, '/api/appsetup/convert', { method: 'POST', headers: writes(), body: { code: 'c', state } })
+    const again = await req(surface.port, '/api/appsetup/convert', { method: 'POST', headers: writes(), body: { code: 'c', state } })
+    assert.equal(again.status, 409)
+    assert.match(again.text, /already converted/)
+    assert.equal(ghCalls.length, 1)
+  })
+
+  test('a state this surface cannot have minted never reaches the daemon', async () => {
+    const res = await req(surface.port, '/api/appsetup/convert', {
+      method: 'POST', headers: writes(), body: { code: 'c', state: 'not-a-state' },
+    })
+    assert.equal(res.status, 409)
+    assert.match(res.text, /is not a setup state curia minted/)
+    assert.equal(bodies.length, 0)
+  })
+
+  test('a conversion code shaped like a URL is refused rather than composed into one', async () => {
+    const { state } = await begin()
+    const res = await req(surface.port, '/api/appsetup/convert', {
+      method: 'POST', headers: writes(), body: { code: '../../evil', state },
+    })
+    assert.equal(res.status, 409)
+    assert.match(res.text, /is not a GitHub conversion code/)
+    assert.equal(ghCalls.length, 0)
+  })
+
+  test('both routes are writes: no Origin, no setup', async () => {
+    for (const route of ['/api/appsetup/begin', '/api/appsetup/convert']) {
+      const res = await req(surface.port, route, {
+        method: 'POST', headers: served({ 'content-type': 'application/json' }), body: { name: 'curia.sh' },
+      })
+      assert.equal(res.status, 403)
+      assert.match(res.text, /must carry an Origin header/)
+    }
+    assert.equal(bodies.length, 0)
+  })
+})

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -22,6 +22,16 @@ Run on 2026-08-16, as [#352](https://github.com/alp82/curia/issues/352). The cut
 
 None of this is secret. The app id travels in every JWT the daemon signs. The private key is the secret, and it is never in this repo.
 
+## Steps 1 to 3, from Atlas
+
+[#694](https://github.com/alp82/curia/issues/694) replaced the first three steps below with one press. Atlas asks the daemon for a manifest, the browser posts it to `https://github.com/settings/apps/new`, and GitHub redirects back with a one-hour conversion code. The daemon converts that code itself: it writes the private key to `daemon/.curia-app.pem` at mode 0600, writes `CURIA_GH_APP_ID` and `CURIA_GH_APP_KEY_FILE` into `daemon/.env.daemon`, and adopts the app in process, so step 6 and the restart are gone too.
+
+The manifest states the five permissions of step 2 and no events, so nothing on the **Permissions & events** page has to be set by hand. Neither the browser nor the dashboard sidecar ever sees the conversion response: the browser carries `code` and `state` back and gets the app id, the slug, the bot login and the install link.
+
+Steps 4 and 5 stay yours. An installation is granted per owner, and only a human can grant it.
+
+The manual route below still works, and it is what to follow when the box has no Atlas reachable.
+
 ## 1. Create the app
 
 1. Open <https://github.com/settings/apps/new>.


### PR DESCRIPTION
Closes part of [#685](https://github.com/alp82/curia/issues/685). Implements alp82/curia#694.

## What this builds

The daemon creates the setup state, converts the manifest code GitHub redirects back with, stores the private key and the two env keys, and adopts the app in the running process.

- `daemon/src/appsetup.mjs` — the manifest (five repository permissions, no events, webhook inactive, `public: true`), the single-use state, the one conversion call, the 0600 key write, the `.env.daemon` upsert that leaves every other line alone, and the adoption seam.
- `daemon/src/index.mjs` — `POST /app/setup` and `POST /app/convert`, plus the adoption itself: a converted app becomes a new minter, the live dispatcher takes it, and the installation read runs again. No restart.
- `daemon/src/dashboard.mjs` — `POST /api/appsetup/begin` and `POST /api/appsetup/convert`. The sidecar relays `code` and `state` and nothing else, and it composes the redirect from curia's own records rather than from anything the browser said.
- `docs/github-app.md` — steps 1 to 3 and step 6 now have a one-press route; steps 4 and 5 stay the operator's, because only a human grants an installation.

## Why the daemon owns the conversion

The conversion response carries curia's one durable secret. The sidecar holds no secret (#263) and a browser must hold this one least of all, so the browser posts the manifest to github.com and carries `code` and `state` back. What it gets in return is the app's public facts: app id, slug, bot login, install link.

The state is the gate. A conversion code arrives on a plain redirect that anything can forge, so a code with a state curia never minted is refused before any call leaves the box. The state is consumed *before* the conversion call, which makes a replay a refusal even while the first conversion is still in flight.

## Tests

`daemon/test/appsetup.test.mjs`, 27 cases against a fake GitHub: success, replay (both settled and in-flight), bad state (forged, absent, lapsed, expired code), and failed storage (key file and env file, each naming its own half, neither adopting). The relay cases run a real sidecar in front of a real `AppSetup` and assert the browser's wire carries no `PRIVATE KEY` and no `client_secret`.

`npm test` in `daemon/`: 3270 passing, 0 failing, 0 cancelled (baseline 3243).

## Deliberately left out

No Atlas screen. This ticket is the daemon and the relay; the setup screen and the per-owner installation rows belong to the sibling ticket, so `DASHBOARD_PROTO` is unbumped and the shipped page is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5