### PR TITLE
The review gate asks for a preview when the change has a page (alp82/curia#735)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -442,6 +442,10 @@ _Avoid_: hook fallback.
 **Review gate**:
 The one approval before a merge, and its own escalation kind. Only the daemon opens it, and it composes every link from its own records. The ✅ press posts a real GitHub approval on the pull request (#391), under the host `gh` login, because an app cannot approve for a human and GitHub refuses a self-approval. What GitHub carries is what the journal calls approved: a press whose approval fails reads as not approved to the agent, to the Stop hook and to `/status`. Branch protection on the watched repo is what makes the press binding, and it is the operator's own optional act: curia requires no setting in a watched repo, and nothing in the daemon reads the rule.
 
+**Preview expectation**:
+What the review gate asks of a change that has a page to look at (#735). A task is applicable when its diff digest carries at least one **source** file that renders a page — markup, styles, a component or a template; tests, docs and generated files never count, and neither does server code, schema or config. Curia reads that off the digest it already measured, never off the agent's account of its own work. An applicable gate with no preview is bounced once, with the rule and two ways on: publish one, or say in the summary why there is nothing to see. The second call opens the gate either way and the card carries the absence in the link's place. A backend-only task never meets it, and a diff curia could not count never triggers it.
+_Avoid_: preview requirement, mandatory preview.
+
 **Cross-check**:
 The operator's third choice at the review gate. Curia spawns a reviewer on the other provider, and the verdict returns to the builder. The press answers neither way: nothing merges and nothing is rejected.
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -53,6 +53,7 @@ import {
 } from './credentials.mjs'
 import { CREDENTIALS_HASH } from './dashboard.mjs'
 import { readDiffDigest, readFileHunks, digestLine, sliceFromPatch, capText } from './diffdigest.mjs'
+import { previewExpectation } from './previewgate.mjs'
 import { transcriptReset, holdVerdict, hottestPct, WARM_PCT } from './usage.mjs'
 import { transcriptActivity } from './transcript.mjs'
 // #698: the fog classifier the map snapshot already owns. The empty-map
@@ -4003,6 +4004,35 @@ export class Dispatcher {
     // opens after the agent has died) reads this one stored answer.
     const { digest, error: digestError } = await this.deps.readDiffDigest(wtPath)
     if (!digest) this.log(`review gate for ${repo}#${ticket}: the diff could not be counted (${digestError})`)
+
+    // #735: does this change have a page to look at? The rule and its words
+    // live in previewgate.mjs; the digest just read is the whole evidence, so
+    // nothing here asks the agent what its change was about. A first applicable
+    // call with no preview is bounced once — the agent publishes one, or says
+    // in its summary why there is nothing to see — and the second call opens
+    // the gate either way. Backend-only work never reaches any of this.
+    //
+    // NO WORKER RECORD, NO BOUNCE. The ask is remembered on the record, so a
+    // gate curia has nowhere to remember it on reads as already asked — one
+    // missing line on a card beats a loop an agent cannot leave.
+    const expectation = previewExpectation({ digest, preview, asked: w ? w.previewAsked === true : true })
+    if (expectation.bounce) {
+      if (w) w.previewAsked = true
+      this.reduction.journal('preview_expected', {
+        repo, ticket, agent: agentName, files: expectation.paths.slice(0, 10),
+      })
+      this.notify(ticket, `🖼️ \`${agentName}\` asked for the review gate on a change that touches a page with no preview published — bounced once, and the next call opens the gate either way`)
+      return { ok: false, text: expectation.bounce }
+    }
+    // The second call. The absence goes on the card where the link would have
+    // been, because an operator who cannot look at the page must at least know
+    // that curia asked and got nothing.
+    if (expectation.line) {
+      links.push(expectation.line)
+      this.reduction.journal('preview_missing', {
+        repo, ticket, agent: agentName, files: expectation.paths.slice(0, 10),
+      })
+    }
 
     const { text } = reviewGateText({
       repo, ticket: map ?? ticket, title, summary, charting, links, mapDispatch, body,

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1750,7 +1750,7 @@ function buildMcpServer(agent, ticket) {
   // differ, and the daemon composes every one of them from its own records.
   server.tool(
     'request_review',
-    'THE review gate: ask the human "is this done?" and BLOCK until they answer. curia shows them the pull request, the preview and the ticket — you do not pass links, it knows them. On approval you merge the pull request and then resolve the ticket. A rejection comes back as the human\'s own words: fix, commit, open_pull_request again, and call this again.',
+    'THE review gate: ask the human "is this done?" and BLOCK until they answer. curia shows them the pull request, the preview and the ticket — you do not pass links, it knows them. On approval you merge the pull request and then resolve the ticket. A rejection comes back as the human\'s own words: fix, commit, open_pull_request again, and call this again. If your diff changed a page — markup, styles, a component or a template — publish_preview FIRST: curia checks for one here, and a first call without it comes back asking for one.',
     {
       // #418, ADR-0019: `summary` and `charting` are Grade B block prose, and
       // the operator reads both on every ticket. Optional to zod for the same

--- a/daemon/src/previewgate.mjs
+++ b/daemon/src/previewgate.mjs
@@ -1,0 +1,109 @@
+// The preview expectation at the review gate (#735, on #685's map).
+//
+// #40 gave the daemon the only honest preview link there is: one it allocated
+// itself, through `publish_preview`, and #563 made that allocation survive a
+// restart. The gate has always PRINTED that link when one existed. What it
+// never did was NOTICE when one should have and did not — so a change to a
+// page reached the operator as a diff and a pull request, and the one thing
+// the operator wanted to do with it, look at it, was the thing curia had not
+// set up.
+//
+// This module answers one question, from evidence curia already counted:
+//
+//   does this change have a page to look at?
+//
+// THE RULE, in these words, because a rule the agent cannot read is a rule it
+// cannot satisfy — the refusal prints it verbatim:
+//
+//   A task is applicable when its committed diff changes at least one SOURCE
+//   file that renders a page: markup, styles, a component, or a template.
+//   Tests, docs and generated files never make a task applicable, and a change
+//   of only server code, schema or config never does.
+//
+// The evidence is the gate's own diff digest (#355) — the file list curia
+// measured at the instant the gate opened, against the merge base. Nothing
+// here asks the agent what its change was about, for the same reason #40 does
+// not take a `preview_url` from it: at the gate, the agent's account of the
+// work is the thing being judged, not the thing deciding what to judge.
+//
+// classOf (diffdigest.mjs) is reused rather than re-implemented: it is what the
+// gate card already ranks by, and one classifier means one answer. A snapshot
+// `.html` under `__tests__/` and a mock-up in `docs/` are both changes to a
+// page, and neither is a page the operator reviews.
+//
+// IT NEVER BLOCKS REVIEW. An applicable gate that carries no preview is
+// BOUNCED ONCE, with the rule and both ways out. The second call opens, and the
+// card says curia asked and got nothing — a fact the operator can weigh, which
+// is what a gate is for. Backend-only work never sees any of this, and a diff
+// curia could not count is never treated as applicable: an unreadable digest is
+// an absence of evidence, and #355 settled that it must not render as a fact.
+
+import { classOf } from './diffdigest.mjs'
+
+// Printed on the bounce. One sentence, and one an agent can act on.
+export const PREVIEW_RULE = 'a task needs a preview when its diff changes a source file that renders a page — markup, styles, a component or a template; tests, docs and generated files do not count, and neither does server code, schema or config'
+
+// The extensions that render a page. Deliberately narrow: an extension that is
+// sometimes a page and usually not (`.js`, `.ts`, `.json`, `.yaml`) is left out,
+// because a false expectation costs every backend ticket one bounced call, and a
+// missed one costs a link the agent can still publish by hand. `.md` and `.mdx`
+// are out for a second reason on top: `classOf` calls them doc, and one
+// classifier means one answer here and on the card.
+const PAGE_EXT = /\.(html?|css|s[ac]ss|less|styl|jsx|tsx|vue|svelte|astro|ejs|hbs|handlebars|pug|jade|njk|liquid|twig|erb|haml|slim|blade\.php)$/i
+
+// One file. `true` when changing it changes something a person can look at.
+export function rendersAPage(file) {
+  const p = String(file ?? '')
+  if (!PAGE_EXT.test(p)) return false
+  // Only source. `classOf` asks generated first, so a built `dist/app.css` and a
+  // `__snapshots__` page are out for the same reason a doc mock-up is.
+  return classOf(p) === 'source'
+}
+
+// The applicable files in one digest, in the digest's own ranked order. An
+// absent or uncounted digest yields none — never an expectation.
+export function pageFiles(digest) {
+  return (digest?.list ?? []).map((f) => f.path).filter((p) => rendersAPage(p))
+}
+
+// How many of the applicable paths the bounce names. Enough to show the agent
+// what curia saw, short enough for a tool result.
+const NAMED = 3
+
+export function bounceText(paths) {
+  const named = paths.slice(0, NAMED)
+  const rest = paths.length - named.length
+  return [
+    '❌ no gate yet — this change touches a page and no preview is published.',
+    '',
+    ...named.map((p) => `• ${p}`),
+    ...(rest > 0 ? [`• …and ${rest} more`] : []),
+    '',
+    `curia asks for one because ${PREVIEW_RULE}.`,
+    '',
+    'Two ways on, and both end at the gate:',
+    '• Start your dev server, call `publish_preview` with its port and the PATH the change is on, then call `request_review` again. Curia allocates the link and puts it on the card itself.',
+    '• If there is nothing to look at — no dev server serves this, or the change is one the operator would only read — say which in your summary and call `request_review` again. The second call opens the gate, and the card says curia asked and got no preview.',
+  ].join('\n')
+}
+
+// The line the gate card carries when the second call opens without one. It
+// sits with the other links, in the place the preview would have taken, because
+// its absence is the fact it replaces.
+export const NO_PREVIEW_LINE = '_No preview — curia asked for one on this change and none was published; the summary should say why._'
+
+// The gate's whole decision, in one call:
+//
+//   { expected, paths, bounce, line }
+//
+// `bounce` is set only on the first applicable call with no preview, and the
+// caller refuses with it. `line` is set on the second, and the caller pushes it
+// onto the links. Both are null for a published preview and for backend-only
+// work, which is the case that must cost nothing.
+export function previewExpectation({ digest, preview = null, asked = false } = {}) {
+  if (preview?.url) return { expected: false, paths: [], bounce: null, line: null }
+  const paths = pageFiles(digest)
+  if (!paths.length) return { expected: false, paths: [], bounce: null, line: null }
+  if (asked) return { expected: true, paths, bounce: null, line: NO_PREVIEW_LINE }
+  return { expected: true, paths, bounce: bounceText(paths), line: null }
+}

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -4634,6 +4634,92 @@ describe('the diff digest at the gate (#355)', () => {
   })
 })
 
+// The preview at the gate (#735). The rule itself is pinned in
+// previewgate.test.mjs; what is pinned here is what the GATE does with it — one
+// bounce, never a block, and the operator's link composed by curia either way.
+describe('the preview the gate expects (#735)', () => {
+  const digestOf = (...paths) => ({
+    readDiffDigest: async () => ({
+      digest: {
+        uncommitted: false, files: paths.length, added: 1, deleted: 0, capped: false,
+        rank_rule: 'r', list: paths.map((p) => ({ path: p, added: 1, deleted: 0, status: 'M', binary: false, untracked: false, hunks: 1, from: null })),
+      },
+      error: null,
+    }),
+  })
+
+  test('a backend-only task reaches review with no preview and no bounce', async () => {
+    let asked = null
+    const d = makeDispatcher(digestOf('daemon/src/dispatch.mjs'),
+      { askReview: async (a, t, text) => { asked = text; return { text: 'approve', status: 'answered' } } })
+    liveAgent(d)
+
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+
+    assert.equal(r.approved, true)
+    assert.ok(!/preview/i.test(asked), 'a backend-only gate must not mention a preview at all')
+    assert.ok(!events.some((e) => e.type === 'preview_expected'))
+  })
+
+  test('a task that changed a page is bounced once instead of gating', async () => {
+    let asked = false
+    const d = makeDispatcher(digestOf('web/index.html', 'daemon/src/dispatch.mjs'),
+      { askReview: async () => { asked = true; return { text: 'approve', status: 'answered' } } })
+    const w = liveAgent(d)
+
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+
+    assert.equal(r.ok, false)
+    assert.equal(asked, false, 'no gate opened')
+    assert.match(r.text, /no preview is published/)
+    assert.match(r.text, /web\/index\.html/)
+    assert.equal(w.previewAsked, true, 'the ask must be remembered, or the agent is trapped')
+    const journalled = events.find((e) => e.type === 'preview_expected')
+    assert.deepEqual(journalled.files, ['web/index.html'])
+  })
+
+  test('the second call opens the gate and says curia asked and got nothing', async () => {
+    let asked = null
+    const d = makeDispatcher(digestOf('web/index.html'),
+      { askReview: async (a, t, text) => { asked = text; return { text: 'approve', status: 'answered' } } })
+    liveAgent(d)
+
+    await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+    const r = await d.requestReview('curia-42', { summary: 'nothing to look at — this page is generated at build time', charting: 'none' })
+
+    assert.equal(r.approved, true, 'the expectation must never block review')
+    assert.match(asked, /No preview — curia asked for one/)
+    assert.ok(events.some((e) => e.type === 'preview_missing'))
+  })
+
+  test('a published preview gates on the first call, with curia\'s own link', async () => {
+    let asked = null
+    const d = makeDispatcher(digestOf('web/index.html'),
+      { askReview: async (a, t, text) => { asked = text; return { text: 'approve', status: 'answered' } } })
+    liveAgent(d)
+    // allocated by the registry (#40), never a string the agent handed over
+    d.previews = { get: () => ({ servePort: 8500, devPort: 5173, url: 'https://box.ts.net:8500/curia-check' }) }
+
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+
+    assert.equal(r.approved, true)
+    assert.match(asked, /Preview: https:\/\/box\.ts\.net:8500\/curia-check/)
+    assert.ok(!/curia asked for one/.test(asked))
+    assert.ok(!events.some((e) => e.type === 'preview_expected'))
+  })
+
+  test('a diff curia could not count never bounces the gate', async () => {
+    const d = makeDispatcher({ readDiffDigest: async () => ({ digest: null, error: 'the agent worktree is gone' }) },
+      { askReview: async () => ({ text: 'approve', status: 'answered' }) })
+    liveAgent(d)
+
+    const r = await d.requestReview('curia-42', { summary: 's', charting: 'none' })
+
+    assert.equal(r.approved, true)
+    assert.ok(!events.some((e) => e.type === 'preview_expected'))
+  })
+})
+
 // The hunks, on demand (#355). The browser names an escalation id or an agent,
 // and these are what resolve that name to a worktree — the #266 seam.
 describe('the hunks the console asks for (#355)', () => {

--- a/daemon/test/previewgate.test.mjs
+++ b/daemon/test/previewgate.test.mjs
@@ -1,0 +1,100 @@
+// The preview expectation (#735). The rule that decides whether a task has a
+// page to look at, read off the gate's own diff digest.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  PREVIEW_RULE, NO_PREVIEW_LINE, rendersAPage, pageFiles, previewExpectation,
+} from '../src/previewgate.mjs'
+
+const digestOf = (...paths) => ({ files: paths.length, list: paths.map((p) => ({ path: p })) })
+
+describe('what counts as a page (#735)', () => {
+  test('markup, styles, components and templates do', () => {
+    for (const p of [
+      'web/index.html', 'web/app.css', 'ui/theme.scss', 'app/Card.tsx', 'app/Card.jsx',
+      'ui/Panel.vue', 'ui/Panel.svelte', 'site/page.astro',
+      'views/show.ejs', 'views/show.hbs', 'views/show.pug', 'views/show.njk',
+      'views/show.liquid', 'views/show.twig', 'views/show.erb', 'views/show.blade.php',
+    ]) assert.equal(rendersAPage(p), true, p)
+  })
+
+  test('server code, schema and config do not', () => {
+    for (const p of [
+      'daemon/src/dispatch.mjs', 'api/handler.ts', 'api/handler.js', 'db/schema.sql',
+      'cmd/main.go', 'lib/thing.py', 'config/curia.yaml', 'package.json', 'Dockerfile',
+    ]) assert.equal(rendersAPage(p), false, p)
+  })
+
+  test('tests, docs and generated files never make a task applicable', () => {
+    // The gate ranks by the same classifier, so one file has one class here and
+    // on the card. A snapshot page is not a page the operator reviews.
+    for (const p of [
+      'test/__snapshots__/page.html', 'docs/adr/0026-look.md', 'docs/mockup.html',
+      'dist/app.css', 'web/vendor/bootstrap.css', 'app/Card.test.tsx',
+      'e2e/checkout.html', 'build/index.html', 'site/styles.min.css',
+    ]) assert.equal(rendersAPage(p), false, p)
+  })
+})
+
+describe('the expectation the gate acts on (#735)', () => {
+  test('a backend-only change expects nothing, and costs nothing', () => {
+    const e = previewExpectation({ digest: digestOf('daemon/src/dispatch.mjs', 'daemon/test/dispatch.test.mjs') })
+    assert.equal(e.expected, false)
+    assert.equal(e.bounce, null)
+    assert.equal(e.line, null)
+  })
+
+  test('a diff curia could not count is never treated as applicable', () => {
+    // #355: null is not empty, and an absence of evidence must not render as a
+    // fact. An uncounted gate asks for nothing.
+    for (const digest of [null, undefined, {}]) {
+      assert.equal(previewExpectation({ digest }).expected, false)
+    }
+  })
+
+  test('a page change with a published preview asks for nothing', () => {
+    const e = previewExpectation({
+      digest: digestOf('web/app.css'),
+      preview: { url: 'https://box.ts.net:8500/curia-check' },
+    })
+    assert.equal(e.expected, false)
+    assert.equal(e.bounce, null)
+  })
+
+  test('a page change with no preview is bounced once, with the rule and both ways out', () => {
+    const e = previewExpectation({ digest: digestOf('web/index.html', 'daemon/src/x.mjs') })
+    assert.equal(e.expected, true)
+    assert.deepEqual(e.paths, ['web/index.html'])
+    assert.match(e.bounce, /no gate yet/)
+    assert.match(e.bounce, /web\/index\.html/)
+    assert.ok(e.bounce.includes(PREVIEW_RULE), 'the rule the agent must satisfy is printed')
+    assert.match(e.bounce, /publish_preview/)
+    assert.match(e.bounce, /call `request_review` again/)
+    assert.equal(e.line, null)
+  })
+
+  test('the bounce names a few files and counts the rest', () => {
+    const e = previewExpectation({ digest: digestOf('a.css', 'b.css', 'c.css', 'd.css', 'e.css') })
+    assert.match(e.bounce, /• a\.css/)
+    assert.match(e.bounce, /• c\.css/)
+    assert.ok(!e.bounce.includes('• d.css'), 'the list stops')
+    assert.match(e.bounce, /and 2 more/)
+  })
+
+  test('the second call opens the gate and carries the absence as a line', () => {
+    const e = previewExpectation({ digest: digestOf('web/index.html'), asked: true })
+    assert.equal(e.expected, true)
+    assert.equal(e.bounce, null, 'review is never blocked')
+    assert.equal(e.line, NO_PREVIEW_LINE)
+    assert.match(e.line, /curia asked for one/)
+  })
+
+  test('pageFiles keeps the digest order it was given', () => {
+    assert.deepEqual(
+      pageFiles(digestOf('daemon/src/a.mjs', 'z.css', 'a.html')),
+      ['z.css', 'a.html'],
+    )
+  })
+})


### PR DESCRIPTION
Closes work on alp82/curia#735, a child of the alp82/curia#685 map.

## What changed

The review gate has always printed the preview link when one existed (#40, made restart-safe by #563). It never noticed when one *should* have existed and didn't, so a change to a page reached the operator as a diff and a pull request, with no way to look at the thing that changed.

`daemon/src/previewgate.mjs` answers one question, from evidence curia already measured: does this change have a page to look at?

## The applicability rule

A task is applicable when its diff digest carries at least one **source** file that renders a page: markup, styles, a component, or a template (`.html`, `.css`/`.scss`, `.tsx`/`.jsx`, `.vue`, `.svelte`, `.astro`, and the common template extensions).

- The evidence is the gate's own diff digest (#355), the file list curia counted at the instant the gate opened. The agent's account of its work is what the gate judges, so it never decides what to judge.
- `classOf` from `diffdigest.mjs` is reused rather than re-implemented, so tests, docs, and generated files never make a task applicable, and one classifier gives one answer here and on the card.
- Server code, schema, and config carry no page extension, so backend-only work fails the rule cleanly and reaches review untouched.
- A diff curia could not count is never applicable. An absence of evidence must not render as a fact.

## It never blocks review

An applicable gate with no preview is bounced **once**, with the rule and two ways on: publish a preview, or say in the summary why there is nothing to see. The second call opens the gate either way, and the card carries the absence where the link would have been, so an operator who can't look at the page knows curia asked and got nothing. Both bounce and absence are journalled (`preview_expected`, `preview_missing`).

## Tests

`npm test` in `daemon/`: 3377 passing, 0 failing, 0 cancelled (baseline on main is 3362). New coverage in `daemon/test/previewgate.test.mjs` (the rule) and `daemon/test/dispatch.test.mjs` (what the gate does with it).

## Left out

No preview is published on the agent's behalf. Only the agent knows what it started and on which port, and #40 settled that curia allocates the link rather than trusting a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
