### PR TITLE
Accept a typed composite-send payload (alp82/curia#691)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -420,11 +420,11 @@ What the operator said, as against what Discord kept in the message ([#697](http
 _Avoid_: message content (that names the Discord field, which is only one of the segments).
 
 **Ending report**:
-What `report_result` puts in the thread, in the agent's own voice, as the first of the ending's two messages (#253, #419). It is typed: `headline` says what the work came to in one line, `summary` says what changed, and a `visual` and a `detail` are the agent's judgment. curia lays the parts out and appends the pull-request link. The same headline leads the resolution comment curia writes, and it becomes the gist of the map pointer. A cross-check reviewer's report is a **verdict** instead: it is typed on its own fields (#421), and it wears the 🔎 signal rather than the ✅ of an ending.
+What `report_result` puts in the thread, in the agent's own voice, as the first of the ending's two messages (#253, #419). It is typed: `headline` says what the work came to in one line, `summary` says what changed, and a `table`, a `diagram` and a `detail` are the agent's judgment. curia lays the parts out and appends the pull-request link. The same headline leads the resolution comment curia writes, and it becomes the gist of the map pointer. A cross-check reviewer's report is a **verdict** instead: it is typed on its own fields (#421), and it wears the 🔎 signal rather than the ✅ of an ending.
 _Avoid_: final summary, result message.
 
 **Status line**:
-What `notify` puts in the thread, in the agent's own voice, while the work goes on (#420). It is typed: `message` says what happened, and a `visual` and a `detail` are the agent's judgment. Its `kind` says what the operator must DO, never how the agent rates its own news. `progress` needs nothing from them, `look` puts a file or a page in front of their eyes now, and `ask` wants a reply nothing is blocked on. A status line asks for no decision, so an agent that cannot go on without the answer calls `ask_human` instead.
+What `notify` puts in the thread, in the agent's own voice, while the work goes on (#420). It is typed: `message` says what happened, and a `table`, a `diagram` and a `detail` are the agent's judgment. Its `kind` says what the operator must DO, never how the agent rates its own news. `progress` needs nothing from them, `look` puts a file or a page in front of their eyes now, and `ask` wants a reply nothing is blocked on. A status line asks for no decision, so an agent that cannot go on without the answer calls `ask_human` instead.
 _Avoid_: status update, progress ping.
 
 **Lint gate**:

--- a/daemon/src/attachments.mjs
+++ b/daemon/src/attachments.mjs
@@ -53,6 +53,10 @@ const TEXT_MIME_BY_EXT = {
   '.log': 'text/plain',
 }
 
+// The image forms, in the agent's own terms. `picture` (ADR-0026) takes one of
+// these and nothing else, so the lint and the attachment check read one list.
+export const IMAGE_EXTENSIONS = Object.keys(IMAGE_MIME_BY_EXT)
+
 // What an agent may attach, in the agent's own terms. Exported so the tool
 // hint names the same list the check enforces.
 export const ALLOWED_EXTENSIONS = [...Object.keys(IMAGE_MIME_BY_EXT), ...Object.keys(TEXT_MIME_BY_EXT)]

--- a/daemon/src/card.mjs
+++ b/daemon/src/card.mjs
@@ -32,11 +32,21 @@ export function composeOpening(opening = {}) {
   ].join('\n')
 }
 
-// The visual arrives as rows and leaves as a fenced block. curia writes the
-// fence, so an agent can never send a broken one (#432 reads it either way).
+// A table or a diagram arrives as rows and leaves as a fenced block. curia
+// writes the fence, so an agent can never send a broken one (#432 reads it
+// either way).
 export function visualBlock(visual) {
   const body = unfence(visual)
   return `\`\`\`\n${body}\n\`\`\``
+}
+
+// The two geometry fields ADR-0026 (#640) split the retired `visual` field
+// into, in the order the operator reads them: the table states, the diagram
+// shows. `picture` is the third of the trio and it is not a block — it is a
+// file the reader looks at, so it rides the message's files rather than its
+// text.
+function visualBlocks(payload = {}) {
+  return ['table', 'diagram'].filter((f) => has(payload[f])).map((f) => visualBlock(payload[f]))
 }
 
 // The consequence and the example, under the thing they belong to. `↳` is the
@@ -56,7 +66,7 @@ const APPROVE_REJECT = ['✅ Approve', '❌ Reject']
 export function composeCard(kind, payload = {}) {
   const parts = []
   if (has(payload.headline)) parts.push(`**${String(payload.headline).trim()}**`)
-  if (has(payload.visual)) parts.push(visualBlock(payload.visual))
+  parts.push(...visualBlocks(payload))
 
   if (kind === 'free-text') {
     // A round is typed now (#285 wrote the numbers by hand inside one prose
@@ -96,7 +106,7 @@ export function composeCard(kind, payload = {}) {
 export function composeReviewBody(payload = {}) {
   const parts = []
   if (has(payload.headline)) parts.push(`**${String(payload.headline).trim()}**`)
-  if (has(payload.visual)) parts.push(visualBlock(payload.visual))
+  parts.push(...visualBlocks(payload))
   if (has(payload.detail)) parts.push(`Details: ||${String(payload.detail).trim()}||`)
   return parts.join('\n\n')
 }
@@ -111,7 +121,7 @@ export function composeReviewBody(payload = {}) {
 export function composeResultBody(payload = {}) {
   const parts = []
   if (has(payload.headline)) parts.push(`**${String(payload.headline).trim()}**`)
-  if (has(payload.visual)) parts.push(visualBlock(payload.visual))
+  parts.push(...visualBlocks(payload))
   if (has(payload.summary)) parts.push(String(payload.summary).trim())
   if (has(payload.detail)) parts.push(`Details: ||${String(payload.detail).trim()}||`)
   return parts.join('\n\n')
@@ -175,7 +185,7 @@ export function composeNotify(payload = {}) {
   const kind = NOTIFY_KINDS.includes(payload.kind) ? payload.kind : DEFAULT_NOTIFY_KIND
   const parts = []
   if (has(payload.message)) parts.push(`${NOTIFY_SIGNAL[kind]} ${String(payload.message).trim()}`)
-  if (has(payload.visual)) parts.push(visualBlock(payload.visual))
+  parts.push(...visualBlocks(payload))
   if (has(payload.detail)) parts.push(`Details: ||${String(payload.detail).trim()}||`)
   if (kind === 'ask' && parts.length) parts.push(smallPrint(ASK_LINE))
   return parts.join('\n\n')
@@ -217,7 +227,7 @@ export function composeVerdict(payload = {}) {
   if (has(payload.headline)) parts.push(`**${String(payload.headline).trim()}**`)
   const grade = verdictGrade(findings)
   if (grade) parts.push(`${VERDICT_SIGNAL[grade]} **${grade}** — ${findingCounts(findings)}`)
-  if (has(payload.visual)) parts.push(visualBlock(payload.visual))
+  parts.push(...visualBlocks(payload))
   if (has(payload.summary)) parts.push(String(payload.summary).trim())
   for (const [i, f] of (findings ?? []).entries()) {
     const severity = String(f?.severity ?? '').trim().toLowerCase()

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -77,7 +77,7 @@ import {
   isTyped, floorFaults, hasText, lintAskHuman, lintRequestReview, reviewFloorFaults,
   lintResult, resultFloorFaults,
   lintNotify, notifyFloorFaults, notifyHasText,
-  lintVerdict, verdictFloorFaults, VERDICT_SEVERITIES,
+  lintVerdict, verdictFloorFaults, VERDICT_SEVERITIES, hasVisualField,
 } from './lint.mjs'
 import {
   composeCard, composeReviewBody, composeResultReport, composeOpening, optionLabels, derivedRecommended,
@@ -786,7 +786,9 @@ function askHumanGate(agentName, kind, raw) {
         questions: raw.questions,
         options: raw.options,
         detail: raw.detail,
-        visual: raw.visual,
+        picture: raw.picture,
+        table: raw.table,
+        diagram: raw.diagram,
         timeline: raw.timeline,
         preview_url: raw.preview_url,
       },
@@ -1558,7 +1560,40 @@ function startKeepAlive(extra, id, label = null) {
 // inside your workspace" — pointed it straight at the form that got dropped.
 // It also names the allowed types, from the same list the check enforces: an
 // agent does not attach the diff it never learned it could send (#430).
-const FILES_HINT = `Files inside your workspace to show the human: a screenshot, a render, a diff, a note. Allowed: ${ALLOWED_EXTENSIONS.join(', ')}. Give a path relative to your workspace, or an absolute path under ${GUEST_WT}/.`
+const FILES_HINT = `Files inside your workspace for the human to DOWNLOAD: a screenshot, a render, a diff, a note. Allowed: ${ALLOWED_EXTENSIONS.join(', ')}. Give a path relative to your workspace, or an absolute path under ${GUEST_WT}/.`
+
+// The three visual fields of ADR-0026 (#640), declared once for the four tools
+// that take them. One home, so a wording that drifts on one surface cannot say
+// something else on another.
+//
+// The retired `visual` stays declared for the reason `prompt` does: zod strips
+// a key it does not declare, and a stripped `visual` would take the agent's
+// rows with it. Declared, it reaches the floor, which refuses the call and says
+// where the rows go.
+const VISUAL_SHAPE = {
+  visual: z.string().optional().describe('RETIRED. Send `table` for a table, `diagram` for a drawing, or `picture` for an image. Curia refuses a call that carries this.'),
+  picture: z.string().optional().describe('One image the human LOOKS AT in place: a screenshot, a render, a mock. A path, as `attachments` takes.'),
+  table: z.string().optional().describe('A table, as rows. Curia writes the fence. At most 42 columns by 20 lines, and the columns must line up.'),
+  diagram: z.string().optional().describe('An ASCII drawing, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+}
+
+// `images` was renamed `attachments` by ADR-0026 (#640): the field has taken a
+// .patch, a .diff, a .md, a .txt and a .log since it shipped, so the name has
+// never been true. The old one stays declared so a call that carries it is
+// named rather than stripped.
+const ATTACHMENT_SHAPE = {
+  images: z.array(z.string()).optional().describe('RETIRED. Send the same paths under `attachments`. Curia refuses a call that carries this.'),
+  attachments: z.array(z.string()).optional().describe(FILES_HINT),
+}
+
+// Every path an outbound file arrives on, in one list (ADR-0026). `picture` is
+// what a reader looks at and `attachments` is what a reader downloads, and both
+// are files this box has to contain and hand to Discord. One helper, so neither
+// one is dropped on the surface that forgot to name it.
+const sentFiles = (raw, attachments) => [
+  ...(raw?.picture ? [raw.picture] : []),
+  ...(attachments ?? []),
+]
 
 function buildMcpServer(agent, ticket) {
   const server = new McpServer({ name: 'curia-daemon', version: '0.1.0' }, { capabilities: { logging: {} } })
@@ -1610,16 +1645,16 @@ function buildMcpServer(agent, ticket) {
       message: z.string().optional().describe('What happened, in plain words, at most 600 characters. The thread reads this.'),
       kind: z.enum(NOTIFY_KINDS).optional().describe('What the operator must do: `progress` (nothing), `look` (open something now), `ask` (reply when they can). Defaults to `progress`.'),
       detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters.'),
-      visual: z.string().optional().describe('A table or an ASCII diagram, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+      ...VISUAL_SHAPE,
       opening: z.object({
         goal: z.string().optional().describe('Your reading of the ticket goal, in one line.'),
         first_step: z.string().optional().describe('Your first step, in one line.'),
       }).optional().describe('Your one work opening. Send it on the first notify call only.'),
       phase: z.string().optional().describe('Your working phase: explore, think, build, test, fix, or ship.'),
       label: z.string().optional().describe('What you are doing now, in one line of at most 20 characters.'),
-      images: z.array(z.string()).optional().describe(FILES_HINT),
+      ...ATTACHMENT_SHAPE,
     },
-    async ({ images, ...raw }) => {
+    async ({ attachments, ...raw }) => {
       if (raw.opening && reduction.hasAgentOpening(agent)) {
         return { content: [{ type: 'text', text: 'opening: already sent for this dispatch.' }] }
       }
@@ -1634,9 +1669,9 @@ function buildMcpServer(agent, ticket) {
         return { content: [{ type: 'text', text: verdict.reject ?? verdict.refuse }] }
       }
       const flags = verdict.flags ?? null
-      const { files, refusals } = outboundFiles(agent, images)
+      const { files, refusals } = outboundFiles(agent, sentFiles(raw, attachments))
       reduction.journal('notify', {
-        agent, ticket, ...raw, images: files.map((f) => f.attachment), refusals,
+        agent, ticket, ...raw, attachments: files.map((f) => f.attachment), refusals,
         ...(flags ? { lint_flags: flags } : {}),
       })
       if (raw.phase && raw.label) {
@@ -1653,7 +1688,7 @@ function buildMcpServer(agent, ticket) {
           ? statusLine.settle().then(() => bridge.notify(ticket, composeOpening(raw.opening), { as: speaker }))
           : Promise.resolve()
         const body = composeNotify(raw)
-        if (raw.message || raw.detail || raw.visual) {
+        if (raw.message || raw.detail || hasVisualField(raw)) {
           sends = sends.then(() => bridge.notify(ticket, body, { files, as: speaker }))
         }
         // A flagged send is CURIA's fact about the agent's text, so curia says
@@ -1759,7 +1794,7 @@ function buildMcpServer(agent, ticket) {
       charting: z.string().optional().describe('CONCRETE map changes you propose, as a numbered list — one line per change: ticket titles to create, fog lines to remove, edges to wire, anything to rule out of scope. At most 600 characters. Name each change; put full ticket bodies and long Decisions-so-far lines in the work you do AFTER approval, not here. Write "none" if there are none. A vague answer here makes the approval a rubber stamp.'),
       headline: z.string().optional().describe('The whole change in one line, at most 150 characters. It sits under the gate heading, so the operator reads it first.'),
       detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters.'),
-      visual: z.string().optional().describe('A table or an ASCII diagram, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+      ...VISUAL_SHAPE,
     },
     async (raw, extra) => {
       // The same gate as `ask_human`, keyed on the same agent-and-kind pair the
@@ -1814,6 +1849,7 @@ function buildMcpServer(agent, ticket) {
       questions: z.array(z.object({
         text: z.string().optional().describe('One question of the round. One line, 250 characters.'),
         recommendation: z.string().optional().describe('Your recommended answer to THIS question. One line, 300 characters.'),
+        background: z.string().optional().describe('What this question rests on, in small print under its line. Block prose, 600 characters. Write one only where the question cannot be answered without it.'),
       })).optional().describe('free-text only: the round, one entry per question. Curia numbers them.'),
       options: z.union([
         // The bare-string form is RETIRED with the other two, and it is
@@ -1828,12 +1864,14 @@ function buildMcpServer(agent, ticket) {
         })),
       ]).optional(),
       detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters. Reasoning belongs on the timeline, not here.'),
-      visual: z.string().optional().describe('A table or an ASCII diagram, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+      ...VISUAL_SHAPE,
       timeline: z.boolean().optional().describe('Point the operator at the timeline for the reasoning. Curia composes the link.'),
       preview_url: z.string().optional(),
-      images: z.array(z.string()).optional().describe(FILES_HINT),
+      ...ATTACHMENT_SHAPE,
     },
-    async ({ images, ...raw }, extra) => {
+    // `attachments` is bound aside, because the ANSWER carries a field of that
+    // name too (#34): the files the human replied with.
+    async ({ attachments: sent, ...raw }, extra) => {
       // #164: the reviewer asks nobody. ADR-0010 gives it one output — the
       // verdict — and a question in the ticket thread would put a second voice
       // in front of the operator on a ticket the reviewer is not building.
@@ -1869,7 +1907,8 @@ function buildMcpServer(agent, ticket) {
         // The card is what shows a file, and no card opened. Said rather than
         // swallowed: an agent that thinks the operator saw a screenshot or a
         // diff reads the answer as being about it.
-        if (images?.length) lines.push(`(curia opened no card, so the ${images.length} file(s) you sent with this call were not shown.)`)
+        const shown = sentFiles(raw, sent)
+        if (shown.length) lines.push(`(curia opened no card, so the ${shown.length} file(s) you sent with this call were not shown.)`)
         return {
           content: [
             { type: 'text', text: `${lines.join('\n')}\n\n${recorded.record.answer}` },
@@ -1877,7 +1916,7 @@ function buildMcpServer(agent, ticket) {
           ],
         }
       }
-      const { files, refusals } = outboundFiles(agent, images)
+      const { files, refusals } = outboundFiles(agent, sentFiles(raw, sent))
       const { record, answered } = openEscalation({ agent, ticket, ...open, lint_flags: flags, files })
       const stopKeepAlive = startKeepAlive(extra, record.id, promptTitle(open.prompt))
       // Images the human replies with come back as real content blocks, so the
@@ -1934,7 +1973,7 @@ function buildMcpServer(agent, ticket) {
       summary: z.string().optional().describe('What the work came to, in plain words, at most 600 characters. The thread reads this, and curia records it on the ticket.'),
       headline: z.string().optional().describe('What the work came to, in one line, at most 150 characters. No markdown and no link.'),
       detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters.'),
-      visual: z.string().optional().describe('A table or an ASCII diagram, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+      ...VISUAL_SHAPE,
       // ADR-0019 rule 3: a free record. No surface renders it and no lint reads
       // it, so it stays the one field an agent may shape for itself.
       details: z.record(z.string(), z.any()).optional(),
@@ -2702,7 +2741,7 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
     const agent = body.agent ?? 'synthetic'
     // Same containment as the MCP path: /escalate is loopback-only, but it must
     // not be the softer way to hand the bridge an arbitrary file.
-    const { files } = outboundFiles(agent, body.images ?? body.files)
+    const { files } = outboundFiles(agent, body.attachments ?? body.images ?? body.files)
     // `?wait` is what makes this call a blocked one, so it is also what the
     // record says about itself (#489). Without it the caller has its answer
     // already — the id — and the boot sweep must not read this record as an

--- a/daemon/src/lint.mjs
+++ b/daemon/src/lint.mjs
@@ -12,8 +12,17 @@
 //   option       one choice, by its label                grade A
 //   consequence  what one option costs                   grade A
 //   example      one concrete case for an option         grade B
-//   visual       a code-block table or an ASCII diagram   geometry
+//   picture      an image the reader looks at in place    image path
+//   table        a code-block table                      geometry
+//   diagram      an ASCII drawing                        geometry
 //   detail       short facts, rendered as a spoiler      grade A
+//   prose        the answer, or the intent of a send     grade B, 1600
+//   background   what one question rests on              grade B, 600
+//   label        one message of a send, by its rail      grade A, 20
+//
+// ADR-0026 (#640) split the retired `visual` FIELD into `picture`, `table` and
+// `diagram`, and renamed `images` to `attachments`. `visual` survives as the
+// name of a message FORMAT and as nothing else.
 //
 // `daemon/assets/voice.md` stays the one authority on words. The GRADE decides
 // which of its rules a field is held to. Grade A is inline decision text, so it
@@ -30,6 +39,7 @@
 // and losing no information is the requirement the whole #413 map serves.
 
 import { fenceParts, lintReply } from './messaging.mjs'
+import { IMAGE_EXTENSIONS } from './attachments.mjs'
 
 // The caps ADR-0019 sets. A cap is a ceiling, not a target: a card that says
 // the whole decision in 40 characters is a better card, and no rule here
@@ -44,14 +54,26 @@ export const CAPS = {
   // `summary`, `charting`, the notify `message` and a verdict finding all share
   // one block cap.
   block: 600,
+  // The question background of ADR-0026. It shares the block cap's number and
+  // keeps its own name, because the two move apart the moment either does.
+  background: 600,
+  // The prose message of ADR-0026, which is `CHUNK_LIMIT` minus the rail line
+  // curia writes above it. One number for the lint and the splitter, so no
+  // prose entry is ever cut behind the agent's back.
+  prose: 1600,
+  // The rail label of one message of a send. It is the status-line label rule
+  // of ADR-0021 read on a second surface, so it takes the same 20.
+  label: 20,
   phaseLabel: 20,
+  // The one caption line of a `files` message.
+  caption: 150,
 }
 
 export const WORK_PHASES = ['explore', 'think', 'build', 'test', 'fix', 'ship']
 
-// The `visual` geometry (#414 measured both numbers on a phone). 42 by 20 is
-// under 900 characters, so a visual sits under CODE_BLOCK_LIMIT and never
-// reaches the 1600-character chunk limit either.
+// The geometry of a `table` and a `diagram` (#414 measured both numbers on a
+// phone). 42 by 20 is under 900 characters, so either one sits under
+// CODE_BLOCK_LIMIT and never reaches the chunk limit either.
 export const VISUAL_COLUMNS = 42
 export const VISUAL_LINES = 20
 
@@ -102,7 +124,7 @@ export function gradeA(field, value, cap) {
   if (HEADING_RE.test(text)) faults.push(`${field}: a heading marker.`)
   if (TABLE_RE.test(text)) faults.push(`${field}: a markdown table row. Discord does not render one.`)
   if (QUOTE_RE.test(text)) faults.push(`${field}: a blockquote marker.`)
-  if (FENCE_RE.test(text)) faults.push(`${field}: a code fence. Put a table or a diagram in the visual field.`)
+  if (FENCE_RE.test(text)) faults.push(`${field}: a code fence. Put a table in \`table\` and a diagram in \`diagram\`.`)
   if (LIST_RE.test(text)) faults.push(`${field}: a list marker.`)
   if (LINK_RE.test(text)) faults.push(`${field}: a link. Curia composes every link it shows, so drop it.`)
   return [...faults, ...wordFaults(field, text)]
@@ -140,9 +162,9 @@ export function gradeB(field, value, cap = CAPS.block) {
   return [...faults, ...wordFaults(field, text)]
 }
 
-// ---- the visual: geometry, never words ---------------------------------------
+// ---- the geometry fields: never words ----------------------------------------
 //
-// The agent writes the rows. Curia writes the fence, so a visual can never
+// The agent writes the rows. Curia writes the fence, so a table or a diagram can never
 // arrive with a broken one — and an agent that fenced it anyway loses the
 // fence here rather than a rejection, because the fence is curia's to place.
 
@@ -154,24 +176,113 @@ export function unfence(value) {
   return lines.slice(1, parts[0].close ? -1 : undefined).join('\n')
 }
 
-export function lintVisual(value) {
+export function lintGeometry(field, value) {
   const body = unfence(value)
   const faults = []
   const lines = body.split('\n')
-  if (lines.length > VISUAL_LINES) faults.push(`visual: ${lines.length} lines over the ${VISUAL_LINES} cap. A phone scrolls past a taller one.`)
+  if (lines.length > VISUAL_LINES) faults.push(`${field}: ${lines.length} lines over the ${VISUAL_LINES} cap. A phone scrolls past a taller one.`)
   const widest = lines.reduce((w, l) => Math.max(w, l.length), 0)
-  if (widest > VISUAL_COLUMNS) faults.push(`visual: ${widest} columns over the ${VISUAL_COLUMNS} cap. A phone wraps a wider one and the columns lose their alignment.`)
+  if (widest > VISUAL_COLUMNS) faults.push(`${field}: ${widest} columns over the ${VISUAL_COLUMNS} cap. A phone wraps a wider one and the columns lose their alignment.`)
   // A fence marker INSIDE the rows would close the fence curia puts around
-  // them, and the rest of the visual would render as prose.
-  if (lines.some((l) => FENCE_RE.test(l))) faults.push('visual: a code fence inside the rows. Curia fences the visual itself, so write the rows alone.')
+  // them, and the rest of the block would render as prose.
+  if (lines.some((l) => FENCE_RE.test(l))) faults.push(`${field}: a code fence inside the rows. Curia fences the block itself, so write the rows alone.`)
   return faults
+}
+
+// ---- the table: geometry, and the columns line up ----------------------------
+//
+// This check is WHY ADR-0026 split `table` from `diagram`. One combined field
+// could never run it, because a diagram has no columns to align. A table whose
+// columns drift is unreadable on a phone, and the drift is deterministic, so
+// the lint reads it rather than leaving it to the operator's eye.
+//
+// A cell boundary is a run of two spaces or more, which is the shape every
+// table an agent writes into a code block already takes. A line that yields one
+// cell is a title or a rule, and it is skipped. A row may carry FEWER cells
+// than the header, because a blank cell is a real row, but each cell it does
+// carry must start at one of the header's offsets.
+function cells(line) {
+  const found = []
+  const re = /\S(?:.*?\S)?(?=\s{2,}|$)/g
+  for (const m of line.matchAll(re)) found.push({ at: m.index, text: m[0] })
+  return found
+}
+
+export function lintTable(value) {
+  const faults = lintGeometry('table', value)
+  const rows = unfence(value).split('\n').map((l) => ({ line: l, cells: cells(l) })).filter((r) => r.cells.length > 1)
+  if (rows.length < 2) return faults
+  const offsets = new Set(rows[0].cells.map((c) => c.at))
+  for (const [i, row] of rows.entries()) {
+    if (i === 0) continue
+    if (row.cells.length > rows[0].cells.length) {
+      faults.push(`table: row ${i + 1} has ${row.cells.length} columns where the first row has ${rows[0].cells.length}. Line the columns up with spaces.`)
+      continue
+    }
+    const stray = row.cells.find((c) => !offsets.has(c.at))
+    if (stray) faults.push(`table: row ${i + 1} starts a column at character ${stray.at + 1}, which no column of the first row starts at. Line the columns up with spaces.`)
+  }
+  return faults
+}
+
+// ---- the picture: one image file ---------------------------------------------
+//
+// `picture` is what a reader LOOKS AT and `attachments` is what a reader
+// downloads (ADR-0026). So this field takes one image path and nothing else: a
+// diff or a note under it would be a download the card claims to render.
+// Containment and size stay `attachments.mjs`'s, which is the layer that
+// touches the disk. This is the payload contract, and it reads the name.
+export function lintPicture(field, value) {
+  const text = String(value ?? '').trim()
+  const faults = []
+  if (/\n/.test(text)) {
+    faults.push(`${field}: a newline. This field is one file path, and a second picture is a second message.`)
+    return faults
+  }
+  if (!IMAGE_EXTENSIONS.some((ext) => text.toLowerCase().endsWith(ext))) {
+    faults.push(`${field}: "${text}" is not an image. A picture is one of ${IMAGE_EXTENSIONS.join(', ')}. Put a table in \`table\`, a diagram in \`diagram\`, and any other file in \`attachments\`.`)
+  }
+  return faults
+}
+
+// ---- the three visual fields, together ---------------------------------------
+
+// The fields ADR-0026 (#640) split the retired `visual` field into. Every
+// surface that carried a `visual` carries these three instead.
+export const VISUAL_FIELDS = ['picture', 'table', 'diagram']
+
+export function lintVisualFields(payload = {}, prefix = '') {
+  const faults = []
+  if (present(payload.picture)) faults.push(...lintPicture(`${prefix}picture`, payload.picture))
+  if (present(payload.table)) faults.push(...lintTable(payload.table))
+  if (present(payload.diagram)) faults.push(...lintGeometry(`${prefix}diagram`, payload.diagram))
+  return faults
+}
+
+export const hasVisualField = (payload = {}) => VISUAL_FIELDS.some((f) => present(payload[f]))
+
+// ---- the fields ADR-0026 retired ---------------------------------------------
+//
+// Named rather than dropped, which is the rule the flip (#422) set for `prompt`
+// and `recommended`. A field curia ignored in silence would take the rows or the
+// paths the agent wrote with it, and losing information in silence is the one
+// thing this map forbids.
+const RETIRED_FIELDS = {
+  visual: 'visual: retired by ADR-0026. Send the rows as `table` when they are a table, or as `diagram` when they are a drawing. An image goes in `picture`.',
+  images: 'images: renamed to `attachments` by ADR-0026, because it has taken a .patch, a .diff, a .md, a .txt and a .log since it shipped. Send the same paths under `attachments`.',
+}
+
+export function retiredFieldFaults(payload = {}, prefix = '') {
+  return Object.entries(RETIRED_FIELDS)
+    .filter(([name]) => payload[name] !== undefined && payload[name] !== null)
+    .map(([, text]) => `${prefix}${text}`)
 }
 
 // ---- the shape per surface ---------------------------------------------------
 //
-// Every `ask_human` kind takes `headline` (required), and `detail`, `visual`,
-// `timeline` and `images` (optional). The rest is per kind, and the table is
-// ADR-0019's.
+// Every `ask_human` kind takes `headline` (required), and `detail`, `picture`,
+// `table`, `diagram`, `timeline` and `attachments` (optional). The rest is per
+// kind, and the table is ADR-0019's, as ADR-0026 amended it.
 
 const present = (v) => v !== undefined && v !== null && String(v).trim() !== ''
 
@@ -188,12 +299,12 @@ const present = (v) => v !== undefined && v !== null && String(v).trim() !== ''
 
 // Whether a call carries any typed field at all. It picks the SHAPE a flagged
 // send renders: a typed payload composes a card, and an untyped one carries the
-// prompt it wrote. `images` is not prose and does not type a call by itself.
+// prompt it wrote. `attachments` is not prose and does not type a call by itself.
 export function isTyped(payload = {}) {
   return present(payload.headline)
     || (payload.questions ?? []).length > 0
     || (payload.options ?? []).some((o) => o && typeof o === 'object')
-    || present(payload.detail) || present(payload.visual)
+    || present(payload.detail) || hasVisualField(payload)
 }
 
 // The three fields the untyped call carried, retired by the flip (#422).
@@ -203,7 +314,7 @@ export function isTyped(payload = {}) {
 // silence is the one thing this map forbids. So each one is refused with the
 // place its content goes, and the agent moves the text in one attempt (#416).
 function retiredFaults(payload = {}) {
-  const faults = []
+  const faults = retiredFieldFaults(payload)
   if (present(payload.prompt)) {
     faults.push('prompt: retired by the flip. Write the headline and the parts, and curia lays the card out.')
   }
@@ -259,10 +370,14 @@ export function lintAskHuman(kind, payload = {}) {
   const faults = []
   if (present(payload.headline)) faults.push(...gradeA('headline', payload.headline, CAPS.headline))
   if (present(payload.detail)) faults.push(...gradeA('detail', payload.detail, CAPS.detail))
-  if (present(payload.visual)) faults.push(...lintVisual(payload.visual))
+  faults.push(...lintVisualFields(payload))
   ;(payload.questions ?? []).forEach((q, i) => {
     if (present(q?.text)) faults.push(...gradeA(`questions[${i}].text`, q.text, CAPS.question))
     if (present(q?.recommendation)) faults.push(...gradeA(`questions[${i}].recommendation`, q.recommendation, CAPS.consequence))
+    // ADR-0026: what the question rests on, in small print under its line. It
+    // is block prose, so it keeps its sentences, and it is the one named
+    // exception to ADR-0019's never-stacked small-print rule.
+    if (present(q?.background)) faults.push(...gradeB(`questions[${i}].background`, q.background, CAPS.background))
   })
   ;(payload.options ?? []).forEach((o, i) => {
     if (typeof o !== 'object' || o === null) return
@@ -279,7 +394,7 @@ export function lintRequestReview(payload = {}) {
   const faults = []
   if (present(payload.headline)) faults.push(...gradeA('headline', payload.headline, CAPS.headline))
   if (present(payload.detail)) faults.push(...gradeA('detail', payload.detail, CAPS.detail))
-  if (present(payload.visual)) faults.push(...lintVisual(payload.visual))
+  faults.push(...lintVisualFields(payload))
   if (present(payload.summary)) faults.push(...gradeB('summary', payload.summary))
   if (present(payload.charting)) faults.push(...gradeB('charting', payload.charting))
   return faults
@@ -309,13 +424,13 @@ export function hasText(payload = {}) {
 // either way. After the flip (#422) a report that reaches the thread without a
 // headline is a flagged send, and this is what keeps its one line intact.
 export function isTypedResult(payload = {}) {
-  return present(payload.headline) || present(payload.detail) || present(payload.visual)
+  return present(payload.headline) || present(payload.detail) || hasVisualField(payload)
 }
 
 // The report's floor. `summary` was required by the schema before #419, and the
 // flip (#422) added the `headline` beside it. Both are unconditional now.
 export function resultFloorFaults(payload = {}) {
-  const faults = []
+  const faults = retiredFieldFaults(payload)
   if (!present(payload.headline)) faults.push('headline: missing. Say what the work came to in one line.')
   if (!present(payload.summary)) faults.push('summary: missing. Say what you did and what it came to.')
   // `findings` belongs to the cross-check verdict and to nothing else (#421). A
@@ -332,7 +447,7 @@ export function lintResult(payload = {}) {
   const faults = []
   if (present(payload.headline)) faults.push(...gradeA('headline', payload.headline, CAPS.headline))
   if (present(payload.detail)) faults.push(...gradeA('detail', payload.detail, CAPS.detail))
-  if (present(payload.visual)) faults.push(...lintVisual(payload.visual))
+  faults.push(...lintVisualFields(payload))
   if (present(payload.summary)) faults.push(...gradeB('summary', payload.summary))
   return faults
 }
@@ -342,18 +457,18 @@ export function lintResult(payload = {}) {
 // `notify` asks nothing and blocks nobody, and it is still prose that reaches a
 // human. ADR-0019 gives it the same vocabulary as the surfaces that do ask:
 // `message` is the Grade B prose the thread reads, `detail` is the Grade A
-// spoiler, and `visual` keeps its geometry check.
+// spoiler, and `table` and `diagram` keep their geometry check.
 
 // A status line needs no `isTyped` twin of its own. The report has one because
 // its untyped shape is a DIFFERENT post (#419), and a notify's is not: the
-// message is the line either way, and a detail or a visual only adds to it.
+// message is the line either way, and a detail or a table only adds to it.
 
 // The status line's floor, and the one surface the flip (#422) left as it was.
 // `message` was required by the schema before #420, so it was required before
 // the flip and it is required after it (#438: moving a check off zod decides
 // which layer refuses the call, never whether a silent send lands).
 export function notifyFloorFaults(payload = {}) {
-  const faults = []
+  const faults = retiredFieldFaults(payload)
   const opening = payload.opening
   const hasOpening = opening !== undefined && opening !== null
   const hasPhase = present(payload.phase)
@@ -372,10 +487,10 @@ export function notifyFloorFaults(payload = {}) {
 
 // Whether a status line carries anything a human could read. It is what tells a
 // schema fault curia can still send from one it cannot (ADR-0019), on the
-// surface where a `message` is the field that goes missing. A visual or a
+// surface where a `message` is the field that goes missing. A table or a
 // spoiler alone still says something, and an empty call says nothing.
 export function notifyHasText(payload = {}) {
-  return present(payload.message) || present(payload.detail) || present(payload.visual)
+  return present(payload.message) || present(payload.detail) || hasVisualField(payload)
     || present(payload.opening?.goal) || present(payload.opening?.first_step) || present(payload.label)
 }
 
@@ -383,7 +498,7 @@ export function lintNotify(payload = {}) {
   const faults = []
   if (present(payload.message)) faults.push(...gradeB('message', payload.message))
   if (present(payload.detail)) faults.push(...gradeA('detail', payload.detail, CAPS.detail))
-  if (present(payload.visual)) faults.push(...lintVisual(payload.visual))
+  faults.push(...lintVisualFields(payload))
   if (present(payload.opening?.goal)) faults.push(...gradeA('opening.goal', payload.opening.goal, CAPS.question))
   if (present(payload.opening?.first_step)) faults.push(...gradeA('opening.first_step', payload.opening.first_step, CAPS.question))
   if (present(payload.phase) && !WORK_PHASES.includes(payload.phase)) {
@@ -426,7 +541,7 @@ export function verdictGrade(findings) {
 // summary, whole, with no grade line over it that no severity backs.
 export function isTypedVerdict(payload = {}) {
   return present(payload.headline) || Array.isArray(payload.findings)
-    || present(payload.detail) || present(payload.visual)
+    || present(payload.detail) || hasVisualField(payload)
 }
 
 // The verdict's floor. `summary` was required by the report schema before #421,
@@ -439,7 +554,7 @@ export function isTypedVerdict(payload = {}) {
 // is still required after the flip, because an empty list says "I found
 // nothing" and a missing one says nothing at all.
 export function verdictFloorFaults(payload = {}) {
-  const faults = []
+  const faults = retiredFieldFaults(payload)
   if (!present(payload.headline)) faults.push('headline: missing. Say the verdict in one line.')
   if (!present(payload.summary)) faults.push('summary: missing. Say what you read and what you ran.')
   if (!Array.isArray(payload.findings)) {
@@ -458,7 +573,7 @@ export function lintVerdict(payload = {}) {
   const faults = []
   if (present(payload.headline)) faults.push(...gradeA('headline', payload.headline, CAPS.headline))
   if (present(payload.detail)) faults.push(...gradeA('detail', payload.detail, CAPS.detail))
-  if (present(payload.visual)) faults.push(...lintVisual(payload.visual))
+  faults.push(...lintVisualFields(payload))
   if (present(payload.summary)) faults.push(...gradeB('summary', payload.summary))
   ;(payload.findings ?? []).forEach((f, i) => {
     if (present(f?.text)) faults.push(...gradeB(`findings[${i}].text`, f.text))
@@ -473,7 +588,7 @@ export function lintVerdict(payload = {}) {
 // dies in silence on codex), never about letting a silent gate open. The flip
 // (#422) added the `headline` beside them, and all three are unconditional now.
 export function reviewFloorFaults(payload = {}) {
-  const faults = []
+  const faults = retiredFieldFaults(payload)
   if (!present(payload.headline)) faults.push('headline: missing. Say the whole change in one line.')
   if (!present(payload.summary)) faults.push('summary: missing. Say what you did.')
   if (!present(payload.charting)) faults.push('charting: missing. Write "none" when there is nothing to chart.')

--- a/daemon/src/messaging.mjs
+++ b/daemon/src/messaging.mjs
@@ -27,6 +27,8 @@ export const SIGNALS = {
   dead: '⚰️',
   link: '🔗',
   ask: '❓',
+  // ADR-0026 (#640) added the ninth: the background of a question.
+  background: '💡',
 }
 
 // Discord renders `-# ` as small print — the meta register (#89). Applied per
@@ -53,8 +55,14 @@ export function clampList(lines, max = 10) {
 // without crossing the cap (#119). Decision-bearing text is never silently
 // truncated: a long composed message becomes consecutive chunks, split at
 // paragraph boundaries first, then lines, then a hard slice as the last
-// resort (a single 1600-char line is code, not prose).
-export const CHUNK_LIMIT = 1600
+// resort (a single 1700-char line is code, not prose).
+//
+// ADR-0026 (#640) moved it from 1600 to 1700. The prose message of a composite
+// send caps at 1600, and the rail line curia writes rides the same Discord
+// message, so a full prose field arrives at about 1620. The old limit cut it.
+// 1700 is still 300 under Discord's own 2000, so the margin that keeps a code
+// fence off a split survives.
+export const CHUNK_LIMIT = 1700
 
 // ---- fenced code blocks (#432) ----------------------------------------------
 //

--- a/daemon/src/send.mjs
+++ b/daemon/src/send.mjs
@@ -1,0 +1,270 @@
+// The composite send (#691), against the contract ADR-0026 locks.
+//
+// A typed card fits a decision, and not every exchange is one. An agent that
+// answered an operator question had no field for the answer, so the explanation
+// landed in the one-line spoiler or in an attached markdown file, and the
+// operator named both counterproductive. ADR-0026 set the direction instead: a
+// response returns an ARRAY, and each entry keeps its own format.
+//
+// So this module is the payload contract of that array and nothing else. It
+// says how many messages a send carries, which one may decide, where that one
+// sits, and which fields each format is allowed. It reads pure data and it
+// touches no surface: Discord and Atlas are two renderers of what it accepts,
+// and #716 builds them.
+//
+// NOTHING LOOSENS. Every entry is one of the shapes ADR-0019 already types, and
+// every field is linted by the grade it already had. Composition replaces
+// relaxation, which is the sentence the whole ADR turns on.
+
+import { z } from 'zod'
+import {
+  CAPS, gradeA, gradeB, floorFaults, lintAskHuman, lintVisualFields, hasVisualField,
+  retiredFieldFaults,
+} from './lint.mjs'
+
+// The cap on a send. It is a `curia.yaml` default, `dispatch.messages_per_send`,
+// with a row on the settings screen — the pattern #635 set for the prototype
+// variation count. curia REFUSES a send above the cap, and it never drops a
+// message.
+export const MESSAGES_PER_SEND = 4
+
+// The message catalog of ADR-0026. `visual` names a message FORMAT here, and
+// the field of that name retired with #640.
+export const MESSAGE_FORMATS = ['prose', 'round', 'choice', 'approve-reject', 'preview-review', 'visual', 'files']
+
+// The formats that DECIDE. At most one of these per send, and it posts last, so
+// the buttons sit at the thread bottom.
+export const DECIDING_FORMATS = ['round', 'choice', 'approve-reject', 'preview-review']
+
+// A deciding format is one of the `ask_human` kinds under its ADR-0026 name.
+// `round` is what ADR-0019 calls `free-text`, and the rename stops here: the
+// floor and the word lint of a round are the ones that already ship.
+const KIND_OF = {
+  round: 'free-text',
+  choice: 'choice',
+  'approve-reject': 'approve-reject',
+  'preview-review': 'preview-review',
+}
+
+// Every entry carries these three, whatever its format. `format` says what it
+// is, `label` is what the rail prints, and `attachments` is what a reader
+// downloads — a file rides the message it belongs to.
+const EVERY_MESSAGE = ['format', 'label', 'attachments']
+
+// The three visual fields (#640), which every format that shows something takes.
+const VISUAL = ['picture', 'table', 'diagram']
+
+// The fields each format permits, beyond the three above. A field outside its
+// format's list is NAMED rather than stripped: a dropped field takes the words
+// the agent wrote with it.
+export const CONTENT_FIELDS = {
+  prose: ['prose', 'detail', ...VISUAL],
+  round: ['headline', 'questions', 'detail', 'timeline', ...VISUAL],
+  choice: ['headline', 'options', 'detail', 'timeline', ...VISUAL],
+  'approve-reject': ['headline', 'options', 'detail', 'timeline', ...VISUAL],
+  'preview-review': ['headline', 'options', 'preview_url', 'detail', 'timeline', ...VISUAL],
+  visual: ['detail', ...VISUAL],
+  files: ['caption'],
+}
+
+const present = (v) => v !== undefined && v !== null && String(v).trim() !== ''
+const isDeciding = (m) => DECIDING_FORMATS.includes(m?.format)
+
+// Where the deciding message sits, or -1 when the send decides nothing.
+export const decidingIndex = (messages = []) => messages.findIndex(isDeciding)
+
+// Whether a call arrived in the composite shape at all. It picks which contract
+// reads the call: a `messages` array takes this module's, and everything else
+// keeps the single-message shape ADR-0019 types.
+export const isComposite = (payload = {}) => Array.isArray(payload?.messages)
+
+// ---- the floor ----------------------------------------------------------------
+//
+// A missing or misplaced field is a SCHEMA fault and takes the schema path of
+// ADR-0005, exactly as a single-message floor does. The two are counted
+// together and the difference is what the agent is told.
+
+function messageFloor(m, i, prefix) {
+  const faults = [...retiredFieldFaults(m, prefix)]
+  const format = m?.format
+  if (!present(format)) {
+    faults.push(`${prefix}format: missing. One of ${MESSAGE_FORMATS.join(', ')}.`)
+    return faults
+  }
+  if (!MESSAGE_FORMATS.includes(format)) {
+    faults.push(`${prefix}format: "${format}" is not one of ${MESSAGE_FORMATS.join(', ')}.`)
+    return faults
+  }
+
+  // A field this format does not carry. Named with the format that does carry
+  // it wherever curia can say so, because the agent's next attempt is a move
+  // rather than a rewrite.
+  const allowed = new Set([...EVERY_MESSAGE, ...CONTENT_FIELDS[format]])
+  for (const key of Object.keys(m)) {
+    if (allowed.has(key)) continue
+    // `visual` and `images` are named once, by `retiredFieldFaults`. Naming
+    // them again here would spend the agent's reading on one fault twice.
+    if (key === 'visual' || key === 'images') continue
+    if (m[key] === undefined || m[key] === null) continue
+    const home = MESSAGE_FORMATS.find((f) => f !== format && CONTENT_FIELDS[f]?.includes(key))
+    faults.push(`${prefix}${key}: a \`${format}\` message does not carry it.${home ? ` A \`${home}\` message does.` : ''}`)
+  }
+
+  if (format === 'prose' && !present(m.prose)) {
+    faults.push(`${prefix}prose: missing. A prose message is the answer, or the intent of the send.`)
+  }
+  if (format === 'visual' && !hasVisualField(m)) {
+    faults.push(`${prefix}picture: missing. A visual message shows one thing: a \`picture\`, a \`table\`, or a \`diagram\`.`)
+  }
+  if (format === 'files' && !(m.attachments ?? []).length) {
+    faults.push(`${prefix}attachments: missing. A files message is the artifact that stands alone, so it carries at least one file.`)
+  }
+  if (KIND_OF[format]) faults.push(...floorFaults(KIND_OF[format], m).map((f) => `${prefix}${f}`))
+  return faults
+}
+
+export function sendFloorFaults(messages, { cap = MESSAGES_PER_SEND } = {}) {
+  if (!Array.isArray(messages)) {
+    return ['messages: missing. A send is an ordered array, one entry per message.']
+  }
+  if (!messages.length) {
+    return ['messages: empty. A send carries at least one message.']
+  }
+  const faults = []
+  // The cap REFUSES. curia never drops a message, and the refusal names the
+  // second send rather than only naming the number: an agent that hears the
+  // number alone spends its attempts squeezing.
+  if (messages.length > cap) {
+    faults.push(`messages: ${messages.length} messages over the ${cap} cap. Curia refuses the send, it never drops a message. Send the rest as a second call.`)
+  }
+
+  const rail = messages.length > 1
+  for (const [i, m] of messages.entries()) {
+    const prefix = `messages[${i}].`
+    if (!m || typeof m !== 'object' || Array.isArray(m)) {
+      faults.push(`${prefix}: not a message. Each entry is an object with a \`format\` and its fields.`)
+      continue
+    }
+    // The rail is what gives a grouped block its seams back, so a send of
+    // several needs a label on every one of them. A send of ONE carries no
+    // rail, because there is nothing to count, so its label is optional.
+    if (rail && !present(m.label)) {
+      faults.push(`${prefix}label: missing. Every message of a send of ${messages.length} carries one, at most ${CAPS.label} characters, plain and descriptive: "answer", not "the answer".`)
+    }
+    faults.push(...messageFloor(m, i, prefix))
+  }
+
+  // At most one decision, and it posts LAST. One answer surface, unique
+  // markers, one receipt.
+  const deciding = messages.map((m, i) => (isDeciding(m) ? i : -1)).filter((i) => i >= 0)
+  if (deciding.length > 1) {
+    faults.push(`messages: ${deciding.length} deciding messages at ${deciding.map((i) => i + 1).join(' and ')}. A send decides at most once. Curia refuses the send, it never drops a message.`)
+  } else if (deciding.length === 1 && deciding[0] !== messages.length - 1) {
+    faults.push(`messages: the deciding message is ${deciding[0] + 1} of ${messages.length}. It posts last, so the buttons sit at the thread bottom. Reorder the array and send the same messages again.`)
+  }
+  return faults
+}
+
+// ---- the words ----------------------------------------------------------------
+
+function messageLint(m, prefix) {
+  const faults = []
+  if (present(m?.label)) faults.push(...gradeA(`${prefix}label`, m.label, CAPS.label))
+  // The prose message. Past the cap the agent composes a SECOND prose message,
+  // and `gradeB` names the cap while the send-level guidance names that path.
+  if (present(m?.prose)) faults.push(...gradeB(`${prefix}prose`, m.prose, CAPS.prose))
+  if (present(m?.caption)) faults.push(...gradeA(`${prefix}caption`, m.caption, CAPS.caption))
+  if (present(m?.detail)) faults.push(...gradeA(`${prefix}detail`, m.detail, CAPS.detail))
+  faults.push(...lintVisualFields(m ?? {}, prefix))
+  if (KIND_OF[m?.format]) {
+    // A deciding message is the card ADR-0019 already types, so it takes the
+    // word lint that already ships. `lintAskHuman` reads the visual fields and
+    // the detail too, so those are dropped from the payload it sees rather than
+    // named twice.
+    const { picture, table, diagram, detail, ...card } = m
+    faults.push(...lintAskHuman(KIND_OF[m.format], card).map((f) => `${prefix}${f}`))
+  }
+  return faults
+}
+
+export function lintSend(messages) {
+  if (!Array.isArray(messages)) return []
+  return messages.flatMap((m, i) => messageLint(m, `messages[${i}].`))
+}
+
+// Whether a send carries prose a human could read at all. It is what separates
+// a schema fault curia can still send from one it cannot, on the composite
+// surface: a headline with no options still asks something, and an array of
+// empty objects asks nothing.
+export function sendHasText(messages) {
+  if (!Array.isArray(messages)) return false
+  return messages.some((m) => present(m?.prose) || present(m?.headline) || present(m?.caption)
+    || present(m?.detail) || present(m?.label) || hasVisualField(m ?? {})
+    || (m?.questions ?? []).some((q) => present(q?.text))
+    || (m?.options ?? []).some((o) => present(typeof o === 'object' ? o?.label : o))
+    || (m?.attachments ?? []).length > 0)
+}
+
+// The one line the thread reads as the send's title, for the records that need
+// one string: the journal, the supersession hash and the recorded-answer match
+// all key on a prompt. The deciding message's headline is it when the send
+// decides, and the first prose message otherwise.
+export function sendPrompt(messages) {
+  if (!Array.isArray(messages)) return null
+  const i = decidingIndex(messages)
+  const decided = i >= 0 ? messages[i]?.headline : null
+  if (present(decided)) return String(decided).trim()
+  const prose = messages.find((m) => present(m?.prose))
+  if (prose) return String(prose.prose).trim()
+  const labelled = messages.find((m) => present(m?.label))
+  return labelled ? String(labelled.label).trim() : null
+}
+
+// ---- the shape a tool declares ------------------------------------------------
+//
+// Every field is OPTIONAL to zod, which is the rule ADR-0005 sets for every
+// linted surface: a zod failure is JSON-RPC -32602, #416 measured that carriage
+// dying in silence on codex, and a schema rejection must never trap a question.
+// So the floor above is what refuses a send, and it refuses it in words the
+// agent can read and act on.
+//
+// The two RETIRED fields are declared for the same reason they are on the
+// single-message surfaces: zod strips a key it does not declare, and a stripped
+// `visual` would take the agent's rows with it.
+export const messageSchema = z.object({
+  format: z.enum(MESSAGE_FORMATS).optional().describe(`What this message IS: ${MESSAGE_FORMATS.join(', ')}. At most one deciding message per send (${DECIDING_FORMATS.join(', ')}), and it goes last.`),
+  label: z.string().optional().describe(`What this message is, for the rail curia writes above it. At most ${CAPS.label} characters, plain and descriptive, with no article: "answer", not "the answer". A send of one message needs none.`),
+  attachments: z.array(z.string()).optional().describe('Files for the human to DOWNLOAD, riding the message they belong to.'),
+  prose: z.string().optional().describe(`prose only: the answer, or the intent of the send. Block prose, at most ${CAPS.prose} characters. Past that, write a SECOND prose message and break where the meaning breaks.`),
+  caption: z.string().optional().describe('files only: the one line that says what the files are.'),
+  headline: z.string().optional().describe('The whole decision in one line. One line, no markdown, no link, 150 characters.'),
+  questions: z.array(z.object({
+    text: z.string().optional().describe('One question of the round. One line, 250 characters.'),
+    recommendation: z.string().optional().describe('Your recommended answer to THIS question. One line, 300 characters.'),
+    background: z.string().optional().describe(`What this question rests on, in small print under its line. Block prose, ${CAPS.background} characters.`),
+  })).optional().describe('round only: one entry per question. Curia numbers them.'),
+  options: z.array(z.object({
+    label: z.string().optional().describe('The choice, by its name. One line, 80 characters.'),
+    consequence: z.string().optional().describe('What picking this option costs. One line, 300 characters.'),
+    example: z.string().optional().describe('One concrete case for this option. Block prose, 300 characters.'),
+    recommended: z.boolean().optional(),
+  })).optional(),
+  detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters.'),
+  picture: z.string().optional().describe('One image the human LOOKS AT in place: a screenshot, a render, a mock.'),
+  table: z.string().optional().describe('A table, as rows. Curia writes the fence. At most 42 columns by 20 lines, and the columns must line up.'),
+  diagram: z.string().optional().describe('An ASCII drawing, as rows. Curia writes the fence. At most 42 columns by 20 lines.'),
+  timeline: z.boolean().optional().describe('Point the operator at the timeline for the reasoning. Curia composes the link.'),
+  preview_url: z.string().optional(),
+  visual: z.string().optional().describe('RETIRED. Send `table`, `diagram`, or `picture`. Curia refuses a send that carries this.'),
+  images: z.array(z.string()).optional().describe('RETIRED. Send the same paths under `attachments`. Curia refuses a send that carries this.'),
+})
+
+// The one rule the tool description carries, and no shape catalog under it. A
+// catalog is a second type system over a typed payload, and the first send that
+// needs a shape outside it is refused for being unusual rather than wrong.
+export const SEND_HINT = 'A message exists when a reader would want to skip it on its own.'
+  + ' Anything a reader always reads together stays one message.'
+  + ` At most ${MESSAGES_PER_SEND} messages, at most one of them decides, and the deciding one goes last so the buttons sit at the thread bottom.`
+
+export const sendSchema = z.array(messageSchema).optional()
+  .describe(`The send, in the order the human reads it. ${SEND_HINT}`)

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -2022,12 +2022,13 @@ export function writePrompt(cfgDir, issue, {
     '  every question carries one, so one reply names the exceptions. A question whose answer depends on',
     '  another one still open belongs to the NEXT round. One question is a round of one.',
     // #415, ADR-0019: the agent writes the parts and the bridge lays out the
-    // card. The example and the visual stay judgment fields, because a field
-    // required on every option produces filler rather than evidence.
+    // card. The example, the table and the diagram stay judgment fields,
+    // because a field required on every option produces filler rather than
+    // evidence.
     '- **Write the PARTS of a card, never the card itself.** `headline` says the whole decision in one line.',
     '  Every option of a `choice` carries the `consequence` of picking it. curia lays them out, adds the',
-    '  buttons and writes every link. An `example` or a `visual` is your judgment: add one where it removes',
-    '  prose, and leave it out where it would only say the line above it again in longer words.',
+    '  buttons and writes every link. An `example`, a `table` or a `diagram` is your judgment: add one where it',
+    '  removes prose, and leave it out where it would only say the line above it again in longer words.',
     '- **Never answer for the human.** A question they did not answer comes back in the next round. Only',
     '  the ✅ button takes your recommendations, and only for the questions in the round it sits on.',
     // #56: a daemon crash took an in-flight ask_human down with it, and the agent
@@ -2318,7 +2319,8 @@ export function writeReviewPrompt(cfgDir, issue, {
     '    `note` (worth knowing).',
     '  - `out_of_scope` — true when the finding is real but sits beyond this ticket.',
     '- `detail` — short facts, rendered as a spoiler. Optional.',
-    '- `visual` — a table or a diagram, at most 42 columns by 20 lines. Optional.',
+    '- `table` — a code-block table, at most 42 columns by 20 lines, columns lined up. Optional.',
+    '- `diagram` — an ASCII drawing, at most 42 columns by 20 lines. Optional.',
     '',
     'curia reads the GRADE of the whole verdict off those severities: one blocker makes it `fail`, one',
     'concern makes it `concerns`, and neither makes it `pass`. You never write that word yourself.',

--- a/daemon/test/card.test.mjs
+++ b/daemon/test/card.test.mjs
@@ -11,7 +11,7 @@ import { lintReply, CHUNK_LIMIT } from '../src/messaging.mjs'
 
 const CHOICE = {
   headline: 'A restart forgets every cooling. Re-arm it at boot, and from what?',
-  visual: '09:00  cap lands, cooling until 14:20\n13:02  deploy, memory wiped',
+  diagram: '09:00  cap lands, cooling until 14:20\n13:02  deploy, memory wiped',
   options: [
     {
       label: 'From the journal.',
@@ -31,7 +31,7 @@ describe('composeCard: a choice', () => {
     assert.equal(body.split('\n')[0], `**${CHOICE.headline}**`)
   })
 
-  test('the visual rides a fence curia wrote', () => {
+  test('the diagram rides a fence curia wrote', () => {
     assert.ok(body.includes('```\n09:00  cap lands, cooling until 14:20\n13:02  deploy, memory wiped\n```'))
   })
 
@@ -140,7 +140,7 @@ describe('optionLabels', () => {
 })
 
 describe('composeReviewBody', () => {
-  test('the gate body is the headline, the visual and the spoiler', () => {
+  test('the gate body is the headline, the table and the spoiler', () => {
     const body = composeReviewBody({ headline: 'Typed ask_human.', detail: 'The lint module is daemon/src/lint.mjs.' })
     assert.equal(body, '**Typed ask_human.**\n\nDetails: ||The lint module is daemon/src/lint.mjs.||')
   })
@@ -154,16 +154,16 @@ describe('composeResultReport: the ending report (#419)', () => {
   const REPORT = {
     status: 'resolved',
     headline: 'The ending report is typed, and curia lays it out.',
-    summary: 'The report takes a headline, a summary, a detail and a visual.',
+    summary: 'The report takes a headline, a summary, a detail and a table.',
     detail: 'The composer is daemon/src/card.mjs.',
-    visual: 'headline  150\nsummary   600',
+    table: 'headline  150\nsummary   600',
   }
 
-  test('the parts read top down: headline, visual, summary, spoiler', () => {
+  test('the parts read top down: headline, table, summary, spoiler', () => {
     assert.equal(composeResultBody(REPORT), [
       '**The ending report is typed, and curia lays it out.**',
       '```\nheadline  150\nsummary   600\n```',
-      'The report takes a headline, a summary, a detail and a visual.',
+      'The report takes a headline, a summary, a detail and a table.',
       'Details: ||The composer is daemon/src/card.mjs.||',
     ].join('\n\n'))
   })
@@ -184,8 +184,8 @@ describe('composeResultReport: the ending report (#419)', () => {
     assert.equal(composeResultReport('aborted', {}), '✅ **aborted**')
   })
 
-  test('curia writes the fence, so an agent that fenced its visual is not fenced twice', () => {
-    const body = composeResultBody({ visual: '```\na\nb\n```' })
+  test('curia writes the fence, so an agent that fenced its table is not fenced twice', () => {
+    const body = composeResultBody({ table: '```\na\nb\n```' })
     assert.equal(body, '```\na\nb\n```')
   })
 })
@@ -194,10 +194,10 @@ describe('composeNotify: the status line (#420)', () => {
   const LINE = {
     message: 'The lint reads the notify fields now. The gate refuses a fault.',
     detail: 'The composer is daemon/src/card.mjs.',
-    visual: 'message  600\ndetail   500',
+    table: 'message  600\ndetail   500',
   }
 
-  test('the parts read top down: message, visual, spoiler', () => {
+  test('the parts read top down: message, table, spoiler', () => {
     assert.equal(composeNotify(LINE), [
       '⚙️ The lint reads the notify fields now. The gate refuses a fault.',
       '```\nmessage  600\ndetail   500\n```',
@@ -239,8 +239,8 @@ describe('composeNotify: the status line (#420)', () => {
     assert.equal(composeNotify({}), '')
   })
 
-  test('curia writes the fence, so an agent that fenced its visual is not fenced twice', () => {
-    assert.equal(composeNotify({ message: 'a', visual: '```\nx\n```' }), '⚙️ a\n\n```\nx\n```')
+  test('curia writes the fence, so an agent that fenced its table is not fenced twice', () => {
+    assert.equal(composeNotify({ message: 'a', table: '```\nx\n```' }), '⚙️ a\n\n```\nx\n```')
   })
 })
 
@@ -265,7 +265,7 @@ describe('composeVerdict: the cross-check verdict (#421)', () => {
       { text: 'daemon/src/card.mjs:52 could name the marker helper once.', severity: 'note', out_of_scope: true },
     ],
     detail: 'The suite ran 71 files.',
-    visual: 'blocker  1\nnote     1',
+    table: 'blocker  1\nnote     1',
   }
 
   test('the grade leads under the headline, and curia derives it', () => {
@@ -280,7 +280,7 @@ describe('composeVerdict: the cross-check verdict (#421)', () => {
     assert.ok(body.includes('**2. note** (out of scope)'), 'the scope mark is rendered, never left in the prose')
   })
 
-  test('the parts read top down: headline, grade, visual, summary, findings, spoiler', () => {
+  test('the parts read top down: headline, grade, table, summary, findings, spoiler', () => {
     const body = composeVerdict(VERDICT)
     const at = (s) => body.indexOf(s)
     assert.ok(at('**fail**') < at('```'))

--- a/daemon/test/lint.test.mjs
+++ b/daemon/test/lint.test.mjs
@@ -5,7 +5,7 @@ import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   CAPS, VISUAL_COLUMNS, VISUAL_LINES, SENTENCE_WORDS,
-  gradeA, gradeB, lintVisual, unfence, isTyped, floorFaults, lintAskHuman,
+  gradeA, gradeB, lintGeometry, lintTable, lintPicture, retiredFieldFaults, unfence, isTyped, floorFaults, lintAskHuman,
   lintRequestReview, reviewFloorFaults, hasText,
   isTypedResult, lintResult, resultFloorFaults,
   lintNotify, notifyFloorFaults, notifyHasText,
@@ -117,35 +117,35 @@ describe('grade B: block prose', () => {
   })
 })
 
-describe('the visual: geometry, never words', () => {
+describe('the geometry fields: never words', () => {
   test('rows inside the box pass', () => {
-    assert.deepEqual(lintVisual('09:00  cap lands\n13:02  deploy'), [])
+    assert.deepEqual(lintGeometry('diagram', '09:00  cap lands\n13:02  deploy'), [])
   })
 
   test('a row over the column cap is refused', () => {
-    assert.match(names(lintVisual('x'.repeat(VISUAL_COLUMNS + 1))), new RegExp(`${VISUAL_COLUMNS + 1} columns over the ${VISUAL_COLUMNS} cap`))
+    assert.match(names(lintGeometry('diagram', 'x'.repeat(VISUAL_COLUMNS + 1))), new RegExp(`${VISUAL_COLUMNS + 1} columns over the ${VISUAL_COLUMNS} cap`))
   })
 
-  test('a visual over the line cap is refused', () => {
+  test('a diagram over the line cap is refused', () => {
     const tall = new Array(VISUAL_LINES + 1).fill('row').join('\n')
-    assert.match(names(lintVisual(tall)), new RegExp(`${VISUAL_LINES + 1} lines over the ${VISUAL_LINES} cap`))
+    assert.match(names(lintGeometry('diagram', tall)), new RegExp(`${VISUAL_LINES + 1} lines over the ${VISUAL_LINES} cap`))
   })
 
-  test('a visual the agent fenced itself is measured on its rows', () => {
-    assert.deepEqual(lintVisual('```\nshort row\n```'), [])
+  test('a diagram the agent fenced itself is measured on its rows', () => {
+    assert.deepEqual(lintGeometry('diagram', '```\nshort row\n```'), [])
     assert.equal(unfence('```\nshort row\n```'), 'short row')
     assert.equal(unfence('short row'), 'short row')
   })
 
   test('a fence inside the rows is refused: it would close the fence curia writes', () => {
-    assert.match(names(lintVisual('row one\n```\nrow two')), /a code fence inside the rows/)
+    assert.match(names(lintGeometry('diagram', 'row one\n```\nrow two')), /a code fence inside the rows/)
   })
 
-  test('the visual takes no grade: a semicolon in a diagram passes', () => {
-    assert.deepEqual(lintVisual('a; b; c'), [])
+  test('a diagram takes no grade: a semicolon in it passes', () => {
+    assert.deepEqual(lintGeometry('diagram', 'a; b; c'), [])
   })
 
-  test('the geometry cap keeps a visual under the code-block cap', () => {
+  test('the geometry cap keeps a diagram under the code-block cap', () => {
     assert.ok(VISUAL_COLUMNS * VISUAL_LINES < 1000)
   })
 })
@@ -275,7 +275,7 @@ describe('lintAskHuman', () => {
         { label: 'From a fresh reading.', consequence: 'It answers "am I near the cap", not "did I hit one".' },
       ],
       detail: 'The daemon has journalled provider_cooling with reset_at since #175.',
-      visual: '09:00  cap lands\n13:02  deploy',
+      diagram: '09:00  cap lands\n13:02  deploy',
     })
     assert.deepEqual(faults, [])
   })
@@ -345,9 +345,9 @@ describe('lintResult: the ending report (#419)', () => {
     ticket: '419',
     status: 'resolved',
     headline: 'The ending report is typed, and the lint reads its named fields.',
-    summary: 'The report takes a headline, a summary, a detail and a visual. Curia lays them out.',
+    summary: 'The report takes a headline, a summary, a detail and a table. Curia lays them out.',
     detail: 'The lint module is daemon/src/lint.mjs and the composer is daemon/src/card.mjs.',
-    visual: 'headline  one line, 150\nsummary   block prose, 600',
+    table: 'headline  one line, 150\nsummary   block prose, 600',
   }
 
   test('a typed report passes every grade', () => {
@@ -369,9 +369,9 @@ describe('lintResult: the ending report (#419)', () => {
     assert.match(names(faults), /never cuts it/)
   })
 
-  test('the visual keeps its geometry check and no grade', () => {
-    assert.match(names(lintResult({ visual: 'x'.repeat(VISUAL_COLUMNS + 1) })), /visual: 43 columns/)
-    assert.deepEqual(lintResult({ visual: 'a; b — c' }), [], 'a diagram is not prose')
+  test('the geometry fields keep their check and no grade', () => {
+    assert.match(names(lintResult({ diagram: 'x'.repeat(VISUAL_COLUMNS + 1) })), /diagram: 43 columns/)
+    assert.deepEqual(lintResult({ diagram: 'a; b — c' }), [], 'a diagram is not prose')
   })
 
   test('`details` is a free record: ADR-0019 rule 3, and no lint reads it', () => {
@@ -393,7 +393,7 @@ describe('lintResult: the ending report (#419)', () => {
     assert.equal(isTypedResult({ summary: 'what changed' }), false)
     assert.equal(isTypedResult({ headline: 'h' }), true)
     assert.equal(isTypedResult({ detail: 'd' }), true)
-    assert.equal(isTypedResult({ visual: 'v' }), true)
+    assert.equal(isTypedResult({ diagram: 'v' }), true)
   })
 
   test('a report carrying a summary has text, so the cap ends in a flagged send', () => {
@@ -421,9 +421,9 @@ describe('the status line (#420)', () => {
     assert.match(names(lintNotify({ ...LINE, detail: 'see https://example.com' })), /detail: a link/)
   })
 
-  test('the visual keeps its geometry check and no grade', () => {
-    assert.match(names(lintNotify({ ...LINE, visual: 'x'.repeat(VISUAL_COLUMNS + 1) })), /visual: 43 columns/)
-    assert.deepEqual(lintNotify({ ...LINE, visual: 'a; b — c' }), [], 'a diagram is not prose')
+  test('the geometry fields keep their check and no grade', () => {
+    assert.match(names(lintNotify({ ...LINE, diagram: 'x'.repeat(VISUAL_COLUMNS + 1) })), /diagram: 43 columns/)
+    assert.deepEqual(lintNotify({ ...LINE, diagram: 'a; b — c' }), [], 'a diagram is not prose')
   })
 
   test('the floor is the message, because the schema required it before this ticket', () => {
@@ -433,7 +433,7 @@ describe('the status line (#420)', () => {
 
   test('a status line with words has text, so its cap ends in a flagged send', () => {
     assert.equal(notifyHasText(LINE), true)
-    assert.equal(notifyHasText({ visual: 'a  b' }), true, 'a visual alone still says something')
+    assert.equal(notifyHasText({ diagram: 'a  b' }), true, 'a diagram alone still says something')
     assert.equal(notifyHasText({ images: ['a.png'] }), false, 'a file is not prose, so it is the dead end')
   })
 
@@ -524,5 +524,99 @@ describe('the cross-check verdict (#421)', () => {
 
   test('the three severities, most serious first', () => {
     assert.deepEqual(VERDICT_SEVERITIES, ['blocker', 'concern', 'note'])
+  })
+})
+
+// ---- ADR-0026 (#691): the field vocabulary that replaced `visual` ------------
+
+describe('the table: geometry, and the columns line up', () => {
+  test('a table whose columns line up passes', () => {
+    assert.deepEqual(lintTable('kind      what you must do\nlook      open it now\nprogress  nothing'), [])
+  })
+
+  test('a column that starts where no column of the first row starts is refused', () => {
+    assert.match(names(lintTable('kind      what you must do\nlook    open it now')), /row 2 starts a column at character 9/)
+  })
+
+  test('a row with more columns than the first row is refused', () => {
+    assert.match(names(lintTable('kind      what\nlook      open  now')), /row 2 has 3 columns where the first row has 2/)
+  })
+
+  test('a blank cell is a real row, so fewer columns pass on the offsets that are there', () => {
+    assert.deepEqual(lintTable('kind      what      when\nlook                now'), [])
+  })
+
+  test('a title or a rule line is not a row, so it is skipped', () => {
+    assert.deepEqual(lintTable('the kinds\nkind      what\n--------  ----'), [])
+  })
+
+  test('the table keeps the geometry check every block takes', () => {
+    assert.match(names(lintTable('x'.repeat(VISUAL_COLUMNS + 1))), new RegExp(`table: ${VISUAL_COLUMNS + 1} columns`))
+  })
+})
+
+describe('the picture: one image file', () => {
+  test('an image path passes', () => {
+    assert.deepEqual(lintPicture('picture', 'renders/home.png'), [])
+    assert.deepEqual(lintPicture('picture', '/workspace/a.WEBP'), [])
+  })
+
+  test('a download is not a picture, and the fault says where it goes', () => {
+    const faults = names(lintPicture('picture', 'notes/reading.md'))
+    assert.match(faults, /is not an image/)
+    assert.match(faults, /`attachments`/)
+  })
+
+  test('a second picture is a second message, not a second line', () => {
+    assert.match(names(lintPicture('picture', 'a.png\nb.png')), /a newline/)
+  })
+})
+
+describe('the fields ADR-0026 retired, on every surface', () => {
+  const surfaces = {
+    'ask_human': (p) => floorFaults('free-text', p),
+    notify: notifyFloorFaults,
+    report_result: resultFloorFaults,
+    verdict: verdictFloorFaults,
+    request_review: reviewFloorFaults,
+  }
+
+  for (const [surface, floor] of Object.entries(surfaces)) {
+    test(`\`visual\` is refused on ${surface}, and the rows are named rather than dropped`, () => {
+      const payload = { visual: 'a  b\nc  d' }
+      const faults = names(floor(payload))
+      assert.match(faults, /visual: retired by ADR-0026/)
+      assert.match(faults, /`diagram`/)
+      assert.equal(payload.visual, 'a  b\nc  d', 'the rows are still on the payload')
+    })
+
+    test(`\`images\` is refused on ${surface}, and the paths are named`, () => {
+      assert.match(names(floor({ images: ['/workspace/a.png'] })), /images: renamed to `attachments`/)
+    })
+  }
+
+  test('an empty payload carries neither fault', () => {
+    assert.deepEqual(retiredFieldFaults({}), [])
+    assert.deepEqual(retiredFieldFaults({ table: 'a  b', attachments: [] }), [])
+  })
+})
+
+describe('the question background (ADR-0026)', () => {
+  const round = (background) => ({
+    headline: 'Which cap?',
+    questions: [{ text: 'Which cap re-arms at boot?', background }],
+  })
+
+  test('a background inside the cap passes, and it keeps its sentences', () => {
+    assert.deepEqual(lintAskHuman('free-text', round('The cap landed at 09:00. Cooling ran until 14:20.')), [])
+  })
+
+  test('the background is refused over 600, and it is refused rather than cut', () => {
+    const long = 'x'.repeat(CAPS.background + 1)
+    assert.match(names(lintAskHuman('free-text', round(long))), new RegExp(`questions\\[0\\].background: ${CAPS.background + 1} characters over the ${CAPS.background} cap`))
+  })
+
+  test('the background is block prose, so a list of separable facts passes', () => {
+    assert.deepEqual(lintAskHuman('free-text', round('- the cap landed at 09:00\n- cooling ran until 14:20')), [])
   })
 })

--- a/daemon/test/send.test.mjs
+++ b/daemon/test/send.test.mjs
@@ -1,0 +1,247 @@
+// Tests for src/send.mjs (#691): the composite-send payload contract ADR-0026
+// locks. A send is an ordered array, it carries at most four messages, at most
+// one of them decides, and the deciding one goes last.
+//
+// Every test here reads PURE DATA. Discord and Atlas are two renderers of what
+// this module accepts, and #716 builds them.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  MESSAGES_PER_SEND, MESSAGE_FORMATS, DECIDING_FORMATS, CONTENT_FIELDS,
+  sendFloorFaults, lintSend, sendHasText, sendPrompt, decidingIndex, isComposite,
+  messageSchema, sendSchema,
+} from '../src/send.mjs'
+import { CAPS } from '../src/lint.mjs'
+
+const names = (faults) => faults.join(' | ')
+
+const prose = (label, text = 'The cap landed at 09:00 and cooling ran to 14:20.') => ({
+  format: 'prose', label, prose: text,
+})
+const round = (label = 'decision') => ({
+  format: 'round',
+  label,
+  headline: 'Re-arm cooling at boot, and from what source?',
+  questions: [{ text: 'Should cooling re-arm at boot?', recommendation: 'Yes, from the stored cap.' }],
+})
+
+describe('the catalog', () => {
+  test('the seven formats of ADR-0026, and the four that decide', () => {
+    assert.deepEqual(MESSAGE_FORMATS, ['prose', 'round', 'choice', 'approve-reject', 'preview-review', 'visual', 'files'])
+    assert.deepEqual(DECIDING_FORMATS, ['round', 'choice', 'approve-reject', 'preview-review'])
+    for (const f of DECIDING_FORMATS) assert.ok(MESSAGE_FORMATS.includes(f), `${f} is not in the catalog`)
+  })
+
+  test('every format has its permitted content fields', () => {
+    for (const f of MESSAGE_FORMATS) assert.ok(CONTENT_FIELDS[f]?.length, `${f} permits nothing`)
+  })
+
+  test('the cap is four, which is the ADR-0026 default', () => {
+    assert.equal(MESSAGES_PER_SEND, 4)
+  })
+
+  test('a composite call is one that carries the array, and nothing else is', () => {
+    assert.equal(isComposite({ messages: [] }), true)
+    assert.equal(isComposite({ headline: 'one card' }), false)
+  })
+})
+
+describe('the cap on a send', () => {
+  test('a send of the cap passes', () => {
+    const send = [prose('answer'), prose('cost'), prose('reading'), round()]
+    assert.deepEqual(sendFloorFaults(send), [])
+  })
+
+  test('a send over the cap is REFUSED, and no message is dropped', () => {
+    const send = [prose('a'), prose('b'), prose('c'), prose('d'), round()]
+    const faults = sendFloorFaults(send)
+    assert.match(names(faults), /5 messages over the 4 cap/)
+    assert.match(names(faults), /never drops a message/)
+    assert.match(names(faults), /second call/, 'the refusal names the path, not only the number')
+  })
+
+  test('the cap is a parameter, because it is a curia.yaml row', () => {
+    assert.match(names(sendFloorFaults([prose('a'), round()], { cap: 1 })), /2 messages over the 1 cap/)
+  })
+
+  test('an empty send and a missing one are both named', () => {
+    assert.match(names(sendFloorFaults([])), /messages: empty/)
+    assert.match(names(sendFloorFaults(undefined)), /messages: missing/)
+  })
+})
+
+describe('the deciding message posts last', () => {
+  test('a send whose decision is last passes', () => {
+    assert.deepEqual(sendFloorFaults([prose('answer'), round()]), [])
+    assert.equal(decidingIndex([prose('answer'), round()]), 1)
+  })
+
+  test('a decision that is not last is refused, and the send is not reordered for the agent', () => {
+    const send = [round('decision'), prose('answer')]
+    const faults = sendFloorFaults(send)
+    assert.match(names(faults), /the deciding message is 1 of 2/)
+    assert.match(names(faults), /buttons sit at the thread bottom/)
+    assert.equal(send[0].format, 'round', 'the array the agent sent is untouched')
+    assert.equal(send.length, 2, 'nothing is dropped to make the order legal')
+  })
+
+  test('two decisions are refused, and both are named', () => {
+    const faults = sendFloorFaults([round('one'), prose('answer'), round('two')])
+    assert.match(names(faults), /2 deciding messages at 1 and 3/)
+    assert.match(names(faults), /never drops a message/)
+  })
+
+  test('a send that decides nothing is a send', () => {
+    assert.deepEqual(sendFloorFaults([prose('answer'), { format: 'visual', label: 'the shape', diagram: 'a\nb' }]), [])
+    assert.equal(decidingIndex([prose('answer')]), -1)
+  })
+})
+
+describe('the rail label', () => {
+  test('every message of a send of several carries one', () => {
+    const faults = sendFloorFaults([{ format: 'prose', prose: 'the answer' }, round()])
+    assert.match(names(faults), /messages\[0\]\.label: missing/)
+  })
+
+  test('a send of ONE carries no rail, so its label is optional', () => {
+    assert.deepEqual(sendFloorFaults([{ format: 'prose', prose: 'the answer' }]), [])
+  })
+
+  test('the label is capped at 20 and linted as inline text', () => {
+    assert.match(names(lintSend([prose('x'.repeat(CAPS.label + 1)), round()])), new RegExp(`messages\\[0\\]\\.label: ${CAPS.label + 1} characters over the ${CAPS.label} cap`))
+    assert.match(names(lintSend([prose('see https://x.dev'), round()])), /messages\[0\]\.label: a link/)
+  })
+})
+
+describe('the field vocabulary per format', () => {
+  test('a prose message needs its prose', () => {
+    assert.match(names(sendFloorFaults([{ format: 'prose', label: 'answer' }])), /messages\[0\]\.prose: missing/)
+  })
+
+  test('prose caps at 1600, not at the block cap', () => {
+    assert.deepEqual(lintSend([{ format: 'prose', label: 'answer', prose: 'Short words. '.repeat(100) }]), [])
+    const long = 'Short words here. '.repeat(100)
+    assert.ok(long.length > CAPS.prose)
+    assert.match(names(lintSend([{ format: 'prose', label: 'answer', prose: long }])), new RegExp(`messages\\[0\\]\\.prose: ${long.length} characters over the ${CAPS.prose} cap`))
+  })
+
+  test('a visual message shows one of the three', () => {
+    assert.match(names(sendFloorFaults([{ format: 'visual', label: 'the shape' }])), /A visual message shows one thing/)
+    assert.deepEqual(sendFloorFaults([{ format: 'visual', label: 'the shape', picture: '/workspace/mock.png' }]), [])
+    assert.deepEqual(sendFloorFaults([{ format: 'visual', label: 'the shape', table: 'a  b\nc  d' }]), [])
+  })
+
+  test('a files message carries at least one file', () => {
+    assert.match(names(sendFloorFaults([{ format: 'files', label: 'the diff' }])), /messages\[0\]\.attachments: missing/)
+    assert.deepEqual(sendFloorFaults([{ format: 'files', label: 'the diff', attachments: ['/workspace/a.diff'] }]), [])
+  })
+
+  test('a field outside its format is NAMED rather than stripped, with the format that carries it', () => {
+    const faults = sendFloorFaults([{ format: 'prose', label: 'answer', prose: 'a', questions: [{ text: 'q' }] }])
+    assert.match(names(faults), /messages\[0\]\.questions: a `prose` message does not carry it\. A `round` message does\./)
+  })
+
+  test('a format outside the catalog is named against the catalog', () => {
+    assert.match(names(sendFloorFaults([{ format: 'essay', label: 'answer' }])), /"essay" is not one of prose, round/)
+    assert.match(names(sendFloorFaults([{ label: 'answer' }])), /messages\[0\]\.format: missing/)
+  })
+
+  test('an entry that is not an object is named, and the rest of the send is still read', () => {
+    const faults = sendFloorFaults(['just a string', { format: 'prose', label: 'answer' }])
+    assert.match(names(faults), /messages\[0\]\.: not a message/)
+    assert.match(names(faults), /messages\[1\]\.prose: missing/)
+  })
+})
+
+describe('a deciding message keeps the lint it already had', () => {
+  test('a round takes the ADR-0019 floor under its ADR-0026 name', () => {
+    const faults = sendFloorFaults([{ format: 'round', label: 'decision' }])
+    assert.match(names(faults), /messages\[0\]\.headline: missing/)
+    assert.match(names(faults), /messages\[0\]\.questions: missing/)
+  })
+
+  test('a choice still needs two options, each with its consequence', () => {
+    const faults = sendFloorFaults([{
+      format: 'choice', label: 'decision', headline: 'Which cap?', options: [{ label: 'the stored one' }],
+    }])
+    assert.match(names(faults), /messages\[0\]\.options: a choice needs two options or more/)
+    assert.match(names(faults), /messages\[0\]\.options\[0\]\.consequence: missing/)
+  })
+
+  test('the word lint reaches inside a card of a send', () => {
+    const faults = lintSend([{
+      format: 'round', label: 'decision', headline: 'x'.repeat(CAPS.headline + 1),
+      questions: [{ text: 'Should cooling re-arm?' }],
+    }])
+    assert.match(names(faults), new RegExp(`messages\\[0\\]\\.headline: ${CAPS.headline + 1} characters`))
+  })
+
+  test('the question background is Grade B at 600', () => {
+    const q = (background) => lintSend([{
+      format: 'round', label: 'decision', headline: 'Which cap?', questions: [{ text: 'Which one?', background }],
+    }])
+    assert.deepEqual(q('The cap landed at 09:00. Cooling ran until 14:20.'), [])
+    assert.match(names(q('x'.repeat(CAPS.background + 1))), new RegExp(`messages\\[0\\]\\.questions\\[0\\]\\.background: ${CAPS.background + 1} characters over the ${CAPS.background} cap`))
+  })
+})
+
+describe('the fields ADR-0026 retired', () => {
+  test('a `visual` inside a message is named, and the rows are not dropped', () => {
+    const m = { format: 'prose', label: 'answer', prose: 'a', visual: 'a  b\nc  d' }
+    const faults = sendFloorFaults([m])
+    assert.match(names(faults), /messages\[0\]\.visual: retired by ADR-0026/)
+    assert.match(names(faults), /`table`/)
+    assert.equal(m.visual, 'a  b\nc  d', 'the rows the agent wrote are still on the payload')
+    assert.equal(faults.filter((f) => /\.visual:/.test(f)).length, 1, 'one fault, not two')
+  })
+
+  test('an `images` inside a message is named with its new home', () => {
+    assert.match(names(sendFloorFaults([{ format: 'prose', label: 'answer', prose: 'a', images: ['/workspace/a.png'] }])), /messages\[0\]\.images: renamed to `attachments`/)
+  })
+})
+
+describe('what a send says about itself', () => {
+  test('a send with words has text, and one of empty entries does not', () => {
+    assert.equal(sendHasText([prose('answer')]), true)
+    assert.equal(sendHasText([{ format: 'prose' }, { format: 'round' }]), false)
+    assert.equal(sendHasText('not a send'), false)
+  })
+
+  test('the prompt is the decision when there is one, and the prose otherwise', () => {
+    assert.equal(sendPrompt([prose('answer'), round()]), 'Re-arm cooling at boot, and from what source?')
+    assert.equal(sendPrompt([prose('answer', 'The cap landed at 09:00.')]), 'The cap landed at 09:00.')
+    assert.equal(sendPrompt([]), null)
+  })
+})
+
+describe('the shape a tool declares', () => {
+  test('every field is optional to zod, so a schema rejection never traps a send', () => {
+    assert.equal(messageSchema.safeParse({}).success, true)
+  })
+
+  test('the retired fields stay declared, so curia sees one rather than losing it', () => {
+    const parsed = messageSchema.parse({ format: 'prose', prose: 'a', visual: 'a  b', images: ['/workspace/a.png'] })
+    assert.equal(parsed.visual, 'a  b')
+    assert.deepEqual(parsed.images, ['/workspace/a.png'])
+  })
+
+  test('the format is the one enum zod holds, because it is not prose', () => {
+    assert.equal(messageSchema.safeParse({ format: 'essay' }).success, false)
+    for (const f of MESSAGE_FORMATS) assert.equal(messageSchema.safeParse({ format: f }).success, true, f)
+  })
+
+  test('a send parses as an ordered array of messages', () => {
+    const send = sendSchema.parse([prose('answer'), round()])
+    assert.equal(send.length, 2)
+    assert.equal(send[1].format, 'round')
+    assert.equal(send[1].questions[0].text, 'Should cooling re-arm at boot?')
+  })
+
+  test('the three visual fields ride the message, and `visual` is not one of them', () => {
+    const parsed = messageSchema.parse({ format: 'visual', picture: 'a.png', table: 'a  b', diagram: 'a\nb' })
+    assert.equal(parsed.picture, 'a.png')
+    assert.equal(parsed.table, 'a  b')
+    assert.equal(parsed.diagram, 'a\nb')
+  })
+})

--- a/daemon/test/typedcard.test.mjs
+++ b/daemon/test/typedcard.test.mjs
@@ -58,7 +58,7 @@ describe('a typed card renders as one message the operator can answer', () => {
 
   const CHOICE = {
     headline: 'A restart forgets every cooling. Re-arm it from what source?',
-    visual: '09:00  cap lands\n13:02  deploy, memory wiped',
+    diagram: '09:00  cap lands\n13:02  deploy, memory wiped',
     options: [
       { label: 'From the journal.', consequence: 'A guessed reset holds 55 minutes too long.', recommended: true },
       { label: 'From a fresh reading.', consequence: 'It answers "am I near the cap", not "did I hit one".' },
@@ -75,7 +75,7 @@ describe('a typed card renders as one message the operator can answer', () => {
     assert.match(msg.content, /Recommendation: \*\*A\*\*\./)
   })
 
-  test('the visual rides a fence curia wrote, and the detail rides a spoiler', async () => {
+  test('the diagram rides a fence curia wrote, and the detail rides a spoiler', async () => {
     const msg = await render('choice', CHOICE)
     assert.match(msg.content, /```\n09:00 {2}cap lands\n13:02 {2}deploy, memory wiped\n```/)
     assert.match(msg.content, /Details: \|\|The daemon has journalled provider_cooling since #175\.\|\|/)

--- a/daemon/test/typednotify.test.mjs
+++ b/daemon/test/typednotify.test.mjs
@@ -137,12 +137,12 @@ describe('notify carries the typed fields and the lint gate (#420, real boot)', 
     fs.rmSync(tmp, { recursive: true, force: true })
   })
 
-  test('a typed status line lands with its kind, its spoiler and its visual', async () => {
+  test('a typed status line lands with its kind, its spoiler and its table', async () => {
     const text = await call('curia-420', '420', {
       kind: 'look',
       message: 'The prototype is up. The page is the one this ticket changed.',
       detail: 'The demo is prototypes/select-menu/index.html.',
-      visual: 'kind   you must do\nlook   open it now',
+      table: 'kind   you must do\nlook   open it now',
     })
 
     assert.match(text, /^ok/m)
@@ -150,7 +150,7 @@ describe('notify carries the typed fields and the lint gate (#420, real boot)', 
     const line = events.findLast((e) => e.type === 'notify' && e.agent === 'curia-420')
     assert.equal(line.kind, 'look')
     assert.equal(line.detail, 'The demo is prototypes/select-menu/index.html.')
-    assert.match(line.visual, /look   open it now/)
+    assert.match(line.table, /look   open it now/)
   })
 
   test('an opening and phase update travel through the notify tool', async () => {

--- a/docs/adr/0019-typed-payloads-and-the-lint-grades.md
+++ b/docs/adr/0019-typed-payloads-and-the-lint-grades.md
@@ -3,6 +3,8 @@
 **Status**: accepted (2026-08)
 **Provenance**: [Typed HITL payloads (#413)](https://github.com/alp82/curia/issues/413), [What Discord renders well (#414)](https://github.com/alp82/curia/issues/414), [The card (#415)](https://github.com/alp82/curia/issues/415), [Reject-on-lint live check (#416)](https://github.com/alp82/curia/issues/416), [ADR: typed payloads and the lint contract (#417)](https://github.com/alp82/curia/issues/417), [The select menu, built and judged (#431)](https://github.com/alp82/curia/issues/431), [The chunker breaks a code fence (#432)](https://github.com/alp82/curia/issues/432), [Reject-on-lint on the codex harness (#438)](https://github.com/alp82/curia/issues/438), [Typed notify (#420)](https://github.com/alp82/curia/issues/420), [Typed verdict carriage (#421)](https://github.com/alp82/curia/issues/421), [The flip (#422)](https://github.com/alp82/curia/issues/422)
 
+> **Amended by [ADR-0026](0026-the-composite-send.md) (#640).** The `visual` FIELD below retires, and `picture`, `table` and `diagram` replace it. `images` is renamed `attachments`. The never-stacked small-print rule gains one named exception, the question background. The prose cap of a composite send is 1600, and a question background is Grade B at 600. Everything else on this page stands.
+
 ## Context
 
 Agent prose reaches the operator on five surfaces: `ask_human`, the review gate, `report_result`, `notify` and the cross-check verdict. Every one of them takes a free string today.


### PR DESCRIPTION
Closes alp82/curia#691.

## What this is

The payload contract of the composite send, and nothing else. `daemon/src/send.mjs` is the new module: it reads pure data, so Discord and Atlas are two renderers of what it accepts, and [#716](https://github.com/alp82/curia/issues/716) builds them.

## The send

A send is an ordered array. It carries at most four messages, at most one of them decides, and the deciding one goes last so the buttons sit at the thread bottom. Each entry names a format out of the ADR-0026 catalog (`prose`, `round`, `choice`, `approve-reject`, `preview-review`, `visual`, `files`), a 20-character rail label, its `attachments`, and the content fields that format permits.

A send over the cap is refused whole, and the refusal names the second call rather than only the number: an agent that hears the number alone spends its attempts squeezing. A field outside its format is named with the format that does carry it. Nothing is dropped to make a send legal.

A deciding message keeps the lint it already had. `round` is what ADR-0019 calls `free-text`, and the rename stops at the catalog: the floor and the word lint of a card run unchanged inside a send. Composition replaces relaxation.

## The field vocabulary

The `visual` field retires on every surface. `picture` carries an image the reader looks at in place, `table` carries a code-block table, and `diagram` carries an ASCII drawing. Splitting the two geometry fields is what lets curia check that a table's columns line up, which one combined field could never do, because a diagram has no columns.

`images` is renamed `attachments`. The field has taken a `.patch`, a `.diff`, a `.md`, a `.txt` and a `.log` since it shipped, so the name has never been true.

Both old names stay declared in the tool schemas. zod strips a key it does not declare, and a stripped `visual` would take the agent's rows with it, so each one is refused by name and told where its content goes.

Prose caps at 1600, which is `CHUNK_LIMIT` minus the rail line curia writes above it, so no prose entry is split behind the agent's back. `CHUNK_LIMIT` moves to 1700. A question takes an optional `background` at Grade B and 600 characters, and the signal set gains 💡 as its ninth entry.

## Callers migrated

`card.mjs` composes a `table` and a `diagram` where it composed a `visual`. `index.mjs` declares the new fields once and spreads them into the four tools that take them. `askHumanGate` carries all three onto the record. The `/escalate` route reads `attachments` first and still reads the two older names. The standing orders, `CONTEXT.md` and ADR-0019 say the new names.

## Tests

`npm test` in `daemon/`: 3420 passing, 0 failing, 0 cancelled. The baseline on main is 3362, and the 58 new tests are `daemon/test/send.test.mjs` plus the ADR-0026 blocks in `daemon/test/lint.test.mjs`. Ordering, the cap, two decisions, a decision that is not last, a field outside its format, both retired names on all five surfaces, the table alignment check, the picture check, and the two caps each have a test, and the ordering tests assert the send is not reordered or trimmed for the agent.

## Left out on purpose

Delivery. The rail curia writes, the Discord and Atlas renderings, the small print behind 💡, and the settings row for `dispatch.messages_per_send` are [#716](https://github.com/alp82/curia/issues/716)'s acceptance criteria. `messages` is therefore not declared on the live `ask_human` and `notify` shapes: a schema that accepted an array the daemon then dropped would break the rule this map turns on. `send.mjs` exports the zod `messageSchema` and `sendSchema` ready for that ticket to attach, and the default cap of four lives there until the settings row lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
