### PR TITLE
An empty map asks for a verdict before it closes (alp82/curia#698)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,10 @@ A GitHub issue labeled `wayfinder:map`. It indexes decisions and points to the c
 A ticket whose parent issue is a map.
 
 **Fog**:
-The map section "Not yet specified": work that is coming but not yet sharp enough to state as a ticket.
+The map section "Not yet specified": work that is coming but not yet sharp enough to state as a ticket. A heading, a blank line and an HTML comment inside that section are shape rather than fog, and `None` or `(empty)` is no fog at all.
+
+**Empty map**:
+An open, non-deferred map with at least one child and no open child left. No dispatch ever fires on it again, so the frontier read is the one thing that can notice it ([#485](https://github.com/alp82/curia/issues/485)) — and #316 sat that way for days because a line saying so is not an act. Curia asks the operator one durable question instead ([#698](https://github.com/alp82/curia/issues/698)): a ✅/❌ confirm carrying the map's fog, asked whether the fog is empty or not, journalled as `map_verdict_asked` so neither a second pass nor a restart asks twice. It is the one confirm a boot does not lapse, because it names a map rather than an agent instance. The answer posts a verdict comment on the map either way, and closes it only when the map as it stands THEN has no open child, no fog and no pause. A map that empties again after gaining a child is a new question.
 
 **Charting**:
 The map changes: new tickets, graduated fog, blocking edges, scope rulings. They land two ways. A ticket agent proposes them at the review gate and writes them after the approval. A charting agent writes them as its whole job.

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -29,6 +29,7 @@ import { parseCommand } from './commands.mjs'
 import { safeLeaf } from './attachments.mjs'
 import { REVIEW_KIND, CROSS_CHECK_ANSWER, ALL_AS_RECOMMENDED } from './lifecycle.mjs'
 import { CONFIRM_KIND } from './reduction.mjs'
+import { MAP_CLOSE_VERB } from './github.mjs'
 import { chunkMessage, smallPrint, elapsedLabel } from './messaging.mjs'
 import { ThreadRenamer } from './threadname.mjs'
 
@@ -1247,9 +1248,16 @@ export class DiscordBridge {
 
   #escalationBody(record) {
     if (record.kind === CONFIRM_KIND) {
+      // Every confirm but one is about a live agent and lapses with it. The
+      // empty-map verdict (#698) is about a map, so it lapses with nothing and
+      // waits — including across a restart — and its footer must not promise
+      // an expiry it does not have.
+      const footer = record.action?.verb === MAP_CLOSE_VERB
+        ? '-# ✅ closes the map, and ❌ leaves it open. This question waits until you answer it.'
+        : '-# ✅ executes, and ❌ declines. This confirm lapses when its agent exits.'
       return [
         `❓ ${record.prompt}`,
-        '-# ✅ executes, and ❌ declines. This confirm lapses when its agent exits.',
+        footer,
         `-# ${record.id}`,
       ].join('\n')
     }

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -20,7 +20,7 @@ import { setTimeout as sleepFor } from 'node:timers/promises'
 import {
   repoMaps, mapFrontier, flatFrontier, fetchIssue, claim, unclaim, blockedByOf,
   selectLane, frontierForRepo, filterTakeable, agentOnlyChainCount, directUnblocks, commentIssue, closeIssue, setIssueBody, issueComments,
-  strandedMaps, strandedMapLine,
+  strandedMaps, emptyMapVerdictPrompt, mapCloseBlockers, mapClosedComment, mapHeldComment, MAP_CLOSE_VERB,
   parentNumberOf, hasLabel, findPullRequest, createPullRequest, setPullRequestBody,
   deleteRemoteBranch, pullRequestDiff, approvePullRequest,
 } from './github.mjs'
@@ -55,6 +55,10 @@ import { CREDENTIALS_HASH } from './dashboard.mjs'
 import { readDiffDigest, readFileHunks, digestLine, sliceFromPatch, capText } from './diffdigest.mjs'
 import { transcriptReset, holdVerdict, hottestPct, WARM_PCT } from './usage.mjs'
 import { transcriptActivity } from './transcript.mjs'
+// #698: the fog classifier the map snapshot already owns. The empty-map
+// question reads the same lines the Atlas map view draws, so a card and a
+// screen can never disagree about what is still uncertain.
+import { fogFacts } from './mapsnapshot.mjs'
 import { mintAgentToken, forgetAgentToken, sweepAgentTokens } from './agenttoken.mjs'
 import {
   GUEST_WT, GUEST_CFG, GUEST_DAEMON_HOST, GUEST_GUARD_ENV, ENV_FILE, PORTS_PER_AGENT,
@@ -394,9 +398,10 @@ export class Dispatcher {
     this.routing = routing
     this.reduction = reduction
     this.notify = notify
-    // The plain channel line (#485), injected by index.mjs the way the
-    // backup's announce is (#436): false when there is no bridge yet, so an
-    // alarm that could not be said stands and re-says.
+    // The plain channel line, injected by index.mjs the way the backup's
+    // announce is (#436): false when there is no bridge yet, so a line that
+    // could not be said stands and re-says. The stranded-map watch used it
+    // until #698 turned that alarm into a question with buttons.
     this.announce = announce ?? (async () => false)
     this.openConfirm = openConfirm ?? (() => null)
     this.lapseEscalation = lapseEscalation ?? ((id, reason) => this.reduction.lapse?.(id, reason))
@@ -843,36 +848,101 @@ export class Dispatcher {
   async #watchStrandedMaps(repo, maps, mapItems) {
     try {
       const stranded = strandedMaps(maps, mapItems)
+      const bodies = new Map(maps.map((m) => [m.number, m.body]))
       const now = new Set(stranded.map((m) => m.number))
       for (const s of this.reduction.standingStrandedMaps?.() ?? []) {
         if (s.repo === repo && !now.has(s.map)) {
+          // The fact the question was about is gone. A card still carrying
+          // buttons would ask about a map that has an open child again, so it
+          // lapses with the entry rather than outliving it.
+          this.#lapseMapVerdict(repo, s, 'the map is no longer empty')
           this.reduction.journal('map_stranded_cleared', { repo, map: s.map })
         }
       }
       for (const m of stranded) {
+        // One question per emptying, and the entry is what says so (#698). It
+        // is journalled, so neither a second pass nor a restart asks twice —
+        // and an entry that was already ANSWERED stays quiet for good, because
+        // an operator who said "work remains" has answered this question.
         const entry = this.reduction.strandedMap?.(repo, m.number)
-        if (entry?.said) continue
-        const said = await this.#sayChannel(strandedMapLine(repo, m))
-        // First sighting journals whatever happened. After that, only the say
-        // that finally lands journals — the standing entry already states the
-        // fact, and a tick is too often to restate it.
-        if (!entry || said) this.reduction.journal('map_stranded', { repo, map: m.number, title: m.title, said })
+        if (entry?.asked || entry?.answered) continue
+        const fog = fogFacts(bodies.get(m.number))
+        const record = this.openConfirm({
+          ticket: String(m.number),
+          prompt: emptyMapVerdictPrompt(repo, m, fog),
+          action: { verb: MAP_CLOSE_VERB, repo, map: m.number, title: m.title, fog: fog.map((f) => f.text) },
+          originThreadId: null,
+        })
+        if (!record) {
+          this.log(`the empty-map question for ${repo}#${m.number} could not be opened — the next pass asks again`)
+          continue
+        }
+        this.reduction.journal('map_verdict_asked', {
+          repo, map: m.number, title: m.title, id: record.id, fog: fog.map((f) => f.text),
+        })
       }
     } catch (e) {
       this.log(`the stranded-map watch failed (${e.message}) — the frontier read stands`)
     }
   }
 
-  // The one place `said` is decided, exactly as the backup's #say (#436): a
-  // missing bridge and a failing send are the same answer — the operator did
-  // not read it — so the alarm stands unsaid and re-says on a later pass.
-  async #sayChannel(text) {
+  // Close the open empty-map question for one map, if one is still out. The
+  // record is found by its own verb and map number rather than by an id held
+  // in memory, because the entry that names it outlives every process.
+  #lapseMapVerdict(repo, entry, why) {
+    if (!entry?.asked) return
+    for (const r of this.reduction.openEscalations?.() ?? []) {
+      if (r.action?.verb !== MAP_CLOSE_VERB) continue
+      if (r.action.repo !== repo || r.action.map !== entry.map) continue
+      this.lapseEscalation(r.id, why)
+      this.reduction.journal('map_verdict_lapsed', { repo, map: entry.map, id: r.id, reason: why })
+    }
+  }
+
+  // The executing path of an empty-map verdict (#698). The operator has spoken,
+  // and this is where their word becomes a comment and — only then, and only if
+  // the map still deserves it — a close.
+  //
+  // The re-read is the whole point. A question can sit for days, and the
+  // approval it comes back with is an approval of what the card SAID. So the
+  // close is checked against the map as it stands: a reopened child, a fog line
+  // written since, a pause put on it. Anything that holds it open is posted as
+  // the verdict instead, and the map stays open, said rather than stranded.
+  async #closeEmptyMap(record) {
+    const { repo, map } = record.action ?? {}
+    const approved = record.answer === 'approve'
     try {
-      const res = await this.announce(text)
-      return res !== false
+      if (!approved) {
+        await this.deps.commentIssue(repo, map, mapHeldComment(['the operator says work remains on this map']))
+        this.reduction.journal('map_verdict_answered', { repo, map, id: record.id, answer: 'reject', closed: false })
+        this.log(`${repo}#${map} stays open — the operator says work remains`)
+        return
+      }
+      const issue = await this.deps.fetchIssue(repo, map)
+      const children = (await this.deps.mapFrontier(repo, map)).filter((c) => !c.pull_request)
+      const held = mapCloseBlockers({
+        state: issue.state, labels: issue.labels, children, fog: fogFacts(issue.body),
+      })
+      if (held.length) {
+        // An already-closed map gets no second comment: the close it is held by
+        // is the outcome the operator asked for, and a comment saying so would
+        // be curia arguing with itself.
+        if (issue.state === 'open') await this.deps.commentIssue(repo, map, mapHeldComment(held))
+        this.reduction.journal('map_verdict_answered', { repo, map, id: record.id, answer: 'approve', closed: false, held })
+        this.log(`${repo}#${map} was approved for closing but stays open — ${held.join('; ')}`)
+        return
+      }
+      await this.deps.commentIssue(repo, map, mapClosedComment())
+      await this.deps.closeIssue(repo, map)
+      this.reduction.journal('map_verdict_answered', { repo, map, id: record.id, answer: 'approve', closed: true })
+      this.log(`${repo}#${map} closed on the operator's verdict`)
     } catch (e) {
-      this.log(`a channel line did not reach Discord (${e.message}) — it stands until it does`)
-      return false
+      // A failed write leaves the entry asked and unanswered, so no later pass
+      // asks the question again and no later pass closes anything. The map
+      // stays open and the failure is on the record, which is the safe end of
+      // a close curia could not make.
+      this.log(`the empty-map verdict on ${repo}#${map} failed (${e.message}) — the map stays open`)
+      this.reduction.journal('map_verdict_failed', { repo, map, id: record.id, error: e.message })
     }
   }
 
@@ -5676,6 +5746,9 @@ export class Dispatcher {
   // skipped, never guessed at.
   async onConfirmAnswered(record) {
     const { verb, targets = [] } = record.action ?? {}
+    // The empty-map verdict (#698) rides the same seam and names no agent: its
+    // answer writes a comment on a map, and possibly closes it.
+    if (verb === MAP_CLOSE_VERB) return this.#closeEmptyMap(record)
     if (verb !== 'cancel') {
       this.log(`confirm ${record.id} carries unknown verb "${verb}" — nothing executed`)
       return
@@ -7613,6 +7686,13 @@ export class Dispatcher {
   // must NOT touch confirms — their instances are still matchable live.
   #voidBootConfirms() {
     for (const r of this.reduction.openEscalations()) {
+      // The empty-map question (#698) survives the restart every other confirm
+      // dies of. What kills the others is the instance id: a cancel names a
+      // live agent, and no id minted before the boot names one after it. This
+      // one names a MAP, and a map number means the same thing across a
+      // restart — so lapsing it would be curia forgetting a question it had
+      // already asked, and asking it again on the next pass.
+      if (r.kind === CONFIRM_KIND && r.action?.verb === MAP_CLOSE_VERB) continue
       if (r.kind === CONFIRM_KIND) {
         this.lapseEscalation(r.id, 'the daemon restarted, and agent instances do not match across a restart')
         this.reduction.journal('confirm_lapsed', { id: r.id, reason: 'boot' })

--- a/daemon/src/github.mjs
+++ b/daemon/src/github.mjs
@@ -274,10 +274,73 @@ export function strandedMaps(maps = [], mapItems = {}) {
     .map((m) => ({ number: m.number, title: m.title ?? '' }))
 }
 
-// CuriaBot's line for one stranded map. It names the acts that end it, the way
-// the backup lines do (#436): close the map, or graduate what the fog holds.
-export function strandedMapLine(repo, { number, title }) {
-  return `⚠️ map ${repo}#${number} “${title}” has no open ticket left, but it is still open. Close it with a verdict comment, or graduate what stands under Not yet specified.`
+// The verb an empty-map question carries on its confirm record (#698). It is
+// the one word `onConfirmAnswered` dispatches on, and the one word the boot
+// sweep reads to leave this record standing.
+export const MAP_CLOSE_VERB = 'map_close'
+
+// The question curia asks about one empty map (#698). It replaced the plain
+// alarm line #485 said: an alarm states a fact and waits for someone to act on
+// it, and #316 proved that nobody does. This asks for a VERDICT, and the
+// operator's answer is what closes the map.
+//
+// The fog rides in the question because it is what the answer is about. An
+// operator reading the card on a phone must not have to open the map to see
+// what is still uncertain, and a map with no fog says so in as many words — a
+// silent absence and an absence nobody looked for read the same.
+export function emptyMapVerdictPrompt(repo, { number, title }, fog = []) {
+  const head = `Map ${repo}#${number} “${title}” has no open ticket left. Is the way walked — does no work remain?`
+  const body = fog.length
+    ? [`Still under Not yet specified (${fog.length}):`, ...fog.map((f) => `• ${f.text ?? f}`)]
+    : ['Nothing stands under Not yet specified.']
+  const tail = '✅ posts the verdict and closes the map. ❌ leaves it open, and I stop asking.'
+  return [head, '', ...body, '', tail].join('\n')
+}
+
+// What still holds an empty map open at the moment the operator approves the
+// close (#698). The question was asked off a frontier read that may be minutes
+// old, so the answer is checked against the map as it stands NOW: a child
+// reopened, fog written, or the map paused since the card went out all mean the
+// close the operator approved is no longer the close curia would make.
+//
+// Returns the reasons as sentences, gravest first. Empty means close it.
+export function mapCloseBlockers({ state = 'open', labels = [], children = [], fog = [] } = {}) {
+  const held = []
+  if (state !== 'open') held.push('the map is already closed')
+  if ((labels ?? []).some((l) => (typeof l === 'string' ? l : l.name) === 'wayfinder:deferred')) {
+    held.push('the map is paused (`wayfinder:deferred`), and a pause is only ever ended by hand')
+  }
+  const open = (children ?? []).filter((c) => !c.pull_request && c.state === 'open')
+  if (open.length) {
+    held.push(`${open.length} child ticket(s) reopened or arrived: ${open.map((c) => `#${c.number}`).join(', ')}`)
+  }
+  if ((fog ?? []).length) {
+    held.push(`${fog.length} line(s) still stand under Not yet specified: ${fog.map((f) => f.text ?? f).join('; ')}`)
+  }
+  return held
+}
+
+// The comment curia posts on the map when the operator says the way is walked.
+export function mapClosedComment() {
+  return [
+    '✅ **Closed on the operator’s verdict.** No open child ticket remains, and nothing stands under Not yet specified.',
+    '',
+    '-# curia asked whether any work remained, the operator answered no, and this map closed on that answer.',
+  ].join('\n')
+}
+
+// The comment curia posts when the operator says work remains, and when the
+// approved close is refused by what the map says now. Both are verdicts, and
+// both leave the map open — so both are written down, because a map that stays
+// open for a reason nobody recorded is exactly what #316 was.
+export function mapHeldComment(reasons) {
+  return [
+    '⏸️ **This map stays open.** It has no open child ticket, and curia asked whether the way is walked.',
+    '',
+    ...reasons.map((r) => `- ${r}`),
+    '',
+    '-# curia will not ask again until this map gains an open child and empties once more.',
+  ].join('\n')
 }
 
 // The HITL-free chain count (#81's tickets view): how many open tickets an

--- a/daemon/src/lifecycle.mjs
+++ b/daemon/src/lifecycle.mjs
@@ -109,13 +109,16 @@ export const ENDING = [
         // The map-close is curia-side context, not skill doctrine: manual
         // wayfinder sessions close an emptied map by judgment, and a checklist
         // session exercises none past its steps — so the checklist says it.
-        'If your close left the map with no open child and nothing under Not yet specified, close the',
-        'map itself with a verdict comment: the way is walked, and no one else is dispatched to say so.',
-        // The other emptied ending (#485): no open child, but the fog still
-        // holds patches. The agent must not close then, and it must not stay
-        // silent either — #316 stranded exactly there.
-        'If no open child remains but Not yet specified still holds patches, leave the map open and say',
-        'so in your report_result summary: the map cannot close until that fog is graduated or ruled.',
+        //
+        // The agent no longer closes it (#698). Curia asks the operator whether
+        // the way is walked, and closes on their answer — so an agent closing
+        // the map itself would be answering a question addressed to a person.
+        // What the agent owes is the sentence that tells them what they are
+        // answering, which is the same sentence #485 wanted for the fog case.
+        'Never close the map itself. If your close left it with no open child, say so in your',
+        'report_result summary — curia asks the operator whether the way is walked, and closes the map',
+        'on their answer. Name anything still standing under Not yet specified, because that fog is what',
+        'holds the close and it has to be graduated or ruled before the map can end.',
         ...FOLLOW_UP_RECORD,
       ]
       : [

--- a/daemon/src/mapsnapshot.mjs
+++ b/daemon/src/mapsnapshot.mjs
@@ -38,6 +38,11 @@ export function fogFacts(body) {
   const source = section.lines.slice(section.start + 1, section.end).join('\n')
     .replace(/<!--[\s\S]*?-->/g, '')
   const lines = source.split('\n').map((line) => line.trim()).filter(Boolean)
+    // A sub-heading inside the fog is a shape, not a patch of fog (#698). The
+    // section is written by hand and by charting agents, and both group long
+    // fog under `###` lines — counting those as facts would make an empty map
+    // look uncertain and hold its close forever.
+    .filter((line) => !/^#{1,6}\s/.test(line))
   if (lines[0] && /^none(?:\b|[.!])/i.test(lines[0])) return []
   return lines
     .filter((line) => line.replace(/[*_()]/g, '').trim().toLowerCase() !== 'empty')

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -394,6 +394,19 @@ export class Reduction {
     // frontier read is what observes it.
     if (ev.type === 'map_stranded') this.mapAlarms.set(`${ev.repo}#${ev.map}`, { ...ev, at: ev.ts ?? null })
     if (ev.type === 'map_stranded_cleared') this.mapAlarms.delete(`${ev.repo}#${ev.map}`)
+    // The empty-map verdict (#698) stands on the same entry, because it is the
+    // same fact carried further: #485 raised an alarm about a map, and #698
+    // asks a question about it. Both `asked` and `answered` are merged onto
+    // whatever stands, so a boot rebuilds a question already out and an answer
+    // already given — the two things a restart must not lose. Only the same
+    // `map_stranded_cleared` erases it, and only when the fact itself is gone.
+    if (ev.type === 'map_verdict_asked' || ev.type === 'map_verdict_answered') {
+      const key = `${ev.repo}#${ev.map}`
+      const prior = this.mapAlarms.get(key) ?? { repo: ev.repo, map: ev.map, title: ev.title ?? null }
+      this.mapAlarms.set(key, ev.type === 'map_verdict_asked'
+        ? { ...prior, asked: ev.id, at: ev.ts ?? prior.at ?? null }
+        : { ...prior, answered: ev.answer ?? null, closed: ev.closed ?? false })
+    }
 
     if (ev.type === 'token_warned' || ev.type === 'token_cleared') {
       const key = ev.fault === 'expiring'

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -6498,14 +6498,14 @@ describe('a dead harness under a live pane is a death (#386)', () => {
   })
 })
 
-// The stranded-map watch (#485). An open, non-deferred map whose children are
-// all closed gets no dispatch ever again, so the frontier read is the one place
-// that can say so. The alarm is edge-triggered off the journal like the backup
-// alarm (#436): said once, standing until the map closes, defers, or gains an
-// open child.
-describe('the stranded-map watch (#485)', () => {
-  const map = (n, { state = 'open', labels = [] } = {}) => ({
-    number: n, state, title: 'The journal becomes a queryable store',
+// The empty-map question (#485, asked rather than announced by #698). An open,
+// non-deferred map whose children are all closed gets no dispatch ever again,
+// so the frontier read is the one place that can notice it. #485 said a line
+// about it. #698 asks the operator a durable question instead, and their answer
+// is what posts the verdict and closes the map.
+describe('the empty-map question (#485, #698)', () => {
+  const map = (n, { state = 'open', labels = [], body = null } = {}) => ({
+    number: n, state, body, title: 'The journal becomes a queryable store',
     labels: [{ name: 'wayfinder:map' }, ...labels.map((name) => ({ name }))],
   })
   const closedChild = (n) => ({ number: n, state: 'closed', assignees: [], labels: [{ name: 'wayfinder:task' }] })
@@ -6513,38 +6513,76 @@ describe('the stranded-map watch (#485)', () => {
     number: n, state: 'open', assignees: [], labels: [{ name: 'wayfinder:task' }],
     issue_dependencies_summary: { blocked_by: 0 },
   })
+  const answered = (record, answer) => {
+    Object.assign(record, { status: 'answered', answer, answered_by: 'alp' })
+    return record
+  }
+  const verdicts = () => confirms.filter((r) => r.action?.verb === 'map_close')
 
-  test('an all-closed map is said once, journalled, and the second pass is quiet', async () => {
-    const says = []
+  test('an all-closed map is asked once, journalled, and the second pass is quiet', async () => {
     const d = makeDispatcher({
       repoMaps: async () => [map(316)],
       mapFrontier: async () => [closedChild(1), closedChild(2)],
     })
-    d.announce = async (text) => { says.push(text); return true }
 
     await d.frontier()
-    assert.equal(says.length, 1)
-    assert.match(says[0], /#316/)
-    assert.match(says[0], /no open ticket left/)
-    const ev = events.find((e) => e.type === 'map_stranded')
+    assert.equal(verdicts().length, 1)
+    assert.match(verdicts()[0].prompt, /o\/r#316/)
+    assert.match(verdicts()[0].prompt, /no open ticket left/)
+    assert.deepEqual(verdicts()[0].action, {
+      verb: 'map_close', repo: 'o/r', map: 316, title: 'The journal becomes a queryable store', fog: [],
+    })
+    const ev = events.find((e) => e.type === 'map_verdict_asked')
     assert.equal(ev.repo, 'o/r')
     assert.equal(ev.map, 316)
-    assert.equal(ev.said, true)
 
     await d.frontier()
-    assert.equal(says.length, 1, 'a standing alarm is not re-said')
-    assert.equal(events.filter((e) => e.type === 'map_stranded').length, 1)
+    assert.equal(verdicts().length, 1, 'a question already asked is not asked again')
+    assert.equal(events.filter((e) => e.type === 'map_verdict_asked').length, 1)
   })
 
-  test('an open child, an empty map, and a deferred map raise nothing', async () => {
-    const says = []
+  test('the question carries the fog, ignoring headings, blank lines and HTML comments', async () => {
+    const body = [
+      '## Not yet specified',
+      '',
+      '### The retention questions',
+      '',
+      '<!-- charting note, not a fog fact -->',
+      '- Pick the retention period',
+      '',
+      '## Out of scope',
+      '- something else entirely',
+    ].join('\n')
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316, { body })],
+      mapFrontier: async () => [closedChild(1)],
+    })
+
+    await d.frontier()
+    assert.deepEqual(verdicts()[0].action.fog, ['Pick the retention period'])
+    assert.match(verdicts()[0].prompt, /Still under Not yet specified \(1\)/)
+    assert.match(verdicts()[0].prompt, /• Pick the retention period/)
+  })
+
+  test('a map with no fog is still asked — the question is durable either way', async () => {
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316, { body: '## Not yet specified\n\nNone. The child set covers it.\n' })],
+      mapFrontier: async () => [closedChild(1)],
+    })
+
+    await d.frontier()
+    assert.equal(verdicts().length, 1)
+    assert.deepEqual(verdicts()[0].action.fog, [])
+    assert.match(verdicts()[0].prompt, /Nothing stands under Not yet specified/)
+  })
+
+  test('an open child, an empty map, and a deferred map ask nothing', async () => {
     let maps = [map(316)]
     let children = [closedChild(1), openChild(2)]
     const d = makeDispatcher({
       repoMaps: async () => maps,
       mapFrontier: async () => children,
     })
-    d.announce = async (text) => { says.push(text); return true }
 
     await d.frontier()
     children = []
@@ -6553,56 +6591,149 @@ describe('the stranded-map watch (#485)', () => {
     children = [closedChild(1)]
     await d.frontier()
 
-    assert.equal(says.length, 0)
-    assert.ok(!events.some((e) => e.type === 'map_stranded'))
+    assert.equal(verdicts().length, 0)
+    assert.ok(!events.some((e) => e.type === 'map_verdict_asked'))
   })
 
-  test('the alarm clears when a child reopens, and again when the map closes', async () => {
+  test('a child reopening lapses the standing question, and an emptying asks again', async () => {
     let maps = [map(316)]
     let children = [closedChild(1)]
-    const says = []
     const d = makeDispatcher({
       repoMaps: async () => maps,
       mapFrontier: async () => children,
     })
-    d.announce = async (text) => { says.push(text); return true }
 
     await d.frontier()
-    assert.equal(says.length, 1)
+    assert.equal(verdicts().length, 1)
 
     children = [closedChild(1), openChild(2)]
     await d.frontier()
     assert.ok(events.some((e) => e.type === 'map_stranded_cleared' && e.map === 316))
+    assert.ok(lapses.some((l) => l.id === verdicts()[0].id && /no longer empty/.test(l.reason)))
 
-    // it re-strands and is news again
     children = [closedChild(1), closedChild(2)]
     await d.frontier()
-    assert.equal(says.length, 2)
+    assert.equal(verdicts().length, 2, 'a map that empties again is a new question')
 
     maps = [map(316, { state: 'closed' })]
     await d.frontier()
     assert.equal(events.filter((e) => e.type === 'map_stranded_cleared').length, 2)
   })
 
-  test('an alarm the bridge could not carry stands unsaid and re-says when it returns', async () => {
+  test('approve posts the verdict and closes the map — comment first, close after', async () => {
+    const acts = []
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316)],
+      mapFrontier: async () => [closedChild(1)],
+      fetchIssue: async () => ({ number: 316, state: 'open', labels: [], body: '## Not yet specified\n\nNone.\n' }),
+      commentIssue: async (repo, n, body) => acts.push(`comment:${repo}#${n}:${body.split('\n')[0]}`),
+      closeIssue: async (repo, n) => acts.push(`close:${repo}#${n}`),
+    })
+
+    await d.frontier()
+    await d.onConfirmAnswered(answered(verdicts()[0], 'approve'))
+
+    assert.equal(acts.length, 2)
+    assert.match(acts[0], /^comment:o\/r#316:✅ \*\*Closed on the operator/)
+    assert.equal(acts[1], 'close:o/r#316')
+    const ev = events.find((e) => e.type === 'map_verdict_answered')
+    assert.deepEqual([ev.answer, ev.closed], ['approve', true])
+  })
+
+  test('decline leaves the map open, says why on the map, and never asks again', async () => {
+    const acts = []
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316)],
+      mapFrontier: async () => [closedChild(1)],
+      commentIssue: async (repo, n, body) => acts.push({ n, body }),
+      closeIssue: async () => acts.push({ closed: true }),
+    })
+
+    await d.frontier()
+    await d.onConfirmAnswered(answered(verdicts()[0], 'reject'))
+
+    assert.equal(acts.length, 1)
+    assert.match(acts[0].body, /stays open/)
+    assert.match(acts[0].body, /work remains/)
+    const ev = events.find((e) => e.type === 'map_verdict_answered')
+    assert.deepEqual([ev.answer, ev.closed], ['reject', false])
+
+    await d.frontier()
+    assert.equal(verdicts().length, 1, 'an answered question is never re-asked')
+  })
+
+  // The question can sit for days, so the approval it comes back with is an
+  // approval of what the CARD said. Everything below changed between the two.
+  const refusedClose = async (issue, children) => {
+    const acts = []
+    let asked = false
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316)],
+      mapFrontier: async () => (asked ? children : [closedChild(1)]),
+      fetchIssue: async () => ({ number: 316, ...issue }),
+      commentIssue: async (repo, n, body) => acts.push({ body }),
+      closeIssue: async () => acts.push({ closed: true }),
+    })
+    await d.frontier()
+    asked = true
+    await d.onConfirmAnswered(answered(verdicts()[0], 'approve'))
+    assert.ok(!acts.some((a) => a.closed), 'the close is held')
+    assert.match(acts.at(-1).body, /stays open/)
+    assert.equal(events.filter((e) => e.type === 'map_verdict_answered').at(-1).closed, false)
+    return acts.at(-1).body
+  }
+
+  test('fog written since the question was asked refuses the approved close', async () => {
+    const body = await refusedClose(
+      { state: 'open', labels: [], body: '## Not yet specified\n\n- Pick the retention period\n' }, [])
+    assert.match(body, /still stand under Not yet specified: Pick the retention period/)
+  })
+
+  test('a child that reopened since the question was asked refuses the approved close', async () => {
+    const body = await refusedClose({ state: 'open', labels: [], body: '' }, [openChild(2)])
+    assert.match(body, /child ticket\(s\) reopened or arrived: #2/)
+  })
+
+  test('a map paused since the question was asked is never closed by the answer', async () => {
+    const body = await refusedClose({ state: 'open', labels: [{ name: 'wayfinder:deferred' }], body: '' }, [])
+    assert.match(body, /paused/)
+  })
+
+  test('a failed write leaves the map open, and no pass retries the close', async () => {
+    const d = makeDispatcher({
+      repoMaps: async () => [map(316)],
+      mapFrontier: async () => [closedChild(1)],
+      fetchIssue: async () => ({ number: 316, state: 'open', labels: [], body: '' }),
+      commentIssue: async () => { throw new Error('gh: 502') },
+      closeIssue: async () => { throw new Error('the close must never be reached') },
+    })
+
+    await d.frontier()
+    await d.onConfirmAnswered(answered(verdicts()[0], 'approve'))
+
+    assert.match(events.find((e) => e.type === 'map_verdict_failed').error, /502/)
+    await d.frontier()
+    assert.equal(verdicts().length, 1)
+  })
+
+  test('a restart keeps the question standing — boot lapses every confirm but this one', async () => {
     const d = makeDispatcher({
       repoMaps: async () => [map(316)],
       mapFrontier: async () => [closedChild(1)],
     })
-    // the constructor default announce is the no-bridge answer: false
-
     await d.frontier()
-    assert.equal(events.find((e) => e.type === 'map_stranded').said, false)
+    const asked = verdicts()[0]
 
-    await d.frontier()
-    assert.equal(events.filter((e) => e.type === 'map_stranded').length, 1,
-      'a standing unsaid alarm does not journal every pass')
+    await d.reconcile({ boot: true })
 
-    const says = []
-    d.announce = async (text) => { says.push(text); return true }
+    assert.equal(asked.status, 'open', 'the map question outlives the process that asked it')
+    assert.ok(!lapses.some((l) => l.id === asked.id))
     await d.frontier()
-    assert.equal(says.length, 1)
-    assert.equal(events.filter((e) => e.type === 'map_stranded').at(-1).said, true)
+    assert.equal(verdicts().length, 1, 'and a boot does not ask it a second time')
+
+    // the answer still executes after the restart
+    await d.onConfirmAnswered(answered(asked, 'approve'))
+    assert.ok(events.some((e) => e.type === 'map_verdict_answered'))
   })
 })
 

--- a/daemon/test/frontier.test.mjs
+++ b/daemon/test/frontier.test.mjs
@@ -48,7 +48,10 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { filterTakeable, selectLane, frontierForRepo, agentOnlyChainCount, strandedMaps, strandedMapLine } from '../src/github.mjs'
+import {
+  filterTakeable, selectLane, frontierForRepo, agentOnlyChainCount, strandedMaps,
+  emptyMapVerdictPrompt, mapCloseBlockers, mapClosedComment, mapHeldComment,
+} from '../src/github.mjs'
 
 // Small fixture builder -- keeps the field-notes ground truth readable below.
 // assignees/labels use the real gh shape: arrays of objects, not strings.
@@ -320,11 +323,65 @@ describe('strandedMaps (#485)', () => {
     assert.deepEqual(strandedMaps(maps, items), [])
   })
 
-  test('the line names the map and both acts that end it', () => {
-    const line = strandedMapLine('o/r', { number: 316, title: 'The journal becomes a queryable store' })
-    assert.match(line, /o\/r#316/)
-    assert.match(line, /no open ticket left/)
-    assert.match(line, /Close it with a verdict comment/)
-    assert.match(line, /Not yet specified/)
+})
+
+// The empty-map verdict (#698). #485 said a line about a stranded map and
+// waited for someone to act on it. This asks the operator a question instead,
+// and the answer is what closes the map.
+describe('the empty-map question (#698)', () => {
+  const map = { number: 316, title: 'The journal becomes a queryable store' }
+
+  test('the question names the map, its fog, and what each answer does', () => {
+    const prompt = emptyMapVerdictPrompt('o/r', map, [
+      { text: 'Pick the retention period' },
+      { text: 'Decide whether exports include raw rows' },
+    ])
+    assert.match(prompt, /o\/r#316/)
+    assert.match(prompt, /no open ticket left/)
+    assert.match(prompt, /Still under Not yet specified \(2\)/)
+    assert.match(prompt, /• Pick the retention period/)
+    assert.match(prompt, /• Decide whether exports include raw rows/)
+    assert.match(prompt, /✅ posts the verdict and closes the map/)
+  })
+
+  test('a map with no fog says so — an absence nobody looked for reads the same as silence', () => {
+    const prompt = emptyMapVerdictPrompt('o/r', map, [])
+    assert.match(prompt, /Nothing stands under Not yet specified/)
+    assert.doesNotMatch(prompt, /Still under Not yet specified/)
+  })
+})
+
+// What still holds an approved close (#698). The question can sit for days, so
+// the approval is checked against the map as it stands rather than as it read.
+describe('mapCloseBlockers (#698)', () => {
+  test('an open, unlabelled, childless, fogless map closes', () => {
+    assert.deepEqual(mapCloseBlockers({ state: 'open', labels: [], children: [], fog: [] }), [])
+    assert.deepEqual(mapCloseBlockers(), [])
+  })
+
+  test('a closed map, a reopened child, and standing fog each hold it', () => {
+    assert.match(mapCloseBlockers({ state: 'closed' })[0], /already closed/)
+    const child = mapCloseBlockers({ children: [{ number: 9, state: 'open' }] })
+    assert.match(child[0], /1 child ticket\(s\) reopened or arrived: #9/)
+    const fog = mapCloseBlockers({ fog: [{ text: 'Pick the retention period' }] })
+    assert.match(fog[0], /1 line\(s\) still stand under Not yet specified: Pick the retention period/)
+  })
+
+  test('a paused map is never closed by an answer — a pause is only ever ended by hand', () => {
+    const held = mapCloseBlockers({ labels: [{ name: 'wayfinder:deferred' }] })
+    assert.match(held[0], /paused/)
+    assert.deepEqual(mapCloseBlockers({ labels: ['wayfinder:deferred'] }).length, 1)
+  })
+
+  test('a closed child and a pull request hold nothing', () => {
+    assert.deepEqual(mapCloseBlockers({
+      children: [{ number: 9, state: 'closed' }, { number: 10, state: 'open', pull_request: {} }],
+    }), [])
+  })
+
+  test('both comments say which way the verdict went, and why', () => {
+    assert.match(mapClosedComment(), /Closed on the operator’s verdict/)
+    assert.match(mapHeldComment(['the operator says work remains on this map']), /stays open/)
+    assert.match(mapHeldComment(['the operator says work remains on this map']), /- the operator says work remains/)
   })
 })

--- a/daemon/test/mapsnapshot.test.mjs
+++ b/daemon/test/mapsnapshot.test.mjs
@@ -193,6 +193,51 @@ test('fog returns the facts under Not yet specified', async () => {
   ])
 })
 
+// #698: the empty-map question shows this same fog, so a `###` line grouping
+// it would read as a patch of uncertainty and hold a finished map open.
+test('a sub-heading inside the fog is a shape, not a fact', async () => {
+  const body = [
+    '## Not yet specified',
+    '',
+    '### The retention questions',
+    '',
+    '- Pick the retention period',
+    '',
+    '#### Later',
+    '- Decide whether exports include raw rows',
+  ].join('\n')
+  const github = {
+    repoMaps: async () => [issue(10, 'the map', { body })],
+    mapFrontier: async () => [],
+    blockedByOf: async () => [],
+  }
+  const journal = { mapSnapshotFacts: async () => new Map() }
+
+  const { maps: [map] } = await readMapSnapshot({
+    watch: [{ repo: 'o/r', mode: 'map' }], routing, github, journal,
+  })
+
+  assert.deepEqual(map.fog, [
+    { text: 'Pick the retention period' },
+    { text: 'Decide whether exports include raw rows' },
+  ])
+})
+
+test('a fog section that is nothing but headings is empty fog', async () => {
+  const github = {
+    repoMaps: async () => [issue(10, 'the map', { body: '## Not yet specified\n\n### Open questions\n' })],
+    mapFrontier: async () => [],
+    blockedByOf: async () => [],
+  }
+  const journal = { mapSnapshotFacts: async () => new Map() }
+
+  const { maps: [map] } = await readMapSnapshot({
+    watch: [{ repo: 'o/r', mode: 'map' }], routing, github, journal,
+  })
+
+  assert.deepEqual(map.fog, [])
+})
+
 test('None and empty Not yet specified sections return no fog', async () => {
   const github = {
     repoMaps: async () => [


### PR DESCRIPTION
Implements `alp82/curia#698`, a child of the Atlas execution map `alp82/curia#685`.

## What changed

A map with no open child used to get a channel line saying it was stranded (#485). A line states a fact and waits for someone to act on it, and #316 sat open for days because nobody did. Curia now asks the operator a question, and their answer closes the map.

- **One durable question per emptying.** The frontier watch opens a ✅/❌ confirm carrying the map's fog, whether the fog is empty or not, and journals `map_verdict_asked`. A second pass sees the entry and stays quiet. An answered entry stays quiet for good.
- **A restart keeps it.** Boot lapses every confirm because agent instance ids don't survive a restart. This one names a map, and a map number means the same thing on either side of a boot, so it is skipped. Its answer still executes afterwards.
- **The verdict is posted, then the close is checked.** ✅ re-reads the map: an open child that reopened, fog written since, a `wayfinder:deferred` pause, or an already-closed map each hold the close, and each is written onto the map as the verdict comment. ❌ posts the operator's word and leaves the map open. A paused map is never closed by an answer.
- **Fog ignores sub-headings**, the way it already ignored blank lines and HTML comments. A `###` grouping inside "Not yet specified" is shape, not a patch of uncertainty. The map snapshot Atlas draws and the card the operator answers read the same lines.
- **Agents no longer close an emptied map themselves.** The resolve checklist asks them to report what they left instead, which is what the operator answers.

## Acceptance criteria

| Criterion | Where |
| --- | --- |
| One durable question, fog present or not | `the empty-map question (#485, #698)` in `daemon/test/dispatch.test.mjs` |
| Fog shown, headings and comments ignored | same suite, plus `daemon/test/mapsnapshot.test.mjs` |
| A restart repeats nothing and loses no answer | `a restart keeps the question standing` |
| Verdict posted, close only when nothing remains | `approve posts the verdict and closes the map`, and the three refusal tests |
| Reconcile never asks or closes twice | `an all-closed map is asked once`, `decline ... never asks again` |

## Tests

`npm test` in `daemon/`: 3259 passing, 0 failing, 0 cancelled. Baseline on main is 3243, so the 16 new tests are the difference. Everything runs against injected fakes. No real GitHub issue was read, commented on, or closed.

## Left out

The pure fog classifier stays in `mapsnapshot.mjs` rather than moving to its own module. It is one exported function with one rule, and both callers now import it from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
