### PR TITLE
Route reasoning effort across every harness (alp82/curia#707)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,6 +120,9 @@ A key under `models:` in `routing.yaml`. It is the dispatch vocabulary that `mod
 **Model name**:
 What curia tells a human is running. The status line uses the transcript model, then `models.<label>.id`, then the routing label. Cooling, fallback, and `status` keep the routing label.
 
+**Reasoning effort**:
+How deep an agent thinks, stated rather than inherited. A model states its own default in `models.<x>.reasoning_effort`, and a ticket type overrides it in the `effort:` table, keyed the way `defaults:` is. A `model:` label moves the model and leaves the type's depth alone, because the two are separate decisions. A depth holds only where the model has the word for it - its own `efforts` list, else its harness's - so a fallback that crosses to a shorter vocabulary keeps the type's depth where it exists there and takes that model's own default where it does not. Nothing invents one, and a routing with no `effort:` table leaves every model on its default. It is never a spawn flag: each harness is told through its config file or through the agent's environment, both of which every spawn and every resume rewrite, so a resumed agent runs at the depth it was dispatched at. All four harnesses in the image answer for it, and the codex row is the only one measured. See [#707](https://github.com/alp82/curia/issues/707).
+
 **Harness**:
 The program an agent runs under: claude or codex. It is a function of the model: `models.<x>.harness` states one value, and no command overrides it. A pin that disagreed with the model built `codex --model opus`, which is not a model.
 _Avoid_: backend, lane.

--- a/config/routing.yaml
+++ b/config/routing.yaml
@@ -33,6 +33,33 @@ defaults:
   # A `model:<x>` label on the map still beats this row (resolveModel).
   map: fable
 
+# HOW DEEP EACH KIND OF WORK THINKS (#707). `defaults` above says WHICH model a
+# ticket type gets; this says how hard that model is asked to think on it. Two
+# tables because they answer two questions: a `model:` label on a ticket moves
+# the first and leaves this one alone, so naming a model never quietly changes
+# the depth the work was meant to run at.
+#
+# A row holds only where the model accepts the word (`efforts` under `models`
+# and `harnesses` below). Where it does not, that model's own
+# `reasoning_effort` stands — which is also what a fallback lands on when the
+# chain crosses to a model with a shorter vocabulary.
+#
+# `untyped` is the row for a ticket with no `wayfinder:` label AND the answer
+# for a type with no row of its own, so this table needs no entry per label
+# curia might meet.
+#
+# The values below are the depths the operator asked for, not measured
+# optimums: research is the bulk lane #13 sends to spread quota, so it thinks
+# shallow; charting is the one job worth the strongest model at the highest
+# depth, for the reason `defaults.map` names fable.
+effort:
+  grilling: high
+  prototype: high
+  research: low
+  task: high
+  untyped: high
+  map: max
+
 # `context_window` feeds the status line's context % (#146), and it is the LAST
 # resort for it since #178. It used to say 200000 for the three anthropic models
 # here; the real window is 1000000, so every context figure the claude harness ever
@@ -126,6 +153,11 @@ harnesses:
     template: 'claude --model {model} --permission-mode bypassPermissions "$(cat {prompt_file})"'
     resume_template: 'claude --model {model} --permission-mode bypassPermissions --continue "Continue the interrupted work."'
     ready: '⏵⏵|bypass permissions'
+    # The effort words this CLI takes (#707). It bounds the `effort` table
+    # above: a ticket type asking for a word missing here leaves the model on
+    # its own `reasoning_effort` rather than being handed one the CLI would
+    # reject. A harness that states no list accepts whatever it is given.
+    efforts: [low, medium, high, xhigh, max]
     # MEASURED on the box, two live dispatches, 2026-08-04 (#194,
     # docs/live-checks/194): the client's MCP handshake landed 3.7 s and 3.2 s
     # after spawn, and the composer marker 6.0 s after it both times — so the
@@ -150,6 +182,10 @@ harnesses:
     template: 'codex --model {model} --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust "$(cat {prompt_file})"'
     resume_template: 'codex resume --last --model {model} --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust "Continue the interrupted work."'
     ready: '·\s[~/]'
+    # See the claude row. `max` and `ultra` are gpt-5.6 words that gpt-5.5 does
+    # not have, so a model here narrows this list with an `efforts` list of its
+    # own the day a 5.5 model is configured beside the 5.6 one.
+    efforts: [low, medium, high, xhigh, max, ultra]
     # MEASURED on the box, three live dispatches, 2026-08-04 (#158,
     # docs/live-checks/158). This harness does NOT behave like the claude one. Its
     # handshake and its composer marker land within ~100 ms of each other and in

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -38,7 +38,7 @@
      2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
         nobody has computed is not an empty frontier. Every section that can fail
         on its own says which of the two it is. -->
-<meta name="curia-dashboard" content="proto=7">
+<meta name="curia-dashboard" content="proto=8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark light">
 <title>Atlas · Curia</title>
@@ -2028,7 +2028,7 @@ function drillIn(page, p) {
 const SET_SECTIONS = [
   {
     key: "routing", title: "Routing", gist: gistRouting, body: setRouting,
-    hint: "The model each ticket type gets when no label on the ticket says otherwise.",
+    hint: "The model each ticket type gets when no label on the ticket says otherwise, and how deep it thinks on it. A model: label moves the model and leaves the depth alone.",
     patch: patchRouting, count: countRouting,
   },
   {
@@ -2088,13 +2088,18 @@ function patchRouting(out) {
   draft.routing.defaults.forEach((row, i) => {
     if (row.model !== settings.routing.defaults[i]?.model) defaults[row.type] = row.model;
   });
+  const effort = {};
+  (draft.routing.effort ?? []).forEach((row, i) => {
+    if (row.effort !== settings.routing.effort?.[i]?.effort) effort[row.type] = row.effort;
+  });
   const models = {};
   draft.routing.models.forEach((m, i) => {
     if (m.active !== settings.routing.models[i]?.active) models[m.name] = { active: m.active };
   });
-  if (Object.keys(defaults).length || Object.keys(models).length) {
+  if (Object.keys(defaults).length || Object.keys(effort).length || Object.keys(models).length) {
     out.routing = {};
     if (Object.keys(defaults).length) out.routing.defaults = defaults;
+    if (Object.keys(effort).length) out.routing.effort = effort;
     if (Object.keys(models).length) out.routing.models = models;
   }
 }
@@ -2104,7 +2109,10 @@ function patchRouting(out) {
    change however many repos moved inside it. */
 function countDispatch(p) { return Object.keys(p.dispatch ?? {}).length; }
 function countWatch(p) { return p.watch ? 1 : 0; }
-function countRouting(p) { return Object.keys(p.routing?.defaults ?? {}).length + Object.keys(p.routing?.models ?? {}).length; }
+function countRouting(p) {
+  return Object.keys(p.routing?.defaults ?? {}).length + Object.keys(p.routing?.effort ?? {}).length
+    + Object.keys(p.routing?.models ?? {}).length;
+}
 
 function changeCount() {
   const p = settingsPatch();
@@ -2255,7 +2263,7 @@ function setRouting() {
       <select onchange="setDefault(${i}, this.value)">
         ${active.map((m) => `<option ${m.name === row.model ? "selected" : ""}>${esc(m.name)}</option>`).join("")}
         ${known ? "" : `<option selected>${esc(row.model)}</option>`}
-      </select>${known ? "" : `<span class="dim-note">switched off \u2014 the daemon refuses this config</span>`}</div>`;
+      </select>${effortPick(row.type)}${known ? "" : `<span class="dim-note">switched off \u2014 the daemon refuses this config</span>`}</div>`;
   }).join("");
   const mgr = `<div class="row"><span class="grow"><a href="#settings"
       onclick="UI.set.models=!UI.set.models;render();return false">${
@@ -2270,6 +2278,27 @@ function setRouting() {
         <span class="key dim-note">runs on ${esc(m.provider ?? "?")} \u00b7 ${esc(m.harness ?? "?")}</span></div>`).join("")}</div>`
     : "";
   return `<div class="rows">${rows}${mgr}</div>${table}`;
+}
+
+/* The depth beside the model (#707). One ticket type is one decision made of
+   two halves — which model, and how hard it thinks — so they sit on one row
+   rather than in two lists an operator would have to read together.
+
+   A type with no `effort` row in routing.yaml gets no picker: the screen edits
+   the rows that are there and adds none, which is the same rule the model
+   column and the daemon's own refusal already keep. */
+function effortRow(type) {
+  return (draft.routing.effort ?? []).findIndex((r) => r.type === type);
+}
+function effortPick(type) {
+  const i = effortRow(type);
+  if (i < 0) return "";
+  const row = draft.routing.effort[i];
+  const words = settings.routing.efforts ?? [];
+  const known = words.includes(row.effort);
+  return `<select title="reasoning effort" onchange="setEffort(${i}, this.value)">
+    ${words.map((e) => `<option ${e === row.effort ? "selected" : ""}>${esc(e)}</option>`).join("")}
+    ${known ? "" : `<option selected>${esc(row.effort)}</option>`}</select>`;
 }
 
 function gistProjects() { return esc(`${draft.watch.length} repo${draft.watch.length === 1 ? "" : "s"} watched`); }
@@ -2715,6 +2744,7 @@ function discardEdits() {
   render();
 }
 function setDefault(i, model) { draft.routing.defaults[i].model = model; dirty(); }
+function setEffort(i, effort) { draft.routing.effort[i].effort = effort; dirty(); }
 function setModelActive(i, on) { draft.routing.models[i].active = on; dirty(); }
 function setDispatchField(key, value) {
   draft.dispatch[key] = typeof value === "boolean" ? value : Number(value);

--- a/daemon/src/config.mjs
+++ b/daemon/src/config.mjs
@@ -7,7 +7,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { parse } from 'yaml'
 import { DEFAULT_RANGE as DEFAULT_PREVIEW_RANGE, DEFAULT_PROXY_FROM } from './preview.mjs'
-import { DEFAULT_SKILLS, defaultSkillsRoot, HARNESS_NAMES, harnessProvider } from './workspace.mjs'
+import { DEFAULT_SKILLS, defaultSkillsRoot, EFFORT_HARNESSES, effortRouteFor, HARNESS_NAMES, harnessProvider } from './workspace.mjs'
 import { LIMIT_PATTERNS, SAFE_SUBSTITUTION } from './routing.mjs'
 import { DEFAULT_INDEX, REBUILD_CMD } from './attach.mjs'
 import { PROBE_MODEL } from './usage.mjs'
@@ -25,7 +25,7 @@ import { CONSUMER_NAMES, consumerContractFault, providerContractFault } from './
 export const WATCH_MODES = ['auto', 'map', 'ready-for-agent']
 
 // Every reasoning effort any configured model accepts, unioned.
-const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
+export const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
 
 // A GitHub login as GitHub itself allows one: letters, digits and single
 // hyphens, no hyphen at either end, 39 characters at most. The whole point of
@@ -544,6 +544,25 @@ export function loadRoutingConfig(file, { localFile } = {}) {
     if (m.reasoning_effort !== undefined && !REASONING_EFFORTS.includes(m.reasoning_effort)) {
       fail(src, `models.${name}.reasoning_effort must be one of ${REASONING_EFFORTS.join('|')} (got ${JSON.stringify(m.reasoning_effort)})`)
     }
+    // Which efforts this model accepts (#707). Optional, and its absence is not
+    // an empty set: a model that states no list takes whatever effort routing
+    // hands it. The list is what makes the FALLBACK rule decidable — a chain
+    // that crosses to a model with a shorter vocabulary keeps the ticket type's
+    // effort only where the word exists there — so it is stated per model or,
+    // one level up, per harness.
+    if (m.efforts !== undefined) {
+      if (!Array.isArray(m.efforts) || !m.efforts.length) {
+        fail(src, `models.${name}.efforts must be a non-empty list of efforts`)
+      }
+      for (const e of m.efforts) {
+        if (!REASONING_EFFORTS.includes(e)) {
+          fail(src, `models.${name}.efforts names "${e}", which is not one of ${REASONING_EFFORTS.join('|')}`)
+        }
+      }
+      if (m.reasoning_effort !== undefined && !m.efforts.includes(m.reasoning_effort)) {
+        fail(src, `models.${name}.reasoning_effort is ${JSON.stringify(m.reasoning_effort)}, which its own \`efforts\` list does not carry`)
+      }
+    }
     // Optional (#146), and since #178 the LAST resort for the status line's
     // context %: the transcript's own window wins, then the live
     // `GET /v1/models/<id>` lookup, then this. Omitting it everywhere is the
@@ -634,6 +653,28 @@ export function loadRoutingConfig(file, { localFile } = {}) {
     if (!HARNESS_NAMES.includes(name)) {
       fail(src, `harnesses.${name} has no entry in the HARNESS table in workspace.mjs — an agent under it would get no config dir, no curia tools and no Stop hook. Known harnesses: ${HARNESS_NAMES.join(', ')}`)
     }
+    // The harness's own effort vocabulary (#707), and the route by which it is
+    // told one. The list is optional — a harness that states none accepts
+    // whatever a model on it accepts — and the ROUTE is not: every harness the
+    // worker image carries has a row in EFFORT_ROUTE, and a configured harness
+    // with no row would spawn agents whose depth nothing states, which is the
+    // quiet downgrade #707 exists to end. Code rather than config, so it is
+    // asserted here instead of trusted.
+    if (b.efforts !== undefined) {
+      if (!Array.isArray(b.efforts) || !b.efforts.length) {
+        fail(src, `harnesses.${name}.efforts must be a non-empty list of efforts`)
+      }
+      for (const e of b.efforts) {
+        if (!REASONING_EFFORTS.includes(e)) {
+          fail(src, `harnesses.${name}.efforts names "${e}", which is not one of ${REASONING_EFFORTS.join('|')}`)
+        }
+      }
+    }
+    try {
+      effortRouteFor(name)
+    } catch {
+      fail(src, `harnesses.${name} has no reasoning-effort route in the EFFORT_ROUTE table in workspace.mjs — an agent under it would run at whatever depth its model happens to default to. Known harnesses: ${EFFORT_HARNESSES.join(', ')}`)
+    }
     // The credential half of that same question (#648). A harness whose provider
     // has no contract row would spawn agents curia cannot give a credential to,
     // cannot say an expiry for, and cannot sign back in — the shape ADR-0027
@@ -683,6 +724,21 @@ export function loadRoutingConfig(file, { localFile } = {}) {
   }
   for (const [name, m] of Object.entries(cfg.models)) {
     if (!cfg.harnesses[m.harness]) fail(src, `models.${name}.harness names unknown harness "${m.harness}"`)
+  }
+
+  // THE TICKET-TYPE EFFORT TABLE (#707). Optional whole: a routing.yaml written
+  // before this key existed states no type effort, and every model then runs at
+  // its own `reasoning_effort` the way it always did.
+  //
+  // The rows are NOT checked against `defaults`. The two tables are keyed the
+  // same way and answer different questions, and a type that routes to a model
+  // by inheritance still deserves a depth of its own.
+  cfg.effort = cfg.effort ?? {}
+  if (typeof cfg.effort !== 'object' || Array.isArray(cfg.effort)) fail(src, '`effort` must be a mapping of ticket type to effort')
+  for (const [type, effort] of Object.entries(cfg.effort)) {
+    if (!REASONING_EFFORTS.includes(effort)) {
+      fail(src, `effort.${type} must be one of ${REASONING_EFFORTS.join('|')} (got ${JSON.stringify(effort)})`)
+    }
   }
 
   // The consumer contract, checked at the same boot (#648). This table is code

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -72,7 +72,12 @@ export const daemonPort = () => Number(process.env.PORT ?? DEFAULT_DAEMON_PORT)
 // POSTs `/api/reauth`, a route a proto-6 sidecar does not serve — so a screen
 // built for the 3am no-ssh recovery would answer 404 at the press it exists
 // for. It also reads two fields a proto-6 daemon's `/overview` does not carry.
-export const DASHBOARD_PROTO = 7
+// Bumped to 8 by #707: the Routing section draws a reasoning effort beside
+// every ticket type, off two `/api/settings` fields a proto-7 sidecar does not
+// carry — and its save posts `routing.effort`, which that sidecar's closed set
+// refuses by name. So an old server must refuse this page rather than draw a
+// depth picker whose every change is declined at the Save.
+export const DASHBOARD_PROTO = 8
 
 // The Credentials screen's own hash (#661). It is here rather than in the
 // daemon that links to it, because the page's screen names are this file's half

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -26,6 +26,7 @@ import {
 } from './github.mjs'
 import {
   resolveModel, candidates, buildSpawnCmd, buildResumeCmd, spawnModelId, parseUsageLimit, parseCreditGate,
+  resolveEffort, routingType,
   carriesLimitPhrase, resolveReviewer, isActive, Cooling, SAME_PROVIDER_STAMP, namedModel,
 } from './routing.mjs'
 import { hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey, paneShowsActiveTurn } from './tmux.mjs'
@@ -34,7 +35,7 @@ import {
   removeConfigDir, removeCredentials, createReviewCheckout, reviewPathFor, writeReviewPrompt,
   seedConfigDir, writeConnectionSettings, writePrompt, worktreePathFor, cfgDirFor,
   branchFor, defaultBranchOf, commitsOnBranch, changedFilesOnBranch, uncommittedFiles,
-  pushBranch, hasUnpushedCommits, hasUncommittedChanges, salvageLocalOnlyWork, agentEnv, setGitIdentity,
+  pushBranch, hasUnpushedCommits, hasUncommittedChanges, salvageLocalOnlyWork, agentEnv, effortEnv, setGitIdentity,
   untrustedProjectConfig, plantedSkills,
 } from './workspace.mjs'
 // the agent's minted GitHub credential (#389, ADR-0018)
@@ -1374,6 +1375,10 @@ export class Dispatcher {
     if (charting && typeLabel !== MAP_LABEL) {
       return `❌ ${repo}#${n} is not a \`${MAP_LABEL}\` issue — curia dispatches no charting agent on it`
     }
+    // The ticket type, in the routing vocabulary, read once here (#707): it
+    // picks the effort row now and it re-picks it on every fallback and every
+    // resume, so it rides on the agent record beside the model.
+    const type = routingType(labels)
     const modelName = resolveModel(this.routing, labels, model)
     if (!this.routing.models[modelName]) {
       return `❌ unknown model \`${modelName}\` — configured models: ${Object.keys(this.routing.models).join(', ')}`
@@ -1425,6 +1430,10 @@ export class Dispatcher {
     // always the model typed. `review` reads its harness the same way.
     const useModel = cands[0]
     const harnessName = this.routing.models[useModel].harness
+    // Resolved against the model actually being spawned (#707), which is not
+    // always the one asked for: a cooled model's chain can cross harnesses, and
+    // the depth follows the model that runs rather than the one that did not.
+    const effort = this.#effortFor(useModel, type)
     if (!this.routing.harnesses[harnessName]) {
       return `❌ unknown harness \`${harnessName}\` — configured harnesses: ${Object.keys(this.routing.harnesses).join(', ')}`
     }
@@ -1492,7 +1501,7 @@ export class Dispatcher {
       const mapNumber = charting ? (newMap ? null : Number(n)) : await this.#mapNumberFor(repo, full)
       this.#assertTracker(repo, n, session, wtPath, mapNumber, { charting })
       this.#assertNoPlantedConfig(wtPath, harnessName)
-      this.#armAgent({ session, ticket: n, harness: harnessName, model: useModel, wtPath, cfgDir })
+      this.#armAgent({ session, ticket: n, harness: harnessName, model: useModel, wtPath, cfgDir, effort })
       // #157: the prompt NAMES the published ports, so they are allocated before
       // it is written and handed to the container after. The allocation is a
       // bind probe, a set lookup and an in-memory reservation — docker binds
@@ -1519,7 +1528,7 @@ export class Dispatcher {
 
       const plan = await this.#spawnPlan({
         session, ticket: n, repo, harness: harnessName, model: useModel,
-        wtPath, cfgDir, promptFile, ports, resume: conversationResume,
+        wtPath, cfgDir, promptFile, ports, effort, resume: conversationResume,
       })
       const container = plan.container
       const exitMarker = newExitMarker()
@@ -1538,6 +1547,7 @@ export class Dispatcher {
         // new-map agent would be sent to `chart new`, and `chart` refuses a
         // handle no issue answers to.
         ...(newMap ? { newMap: true } : {}),
+        effort, routing_type: type,
         // The journal is the state home for what a restart cannot re-derive
         // from tmux: which image this agent runs and which ports it published.
         sandbox: 'docker', image: container.image, ports: container.ports,
@@ -1548,6 +1558,11 @@ export class Dispatcher {
         repo, ticket: n, title: full.title, session, instance, wtPath, cfgDir, promptFile,
         model: useModel, requestedModel: modelName, harness: harnessName,
         provider: this.routing.models[useModel].provider,
+        // The depth this agent runs at, and the type that picked it (#707).
+        // Both ride the record because both outlive the labels: a fallback and
+        // a resume re-resolve the effort from the type, and the status line
+        // reads the effort rather than guessing it off the model's own default.
+        effort, routingType: type,
         // #156: the published loopback ports. #157 hands them to
         // `publish_preview` as its port bound.
         ports: container.ports,
@@ -1629,11 +1644,20 @@ export class Dispatcher {
     }
   }
 
+  // HOW DEEP THIS AGENT THINKS (#707), resolved once per spawn and read
+  // everywhere after. The type is the ticket's, the model is the one actually
+  // being spawned — so a fallback re-asks this question rather than carrying
+  // the cooled model's answer, and lands on the type's effort where the new
+  // model accepts it and on that model's own default where it does not.
+  #effortFor(model, type) {
+    return resolveEffort(this.routing, model, type)
+  }
+
   // Seed the config dir and write the connection settings, in the agent's own
   // view of the paths — the container's mount points, which is the only view
   // there is since #195. Shared by the first dispatch and by the cross-harness
   // respawn a usage limit forces.
-  #armAgent({ session, ticket, harness, model, wtPath, cfgDir }) {
+  #armAgent({ session, ticket, harness, model, wtPath, cfgDir, effort = null }) {
     this.deps.seedConfigDir(cfgDir, GUEST_WT, this.config.skills, harness, { sandboxed: true })
     // A FRESH secret per arm (#159), minted before the connection settings that carry it.
     // The cross-harness respawn arms again, so the pane a usage limit killed
@@ -1642,7 +1666,11 @@ export class Dispatcher {
     this.deps.writeConnectionSettings({
       wtPath: GUEST_WT, hostWtPath: wtPath, cfgDir, agent: session, ticket,
       daemonPort: this.daemonPort, daemonHost: GUEST_DAEMON_HOST, token,
-      harness, reasoningEffort: this.routing.models[model].reasoning_effort ?? null,
+      // The RESOLVED effort (#707), not the model's own default: the ticket
+      // type's row beats it wherever this model accepts the word, and the
+      // resolution ran once, at the caller, so the depth the status line says
+      // and the depth the harness is told are the same fact.
+      harness, reasoningEffort: effort,
       // The codex harness turns this into its skill deny list (#171); the
       // claude harness does not read it.
       skills: this.config.skills,
@@ -1653,13 +1681,13 @@ export class Dispatcher {
   // line and an EMPTY pane environment: the container carries its own through
   // `--env-file`, and a pane env would put every value of it in `ps` — the cost
   // #155 measured and asked #156 not to repeat.
-  async #spawnPlan({ session, ticket, repo, harness, model, wtPath, cfgDir, promptFile, ports, reviewer = false, resume = false }) {
+  async #spawnPlan({ session, ticket, repo, harness, model, wtPath, cfgDir, promptFile, ports, effort = null, reviewer = false, resume = false }) {
     const harnessCmd = resume
       ? buildResumeCmd(this.routing, harness, model)
       : buildSpawnCmd(this.routing, harness, model, path.join(GUEST_CFG, path.basename(promptFile)))
     const container = await this.#prepareContainer({
       session, ticket, repo, harness, model, wtPath, cfgDir, spawnCmd: harnessCmd,
-      sandbox: this.config.sandbox, ports, reviewer,
+      sandbox: this.config.sandbox, ports, effort, reviewer,
     })
     return { container, shellCmd: container.shellCmd, env: {} }
   }
@@ -2258,7 +2286,7 @@ export class Dispatcher {
   // names them and is written first (#157). Every step here can fail, and all of
   // them run inside #dispatch's try — so a failure unclaims the ticket rather
   // than leaving it assigned to an agent that never ran.
-  async #prepareContainer({ session, ticket, repo, harness, model, wtPath, cfgDir, spawnCmd, sandbox, ports, reviewer = false }) {
+  async #prepareContainer({ session, ticket, repo, harness, model, wtPath, cfgDir, spawnCmd, sandbox, ports, effort = null, reviewer = false }) {
     // Built on demand rather than at boot: the tag is a content address, so a
     // pinned version bump or a Dockerfile edit names an image the box does not
     // have, and this is the first place that matters (#154).
@@ -2367,6 +2395,12 @@ export class Dispatcher {
     this.#writeModelCredential(harness, cfgDir, ticket)
     const envFile = writeEnvFile(path.join(cfgDir, ENV_FILE), {
       ...agentEnv(GUEST_CFG, harness, { sandboxed: true }),
+      // The reasoning effort, for a harness whose route is its environment
+      // (#707) — nothing for one that states it in its config file, and nothing
+      // when routing states no effort at all. It is written into the env file
+      // every container is built with, so a resume inherits the depth its first
+      // turn ran at rather than dropping back to the model's own default.
+      ...effortEnv(harness, effort),
       // The PATH to the credential above, and no credential in it (#389). It is
       // set here rather than inside `agentEnv`, because this is where the file
       // it names gets written.
@@ -2738,7 +2772,13 @@ export class Dispatcher {
     try {
       checkout = await this.deps.createReviewCheckout(this.root, repo, ticket)
       this.#assertNoPlantedConfig(checkout.path, harnessName)
-      this.#armAgent({ session, ticket, harness: harnessName, model, wtPath: checkout.path, cfgDir })
+      // A cross-check is a spawn like any other, so it takes the ticket type's
+      // depth too (#707) — a reading of a diff on a `wayfinder:task` ticket is
+      // task-depth work, and the reviewer's own model default answers where the
+      // pairing crossed to a model that has no word for it.
+      const type = routingType((issue.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name)))
+      const effort = this.#effortFor(model, type)
+      this.#armAgent({ session, ticket, harness: harnessName, model, wtPath: checkout.path, cfgDir, effort })
       // No published ports: a reviewer starts no dev server, and
       // `publish_preview` is one of the four tools curia refuses it. Three
       // ports per reviewer would be three ports a builder could not have.
@@ -2752,7 +2792,7 @@ export class Dispatcher {
 
       const plan = await this.#spawnPlan({
         session, ticket, repo, harness: harnessName, model,
-        wtPath: checkout.path, cfgDir, promptFile, ports: [], reviewer: true,
+        wtPath: checkout.path, cfgDir, promptFile, ports: [], effort, reviewer: true,
       })
       const exitMarker = newExitMarker()
       await this.deps.newSession({ name: session, cwd: checkout.path, env: plan.env, shellCmd: plan.shellCmd, exitMarker })
@@ -2772,7 +2812,7 @@ export class Dispatcher {
       this.reduction.journal('agent_spawned', {
         repo, ticket, agent: session, model, requested_model: model,
         prompt_carries_limit_text: textCarriesLimitPhrase(issue.title, issue.body),
-        harness: harnessName, kind: spawnKind({ reviewer: true }),
+        harness: harnessName, kind: spawnKind({ reviewer: true }), effort, routing_type: type,
       })
 
       const agent = {
@@ -2780,6 +2820,7 @@ export class Dispatcher {
         wtPath: checkout.path, cfgDir, promptFile,
         model, requestedModel: model, harness: harnessName,
         provider: this.routing.models[model].provider,
+        effort, routingType: type,
         ports: null, sandbox: 'docker',
         promptHarness: harnessName,
         spawnedAt: Date.now(), state: 'spawning', resultReceived: false,
@@ -3430,9 +3471,15 @@ export class Dispatcher {
     const allocated = !agent.reviewer && (freshPorts || !agent.ports)
     const ports = agent.reviewer ? [] : (allocated ? await this.#allocatePorts() : agent.ports)
     try {
+      // THE FALLBACK RULE, applied (#707): re-resolved against the model
+      // being spawned now, so the ticket type's effort survives a chain that
+      // keeps the word and gives way to the next model's own default where it
+      // does not. Carrying the dead model's effort would state a depth the new
+      // harness may not have.
+      const effort = this.#effortFor(next, agent.routingType ?? 'untyped')
       this.#armAgent({
         session: agent.session, ticket: agent.ticket, harness: nextHarness,
-        model: next, wtPath: agent.wtPath, cfgDir: agent.cfgDir,
+        model: next, wtPath: agent.wtPath, cfgDir: agent.cfgDir, effort,
       })
       // Fresh numbers force the rewrite whatever the harness did: the prompt on
       // disk names the ports (#157), and keeping it would hand the agent three
@@ -3444,7 +3491,7 @@ export class Dispatcher {
       const plan = await this.#spawnPlan({
         session: agent.session, ticket: agent.ticket, repo: agent.repo,
         harness: nextHarness, model: next, wtPath: agent.wtPath, cfgDir: agent.cfgDir,
-        promptFile: agent.promptFile, ports, reviewer: Boolean(agent.reviewer), resume,
+        promptFile: agent.promptFile, ports, effort, reviewer: Boolean(agent.reviewer), resume,
       })
       // A fresh marker per spawn: the old session is dead, and reusing its nonce
       // would let the previous life's exit line — still on screen for a moment —
@@ -3465,6 +3512,7 @@ export class Dispatcher {
       agent.sandbox = 'docker'
       agent.exitMarker = exitMarker
       agent.model = next
+      agent.effort = effort
       agent.harness = nextHarness
       agent.provider = this.routing.models[next].provider
       agent.spawnedAt = Date.now()

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -448,6 +448,10 @@ const metersFor = (session, model) => agentMeters({
   harness: harnessFor(session),
   cfgDir: cfgDirFor(session),
   model: model ?? dispatcher?.agents.get(session)?.model ?? null,
+  // The depth this agent was spawned at (#707), from the same record the model
+  // comes from. Absent for a session the dispatcher does not hold, and
+  // `agentMeters` falls back to the model's configured default there.
+  effort: dispatcher?.agents.get(session)?.effort ?? null,
   routing: routingConfig,
   account: accountUsage,
   models: modelWindows,

--- a/daemon/src/routing.mjs
+++ b/daemon/src/routing.mjs
@@ -36,6 +36,58 @@ export function namedModel(labels, override) {
   return l ? l.slice('model:'.length) : null
 }
 
+// ---- reasoning effort (#707) ------------------------------------------------
+//
+// THE MODEL SAYS HOW DEEP IT THINKS BY DEFAULT, AND THE TICKET TYPE OVERRIDES
+// IT. Two tables, because the two answer different questions and one table
+// would force a choice between them: `models.<name>.reasoning_effort` is what
+// this model is worth running at when nothing else is said, and `effort.<type>`
+// is how deep THIS KIND OF WORK is, whatever model it lands on.
+//
+// The type table is why effort survives a model label. `model:gpt` picks the
+// model and says nothing about depth, so the type's effort still applies —
+// resolveModel and resolveEffort resolve two facts, and neither reads the
+// other's answer.
+//
+// A type effort holds only where the model ACCEPTS it. Otherwise the model's
+// own default stands, which is the fallback rule in one place: a chain that
+// crosses to a model with a shorter vocabulary keeps the type's depth when that
+// model has the word for it, and takes that model's configured default when it
+// does not. Nothing here invents an effort.
+
+// The ticket type routing keys off, in the vocabulary both tables use.
+// `untyped` is a row name rather than an absence, exactly as `defaults` has it.
+export function routingType(labels) {
+  const l = (labels ?? []).find((x) => x.startsWith('wayfinder:'))
+  return l ? l.slice('wayfinder:'.length) : 'untyped'
+}
+
+// Which efforts a model accepts, most specific answer first: the model's own
+// list, else its harness's, else null — which is not the empty set but the
+// absence of a bound, and reads as accepting whatever it is given.
+export function effortAccepts(routing, model) {
+  const spec = routing?.models?.[model]
+  if (!spec) return null
+  if (Array.isArray(spec.efforts)) return spec.efforts
+  const harness = routing?.harnesses?.[spec.harness]
+  return Array.isArray(harness?.efforts) ? harness.efforts : null
+}
+
+export function acceptsEffort(routing, model, effort) {
+  const accepts = effortAccepts(routing, model)
+  return !accepts || accepts.includes(effort)
+}
+
+// The effort one model runs one ticket type at, or null for "state none" — the
+// answer for a routing carrying no effort table at all, which is how a config
+// written before this key existed goes on behaving.
+export function resolveEffort(routing, model, type = 'untyped') {
+  const own = routing?.models?.[model]?.reasoning_effort ?? null
+  const wanted = routing?.effort?.[type] ?? routing?.effort?.untyped ?? null
+  if (wanted && acceptsEffort(routing, model, wanted)) return wanted
+  return own
+}
+
 // The live index, seeded at boot from the journal (#377). Settled answer 6 made
 // this in-memory only, and a 5-hour window outlives a deploy: a restart inside
 // one forgot every entry, and the next `start` spawned a container straight into

--- a/daemon/src/settings.mjs
+++ b/daemon/src/settings.mjs
@@ -25,10 +25,11 @@
 //    more than it saves. So `parseDocument` in, node edits, `toString` out.
 //
 // 3. THE PATCH IS A CLOSED SET. The screen writes named dispatch values, the
-//    watch list, the routing defaults, and the model switch. Every value is
-//    named in code here and mapped onto an explicit key path. There is
-//    no generic "set this key" route, because a browser that could set any key
-//    could set `dispatch.workspace_root` or `sandbox.image`.
+//    watch list, the routing defaults, the per-type reasoning effort, and the
+//    model switch. Every value is named in code here and mapped onto an
+//    explicit key path. There is no generic "set this key" route, because a
+//    browser that could set any key could set `dispatch.workspace_root` or
+//    `sandbox.image`.
 //
 // 4. THE DAEMON'S OWN LOADERS SAY YES FIRST. The candidate is validated by
 //    `loadCuriaConfig`/`loadRoutingConfig` — the same functions that decide
@@ -51,7 +52,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { parse, parseDocument } from 'yaml'
-import { loadCuriaConfig, loadRoutingConfig, localConfigFile, readLayered, WATCH_MODES } from './config.mjs'
+import { loadCuriaConfig, loadRoutingConfig, localConfigFile, readLayered, REASONING_EFFORTS, WATCH_MODES } from './config.mjs'
 
 // What a new override file says about itself, above the first key. It is the
 // one place the two-file rule is written where the operator meets it: on the
@@ -105,6 +106,21 @@ const REPO_RE = /^[\w.-]+\/[\w.-]+$/
 // the read
 // ---------------------------------------------------------------------------
 
+// Every effort word any configured harness accepts, in ladder order. A harness
+// that states no `efforts` list bounds nothing, so the whole ladder stands —
+// which is the same reading `effortAccepts` makes in routing.mjs, and the
+// reason the two must not be two lists: a screen offering a word the daemon
+// would refuse is a save that fails at the press.
+// The ladder itself is the loader's list, imported rather than repeated: it is
+// the same order a refusal names, and a second copy here would be free to drift
+// the day a word is added to it.
+function effortVocabulary(routing) {
+  const rows = Object.values(routing?.harnesses ?? {})
+  if (!rows.length || rows.some((h) => !Array.isArray(h?.efforts))) return [...REASONING_EFFORTS]
+  const seen = new Set(rows.flatMap((h) => h.efforts))
+  return REASONING_EFFORTS.filter((e) => seen.has(e))
+}
+
 // What the settings screen draws: both layers, merged the way the daemon reads
 // them. Read with a plain parse rather than through the loaders, and
 // deliberately: a config the loaders REFUSE is exactly when the operator most
@@ -128,6 +144,12 @@ export function readSettings({ curiaFile, routingFile }) {
       // An ordered list, not a map: the table draws the rows in the order
       // routing.yaml states them, and `untyped` reads last there for a reason.
       defaults: Object.entries(routing.defaults ?? {}).map(([type, model]) => ({ type, model: String(model ?? '') })),
+      // How deep each ticket type thinks (#707). One row per type the table
+      // states, in file order like `defaults` above — and the vocabulary the
+      // screen may offer, which is the union across the harnesses in play
+      // rather than a list the page could hold a stale copy of.
+      effort: Object.entries(routing.effort ?? {}).map(([type, effort]) => ({ type, effort: String(effort ?? '') })),
+      efforts: effortVocabulary(routing),
       models: Object.entries(routing.models ?? {}).map(([name, m]) => ({
         name,
         provider: m?.provider ?? null,
@@ -165,7 +187,7 @@ export const LIVE_PATHS = {
     'dispatch.auto_dispatch', 'dispatch.max_concurrent', 'dispatch.poll_interval_s',
     'dispatch.prototype_variations', 'watch',
   ],
-  routing: ['defaults.*', 'models.*.active'],
+  routing: ['defaults.*', 'effort.*', 'models.*.active'],
 }
 
 // The six values, out of two loaded configs, in the shape `readSettings` gives
@@ -179,6 +201,7 @@ export function liveSettings({ curia, routing }) {
     watch: (curia?.watch ?? []).map((w) => ({ repo: w?.repo ?? '', mode: w?.mode ?? 'auto' })),
     routing: {
       defaults: Object.entries(routing?.defaults ?? {}).map(([type, model]) => ({ type, model: String(model ?? '') })),
+      effort: Object.entries(routing?.effort ?? {}).map(([type, effort]) => ({ type, effort: String(effort ?? '') })),
       // `active` and the name, because they are what the switch moves. Provider
       // and harness are on the screen's own read and are not reloadable.
       models: Object.entries(routing?.models ?? {}).map(([name, m]) => ({ name, active: m?.active !== false })),
@@ -201,6 +224,11 @@ export function liveDiff(before, after) {
   const [rb, ra] = [rows(before), rows(after)]
   for (const type of new Set([...rb.keys(), ...ra.keys()])) {
     if (!same(rb.get(type), ra.get(type))) out.push(`routing.defaults.${type}`)
+  }
+  const efforts = (s) => new Map((s.routing?.effort ?? []).map((r) => [r.type, r.effort]))
+  const [eb, ea] = [efforts(before), efforts(after)]
+  for (const type of new Set([...eb.keys(), ...ea.keys()])) {
+    if (!same(eb.get(type), ea.get(type))) out.push(`routing.effort.${type}`)
   }
   const switches = (s) => new Map((s.routing?.models ?? []).map((m) => [m.name, m.active !== false]))
   const [sb, sa] = [switches(before), switches(after)]
@@ -289,10 +317,16 @@ function checkPatch(patch) {
   if (r !== undefined) {
     if (!r || typeof r !== 'object' || Array.isArray(r)) refuse('`routing` must be a mapping')
     for (const key of Object.keys(r)) {
-      if (!['defaults', 'models'].includes(key)) refuse(`the settings screen does not write \`routing.${key}\``)
+      if (!['defaults', 'effort', 'models'].includes(key)) refuse(`the settings screen does not write \`routing.${key}\``)
     }
     for (const [type, model] of Object.entries(r.defaults ?? {})) {
       if (typeof model !== 'string' || !model.trim()) refuse(`defaults.${type} must name a model`)
+    }
+    // Shape only, per rule 3 above: which words this box's harnesses accept is
+    // the loader's judgement, and running a second copy of that list here is
+    // how two validators start to disagree.
+    for (const [type, effort] of Object.entries(r.effort ?? {})) {
+      if (typeof effort !== 'string' || !effort.trim()) refuse(`effort.${type} must name a reasoning effort`)
     }
     for (const [name, m] of Object.entries(r.models ?? {})) {
       if (!m || typeof m !== 'object' || typeof m.active !== 'boolean') {
@@ -385,6 +419,12 @@ function editRouting(doc, patch, base) {
       refuse(`routing.yaml has no \`defaults.${type}\` row — the settings screen edits the rows that are there and adds none`)
     }
     settle(doc, ['defaults', type], model, base.defaults[type])
+  }
+  for (const [type, effort] of Object.entries(patch.routing.effort ?? {})) {
+    if (base.effort?.[type] === undefined) {
+      refuse(`routing.yaml has no \`effort.${type}\` row — the settings screen edits the rows that are there and adds none`)
+    }
+    settle(doc, ['effort', type], effort, base.effort[type])
   }
   for (const [name, m] of Object.entries(patch.routing.models ?? {})) {
     if (!base.models?.[name]) refuse(`routing.yaml has no \`models.${name}\` entry — a model is added by hand, not by a checkbox`)

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -1096,10 +1096,17 @@ export function modelName(model, spec, stated = null) {
 // conversation's percent is the defect this argument exists to end, not a
 // fallback. ADR-0016 makes this meter the one signal that a conversation is
 // getting long, so a number about another conversation cannot carry the job.
-export function agentMeters({ harness, cfgDir, model, routing, account, models, transcript, now = Date.now() }) {
+export function agentMeters({ harness, cfgDir, model, effort, routing, account, models, transcript, now = Date.now() }) {
   const spec = routing?.models?.[model] ?? null
   const out = {
-    model: modelName(model, spec), effort: spec?.reasoning_effort ?? null, ctxPct: null, ctxOver: false, windows: null,
+    // The effort meter says the depth this agent was DISPATCHED at (#707), and
+    // the model's own default only where the caller has no such record — a lab
+    // session, or an agent whose spawn predates the field. Those are two
+    // different facts and the caller is the only one that can tell them apart,
+    // which is why this argument exists rather than a second resolution here:
+    // routing's answer today is not what a running agent was told at its spawn.
+    model: modelName(model, spec), effort: effort ?? spec?.reasoning_effort ?? null,
+    ctxPct: null, ctxOver: false, windows: null,
   }
   if (!harness || !cfgDir) return out
 

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -562,6 +562,60 @@ export function configRootEnvFor(harness = 'claude') {
   return CONFIG_ROOT_ENV[harness]
 }
 
+// HOW EACH HARNESS IS TOLD ITS REASONING EFFORT (#707), for all four harnesses
+// the worker image carries since #696 — not only the two the router can select
+// today. The codex row states `model_reasoning_effort` in the config file the
+// daemon already writes for it, and the comment on that line is the rule this
+// table generalizes: a model's own default is not a constant across models, so
+// stating the effort makes the model and the depth two separate visible
+// decisions instead of one that moves under the other.
+//
+// THE ROUTE IS NEVER A SPAWN FLAG, and that is the whole reason this is a table
+// rather than an addition to the harness template. A flag lives on the spawn
+// line only, and a resume runs a DIFFERENT line (`codex resume --last`,
+// `claude --continue`) — so an effort carried by a flag would be the depth the
+// first turn ran at and nothing the resumed agent inherits. Both routes here
+// are re-stated by every arm: the config file lives in the config dir the
+// container mounts, and the environment is written into the env file each
+// container is built with. Spawn and resume read the same answer.
+//
+// `env` is the environment variable the CLI reads; `config` is the key the
+// harness's own config file carries. One or the other, never both.
+//
+// VERIFIED: the codex row, live since #39 and measured on the box. The other
+// three are NOT verified against a running CLI — #696 put the four commands in
+// the image and nothing has dispatched on opencode or pi yet. An environment
+// variable a CLI does not read is a no-op rather than a broken spawn, which is
+// why every unverified row is an `env` row: the wrong answer here costs the
+// depth, not the agent. Correct a row against a live check, not against a
+// reading of these names.
+export const EFFORT_ROUTE = Object.freeze({
+  claude: Object.freeze({ env: 'CLAUDE_CODE_EFFORT' }),
+  codex: Object.freeze({ config: 'model_reasoning_effort' }),
+  opencode: Object.freeze({ env: 'OPENCODE_REASONING_EFFORT' }),
+  pi: Object.freeze({ env: 'PI_REASONING_EFFORT' }),
+})
+
+// Every harness that can be told an effort — the four in the image, which is a
+// longer list than HARNESS_NAMES above (the harnesses the router can select).
+export const EFFORT_HARNESSES = Object.freeze(Object.keys(EFFORT_ROUTE))
+
+export function effortRouteFor(harness) {
+  const route = EFFORT_ROUTE[harness]
+  if (!route) {
+    throw new Error(`no reasoning-effort route for harness "${harness}" — known harnesses: ${EFFORT_HARNESSES.join(', ')}`)
+  }
+  return route
+}
+
+// The part of the agent's environment that carries the effort, or nothing. Two
+// cases write nothing and they are the same case here: a harness whose route is
+// its config file, and an agent routing states no effort for.
+export function effortEnv(harness, effort) {
+  const route = effortRouteFor(harness)
+  return route.env && effort ? { [route.env]: String(effort) } : {}
+}
+
 function harnessDef(harness) {
   const h = HARNESS[harness]
   if (!h) {
@@ -982,7 +1036,7 @@ const HARNESS = {
         // gpt-5.6-sol to low, so changing `models.<name>.id` alone would move
         // the effort underneath the harness without saying so. Stating it makes the
         // model and the depth two separate, visible decisions.
-        ...(reasoningEffort ? [`model_reasoning_effort = ${toml(reasoningEffort)}`, ''] : []),
+        ...(reasoningEffort ? [`${EFFORT_ROUTE.codex.config} = ${toml(reasoningEffort)}`, ''] : []),
         '[features]',
         'hooks = true',
         // The tool set is bounded HERE (#172), and this table is the whole lever:

--- a/daemon/test/config.test.mjs
+++ b/daemon/test/config.test.mjs
@@ -476,6 +476,102 @@ describe('reasoning effort is stated, not inherited (#39)', () => {
   })
 })
 
+// Load a routing file with one whole section replaced, so a test can state the
+// section it is about and inherit the rest (#707).
+function loadWith(dir, replacement) {
+  const head = replacement[0]
+  const base = [
+    'defaults:',
+    '  untyped: gpt',
+    'models:',
+    '  gpt: { provider: openai, harness: codex, id: gpt-5.6-sol, reasoning_effort: high }',
+    'harnesses:',
+    "  codex: { template: 'codex --model {model} \"$(cat {prompt_file})\"', resume_template: 'resume --model {model}', ready: 'x', tool_channel_grace_s: 15 }",
+  ]
+  const out = []
+  let skipping = false
+  for (const line of base) {
+    if (line === head) { skipping = true; out.push(...replacement); continue }
+    if (skipping && !line.startsWith(' ')) skipping = false
+    if (!skipping) out.push(line)
+  }
+  const file = path.join(dir, 'routing.yaml')
+  fs.writeFileSync(file, out.join('\n'))
+  return loadRoutingConfig(file)
+}
+
+describe('the ticket type states a depth of its own (#707)', () => {
+  let dir
+  before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-effort-table-')) })
+  after(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  const lines = (extra = []) => [
+    'defaults:',
+    '  untyped: gpt',
+    'models:',
+    '  gpt: { provider: openai, harness: codex, id: gpt-5.6-sol, reasoning_effort: high }',
+    'harnesses:',
+    "  codex: { template: 'codex --model {model} \"$(cat {prompt_file})\"', resume_template: 'resume --model {model}', ready: 'x', tool_channel_grace_s: 15 }",
+    ...extra,
+  ]
+
+  function load(extra) {
+    const file = path.join(dir, 'routing.yaml')
+    fs.writeFileSync(file, lines(extra).join('\n'))
+    return loadRoutingConfig(file)
+  }
+
+  test('an absent table loads as an empty one, so a config written before this key behaves the same', () => {
+    assert.deepEqual(load([]).effort, {})
+  })
+
+  test('the rows load as written', () => {
+    assert.deepEqual(load(['effort:', '  task: xhigh', '  untyped: low']).effort, { task: 'xhigh', untyped: 'low' })
+  })
+
+  // The two tables are keyed the same way and answer different questions, so a
+  // depth for a type no `defaults` row names is a config, not a mistake.
+  test('a row for a type `defaults` does not carry is not a refusal', () => {
+    assert.deepEqual(load(['effort:', '  grilling: max']).effort, { grilling: 'max' })
+  })
+
+  test('a misspelled effort refuses the boot and names the ladder', () => {
+    assert.throws(() => load(['effort:', '  task: deep']), /effort\.task must be one of low\|medium\|high/)
+  })
+
+  test("a model's own list of accepted efforts loads, and a word outside the ladder refuses", () => {
+    assert.deepEqual(load([]).models.gpt.efforts, undefined)
+    const withList = [
+      'models:',
+      '  gpt: { provider: openai, harness: codex, id: gpt-5.6-sol, reasoning_effort: high, efforts: [low, high] }',
+    ]
+    assert.deepEqual(loadWith(dir, withList).models.gpt.efforts, ['low', 'high'])
+    assert.throws(() => loadWith(dir, [
+      'models:',
+      '  gpt: { provider: openai, harness: codex, efforts: [deep] }',
+    ]), /models\.gpt\.efforts names "deep"/)
+  })
+
+  test('a model whose own default is outside its own list refuses the boot', () => {
+    assert.throws(() => loadWith(dir, [
+      'models:',
+      '  gpt: { provider: openai, harness: codex, reasoning_effort: max, efforts: [low, high] }',
+    ]), /reasoning_effort is "max", which its own `efforts` list does not carry/)
+  })
+
+  test("a harness's own list loads, and an empty one refuses", () => {
+    const ok = loadWith(dir, [
+      'harnesses:',
+      "  codex: { template: 'codex --model {model} \"$(cat {prompt_file})\"', resume_template: 'resume --model {model}', ready: 'x', tool_channel_grace_s: 15, efforts: [low, high] }",
+    ])
+    assert.deepEqual(ok.harnesses.codex.efforts, ['low', 'high'])
+    assert.throws(() => loadWith(dir, [
+      'harnesses:',
+      "  codex: { template: 'codex --model {model} \"$(cat {prompt_file})\"', resume_template: 'resume --model {model}', ready: 'x', tool_channel_grace_s: 15, efforts: [] }",
+    ]), /harnesses\.codex\.efforts must be a non-empty list/)
+  })
+})
+
 // #70. The attach page is an owned, built asset; the config states where it
 // is. The one thing this must never do is resolve to a file that is not there
 // — a ttyd spawned with a `-I` pointing at nothing serves no attach surface at

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -977,6 +977,11 @@ const SETTINGS = () => ({
   watch_modes: ['auto', 'map', 'ready-for-agent'],
   routing: {
     defaults: [{ type: 'grilling', model: 'opus' }, { type: 'research', model: 'gpt' }, { type: 'untyped', model: 'opus' }],
+    // #707: a depth per ticket type, and the words a picker may offer. Only two
+    // of the three types carry one here, which is the ordinary state of a file
+    // an operator has written some rows into and not others.
+    effort: [{ type: 'grilling', effort: 'high' }, { type: 'research', effort: 'low' }],
+    efforts: ['low', 'medium', 'high', 'xhigh'],
     models: [
       { name: 'fable', provider: 'anthropic', harness: 'claude', id: null, active: false },
       { name: 'opus', provider: 'anthropic', harness: 'claude', id: null, active: true },
@@ -1074,6 +1079,33 @@ describe('the settings screen (#265)', () => {
     assert.match(open, /gpt gpt-5\.6-sol runs on openai · codex/, 'the CLI name rides beside the routing label')
   })
 
+  // #707. One ticket type is one decision with two halves, so the depth sits on
+  // the row with the model rather than in a second list somewhere else.
+  test('a ticket type carries its depth beside its model', () => {
+    const html = screen('routing')
+    const selects = [...html.matchAll(/<select[^>]*>[\s\S]*?<\/select>/g)].map((m) => m[0])
+    // three type rows, and the two that state a depth carry a second picker
+    assert.equal(selects.filter((x) => x.includes('setDefault')).length, 3)
+    assert.equal(selects.filter((x) => x.includes('setEffort')).length, 2)
+    const depth = selects.find((x) => x.includes('setEffort(0'))
+    assert.match(depth, /<option selected>high<\/option>/)
+    assert.match(depth, /<option >xhigh<\/option>/, 'the whole vocabulary is on offer, not only the answer')
+  })
+
+  // The screen edits the rows that are there and adds none — the same rule the
+  // model column keeps, and the same one the daemon refuses a save on.
+  test('a type with no effort row gets no picker rather than an invented one', () => {
+    const html = screen('routing')
+    assert.equal(/setEffort\(2/.test(html), false)
+    page.setDefault(2, 'gpt')
+    assert.deepEqual(plain(page.settingsPatch()), { routing: { defaults: { untyped: 'gpt' } } })
+  })
+
+  test('a depth the vocabulary does not carry is still shown rather than silently swapped', () => {
+    page.draft.routing.effort[0].effort = 'ultra'
+    assert.match(screen('routing'), /<option selected>ultra<\/option>/)
+  })
+
   test('a default may only be pointed at a model that is ON', () => {
     const html = screen('routing')
     const options = [...html.matchAll(/<option[^>]*>([^<]+)<\/option>/g)].map((m) => m[1])
@@ -1142,12 +1174,14 @@ describe('the settings screen (#265)', () => {
     assert.deepEqual(plain(page.settingsPatch()), {})
     page.setDispatchField('max_concurrent', '4')
     page.setDefault(1, 'opus')
+    page.setEffort(1, 'medium')
     page.setModelActive(0, true)
     assert.deepEqual(plain(page.settingsPatch()), {
       dispatch: { max_concurrent: 4 },
-      routing: { defaults: { research: 'opus' }, models: { fable: { active: true } } },
+      routing: { defaults: { research: 'opus' }, effort: { research: 'medium' }, models: { fable: { active: true } } },
     })
-    assert.equal(page.changeCount(), 3)
+    // the depth is a change in the operator's own units, like the model beside it
+    assert.equal(page.changeCount(), 4)
   })
 
   test('a number field posts a number, never the string the input holds', () => {

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -5257,6 +5257,103 @@ const TWO_LANE = {
   },
 }
 
+// The same two lanes, with depth stated (#707). The two harnesses accept
+// DIFFERENT effort words on purpose: `xhigh` exists on the claude lane and not
+// on the codex one, which is the whole fallback rule in one fixture.
+const EFFORT_LANE = {
+  ...TWO_LANE,
+  effort: { untyped: 'high', research: 'xhigh' },
+  models: {
+    sonnet: { provider: 'anthropic', harness: 'claude', reasoning_effort: 'medium' },
+    gpt: { provider: 'openai', harness: 'codex', id: 'gpt-5.5', reasoning_effort: 'low' },
+  },
+  harnesses: {
+    claude: { ...TWO_LANE.harnesses.claude, efforts: ['low', 'medium', 'high', 'xhigh'] },
+    codex: { ...TWO_LANE.harnesses.codex, efforts: ['low', 'medium', 'high'] },
+  },
+}
+
+describe('reasoning effort across the harnesses (#707)', () => {
+  const envOf = (session) => fs.readFileSync(path.join(tmp, 'work', 'cfg', session, ENV_FILE), 'utf8')
+  const effortEnvOf = (session) => (/^CLAUDE_CODE_EFFORT=(.*)$/m.exec(envOf(session)) ?? [])[1] ?? null
+
+  // The claude lane is told its depth in the container environment, which is
+  // written once per spawn — so this is also the proof that a resume, which
+  // rewrites the same file, carries it.
+  test('the ticket type\'s effort reaches the claude harness, and beats the model default', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [] }) }, { routing: EFFORT_LANE })
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    // untyped is `high`; sonnet's own default is `medium` and does not win
+    assert.equal(effortEnvOf('curia-42'), 'high')
+    assert.equal(d.agents.get('curia-42').effort, 'high')
+  })
+
+  // The codex lane states it in the config file its own harness row writes, so
+  // there is no variable in the environment at all — one route per harness.
+  test('the codex harness is told through its config, never through the environment', async () => {
+    const arms = []
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      writeConnectionSettings: (opts) => arms.push(opts),
+    }, { routing: EFFORT_LANE })
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    // research asks for `xhigh`, which this harness has no word for, so gpt's
+    // own configured default stands rather than a word the CLI would refuse
+    assert.deepEqual(arms.map((a) => [a.harness, a.reasoningEffort]), [['codex', 'low']])
+    assert.equal(/CLAUDE_CODE_EFFORT|OPENCODE_REASONING_EFFORT/.test(envOf('curia-42')), false)
+  })
+
+  test('a model label moves the model and leaves the type effort alone', async () => {
+    const arms = []
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'model:gpt' }] }),
+      writeConnectionSettings: (opts) => arms.push(opts),
+    }, { routing: EFFORT_LANE })
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    // the label picked codex; `untyped: high` still decides the depth, and gpt's
+    // own `low` default is not what a labelled dispatch quietly falls back to
+    assert.deepEqual(arms.map((a) => [a.harness, a.reasoningEffort]), [['codex', 'high']])
+  })
+
+  test('a fallback keeps the type effort where the next model accepts it', async () => {
+    const d = makeDispatcher({ fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }) },
+      { routing: EFFORT_LANE })
+    // research routes to gpt (codex); openai is cooling, so the chain crosses
+    // to sonnet (claude) — which HAS the word `xhigh` that codex lacked
+    d.cooling.coolProvider('openai', new Date(Date.now() + 3600_000))
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    assert.equal(effortEnvOf('curia-42'), 'xhigh')
+  })
+
+  test('a cross-harness respawn re-resolves the depth for the model it lands on', async () => {
+    const arms = []
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      writeConnectionSettings: (opts) => arms.push(opts),
+      capturePane: async () => "You've hit your usage limit. Upgrade to Plus to continue using Codex\n",
+    }, { routing: EFFORT_LANE, readyTimeoutS: 6 })
+
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    await new Promise((r) => setTimeout(r, 2600))
+
+    // codex ran at its own default because `xhigh` is not its word; the claude
+    // successor runs at the ticket type's `xhigh`, and the agent record says so
+    assert.deepEqual(arms.map((a) => [a.harness, a.reasoningEffort]), [['codex', 'low'], ['claude', 'xhigh']])
+    assert.equal(effortEnvOf('curia-42'), 'xhigh')
+    assert.equal(d.agents.get('curia-42').effort, 'xhigh')
+  })
+
+  test('a routing with no effort table leaves every model on its own default', async () => {
+    const arms = []
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:research' }] }),
+      writeConnectionSettings: (opts) => arms.push(opts),
+    }, { routing: { ...EFFORT_LANE, effort: {} } })
+    await d.start('42', { repo: 'o/r', by: 'test' })
+    assert.deepEqual(arms.map((a) => a.reasoningEffort), ['low'])
+  })
+})
+
 describe('dispatching across two harnesses (#39)', () => {
   test('a research ticket seeds and spawns the codex harness end to end', async () => {
     const seeded = []

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -183,6 +183,7 @@ describe('GET /overview (index.mjs, real boot)', () => {
     assert.deepEqual(o.daemon.config.watch, [{ repo: 'example/fixture', mode: 'ready-for-agent' }])
     assert.deepEqual(o.daemon.config.routing, {
       defaults: [{ type: 'untyped', model: 'sonnet' }],
+      effort: [], // the fixture states no effort table, so there is no row to carry (#707)
       models: [{ name: 'sonnet', active: true }],
     })
     for (const key of ['agents', 'untracked', 'recent', 'escalations', 'review_gate', 'usage', 'pre_cooling', 'events']) {

--- a/daemon/test/reload.test.mjs
+++ b/daemon/test/reload.test.mjs
@@ -187,6 +187,10 @@ describe('POST /reload (index.mjs, real boot)', () => {
     ])
     assert.deepEqual(after.config.routing, {
       defaults: [{ type: 'untyped', model: 'opus' }],
+      // The fixture states no `effort` table, so the live shape carries the
+      // empty list rather than nothing: an absent table and one nobody has
+      // written a row into are the same fact (#707).
+      effort: [],
       models: [{ name: 'sonnet', active: false }, { name: 'opus', active: true }],
     })
     // The older spelling of the same two values moves with them: one daemon,

--- a/daemon/test/routing.test.mjs
+++ b/daemon/test/routing.test.mjs
@@ -53,7 +53,7 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { Cooling, resolveModel, namedModel, candidates, buildSpawnCmd, buildResumeCmd, parseUsageLimit, parseCreditGate, carriesLimitPhrase, providerOf } from '../src/routing.mjs'
+import { Cooling, resolveEffort, routingType, effortAccepts, acceptsEffort, resolveModel, namedModel, candidates, buildSpawnCmd, buildResumeCmd, parseUsageLimit, parseCreditGate, carriesLimitPhrase, providerOf } from '../src/routing.mjs'
 import { OPENAI_CREDIT_GATE_PANE } from './fixtures/panes.mjs'
 
 const routing = {
@@ -678,5 +678,76 @@ describe('parseUsageLimit is per provider (#39)', () => {
     assert.equal(carriesLimitPhrase('the banner says "usage limit reached" wrongly'), true)
     assert.equal(carriesLimitPhrase("the banner says \"You've hit your usage limit\" wrongly"), true)
     assert.equal(carriesLimitPhrase('show the weekly usage limit in the header'), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reasoning effort (#707)
+// ---------------------------------------------------------------------------
+
+const EFFORT_ROUTING = {
+  defaults: { research: 'gpt', task: 'opus', untyped: 'opus' },
+  effort: { research: 'xhigh', task: 'high', untyped: 'medium' },
+  models: {
+    opus: { provider: 'anthropic', harness: 'claude', reasoning_effort: 'medium' },
+    gpt: { provider: 'openai', harness: 'codex', reasoning_effort: 'low' },
+    // a model that narrows its own harness's list
+    terse: { provider: 'openai', harness: 'codex', reasoning_effort: 'low', efforts: ['low'] },
+  },
+  harnesses: {
+    claude: { efforts: ['low', 'medium', 'high', 'xhigh'] },
+    codex: { efforts: ['low', 'medium', 'high'] },
+  },
+}
+
+describe('the ticket type and the model each say something about depth (#707)', () => {
+  test('the type names the row, and a ticket with no type label reads `untyped`', () => {
+    assert.equal(routingType(['wayfinder:research', 'ready-for-agent']), 'research')
+    assert.equal(routingType(['ready-for-agent']), 'untyped')
+    assert.equal(routingType([]), 'untyped')
+    assert.equal(routingType(undefined), 'untyped')
+  })
+
+  test("the type's effort beats the model's own default", () => {
+    assert.equal(EFFORT_ROUTING.models.opus.reasoning_effort, 'medium')
+    assert.equal(resolveEffort(EFFORT_ROUTING, 'opus', 'task'), 'high')
+  })
+
+  test('a type with no row of its own falls to `untyped`, not to the model default', () => {
+    assert.equal(resolveEffort(EFFORT_ROUTING, 'gpt', 'grilling'), 'medium')
+  })
+
+  test('a model default stands where the model has no word for the type effort', () => {
+    // research asks for xhigh; the codex harness's list stops at high
+    assert.equal(resolveEffort(EFFORT_ROUTING, 'gpt', 'research'), 'low')
+    // and the same type on the claude lane keeps it — this is the fallback rule
+    assert.equal(resolveEffort(EFFORT_ROUTING, 'opus', 'research'), 'xhigh')
+  })
+
+  test('a model narrows its harness, and its own list is the one that counts', () => {
+    assert.deepEqual(effortAccepts(EFFORT_ROUTING, 'terse'), ['low'])
+    assert.deepEqual(effortAccepts(EFFORT_ROUTING, 'gpt'), ['low', 'medium', 'high'])
+    assert.equal(resolveEffort(EFFORT_ROUTING, 'terse', 'task'), 'low')
+  })
+
+  test('a stated list is a bound and no list is no bound — the two are not the same absence', () => {
+    const loose = { models: { any: { provider: 'anthropic', harness: 'claude' } }, harnesses: { claude: {} }, effort: { task: 'ultra' } }
+    assert.equal(effortAccepts(loose, 'any'), null)
+    assert.equal(acceptsEffort(loose, 'any', 'ultra'), true)
+    assert.equal(resolveEffort(loose, 'any', 'task'), 'ultra')
+  })
+
+  test('a routing with no effort table at all states nothing, and every model keeps its default', () => {
+    const bare = { models: { opus: { provider: 'anthropic', harness: 'claude' }, gpt: { provider: 'openai', harness: 'codex', reasoning_effort: 'high' } }, harnesses: {} }
+    assert.equal(resolveEffort(bare, 'opus', 'task'), null)
+    assert.equal(resolveEffort(bare, 'gpt', 'task'), 'high')
+  })
+
+  // A model routing does not carry never reaches a spawn — dispatch refuses it
+  // by name first — so this asks only that the resolution stays total: no throw,
+  // no default invented on a model nothing knows.
+  test('a model routing does not carry bounds nothing and defaults nothing', () => {
+    assert.equal(effortAccepts(EFFORT_ROUTING, 'nosuch'), null)
+    assert.equal(resolveEffort(EFFORT_ROUTING, 'nosuch', 'task'), 'high')
   })
 })

--- a/daemon/test/settings.test.mjs
+++ b/daemon/test/settings.test.mjs
@@ -81,6 +81,9 @@ function writeRouting(extra = []) {
     '  # opus until the credits arrive',
     '  untyped: opus',
     '  research: gpt # spread the quota',
+    'effort:',
+    '  untyped: high',
+    '  research: low # the bulk lane thinks shallow',
     'models:',
     '  opus:',
     '    provider: anthropic',
@@ -105,11 +108,13 @@ function writeRouting(extra = []) {
     '    resume_template: claude --model {model} --continue "Continue the interrupted work."',
     "    ready: 'bypass permissions'",
     '    tool_channel_grace_s: 15',
+    '    efforts: [low, medium, high, xhigh]',
     '  codex:',
     '    template: codex --model {model} "$(cat {prompt_file})"',
     '    resume_template: codex resume --last --model {model} "Continue the interrupted work."',
     "    ready: '. [~/]'",
     '    tool_channel_grace_s: 20',
+    '    efforts: [low, medium, high]',
     '',
   ].join('\n'))
 }
@@ -134,6 +139,13 @@ describe('the read the settings screen draws', () => {
     })
     assert.deepEqual(s.watch, [{ repo: 'o/first', mode: 'auto' }, { repo: 'o/second', mode: 'auto' }])
     assert.deepEqual(s.routing.defaults, [{ type: 'untyped', model: 'opus' }, { type: 'research', model: 'gpt' }])
+    // #707: the depth beside the model, in file order like the models above,
+    // and the words a picker may offer — every word ANY harness on this box
+    // accepts, because a row is legal wherever one lane can run it and the
+    // lanes that cannot keep their own default. `ultra` is offered by neither
+    // harness here, so it is not on the list.
+    assert.deepEqual(s.routing.effort, [{ type: 'untyped', effort: 'high' }, { type: 'research', effort: 'low' }])
+    assert.deepEqual(s.routing.efforts, ['low', 'medium', 'high', 'xhigh'])
     assert.deepEqual(s.routing.models.map((m) => m.name), ['opus', 'sonnet', 'gpt'])
     assert.equal(s.routing.models.find((m) => m.name === 'gpt').id, 'gpt-5.6-sol')
   })
@@ -320,6 +332,27 @@ describe('the save lands beside the tracked file, never on it', () => {
   })
 })
 
+describe('the depth each ticket type thinks at (#707)', () => {
+  test('a changed effort lands in the override and the tracked file never moves', () => {
+    const before = fs.readFileSync(routingFile, 'utf8')
+    saveSettings({ ...files(), patch: { routing: { effort: { research: 'medium' } } } })
+    assert.equal(fs.readFileSync(routingFile, 'utf8'), before)
+    assert.equal(loadRoutingConfig(routingFile).effort.research, 'medium')
+    // the row it did not touch still says what the tracked file says
+    assert.equal(loadRoutingConfig(routingFile).effort.untyped, 'high')
+    // and the comment beside the tracked row survived, because the override
+    // holds the answer rather than a rewrite of the file
+    assert.match(before, /research: low # the bulk lane thinks shallow/)
+  })
+
+  test('an effort that comes back to the tracked answer leaves no override behind', () => {
+    saveSettings({ ...files(), patch: { routing: { effort: { research: 'medium' } } } })
+    assert.ok(fs.existsSync(overRouting()))
+    saveSettings({ ...files(), patch: { routing: { effort: { research: 'low' } } } })
+    assert.equal(fs.existsSync(overRouting()), false)
+  })
+})
+
 describe('the daemon\'s own loaders judge the candidate first', () => {
   const refusal = (patch) => {
     const before = {
@@ -405,6 +438,15 @@ describe('the patch is a closed set', () => {
 
   test('a row routing.yaml does not have is not created', () => {
     refused({ routing: { defaults: { grilling: 'opus' } } }, /has no `defaults.grilling` row/)
+    refused({ routing: { effort: { grilling: 'high' } } }, /has no `effort.grilling` row/)
+  })
+
+  test('an effort must name a word, and the loader is what judges which words exist', () => {
+    refused({ routing: { effort: { untyped: '' } } }, /effort.untyped must name a reasoning effort/)
+    // shape passes here and the loader refuses it, which is rule 4: one
+    // validator for the vocabulary, and it is the one the daemon boots on
+    assert.throws(() => saveSettings({ ...files(), patch: { routing: { effort: { untyped: 'deep' } } } }),
+      /effort.untyped must be one of/)
   })
 
   test('a model routing.yaml does not have is not created', () => {
@@ -545,6 +587,7 @@ describe('the closed set a reload applies (#362)', () => {
     ['the prototype count', () => overCuriaFile(['dispatch:', '  prototype_variations: 7']), ['dispatch.prototype_variations']],
     ['the watch list', () => overCuriaFile(['watch:', '  - repo: o/first', '  - repo: o/third']), ['watch']],
     ['a routing default', () => overRoutingFile(['defaults:', '  untyped: sonnet']), ['routing.defaults.untyped']],
+    ['a routing effort', () => overRoutingFile(['effort:', '  untyped: low']), ['routing.effort.untyped']],
     ['a model switch', () => overRoutingFile(['models:', '  sonnet:', '    active: false']), ['routing.models.sonnet.active']],
   ]) {
     test(`${what} is inside the set, and the reload names it`, () => {

--- a/daemon/test/usage.test.mjs
+++ b/daemon/test/usage.test.mjs
@@ -855,6 +855,19 @@ describe('agentMeters', () => {
     assert.deepEqual(m, { model: 'gpt-5.6-sol', effort: 'high', ctxPct: null, ctxOver: false, windows: null })
   })
 
+  // #707: the meter says the depth this agent was DISPATCHED at. A ticket type
+  // can move it off the model's own default, and reading the config today would
+  // say the wrong thing about an agent spawned before an operator changed it.
+  test('the depth an agent was spawned at beats the model default it did not run at', () => {
+    const m = agentMeters({ harness: 'codex', cfgDir: cfgDir(), model: 'gpt', effort: 'xhigh', routing, account: null, now: NOW })
+    assert.equal(m.effort, 'xhigh')
+  })
+
+  test('no dispatch record leaves the model default, which is the only evidence left', () => {
+    const m = agentMeters({ harness: 'codex', cfgDir: cfgDir(), model: 'gpt', effort: null, routing, account: null, now: NOW })
+    assert.equal(m.effort, 'high')
+  })
+
   // #332, building ADR-0016: the meter is the ONE signal that a conversation is
   // getting long, so it has to read the conversation it was asked about. Every
   // overseer conversation writes into one config dir, where newest-by-mtime is

--- a/daemon/test/workspace.test.mjs
+++ b/daemon/test/workspace.test.mjs
@@ -13,6 +13,8 @@ import {
   checkoutTicketBranch, remoteBranchExists, defaultBranchOf,
   // #649, ADR-0028
   hasUncommittedChanges, hasUnpushedCommits, salvageBranchFor, salvageLocalOnlyWork,
+  // #707
+  EFFORT_ROUTE, EFFORT_HARNESSES, effortEnv, effortRouteFor,
 } from '../src/workspace.mjs'
 
 describe('per-agent config dir (#53)', () => {
@@ -1049,5 +1051,41 @@ describe('local-only work and its salvage (#649)', () => {
   test('a clone whose repo curia cannot name has nowhere to push, and says so', async () => {
     fs.writeFileSync(path.join(wt, 'findings.md'), 'six hours of it\n')
     await assert.rejects(() => salvageLocalOnlyWork(wt, null, '42'), /nowhere to push/)
+  })
+})
+
+describe('every harness in the image has a route for its reasoning effort (#707)', () => {
+  // #696 put four commands in the worker image. Each one has to be tellable how
+  // deep to think, or routing's answer stops at the two harnesses that were
+  // here first.
+  test('all four harnesses have a row, and each row states exactly one route', () => {
+    assert.deepEqual([...EFFORT_HARNESSES].sort(), ['claude', 'codex', 'opencode', 'pi'])
+    for (const [harness, route] of Object.entries(EFFORT_ROUTE)) {
+      const stated = ['env', 'config'].filter((k) => route[k])
+      assert.deepEqual(stated.length, 1, `${harness} states ${stated.length} routes`)
+    }
+  })
+
+  test('a harness with no row is named rather than silently left at whatever it defaults to', () => {
+    assert.throws(() => effortRouteFor('gemini'), /no reasoning-effort route for harness "gemini"/)
+  })
+
+  // The environment is written once per container, and a resume builds a
+  // container the same way — so an env route is a route both a spawn and a
+  // resume read. That is why no row is a spawn flag.
+  test('an env-route harness carries the effort as a variable', () => {
+    assert.deepEqual(effortEnv('claude', 'xhigh'), { CLAUDE_CODE_EFFORT: 'xhigh' })
+    assert.deepEqual(effortEnv('opencode', 'high'), { OPENCODE_REASONING_EFFORT: 'high' })
+    assert.deepEqual(effortEnv('pi', 'low'), { PI_REASONING_EFFORT: 'low' })
+  })
+
+  test('a config-route harness carries nothing in the environment', () => {
+    assert.deepEqual(effortEnv('codex', 'high'), {})
+    assert.equal(EFFORT_ROUTE.codex.config, 'model_reasoning_effort')
+  })
+
+  test('an unstated effort writes no variable at all', () => {
+    assert.deepEqual(effortEnv('claude', null), {})
+    assert.deepEqual(effortEnv('claude', undefined), {})
   })
 })


### PR DESCRIPTION
Closes the routing half of [alp82/curia#707](https://github.com/alp82/curia/issues/707). Model defaults and ticket-type overrides now select reasoning effort, and every harness in the image has a route for it.

## What the rule is

A model states the depth it thinks at by default (`models.<x>.reasoning_effort`). A ticket type overrides it (`effort.<type>`, keyed the way `defaults:` is). The two tables answer different questions, so `resolveModel` and `resolveEffort` resolve two facts and neither reads the other's answer — a `model:` label moves the model and leaves the type's depth alone.

A depth holds only where the model has the word for it: its own `efforts` list, else its harness's, else no bound at all. That makes the fallback rule decidable in one place — a chain that crosses to a shorter vocabulary keeps the type's effort where it exists there, and takes the fallback model's own default where it doesn't. Nothing invents an effort, and a `routing.yaml` with no `effort:` table routes exactly as it did before.

## How effort survives spawn and resume

`EFFORT_ROUTE` in `workspace.mjs` carries a row for all four harnesses the image has held since #696, not only the two routing can select today.

**No row is a spawn flag**, and that's the whole reason it's a table rather than an addition to the harness template. A flag lives on the spawn line, and a resume runs a different line (`codex resume --last`, `claude --continue`), so a flag would state the depth of the first turn and nothing a resumed agent inherits. Both routes here are re-stated by every arm:

| harness | route | re-written by |
|---|---|---|
| claude | `CLAUDE_CODE_EFFORT` | the container env file, per spawn and per resume |
| codex | `model_reasoning_effort` in `config.toml` | `writeConnectionSettings`, per arm |
| opencode | `OPENCODE_REASONING_EFFORT` | the container env file |
| pi | `PI_REASONING_EFFORT` | the container env file |

The codex row is the measured one, live since #39. The other three are **not** verified against a running CLI — #696 put the commands in the image and nothing has dispatched on opencode or pi yet. Each unverified row is an environment variable on purpose: a variable a CLI doesn't read is a no-op, so a wrong name there costs the depth rather than the spawn. `config.mjs` refuses a configured harness with no row, so a fifth harness has to answer this before it can boot.

## What else moved

- The dispatcher resolves the depth once per spawn, against the model **actually** spawned, and re-resolves it in `#respawnOn` — so a cross-harness fallback lands on the right rule. The agent record and `agent_spawned` carry `effort` and the routing type.
- The status line's effort meter reads the depth the agent was **dispatched** at, not the model's configured default. Routing's answer today isn't what a running agent was told at its spawn.
- Settings draws the depth beside the model on each ticket-type row. `routing.effort` joins `checkPatch`'s closed set and `LIVE_PATHS`, so an effort change reloads rather than restarts, and `readSettings` also carries the words a picker may offer.
- `config/routing.yaml` states the table and both harness vocabularies, with the reasoning for each depth beside it.

`DASHBOARD_PROTO` goes 7 → 8. The page reads two `/api/settings` fields a proto-7 sidecar doesn't carry, and its save posts `routing.effort`, which that sidecar's closed set refuses by name — a depth picker whose every change is declined at the Save is exactly what the stamp exists to prevent.

## Page contact

Four agents are editing `dashboard.html` in parallel, so this adds one control inside the existing Routing section and touches nothing else: one row primitive extended, two folds (`patchRouting`, `countRouting`), one handler, and the proto stamp. No section was added, reordered, or reflowed.

## Tests

`npm test` in `daemon/`: **3487 pass, 0 fail, 0 cancelled** (baseline on main is 3452). 35 new tests cover the resolution rule, the four harness routes, spawn, cross-harness fallback and respawn, the config table, the save and the live set, the page control, and the meter. Two existing fixtures gained the empty `effort` list the wire now carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
