### PR TITLE
Give each duplicated rule one home (alp82/curia#750)

### DIFF
--- a/daemon/src/agenttoken.mjs
+++ b/daemon/src/agenttoken.mjs
@@ -49,42 +49,108 @@ export const AGENT_ROUTES = new Set(['/mcp', '/agent_done'])
 // curl argument, a JSON string and a TOML string with no escaping rule anywhere.
 const TOKEN_RE = /^[0-9a-f]{64}$/
 
-export function tokensDir(dataDir) {
-  return path.join(dataDir, 'tokens')
+// ---- the file store ---------------------------------------------------------
+
+// The shape both token stores keep: one 0600 file per name, under one directory
+// of the daemon's data dir, holding a 64-hex secret and nothing else.
+//
+// The conversation store (`overseeridentity.mjs`) is the second caller. It
+// keeps its own two rules — which names are valid, and a DURABLE token read
+// back rather than reminted — and takes the rest from here: where the file
+// lives, how the name is asserted before it becomes one, the mode that survives
+// a rewrite, the constant-time compare, the revoke, and the sweep against a
+// positively known list. Two stores that had to agree on all of that by hand is
+// how one of them ends up world-readable.
+export function tokenStore({ dirName, validName, dirMode = null, refusal }) {
+  const dirFor = (dataDir) => path.join(dataDir, dirName)
+
+  // The name comes off a query param at check time, so it is asserted before it
+  // is ever used as a filename. Neither store's shape admits a `/`, which is
+  // what keeps this a basename.
+  const fileFor = (dataDir, name) => (validName(String(name ?? '')) ? path.join(dirFor(dataDir), String(name)) : null)
+
+  const read = (dataDir, name) => {
+    const file = fileFor(dataDir, name)
+    if (!file) return null
+    try {
+      const token = fs.readFileSync(file, 'utf8').trim()
+      return TOKEN_RE.test(token) ? token : null
+    } catch {
+      return null
+    }
+  }
+
+  // A fresh secret, written where the name says.
+  const mint = (dataDir, name) => {
+    const file = fileFor(dataDir, name)
+    if (!file) throw new Error(refusal(name))
+    const token = crypto.randomBytes(32).toString('hex')
+    fs.mkdirSync(dirFor(dataDir), { recursive: true, ...(dirMode === null ? {} : { mode: dirMode }) })
+    fs.writeFileSync(file, token, { mode: 0o600 })
+    // writeFileSync applies the mode only when it CREATES the file, and a name
+    // minted twice already has one (same note as sandbox.mjs's env file).
+    fs.chmodSync(file, 0o600)
+    return token
+  }
+
+  const revoke = (dataDir, name) => {
+    const file = fileFor(dataDir, name)
+    if (file) fs.rmSync(file, { force: true })
+  }
+
+  // Every token whose name is not in a POSITIVELY known list — the same
+  // evidence rule the rest of reconcile runs on. Returns the names collected.
+  const sweep = (dataDir, live) => {
+    let names = []
+    try {
+      names = fs.readdirSync(dirFor(dataDir))
+    } catch {
+      return [] // nothing was ever minted
+    }
+    const keep = new Set([...live].map(String))
+    const swept = []
+    for (const name of names) {
+      if (keep.has(name) || !validName(name)) continue
+      revoke(dataDir, name)
+      swept.push(name)
+    }
+    return swept
+  }
+
+  return {
+    dirFor,
+    fileFor,
+    read,
+    mint,
+    revoke,
+    sweep,
+    // Fails CLOSED in every direction that is not an exact match: no minted
+    // token, an unreadable one, a missing header, a wrong one.
+    matches: (dataDir, name, presented) => tokensEqual(read(dataDir, name), presented),
+  }
 }
 
-// The session name comes off a query param at check time, so it is asserted
-// before it is ever used as a filename. `validSessionName` admits no `/`, which
-// is what keeps this a basename.
-function tokenFile(dataDir, agent) {
-  if (!validSessionName(String(agent ?? ''))) return null
-  return path.join(tokensDir(dataDir), String(agent))
+// ---- the agent's store ------------------------------------------------------
+
+const AGENTS = tokenStore({
+  dirName: 'tokens',
+  validName: (name) => validSessionName(name),
+  refusal: (agent) => `refusing to mint an agent token for "${agent}": not a valid curia session name`,
+})
+
+export function tokensDir(dataDir) {
+  return AGENTS.dirFor(dataDir)
 }
 
 // A FRESH secret, overwriting whatever the last arm of this agent left. The
-// cross-harness respawn (#126) rewrites the connection settings, and the pane that died must
-// not keep speaking for the name.
+// cross-harness respawn (#126) rewrites the connection settings, and the pane
+// that died must not keep speaking for the name.
 export function mintAgentToken(dataDir, agent) {
-  const file = tokenFile(dataDir, agent)
-  if (!file) throw new Error(`refusing to mint an agent token for "${agent}": not a valid curia session name`)
-  const token = crypto.randomBytes(32).toString('hex')
-  fs.mkdirSync(tokensDir(dataDir), { recursive: true })
-  fs.writeFileSync(file, token, { mode: 0o600 })
-  // writeFileSync applies the mode only when it CREATES the file, and an agent
-  // armed twice already has one (same note as sandbox.mjs's env file).
-  fs.chmodSync(file, 0o600)
-  return token
+  return AGENTS.mint(dataDir, agent)
 }
 
 export function readAgentToken(dataDir, agent) {
-  const file = tokenFile(dataDir, agent)
-  if (!file) return null
-  try {
-    const token = fs.readFileSync(file, 'utf8').trim()
-    return TOKEN_RE.test(token) ? token : null
-  } catch {
-    return null
-  }
+  return AGENTS.read(dataDir, agent)
 }
 
 // One secret against another, in constant time. The overseer's per-turn secret
@@ -101,34 +167,17 @@ export function tokensEqual(expected, presented) {
   return crypto.timingSafeEqual(a, b)
 }
 
-// Fails CLOSED in every direction that is not an exact match: no minted token,
-// an unreadable one, a missing header, a wrong one. An agent armed before this
-// shipped therefore has no way in — see docs/live-checks/159-worker-token.md for
-// the one restart that costs, and its recovery.
+// An agent armed before #159 shipped has no way in — see
+// docs/live-checks/159-worker-token.md for the one restart that costs, and its
+// recovery.
 export function agentTokenMatches(dataDir, agent, presented) {
-  return tokensEqual(readAgentToken(dataDir, agent), presented)
+  return AGENTS.matches(dataDir, agent, presented)
 }
 
 export function forgetAgentToken(dataDir, agent) {
-  const file = tokenFile(dataDir, agent)
-  if (file) fs.rmSync(file, { force: true })
+  AGENTS.revoke(dataDir, agent)
 }
 
-// Every token whose agent is not in a POSITIVELY known session list — the same
-// evidence rule the rest of reconcile runs on. Returns the names collected.
 export function sweepAgentTokens(dataDir, live) {
-  let names = []
-  try {
-    names = fs.readdirSync(tokensDir(dataDir))
-  } catch {
-    return [] // nothing was ever minted
-  }
-  const keep = new Set(live)
-  const swept = []
-  for (const name of names) {
-    if (keep.has(name) || !validSessionName(name)) continue
-    forgetAgentToken(dataDir, name)
-    swept.push(name)
-  }
-  return swept
+  return AGENTS.sweep(dataDir, live)
 }

--- a/daemon/src/aistack.mjs
+++ b/daemon/src/aistack.mjs
@@ -48,6 +48,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
+import { CFG_DIR, configRootEnvFor } from './workspace.mjs'
 
 // Rule 4. The npm package, its binary, and the runner that fetches it.
 export const CLI_PACKAGE = '@use-aistack/cli'
@@ -95,8 +96,6 @@ export function hasCredential(root) {
 }
 
 // ---- the roots --------------------------------------------------------------
-
-export const CFG_DIR = 'cfg'
 
 // Every config directory on the box, newest write first. The name is the
 // session, and `at` is the directory's own mtime, which is what ranks the codex
@@ -163,11 +162,14 @@ export function codexRoot(root) {
 export function syncEnv(root, { env = process.env } = {}) {
   const claude = claudeRoots(root)
   const codex = codexRoot(root)
+  // The variable names come from `workspace.mjs`, which is where a harness's
+  // config root is decided for the agents themselves. A sync that named them
+  // here would keep scanning the old variable the day one changes.
   return {
     ...env,
     HOME: homeFor(root),
-    ...(claude.length ? { CLAUDE_CONFIG_DIR: claude.join(',') } : {}),
-    ...(codex ? { CODEX_HOME: codex } : {}),
+    ...(claude.length ? { [configRootEnvFor('claude')]: claude.join(',') } : {}),
+    ...(codex ? { [configRootEnvFor('codex')]: codex } : {}),
   }
 }
 

--- a/daemon/src/appsetup.mjs
+++ b/daemon/src/appsetup.mjs
@@ -35,31 +35,26 @@ import path from 'node:path'
 
 import {
   APP_ID_KEY, APP_KEY_FILE_KEY, DEFAULT_KEY_FILE, TokenMinter,
+  READ_PERMISSIONS, WRITE_PERMISSIONS,
 } from './githubapp.mjs'
 
 // ---- the manifest ----------------------------------------------------------
 
 // The five repository permissions of docs/github-app.md step 2, and nothing
-// else. The write set the agents mint (contents, issues, pull requests) plus the
-// two the overseer reads through (commit statuses, metadata), because a minted
-// token may scope DOWN from the installation and never up: an app created
-// without `statuses` would 422 the first read token the overseer asked for.
+// else. DERIVED, not restated: an installation token may scope DOWN from what
+// the app holds and never up, so the app must be created with the union of
+// every set `githubapp.mjs` mints — the write set the agents ask for, plus the
+// read set the overseer asks for. An app created without `statuses` would 422
+// the first read token, and a permission added to either table there would
+// otherwise never reach a newly created App.
 //
-// WORKFLOWS IS DELIBERATELY ABSENT, for the reason githubapp.mjs states at
-// WRITE_PERMISSIONS: an app that can write `.github/workflows/` is a path from
-// a ticket's text to whatever secrets the next CI run holds.
-export const MANIFEST_PERMISSIONS = Object.freeze({
-  contents: 'write',
-  issues: 'write',
-  pull_requests: 'write',
-  statuses: 'read',
-  metadata: 'read',
-})
+// The write value wins where both name a permission, because it is the wider
+// one. WORKFLOWS IS DELIBERATELY ABSENT, and stays absent as long as neither
+// table names it, for the reason githubapp.mjs states at WRITE_PERMISSIONS: an
+// app that can write `.github/workflows/` is a path from a ticket's text to
+// whatever secrets the next CI run holds.
+export const MANIFEST_PERMISSIONS = Object.freeze({ ...READ_PERMISSIONS, ...WRITE_PERMISSIONS })
 
-// Curia polls. It listens for no webhook, so it subscribes to no event — and an
-// app with no events needs no webhook endpoint to be reachable from GitHub at
-// all. `active: false` is how the manifest says that; the url is required
-// alongside it and is never called.
 export const MANIFEST_EVENTS = Object.freeze([])
 
 export const HOMEPAGE_URL = 'https://github.com/alp82/curia'

--- a/daemon/src/overseeridentity.mjs
+++ b/daemon/src/overseeridentity.mjs
@@ -25,11 +25,11 @@
 // nothing else. It is not an agent token, it doesn't reach `AGENT_ROUTES`, and
 // the daemon still composes every canonical command itself.
 
-import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import { isConsoleKey } from './attach.mjs'
-import { tokensEqual } from './agenttoken.mjs'
+import { tokenStore } from './agenttoken.mjs'
+import { writeClaudeConnection } from './workspace.mjs'
 
 // A Discord thread id is digits, and a browser conversation is `console-<n>`.
 // The same two shapes `overseerPaneSession` admits, stated once here because
@@ -63,28 +63,31 @@ export function overseerRoute(key) {
 // container mounts this tree: the daemon writes the secret straight into the
 // pane's connection settings, so the pane reads a file it can already see and
 // this directory stays the daemon's own.
+//
+// The store itself is `agenttoken.mjs`'s, which is where the file-handling rule
+// lives — one 0600 file per name, the name asserted before it becomes one, a
+// constant-time compare, a sweep against a positively known list. What this
+// conversation store keeps of its own is the two things that genuinely differ:
+// which names are keys, and the DURABLE mint below.
+const STORE = tokenStore({
+  dirName: 'overseer-tokens',
+  validName: isOverseerKey,
+  // 0700 rather than the agent store's default: nothing but the daemon ever
+  // reads this tree.
+  dirMode: 0o700,
+  refusal: (key) => `refusing to mint a tool token for "${key}": not an overseer conversation key`,
+})
+
 export function conversationTokensDir(dataDir) {
-  return path.join(dataDir, 'overseer-tokens')
+  return STORE.dirFor(dataDir)
 }
 
-const TOKEN_RE = /^[0-9a-f]{64}$/
-
-// The key is asserted before it is used as a file name. Neither shape admits a
-// separator, so this stays a basename.
 export function conversationTokenFile(dataDir, key) {
-  if (!isOverseerKey(key)) return null
-  return path.join(conversationTokensDir(dataDir), String(key))
+  return STORE.fileFor(dataDir, key)
 }
 
 export function readConversationToken(dataDir, key) {
-  const file = conversationTokenFile(dataDir, key)
-  if (!file) return null
-  try {
-    const token = fs.readFileSync(file, 'utf8').trim()
-    return TOKEN_RE.test(token) ? token : null
-  } catch {
-    return null
-  }
+  return STORE.read(dataDir, key)
 }
 
 // The conversation's token, minted once and read back forever after.
@@ -94,50 +97,26 @@ export function readConversationToken(dataDir, key) {
 // thing that parks and rehydrates, and rewriting its token on every rehydration
 // would leave a running pane holding a secret the daemon no longer honors.
 export function ensureConversationToken(dataDir, key) {
-  const file = conversationTokenFile(dataDir, key)
-  if (!file) throw new Error(`refusing to mint a tool token for "${key}": not an overseer conversation key`)
-  const existing = readConversationToken(dataDir, key)
-  if (existing) return existing
-  const token = crypto.randomBytes(32).toString('hex')
-  fs.mkdirSync(conversationTokensDir(dataDir), { recursive: true, mode: 0o700 })
-  fs.writeFileSync(file, token, { mode: 0o600 })
-  // writeFileSync applies the mode only when it CREATES the file, and a token
-  // file replaced after a revoke can find one there.
-  fs.chmodSync(file, 0o600)
-  return token
+  return STORE.read(dataDir, key) ?? STORE.mint(dataDir, key)
 }
 
 // Fails closed in every direction that isn't an exact match: an unknown key, an
 // unminted conversation, a missing header, a wrong secret.
 export function conversationTokenMatches(dataDir, key, presented) {
-  return tokensEqual(readConversationToken(dataDir, key), presented)
+  return STORE.matches(dataDir, key, presented)
 }
 
 // The revoke. A deleted conversation spends its number for good, so its token
 // must not outlive it: a pane still running on the old secret loses the verbs
 // on its next call.
 export function revokeConversationToken(dataDir, key) {
-  const file = conversationTokenFile(dataDir, key)
-  if (file) fs.rmSync(file, { force: true })
+  STORE.revoke(dataDir, key)
 }
 
 // Every token whose conversation is not in a positively known list, removed.
 // The same evidence rule `sweepAgentTokens` runs on.
 export function sweepConversationTokens(dataDir, keys) {
-  let names = []
-  try {
-    names = fs.readdirSync(conversationTokensDir(dataDir))
-  } catch {
-    return []
-  }
-  const keep = new Set([...keys].map(String))
-  const swept = []
-  for (const name of names) {
-    if (keep.has(name) || !isOverseerKey(name)) continue
-    revokeConversationToken(dataDir, name)
-    swept.push(name)
-  }
-  return swept
+  return STORE.sweep(dataDir, keys)
 }
 
 // ---- the pane's connection settings -----------------------------------------
@@ -149,11 +128,6 @@ export const OVERSEER_CONVERSATION_PARAM = 'conversation'
 export function conversationMcpUrl({ host, port, key, mcpPath }) {
   if (!isOverseerKey(key)) throw new Error(`"${key}" is not an overseer conversation key`)
   return `http://${host}:${port}${mcpPath}?${OVERSEER_CONVERSATION_PARAM}=${key}`
-}
-
-function writeSecretFile(file, data) {
-  fs.writeFileSync(file, data, { mode: 0o600 })
-  fs.chmodSync(file, 0o600)
 }
 
 // The conversation's own project directory, under the one config directory both
@@ -177,22 +151,12 @@ export function conversationHomeFor(overseerHome, sessionId) {
 
 // The pane's whole reach back into the daemon, written by the daemon.
 //
-// `enableAllProjectMcpServers` is what makes the harness trust a project server
-// with no prompt, the same pair `workspace.mjs` writes for an agent worktree.
+// It is the SAME pair `workspace.mjs` writes for an agent worktree, so it is
+// written by the same function — the pane differs only in the directory, the
+// server name, and having no Stop hook: a conversation ends when the operator
+// stops talking, not when a turn returns.
 export function writeConversationConnection({ home, url, token, serverName, header }) {
-  fs.mkdirSync(home, { recursive: true })
-  writeSecretFile(path.join(home, '.mcp.json'), JSON.stringify({
-    mcpServers: {
-      [serverName]: { type: 'http', url, headers: { [header]: token } },
-    },
-  }, null, 2))
-  const dotClaude = path.join(home, '.claude')
-  fs.mkdirSync(dotClaude, { recursive: true })
-  writeSecretFile(path.join(dotClaude, 'settings.json'), JSON.stringify({
-    enableAllProjectMcpServers: true,
-    permissions: { defaultMode: 'bypassPermissions' },
-  }, null, 2))
-  return path.join(home, '.mcp.json')
+  return writeClaudeConnection({ dir: home, serverName, url, header, token })
 }
 
 // ---- carrying a conversation into its own project directory -----------------

--- a/daemon/src/overseerturn.mjs
+++ b/daemon/src/overseerturn.mjs
@@ -39,7 +39,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk'
-import { seedConfigDir, agentEnv } from './workspace.mjs'
+import { seedConfigDir, agentEnv, cfgDirFor } from './workspace.mjs'
 import { buildSystemPrompt, toolsFor, checkoutReport } from './overseerprompt.mjs'
 import { syncCheckouts, checkoutsRootFor } from './checkouts.mjs'
 import { installCredentialConfig, unroutedOwners, unroutedNote } from './overseercreds.mjs'
@@ -81,7 +81,7 @@ export const CONTAINER_MAX_TURNS = 40
 // old tree any more, and the cutover copied no history (ADR-0016), so whatever
 // a box still carries there is dead paper.
 export function overseerConfigDirFor(workspaceRoot) {
-  return path.join(workspaceRoot, 'cfg', 'curia-overseer')
+  return cfgDirFor(workspaceRoot, 'curia-overseer')
 }
 
 // The cwd every turn runs in, and it never moves: `resume` is keyed by cwd

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -63,8 +63,14 @@ export function worktreePathFor(root, repo, n) {
   return path.join(root, 'repos', repo.replace('/', '__'), 'wt', String(n))
 }
 
+// The one directory name under the workspace root that holds every agent's
+// config dir. Named once because two readers walk it: `cfgDirFor` writes a
+// session's dir here, and `aistack.mjs` enumerates the same tree to find the
+// roots a usage sync scans.
+export const CFG_DIR = 'cfg'
+
 export function cfgDirFor(root, session) {
-  return path.join(root, 'cfg', session)
+  return path.join(root, CFG_DIR, session)
 }
 
 export function branchFor(n) {
@@ -541,6 +547,21 @@ export function removeCredentials(cfgDir) {
 
 export const HARNESS_NAMES = ['claude', 'codex']
 
+// WHICH ENVIRONMENT VARIABLE CARRIES A HARNESS'S CONFIG ROOT. The HARNESS rows
+// below build their env from this map rather than spelling the name inline, and
+// `aistack.mjs` reads it rather than naming the same two variables a second
+// time — a harness whose CLI reads a different variable is then answered here,
+// once, for the agent spawn and the usage sync alike.
+export const CONFIG_ROOT_ENV = Object.freeze({
+  claude: 'CLAUDE_CONFIG_DIR',
+  codex: 'CODEX_HOME',
+})
+
+export function configRootEnvFor(harness = 'claude') {
+  harnessDef(harness)
+  return CONFIG_ROOT_ENV[harness]
+}
+
 function harnessDef(harness) {
   const h = HARNESS[harness]
   if (!h) {
@@ -686,6 +707,39 @@ function writeSecretFile(file, data) {
   fs.chmodSync(file, 0o600) // the mode applies only on create; a reused config dir already has one
 }
 
+// THE CLAUDE HARNESS'S WHOLE REACH BACK INTO THE DAEMON, in one writer.
+//
+// A `.mcp.json` beside a `.claude/settings.json` that says
+// `enableAllProjectMcpServers` — the pair is what makes the CLI trust a project
+// server with no prompt, and either file alone is a harness with no tools. Two
+// callers write it: an agent worktree here, and a conversation's own project
+// directory (`overseeridentity.mjs`). They differ in the directory, the server
+// name and whether a Stop hook rides along; everything else — the shape of the
+// server entry, the header that carries the secret, the bypass mode, the 0600
+// on both files — is one rule and lives here.
+//
+// Returns the path of the `.mcp.json` it wrote.
+export function writeClaudeConnection({ dir, serverName, url, header, token, hooks = null }) {
+  fs.mkdirSync(dir, { recursive: true })
+  const mcpFile = path.join(dir, '.mcp.json')
+  writeSecretFile(mcpFile, JSON.stringify({
+    mcpServers: {
+      // #159. Claude Code sends a per-server `headers` object on every request
+      // to an http MCP server (`claude mcp add --header` writes this exact
+      // shape).
+      [serverName]: { type: 'http', url, headers: { [header]: token } },
+    },
+  }, null, 2))
+  const dotClaude = path.join(dir, '.claude')
+  fs.mkdirSync(dotClaude, { recursive: true })
+  writeSecretFile(path.join(dotClaude, 'settings.json'), JSON.stringify({
+    enableAllProjectMcpServers: true,
+    permissions: { defaultMode: 'bypassPermissions' },
+    ...(hooks ? { hooks } : {}),
+  }, null, 2))
+  return mcpFile
+}
+
 const HARNESS = {
   claude: {
     // The CLI's global-memory file, and the ONLY per-session channel either
@@ -743,7 +797,7 @@ const HARNESS = {
     // frozen-credential shape #53 fixed for the bare path, accepted back by
     // #148 as the sandbox's one remaining host-secret exposure.
     env: (cfgDir, { sandboxed = false } = {}) => ({
-      CLAUDE_CONFIG_DIR: cfgDir,
+      [CONFIG_ROOT_ENV.claude]: cfgDir,
       ...(sandboxed ? {} : { CLAUDE_SECURESTORAGE_CONFIG_DIR: path.join(os.homedir(), '.claude') }),
       CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT: String(86_400_000),
     }),
@@ -809,25 +863,14 @@ const HARNESS = {
     // with per-agent substitution. Both land in the worktree and are hidden from
     // git by the base clone's info/exclude (see ensureBaseClone).
     connectionSettings: ({ wtPath, agent, ticket, daemonPort, daemonHost, token }) => {
-      writeSecretFile(path.join(wtPath, '.mcp.json'), JSON.stringify({
-        mcpServers: {
-          [MCP_SERVER_NAME]: {
-            type: 'http',
-            url: curiaMcpUrl(daemonPort, agent, ticket, daemonHost),
-            // #159. Claude Code sends a per-server `headers` object on every
-            // request to an http MCP server (`claude mcp add --header` writes
-            // this exact shape).
-            headers: { [TOKEN_HEADER]: token },
-          },
-        },
-      }, null, 2))
-      const dotClaude = path.join(wtPath, '.claude')
-      fs.mkdirSync(dotClaude, { recursive: true })
-      writeSecretFile(path.join(dotClaude, 'settings.json'), JSON.stringify({
-        enableAllProjectMcpServers: true,
-        permissions: { defaultMode: 'bypassPermissions' },
+      writeClaudeConnection({
+        dir: wtPath,
+        serverName: MCP_SERVER_NAME,
+        url: curiaMcpUrl(daemonPort, agent, ticket, daemonHost),
+        header: TOKEN_HEADER,
+        token,
         hooks: { Stop: [{ hooks: [{ type: 'command', command: stopHookCommand(daemonPort, agent, daemonHost, token) }] }] },
-      }, null, 2))
+      })
     },
   },
 
@@ -847,7 +890,7 @@ const HARNESS = {
     // CLAUDE_SECURESTORAGE_CONFIG_DIR has no codex equivalent). Sharing the
     // host's credentials therefore has to happen inside the dir.
     hostStore: () => path.join(os.homedir(), '.codex'),
-    env: (cfgDir) => ({ CODEX_HOME: cfgDir }),
+    env: (cfgDir) => ({ [CONFIG_ROOT_ENV.codex]: cfgDir }),
 
     // A SYMLINK to the host's auth.json, which is the same shared-store property
     // #53 landed for Claude and — read this carefully — reached by the opposite

--- a/daemon/test/appsetup.test.mjs
+++ b/daemon/test/appsetup.test.mjs
@@ -19,7 +19,9 @@ import {
   AppSetup, buildManifest, upsertEnv, minterForAdopted,
   MANIFEST_PERMISSIONS, MANIFEST_ACTION, STATE_TTL_MS, MAX_PENDING, STATE_RE,
 } from '../src/appsetup.mjs'
-import { APP_ID_KEY, APP_KEY_FILE_KEY, appConfigFrom } from '../src/githubapp.mjs'
+import {
+  APP_ID_KEY, APP_KEY_FILE_KEY, appConfigFrom, ROLES, permissionsFor,
+} from '../src/githubapp.mjs'
 import { DashboardSurface, DEFAULT_DASHBOARD_INDEX } from '../src/dashboard.mjs'
 import { serveHosts, LOGIN_HEADER } from '../src/identity.mjs'
 
@@ -52,6 +54,28 @@ describe('the manifest (#694)', () => {
     // ADR-0018's one absence: an app that writes `.github/workflows/` lets any
     // agent rewrite CI, and the PATs it replaced could not do it either.
     assert.equal(m.default_permissions.workflows, undefined)
+  })
+
+  // The manifest is DERIVED from the tables in githubapp.mjs, so this fails the
+  // day a permission is added to either one and the manifest does not follow —
+  // which is the App created without it, and the 422 on the first token that
+  // asks for it.
+  test('it holds every permission any minted token can ask for, at least as wide', () => {
+    const m = buildManifest({ name: 'curia.sh', redirectUrl: REDIRECT })
+    const width = { read: 1, write: 2 }
+    for (const role of Object.keys(ROLES)) {
+      for (const [name, level] of Object.entries(permissionsFor(role))) {
+        assert.ok(m.default_permissions[name], `the manifest omits ${name}, which the ${role} token asks for`)
+        assert.ok(
+          width[m.default_permissions[name]] >= width[level],
+          `the manifest grants ${name} at ${m.default_permissions[name]}, narrower than the ${role} token's ${level}`,
+        )
+      }
+    }
+    // And nothing beyond them: a permission in the manifest that no token asks
+    // for is reach curia does not use.
+    const asked = new Set(Object.keys(ROLES).flatMap((r) => Object.keys(permissionsFor(r))))
+    assert.deepEqual(Object.keys(m.default_permissions).filter((k) => !asked.has(k)), [])
   })
 
   test('it subscribes to no events and activates no webhook — curia polls', () => {


### PR DESCRIPTION
Closes nothing on its own — this is `alp82/curia#750`, a child of the execution map `alp82/curia#685`.

The parallel batch that landed #692 through #701 left four rules written twice. Each now has one home, and the daemon does exactly what it did before.

**The App manifest derives.** `MANIFEST_PERMISSIONS` was its own frozen literal restating `WRITE_PERMISSIONS` and `READ_PERMISSIONS`. It is now their union, the write value winning where both name a permission — which reproduces the old literal exactly, keys and order included. A new test in `appsetup.test.mjs` walks every role `githubapp.mjs` mints and fails when the manifest omits a permission or grants it narrower, so a permission added to either table cannot silently miss a newly created App. `workflows` stays absent, because neither table names it.

**The token stores share their shape.** `tokenStore` in `agenttoken.mjs` owns the file handling both stores had written out by hand: the directory, the name asserted before it is used as a filename, the 0600 that a `chmod` keeps across a rewrite, the constant-time compare, the revoke, the sweep against a positively known list. The conversation store keeps its two real differences — `isOverseerKey` and the durable read-then-mint — plus its 0700 directory. Every exported name on both modules is unchanged.

**One module knows the config root.** `CONFIG_ROOT_ENV` in `workspace.mjs` maps harness to environment variable; the HARNESS rows build their env from it, and `aistack.mjs` reads `configRootEnvFor` instead of naming `CLAUDE_CONFIG_DIR` and `CODEX_HOME` a second time. `CFG_DIR` moves to `workspace.mjs` beside `cfgDirFor`, and `overseerturn.mjs` stops spelling `cfg` inline as well.

**One connection writer.** `writeClaudeConnection` writes the `.mcp.json` / `.claude/settings.json` pair for the agent worktree and the conversation pane alike. The pane differs only in the directory, the server name, and having no Stop hook.

Left alone deliberately: the `overseertoken.mjs` / `overseeridentity.mjs` / `overseercreds.mjs` naming, which the ticket marks optional and outside its criteria.

Suite: 3361 → 3362 passing, 0 failing, 0 cancelled. The one extra is the new manifest-agreement test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5