### PR TITLE
Finish GitHub App setup in Atlas Settings (alp82/curia#705)

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -38,7 +38,7 @@
      2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
         nobody has computed is not an empty frontier. Every section that can fail
         on its own says which of the two it is. -->
-<meta name="curia-dashboard" content="proto=7">
+<meta name="curia-dashboard" content="proto=8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark light">
 <title>Atlas · Curia</title>
@@ -572,6 +572,10 @@ var UI = {
      of sections: which section is open, and whether the phone is on the list
      in front of it. */
   drill: {},
+  /* The GitHub App setup (#705). `busy` is the conversion in flight on the
+     return from github.com, and `facts` and `error` are what it answered.
+     `name` is the app name being typed. */
+  app: { busy: false, facts: null, error: null, name: "" },
   /* Which `?` explanations are open, by row id. Page-wide, because the frame
      hands the same affordance to every section on every page. */
   hints: {},
@@ -2045,6 +2049,13 @@ const SET_SECTIONS = [
     patch: patchDispatch, count: countDispatch,
   },
   {
+    /* #705. It sits after the three that write curia.yaml because it writes
+       neither file: what it changes lives on github.com and in the daemon's
+       own env, and the save dock has nothing to do with it. */
+    key: "github", title: "GitHub App", gist: gistApp, body: setApp,
+    hint: "curia's own GitHub identity. It is created once, installed on each watched owner, and the daemon mints every token an agent uses from its key.",
+  },
+  {
     key: "maintenance", title: "Maintenance", gist: gistMaintenance, body: setMaintenance,
     hint: "Whether the daemon runs what the files say, and the restart for the keys a save cannot apply.",
   },
@@ -2368,6 +2379,203 @@ function setMaintenance(p) {
       Agent panes live in their own container, so they survive it.`)}
     ${writes ? `<div class="row"><span class="grow dim-note">where a save lands</span>${qq("set-writes")}</div>${qhint("set-writes", writes)}` : ""}
   </div>`;
+}
+
+/* ---- the GitHub App (#705, on the daemon flow of #694) ----------------------
+
+   docs/github-app.md is a seven-step checklist a human does by hand. This
+   section is steps 1-3 and 6 of it: name the app, create it on github.com, and
+   see where it is installed. Steps 4 and 5 stay manual, because only a person
+   can press Install on GitHub and choose the repositories.
+
+   THE PAGE HOLDS NO SECRET AND TOUCHES NO KEY. The daemon states the manifest
+   and mints the state; the browser posts that manifest to github.com as a form
+   and carries `code` and `state` back; the daemon converts, stores the private
+   key at 0600 and adopts the app in process. What comes back here is the set of
+   facts already public on the app's own settings page. That boundary is #694's
+   and this section does not widen it — in particular the redirect github.com
+   returns to is composed by the DAEMON from curia's own records, never from
+   anything typed on this page.
+
+   Adoption is in process, so a restart is in none of it: the created app is
+   stated from the same poll everything else on Atlas reads. */
+
+const MANUAL_SETUP_DOC = "https://github.com/alp82/curia/blob/main/docs/github-app.md";
+
+const appWire = (p) => p?.overview?.github_app ?? null;
+
+function gistApp(p) {
+  const a = appWire(p);
+  if (!a) return `<span class="dim-note">curia cannot tell</span>`;
+  if (!a.configured) return `<span style="color:var(--warn)">no app — no agent can be dispatched</span>`;
+  const owners = a.owners ?? [];
+  if (!owners.length) return `<span class="dim-note">app ${esc(a.app_id)} · no watched owner</span>`;
+  const on = owners.filter((o) => o.installed === true).length;
+  return `<span style="color:var(--${on === owners.length ? "ok" : "warn"})">${esc(on)} of ${esc(owners.length)} owner${
+    owners.length === 1 ? "" : "s"} installed</span>`;
+}
+
+function setApp(p) {
+  const a = appWire(p);
+  /* Null is not empty (rule 2): a daemon that carries no section at all is not
+     a box with no app. */
+  if (!a) {
+    return `<div class="unread">This snapshot carries no GitHub App section — the daemon answering it is older than this page.</div>`;
+  }
+  return `${appConversion()}${a.configured ? appIdentity(a) : appCreate()}${appOwners(a)}
+    <p class="qhint" style="margin-top:10px">Creating the app is steps 1-3 of
+      <a href="${MANUAL_SETUP_DOC}">docs/github-app.md</a>. Installing it on an owner and choosing that
+      owner's repositories are steps 4 and 5, and both happen on github.com — only a person can grant a
+      repository. The private key never reaches this page: the daemon converts the manifest, stores the key
+      on the box, and mints with it without a restart.</p>`;
+}
+
+/* What a conversion in THIS tab answered, above everything else: it is the
+   answer to a press the operator made a moment ago on another site, and a
+   failure there is the one thing that has to be read before the rows below. */
+function appConversion() {
+  if (UI.app.busy) return `<div class="later">Converting the manifest GitHub sent back…</div>`;
+  if (UI.app.error) return `<div class="unread">The GitHub App setup failed — ${esc(UI.app.error)}</div>`;
+  const f = UI.app.facts;
+  if (!f) return "";
+  return `<div class="gh-connect"><span class="dot"></span>Created
+    <b class="mono">${esc(f.name ?? f.slug ?? f.app_id)}</b>
+    <span class="dim-note">the daemon adopted it — no restart</span></div>`;
+}
+
+/* No app yet. One field, one press, and the manual route beside it. */
+function appCreate() {
+  return `<p class="unread">This box has no GitHub App, so no agent can be dispatched. Name one, and curia
+      states the manifest GitHub creates it from.</p>
+    <div class="rows">
+      <div class="row"><label class="key grow" for="set-app-name">app name</label>
+        <input type="text" id="set-app-name" placeholder="curia-yourname" size="24"
+          value="${esc(UI.app.name ?? "")}" oninput="UI.app.name=this.value">${qq("set-app-name")}</div>
+      ${qhint("set-app-name", `A GitHub app name is unique across the whole of GitHub, so <span class="mono">curia</span>
+        itself is taken. GitHub refuses a name in use, and the setup starts again with another.`)}
+      <div class="row"><span class="grow"><button class="btn primary" ${anyBusy() ? "disabled" : ""}
+        onclick="beginAppSetup()">Create the App on GitHub</button>
+        <a href="${MANUAL_SETUP_DOC}">set it up by hand instead</a></span></div>
+      ${said("appsetup")}
+    </div>`;
+}
+
+/* The app this daemon runs, in the facts its own settings page states. */
+function appIdentity(a) {
+  const row = (key, value) => `<div class="row"><span class="key grow">${esc(key)}</span>
+    <span class="key mono">${value}</span></div>`;
+  const name = a.html_url
+    ? `<a href="${esc(a.html_url)}">${esc(a.name ?? a.slug ?? "the app")}</a>`
+    : esc(a.name ?? a.slug ?? "—");
+  return `<div class="rows">
+    ${row("app", name)}
+    ${row("app id", esc(a.app_id ?? "—"))}
+    ${row("commits as", esc(a.bot_login ?? "not read yet"))}
+    ${row("key", esc(a.key_file ?? "—"))}
+  </div>`;
+}
+
+/* One row per watched OWNER, because an installation is per owner. Three
+   states, each with a word beside its color: installed, not installed, and not
+   measured — which is what a GitHub curia could not read looks like, and never
+   the same fact as an owner it read as missing. */
+function appOwners(a) {
+  const owners = a.owners ?? [];
+  const foot = `<div class="row"><span class="grow"><button class="btn sm" ${anyBusy() ? "disabled" : ""}
+      onclick="refreshInstalls()">Re-read installations</button>
+      <span class="dim-note">${a.read_at ? "read " + esc(ago(a.read_at)) : "not read yet"}</span></span>
+      ${qq("set-app-installs")}</div>
+    ${qhint("set-app-installs", `curia reads this by itself when the watch list changes. After the install on
+      github.com, this press turns the owner green — there is no second setup to run.`)}
+    ${a.error ? `<div class="unread">The last read of GitHub failed — ${esc(a.error)}. The rows above are the reading before it.</div>` : ""}
+    ${said("appsetup-refresh")}`;
+  if (!owners.length) {
+    return `<div class="h-sect"><h3>Owners</h3>
+      <div class="empty">No repo is watched, so there is no owner to install on.</div>
+      <div class="rows">${foot}</div></div>`;
+  }
+  const rows = owners.map((o) => {
+    const link = o.install_url
+      ? `<a href="${esc(o.install_url)}">install on GitHub</a>`
+      : `<span class="dim-note">curia has not read the app's slug, so it states no install link</span>`;
+    let state;
+    if (o.installed === true) state = `<span style="color:var(--ok)">installed ✓</span>`;
+    else if (o.installed === false) state = `<span style="color:var(--warn)">not installed</span>`;
+    else state = `<span class="dim-note">not measured</span>`;
+    return `<div class="row"><span class="key grow">${esc(o.owner)}</span>${state}
+      ${o.installed === true ? "" : link}</div>`;
+  }).join("");
+  return `<div class="h-sect"><h3>Owners (${esc(owners.length)})</h3>
+    <div class="rows">${rows}${foot}</div></div>`;
+}
+
+/* The presses. The first asks the DAEMON for a manifest and a state, then hands
+   both to github.com as a form POST — the only shape GitHub's manifest flow
+   takes, and the reason this is not a fetch. */
+async function beginAppSetup() {
+  const name = typed("set-app-name") || String(UI.app.name ?? "").trim();
+  if (!name) return refuse("appsetup", "Name the app first — GitHub needs a name, and it must be free across the whole of GitHub.");
+  const out = await verb("appsetup", "/api/appsetup/begin", { name });
+  if (!out || !out.action || !out.manifest) return;
+  postManifest(out.action, out.manifest);
+}
+
+function postManifest(action, manifest) {
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.action = action;
+  const field = document.createElement("input");
+  field.type = "hidden";
+  field.name = "manifest";
+  field.value = JSON.stringify(manifest);
+  form.appendChild(field);
+  document.body.appendChild(form);
+  form.submit();
+}
+
+/* A function declaration rather than a const, for the reason DRILL_PAGES is a
+   `var`: a top-level const is not reachable from the vm the page's test drives
+   it in. */
+function refreshInstalls() { return verb("appsetup-refresh", "/api/appsetup/refresh", {}); }
+
+/* GitHub's redirect back. The daemon composed the address it lands on, and the
+   two values on it are the whole of what this page relays: the conversion, the
+   private key and the adoption are the daemon's, and the conversion response
+   never crosses back to the browser. */
+function appSetupReturn() {
+  let q;
+  try { q = new URLSearchParams(String(location.search ?? "")); } catch { return null; }
+  const code = q.get("code");
+  const state = q.get("state");
+  if (!code || !state) return null;
+  /* Off the address bar at once: a conversion code is good exactly once, and a
+     reload of a spent one would read as a failure the operator caused. */
+  try { history.replaceState(null, "", location.pathname + "#settings"); } catch { /* no history here */ }
+  return { code, state };
+}
+
+async function finishAppSetup(code, state) {
+  UI.app.busy = true;
+  UI.app.facts = null;
+  UI.app.error = null;
+  render();
+  try {
+    const res = await fetch("/api/appsetup/convert", {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ code, state }),
+    });
+    const b = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(b.error || ("the console answered " + res.status));
+    UI.app.facts = b;
+  } catch (e) {
+    UI.app.error = e.message;
+  }
+  UI.app.busy = false;
+  render();
+  /* The daemon adopted the app in process, so the next read already carries it.
+     That is what "without a restart" means on this screen. */
+  tick();
 }
 
 /* ---- the chat (#267, many conversations by #333) ----------------------------
@@ -2983,7 +3191,14 @@ document.addEventListener("visibilitychange", () => {
    render into no document. */
 if (typeof document !== "undefined" && document.getElementById("app")) {
   const initial = routeName(location.hash.slice(1));
-  enter(NAMES.includes(initial) ? initial : "home");
+  /* A return from github.com (#705) lands on the section that sent the operator
+     there, with the conversion already in flight. */
+  const setup = appSetupReturn();
+  enter(setup ? "settings" : (NAMES.includes(initial) ? initial : "home"));
+  if (setup) {
+    UI.drill.settings = { open: "github", list: false };
+    finishAppSetup(setup.code, setup.state);
+  }
   /* The file read happens at boot even when the operator lands somewhere else
      (#362): the stale-daemon marker on the Settings nav item compares the two,
      and a marker that needed the section opened would be a marker nobody sees.

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -72,7 +72,7 @@ export const daemonPort = () => Number(process.env.PORT ?? DEFAULT_DAEMON_PORT)
 // POSTs `/api/reauth`, a route a proto-6 sidecar does not serve — so a screen
 // built for the 3am no-ssh recovery would answer 404 at the press it exists
 // for. It also reads two fields a proto-6 daemon's `/overview` does not carry.
-export const DASHBOARD_PROTO = 7
+export const DASHBOARD_PROTO = 8
 
 // The Credentials screen's own hash (#661). It is here rather than in the
 // daemon that links to it, because the page's screen names are this file's half
@@ -909,6 +909,12 @@ export class DashboardSurface {
           if (out.ok === false) throw refuse(out.error)
           return out
         })
+      }
+      // The install reading again (#705). No body at all: what it re-reads is
+      // the watch list this daemon already runs, and the answer is the same
+      // public shape `/overview` carries.
+      if (url.pathname === '/api/appsetup/refresh') {
+        return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/app/installs' }))
       }
       if (url.pathname === '/api/console/new') {
         return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/console/new' }))

--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -305,6 +305,8 @@ export class TokenMinter {
 
   #bot = null
 
+  #facts = null
+
   // `<owner>|<role>` → the promise of a mint that has not answered yet (#390).
   #minting = new Map()
 
@@ -415,10 +417,29 @@ export class TokenMinter {
   // NOT HARD-CODED, though this box's answer is `curia-sh[bot]` and 317489578.
   // The app is per-operator (ADR-0018) and its name has to be free across the
   // whole of GitHub, so another operator's daemon has another bot entirely.
+  // What GitHub says the app IS: its slug, its name and its own settings page.
+  // Read once and kept, for the same reason `botIdentity` keeps its two: none
+  // of it changes for the life of an app.
+  //
+  // Atlas needs the slug (#705), because the install link GitHub offers is
+  // `github.com/apps/<slug>/installations/new` and the slug is nowhere in the
+  // env — the operator sets an app ID and a key file, and that is all.
+  async facts() {
+    if (!this.#facts) {
+      const app = await api('/app', { jwt: this.jwt(), fetchImpl: this.fetchImpl })
+      this.#facts = {
+        id: app?.id ?? null,
+        slug: String(app?.slug ?? '').trim() || null,
+        name: app?.name ?? null,
+        html_url: app?.html_url ?? null,
+      }
+    }
+    return this.#facts
+  }
+
   async botIdentity(token) {
     if (this.#bot) return this.#bot
-    const app = await api('/app', { jwt: this.jwt(), fetchImpl: this.fetchImpl })
-    const slug = String(app?.slug ?? '').trim()
+    const slug = (await this.facts()).slug ?? ''
     if (!slug) throw new Error('GitHub described curia\'s app without a slug, so its bot login cannot be built')
     const login = `${slug}[bot]`
     const user = await api(`/users/${encodeURIComponent(login)}`, { jwt: token, fetchImpl: this.fetchImpl })
@@ -435,6 +456,7 @@ export class TokenMinter {
     this.#minting.clear()
     this.#installations = null
     this.#bot = null
+    this.#facts = null
   }
 }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -280,15 +280,74 @@ if (!appMinter) {
 // round trip, and GitHub being slow must never hold up a boot whose other duties
 // do not need it. Re-run on every reload (#362), because an owner added from the
 // settings screen must get the reading a booted one gets.
-function checkAppInstallations() {
-  if (!appMinter) return
-  appMinter.refreshInstallations().then((installs) => {
+// The last reading, kept so `/overview` can state it without a GitHub call per
+// poll (#705). `at` is null until a pass has landed, and null there is what
+// makes an unread owner read as unmeasured rather than as uninstalled — the
+// same rule the credential watch holds to.
+let appReading = { at: null, installed: new Set(), slug: null, name: null, htmlUrl: null, error: null }
+
+async function readAppInstallations() {
+  if (!appMinter) {
+    appReading = { at: null, installed: new Set(), slug: null, name: null, htmlUrl: null, error: null }
+    return appReading
+  }
+  try {
+    // The facts first: the slug is what the install link is built from, and an
+    // owner row with no link is a row that names a step it cannot start.
+    const facts = await appMinter.facts().catch(() => ({}))
+    const installs = await appMinter.refreshInstallations()
     for (const { id, owner } of installs) log(`GitHub App installed on ${owner} (installation ${id})`)
     const seen = new Set(installs.map((i) => String(i.owner ?? '').toLowerCase()))
     for (const owner of WATCHED_OWNERS) {
       if (!seen.has(owner.toLowerCase())) log(`WARNING: the GitHub App is not installed on ${owner} — no agent can be dispatched to it, every daemon call on it falls back to the host gh login, and the overseer reads ${owner}/* with no credential at all (docs/github-app.md)`)
     }
-  }).catch((e) => log(`could not read the GitHub App's installations (${e.message}) — that is a fact about GitHub rather than about the install`))
+    appReading = {
+      at: new Date().toISOString(),
+      installed: seen,
+      slug: facts.slug ?? null,
+      name: facts.name ?? null,
+      htmlUrl: facts.html_url ?? null,
+      error: null,
+    }
+  } catch (e) {
+    // A GitHub that could not answer is a fact about GitHub and not about the
+    // install, so the last reading STANDS and the failure joins it.
+    log(`could not read the GitHub App's installations (${e.message}) — that is a fact about GitHub rather than about the install`)
+    appReading = { ...appReading, error: e.message }
+  }
+  return appReading
+}
+
+function checkAppInstallations() {
+  if (!appMinter) return
+  readAppInstallations()
+}
+
+// The App, as Atlas reads it (#705). Every field here is already public on the
+// app's own settings page — the private key is not in it and never can be, and
+// nothing in this shape costs a GitHub call: it is the last detached reading
+// plus the watch list this process is running.
+function githubAppOnWire() {
+  const owners = [...new Set(curiaConfig.watch.map(({ repo }) => repo.split('/')[0]))]
+  const slug = appReading.slug
+  return {
+    configured: Boolean(appMinter),
+    app_id: appMinter?.appId ?? null,
+    slug,
+    name: appReading.name,
+    html_url: appReading.htmlUrl,
+    bot_login: slug ? `${slug}[bot]` : null,
+    key_file: appMinter?.keyFile ?? null,
+    read_at: appReading.at,
+    error: appReading.error,
+    owners: owners.map((owner) => ({
+      owner,
+      // Three states, and the third is not the second: true installed, false
+      // measured and absent, null nothing has measured it yet.
+      installed: appReading.at ? appReading.installed.has(owner.toLowerCase()) : null,
+      install_url: slug ? `https://github.com/apps/${slug}/installations/new` : null,
+    })),
+  }
 }
 
 // #390: the DAEMON cuts over. Every `gh` child it spawns for a named repo now
@@ -2498,6 +2557,9 @@ async function overview() {
     // live in a Discord line and a log only ssh could read, and the 4897a82
     // rollback was diagnosed over ssh because of it.
     deploy: selfDeploy.status(),
+    // The GitHub App and where it is installed (#705). The last detached
+    // reading, never a call on the poll — see githubAppOnWire.
+    github_app: githubAppOnWire(),
   }
 }
 
@@ -2954,6 +3016,16 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
       // is this box failing, and it answers 500 so the two never read the same.
       return json(e?.refusal ? 409 : 500, { ok: false, error: e.message })
     }
+  }
+
+  // The install reading, on demand (#705). The operator installs the app on
+  // github.com and comes back to Atlas, and this is the press that turns the
+  // owner green — the same read the watch takes, asked for rather than waited
+  // for. It answers the wire shape whether the read landed or failed, because
+  // an owner whose state could not be measured is a row too.
+  if (url.pathname === '/app/installs' && req.method === 'POST') {
+    await readAppInstallations()
+    return json(200, githubAppOnWire())
   }
 
   if (url.pathname === '/reload' && req.method === 'POST') {

--- a/daemon/test/appsetup.test.mjs
+++ b/daemon/test/appsetup.test.mjs
@@ -358,6 +358,13 @@ describe('the sidecar relays code and state, and nothing else (#694)', () => {
       try {
         if (r.url === '/app/setup') return res.end(JSON.stringify(setup.begin({ name: body.name, redirectUrl: body.redirect_url })))
         if (r.url === '/app/convert') return res.end(JSON.stringify(await setup.convert(body)))
+        // #705: the install reading, which is public facts and a watch list.
+        if (r.url === '/app/installs') {
+          return res.end(JSON.stringify({
+            configured: true, app_id: '9', slug: 'curia-sh', bot_login: 'curia-sh[bot]',
+            owners: [{ owner: 'alp82', installed: true, install_url: 'https://github.com/apps/curia-sh/installations/new' }],
+          }))
+        }
       } catch (e) {
         return res.end(JSON.stringify({ ok: false, error: e.message }))
       }
@@ -463,8 +470,21 @@ describe('the sidecar relays code and state, and nothing else (#694)', () => {
     assert.equal(ghCalls.length, 0)
   })
 
-  test('both routes are writes: no Origin, no setup', async () => {
-    for (const route of ['/api/appsetup/begin', '/api/appsetup/convert']) {
+  // #705. Atlas presses this after the operator installs the app on GitHub, and
+  // the whole of what it sends is the press: the watch list is the daemon's and
+  // the browser names no owner.
+  test('the re-read carries no field at all, and answers the same public shape', async () => {
+    const res = await req(surface.port, '/api/appsetup/refresh', { method: 'POST', headers: writes(), body: {} })
+    assert.equal(res.status, 200)
+    assert.deepEqual(bodies.map((b) => b.url), ['/app/installs'])
+    assert.deepEqual(bodies[0].body, {})
+    const out = JSON.parse(res.text)
+    assert.equal(out.owners[0].owner, 'alp82')
+    assert.doesNotMatch(res.text, /PRIVATE KEY|client_secret/)
+  })
+
+  test('all three routes are writes: no Origin, no setup', async () => {
+    for (const route of ['/api/appsetup/begin', '/api/appsetup/convert', '/api/appsetup/refresh']) {
       const res = await req(surface.port, route, {
         method: 'POST', headers: served({ 'content-type': 'application/json' }), body: { name: 'curia.sh' },
       })

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -33,7 +33,8 @@ function loadPage() {
   const ctx = vm.createContext({
     document: { title: '', getElementById: () => null, addEventListener() {}, visibilityState: 'hidden' },
     window: { addEventListener() {} },
-    location: { hash: '' },
+    location: { hash: '', search: '', pathname: '/' },
+    URLSearchParams,
     fetch: () => new Promise(() => {}),
     setTimeout,
     clearTimeout,
@@ -58,7 +59,8 @@ function loadPollingPage({ visibilityState = 'visible', mount = false } = {}) {
   const ctx = vm.createContext({
     document,
     window: { addEventListener() {} },
-    location: { hash: '' },
+    location: { hash: '', search: '', pathname: '/' },
+    URLSearchParams,
     fetch: async (url) => {
       reads.push(url)
       return { ok: true, json: async () => url === '/api/settings' ? SETTINGS() : payload() }
@@ -177,6 +179,20 @@ const OVERVIEW = () => ({
     { ts: at(60), type: 'credentials_swept', agent: 'curia-263', ticket: '263', repo: 'alp82/curia' },
   ],
   deploy: { in_flight: null, last: null, verdict_read_error: null },
+  // The GitHub App and where it is installed (#705). The ordinary box: an app
+  // created, and the one watched owner it is installed on.
+  github_app: {
+    configured: true,
+    app_id: '317489578',
+    slug: 'curia-sh',
+    name: 'curia-sh',
+    html_url: 'https://github.com/apps/curia-sh',
+    bot_login: 'curia-sh[bot]',
+    key_file: '/srv/curia/daemon/.curia-app.pem',
+    read_at: at(90),
+    error: null,
+    owners: [{ owner: 'alp82', installed: true, install_url: 'https://github.com/apps/curia-sh/installations/new' }],
+  },
   frontier: {
     computed_at: at(120),
     repos: [
@@ -1024,7 +1040,7 @@ describe('the settings screen (#265)', () => {
 
   test('the main list names every section, each with a gist of its own', () => {
     const html = screen()
-    assert.deepEqual(rows(html), ['routing', 'projects', 'dispatch', 'maintenance'])
+    assert.deepEqual(rows(html), ['routing', 'projects', 'dispatch', 'github', 'maintenance'])
     const t = text(html)
     assert.match(t, /Routing opus untyped · 2 of 3 models on/)
     assert.match(t, /Projects 2 repos watched/)
@@ -1273,7 +1289,7 @@ describe('the settings screen (#265)', () => {
     assert.match(text(html), /The daemon is running these files\./)
     assert.ok(!html.includes('restart-hot'), 'an ordinary restart button, because nothing disagrees')
     assert.match(html, /doRestart\(\)/, 'the one restart button lives here now')
-    assert.deepEqual(rows(html), ['routing', 'projects', 'dispatch', 'maintenance'], 'the fourth section, and it reads last')
+    assert.deepEqual(rows(html), ['routing', 'projects', 'dispatch', 'github', 'maintenance'], 'still the last section, and it still reads last')
   })
 
   test('a daemon running something else names the keys, and the button goes red', () => {
@@ -1893,6 +1909,10 @@ describe('the chat screen (#267, the picker of #333)', () => {
     assert.match(src, new RegExp(`<meta name="curia-dashboard" content="proto=${DASHBOARD_PROTO}">`))
     assert.match(src, /"\/api\/console\/new"/)
     assert.match(src, /"\/api\/console\/delete"/)
+    // #705 added a route to both halves and a field to `/overview`. A page
+    // that read `github_app` from an older daemon would draw "no app" over a
+    // box that has one, which is what the stamp exists to refuse.
+    assert.match(src, /"\/api\/appsetup\/refresh"/)
   })
 
   // Arriving is what takes the read. Settings holds its copy because a config
@@ -2103,5 +2123,212 @@ describe('the Credentials screen (#661)', () => {
     assert.match(src, new RegExp(`<meta name="curia-dashboard" content="proto=${DASHBOARD_PROTO}">`))
     assert.match(src, /"\/api\/reauth"/)
     assert.match(src, /credentials:\s*\["Credentials",\s*screenCredentials\]/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The GitHub App section (#705), on the daemon flow of #694.
+//
+// What is pinned here is the half a human reading the preview cannot check:
+// that a box with no app offers the create path and a box with one states its
+// facts without a restart in the sentence, that every watched owner carries a
+// state WORD beside its color and an install link where the state is not
+// installed, that an unmeasured owner never renders as an uninstalled one, and
+// — the boundary #694 drew — that the browser relays `code` and `state` and
+// nothing else, to a redirect it never composed.
+
+describe('the GitHub App section (#705)', () => {
+  let page
+
+  beforeEach(() => {
+    page = loadPage()
+    page.settings = SETTINGS()
+    page.draft = JSON.parse(JSON.stringify(page.settings))
+    page.UI.drill.settings = { open: 'github', list: false }
+  })
+
+  const screen = (p = payload()) => page.screenSettings(p)
+  const withApp = (app) => payload({ github_app: app })
+  const noApp = () => withApp({
+    configured: false,
+    app_id: null, slug: null, name: null, html_url: null, bot_login: null, key_file: null,
+    read_at: null, error: null,
+    owners: [
+      { owner: 'alp82', installed: null, install_url: null },
+      { owner: 'example', installed: null, install_url: null },
+    ],
+  })
+
+  test('the list row says whether the app exists and how many owners hold it', () => {
+    assert.match(text(screen()), /GitHub App 1 of 1 owner installed/)
+    assert.match(text(screen(noApp())), /GitHub App no app — no agent can be dispatched/)
+  })
+
+  test('a box with no app offers the name, the create action and the manual route', () => {
+    const html = screen(noApp())
+    assert.match(html, /id="set-app-name"/)
+    assert.match(html, /onclick="beginAppSetup\(\)"/)
+    assert.match(html, /docs\/github-app\.md/)
+    assert.match(text(html), /no GitHub App, so no agent can be dispatched/)
+  })
+
+  test('a created app states its own facts, and a restart is in none of them', () => {
+    const t = text(screen())
+    assert.match(t, /app id 317489578/)
+    assert.match(t, /commits as curia-sh\[bot\]/)
+    assert.match(t, /\.curia-app\.pem/)
+    assert.match(t, /mints with it without a restart/)
+    assert.ok(!screen().includes('id="set-app-name"'), 'there is nothing left to create')
+  })
+
+  test('a conversion that just landed says so from the page that asked for it', () => {
+    page.UI.app.facts = { ok: true, app_id: '9', slug: 'curia-box', name: 'curia-box' }
+    assert.match(text(screen()), /Created curia-box the daemon adopted it — no restart/)
+    page.UI.app.facts = null
+    page.UI.app.error = 'that GitHub App setup was already converted'
+    assert.match(text(screen()), /The GitHub App setup failed — that GitHub App setup was already converted/)
+  })
+
+  test('every watched owner carries its state and, where it is missing, GitHub’s install link', () => {
+    const p = withApp({
+      ...OVERVIEW().github_app,
+      owners: [
+        { owner: 'alp82', installed: true, install_url: 'https://github.com/apps/curia-sh/installations/new' },
+        { owner: 'example', installed: false, install_url: 'https://github.com/apps/curia-sh/installations/new' },
+      ],
+    })
+    const t = text(screen(p))
+    assert.match(t, /alp82 installed ✓/)
+    assert.match(t, /example not installed install on GitHub/)
+    assert.match(screen(p), /href="https:\/\/github\.com\/apps\/curia-sh\/installations\/new"/)
+  })
+
+  // The rule the whole page holds to (#262 rule 2), on the one section where
+  // getting it wrong sends the operator to GitHub to repair an install that is
+  // already right.
+  test('an owner nothing has measured is not an owner without the app', () => {
+    const t = text(screen(noApp()))
+    assert.match(t, /alp82 not measured/)
+    assert.ok(!t.includes('not installed'), 'unmeasured says its own word')
+  })
+
+  test('a snapshot older than this page says so, rather than drawing a box with no app', () => {
+    const p = payload()
+    delete p.overview.github_app
+    assert.match(text(screen(p)), /carries no GitHub App section/)
+  })
+
+  // ---- the two presses ------------------------------------------------------
+
+  test('the re-read is one press, and it names what it is for', () => {
+    assert.match(screen(), /onclick="refreshInstalls\(\)"/)
+    page.UI.hints['set-app-installs'] = true
+    assert.match(text(screen()), /turns the owner green — there is no second setup to run/)
+  })
+
+  test('the re-read asks the sidecar and nothing else', async () => {
+    const calls = []
+    page.fetch = async (path, init) => {
+      if (path.startsWith('/api/appsetup')) calls.push([path, init.body])
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+    await page.refreshInstalls()
+    assert.deepEqual(calls, [['/api/appsetup/refresh', '{}']])
+  })
+
+  test('a GitHub curia could not read leaves the last reading standing and says the failure', () => {
+    const t = text(screen(withApp({ ...OVERVIEW().github_app, error: 'GitHub answered HTTP 502' })))
+    assert.match(t, /The last read of GitHub failed — GitHub answered HTTP 502/)
+    assert.match(t, /alp82 installed ✓/, 'the reading before it still stands')
+  })
+
+  test('create with no name is refused here, before it costs a call', async () => {
+    let calls = 0
+    page.fetch = async () => { calls += 1; return { ok: true, json: async () => ({}) } }
+    await page.beginAppSetup()
+    assert.equal(calls, 0)
+    assert.match(page.UI.act.said.text, /Name the app first/)
+  })
+
+  // The manifest travels as a FORM POST to github.com, which is the only shape
+  // GitHub's manifest flow takes. The action and the manifest are both the
+  // daemon's — the page composes neither, and in particular composes no
+  // redirect: a browser-named one would be a way to send the conversion code
+  // somewhere else (#694).
+  test('the manifest is posted to the action the daemon stated, with the state on it', async () => {
+    const node = () => ({ children: [], appendChild(c) { this.children.push(c) } })
+    const form = node()
+    let submitted = false
+    form.submit = () => { submitted = true }
+    const created = []
+    page.document.createElement = (tag) => {
+      const el = tag === 'form' ? form : node()
+      created.push(tag)
+      return el
+    }
+    page.document.body = node()
+    page.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        state: 'a'.repeat(64),
+        action: 'https://github.com/settings/apps/new?state=' + 'a'.repeat(64),
+        manifest: { name: 'curia-box', redirect_url: 'https://box.ts.net:8443/' },
+      }),
+    })
+    page.UI.app.name = 'curia-box'
+    await page.beginAppSetup()
+    assert.equal(form.method, 'POST')
+    assert.match(form.action, /^https:\/\/github\.com\/settings\/apps\/new\?state=a{64}$/)
+    assert.deepEqual(form.children.map((c) => [c.name, c.type]), [['manifest', 'hidden']])
+    assert.deepEqual(JSON.parse(form.children[0].value), {
+      name: 'curia-box', redirect_url: 'https://box.ts.net:8443/',
+    })
+    assert.ok(submitted)
+  })
+
+  // THE BOUNDARY. GitHub redirects back to the address the daemon composed,
+  // with a code and a state on it. Those two values are the whole of what the
+  // browser relays, and what comes back is the app's public facts — the
+  // conversion response and the private key never cross this wire.
+  test('the return from github.com relays code and state, and nothing else', async () => {
+    const sent = []
+    page.location.search = '?code=abc123&state=' + 'b'.repeat(64) + '&redirect_uri=https://evil.example'
+    page.fetch = async (path, init) => {
+      if (!path.startsWith('/api/appsetup')) return { ok: true, json: async () => ({}) }
+      sent.push([path, JSON.parse(init.body)])
+      return { ok: true, json: async () => ({ ok: true, app_id: '9', slug: 'curia-box', name: 'curia-box' }) }
+    }
+    const back = page.appSetupReturn()
+    await page.finishAppSetup(back.code, back.state)
+    assert.deepEqual(sent, [['/api/appsetup/convert', { code: 'abc123', state: 'b'.repeat(64) }]])
+    assert.equal(page.UI.app.busy, false)
+    assert.equal(page.UI.app.facts.slug, 'curia-box')
+  })
+
+  test('a spent code is taken off the address bar, so a reload is not a second failure', () => {
+    const replaced = []
+    page.location.search = '?code=abc123&state=' + 'b'.repeat(64)
+    page.location.pathname = '/'
+    page.history = { replaceState: (_s, _t, url) => replaced.push(url) }
+    const back = page.appSetupReturn()
+    assert.equal(back.code, 'abc123')
+    assert.equal(back.state, 'b'.repeat(64))
+    assert.deepEqual(replaced, ['/#settings'])
+  })
+
+  test('an ordinary address starts no conversion at all', () => {
+    page.location.search = ''
+    assert.equal(page.appSetupReturn(), null)
+    page.location.search = '?code=abc123'
+    assert.equal(page.appSetupReturn(), null, 'a code with no state is not a return curia started')
+  })
+
+  test('a refused conversion is the operator’s own sentence, not a status code', async () => {
+    page.fetch = async (path) => (path.startsWith('/api/appsetup')
+      ? { ok: false, json: async () => ({ error: 'that GitHub App setup did not start on this box, or it lapsed' }) }
+      : { ok: true, json: async () => ({}) })
+    await page.finishAppSetup('abc123', 'c'.repeat(64))
+    assert.match(page.UI.app.error, /did not start on this box/)
+    assert.equal(page.UI.app.facts, null)
   })
 })

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -198,6 +198,27 @@ describe('GET /overview (index.mjs, real boot)', () => {
     assert.deepEqual(o.bridge_health, { state: 'down', since: null, unhealthy_for_s: 0, last_error: null })
   })
 
+  // #705. Atlas draws the App section off this, and a box with no app is the
+  // state the section exists FOR — so the field is present, states that there
+  // is no app, and still names every watched owner. Nothing here costs a
+  // GitHub call: the reading is the detached one the watch takes.
+  test('the GitHub App section answers on a box that has no app, and names the watched owners', async () => {
+    const o = await overview()
+    assert.equal(o.github_app.configured, false)
+    assert.equal(o.github_app.app_id, null)
+    assert.equal(o.github_app.key_file, null)
+    assert.equal(o.github_app.read_at, null)
+    assert.deepEqual(o.github_app.owners, [
+      // Null, not false: nothing measured this owner, and an unmeasured
+      // install and a missing one are opposite facts on the page.
+      { owner: 'example', installed: null, install_url: null },
+    ])
+    // The whole shape is public facts. The one durable secret is the private
+    // key, and no spelling of it is on this wire.
+    assert.equal(JSON.stringify(o.github_app).includes('PRIVATE KEY'), false)
+    assert.equal('pem' in o.github_app, false)
+  })
+
   test('an unreadable fleet is null and says why, and every other section still answers', async () => {
     // The evidence rule on a page (tmux.mjs): a wedged tmux is not "no agents".
     // Serving `[]` here would draw an idle box over a live one, and 500-ing the

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -24,11 +24,13 @@ None of this is secret. The app id travels in every JWT the daemon signs. The pr
 
 ## Steps 1 to 3, from Atlas
 
+**Where it is.** Atlas → **Settings** → **GitHub App** ([#705](https://github.com/alp82/curia/issues/705)). The section names the app, creates it, and then lists every watched owner with the install state curia last measured and GitHub's own install link beside the ones it is missing from. **Re-read installations** takes that reading again — press it after installing on GitHub, and the owner turns green with no second setup and no restart.
+
 [#694](https://github.com/alp82/curia/issues/694) replaced the first three steps below with one press. Atlas asks the daemon for a manifest, the browser posts it to `https://github.com/settings/apps/new`, and GitHub redirects back with a one-hour conversion code. The daemon converts that code itself: it writes the private key to `daemon/.curia-app.pem` at mode 0600, writes `CURIA_GH_APP_ID` and `CURIA_GH_APP_KEY_FILE` into `daemon/.env.daemon`, and adopts the app in process, so step 6 and the restart are gone too.
 
 The manifest states the five permissions of step 2 and no events, so nothing on the **Permissions & events** page has to be set by hand. Neither the browser nor the dashboard sidecar ever sees the conversion response: the browser carries `code` and `state` back and gets the app id, the slug, the bot login and the install link.
 
-Steps 4 and 5 stay yours. An installation is granted per owner, and only a human can grant it.
+Steps 4 and 5 stay yours. An installation is granted per owner, and only a human can grant it. The owner rows in that section are where a missing one shows.
 
 The manual route below still works, and it is what to follow when the box has no Atlas reachable.
 


### PR DESCRIPTION
Closes the UI half of the App setup flow. [#694](https://github.com/alp82/curia/issues/694) built the daemon side — manifest, state, one-time conversion, key storage, in-process adoption — and shipped no UI on purpose. This is that UI, registered as a fifth section on the drill-in Settings frame from [#699](https://github.com/alp82/curia/issues/699).

For `alp82/curia#705`.

## What the section does

- **No app.** The name field, `Create the App on GitHub`, and the manual route to `docs/github-app.md` beside it. The press asks the daemon for a manifest and a state and hands both to github.com as a form POST — the only shape GitHub's manifest flow takes, and the reason it is not a fetch.
- **The return.** GitHub redirects to the address the *daemon* composed. The page relays `code` and `state`, strips them off the address bar so a reload of a spent code is not a second failure, and states the app the daemon adopted in process. No restart, and the conversion response and the private key never cross to the browser.
- **An app.** Its id, its bot login, its key file, and a link to its own settings page.
- **Owners.** One row per watched owner, because an installation is per owner: `installed ✓`, `not installed` with GitHub's install link, or `not measured` — three states, each with a word beside its color, and the third is never drawn as the second. `Re-read installations` takes the reading the credential watch takes, so an owner turns green after the install with no second setup action.

## The daemon half

`/overview` gains `github_app`: the app's public facts plus one row per watched owner. It costs no GitHub call per poll — it is the detached installation pass the watch already runs, kept, plus a cached `GET /app` for the slug the install link is built from (`TokenMinter.facts()`, which `botIdentity` now reads too). `POST /app/installs` re-runs that pass on demand; `/api/appsetup/refresh` on the sidecar relays the press with no body at all.

## The boundary #694 drew, unweakened

The browser relays `code` and `state` and nothing else, the redirect is composed daemon-side from curia's own records, and no conversion response or key reaches the page. Two tests pin each half — one on the page, one through a real sidecar in front of a real `AppSetup`.

## `DASHBOARD_PROTO`

7 → 8. The page reads an `/overview` field and a sidecar route that neither half of a proto-7 pair has, and a page reading `github_app` from an older daemon would draw "no app" over a box that has one.

## `checkPatch`

Untouched, and deliberately: this section writes neither `curia.yaml` nor `routing.yaml`. It registers no `patch`, `count` or `restarts`, so the save dock never sees it and the sidecar's closed set learns no new key.

## Tests

20 new: the wire shape on a real boot with no app, the section's states and both presses on the page, and the re-read relay through the sidecar. Suite green: **3470 pass, 0 fail, 0 cancelled**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5