### PR TITLE
Compose the App setup redirect from curia's own records

### DIFF
--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -874,7 +874,13 @@ export class DashboardSurface {
         return this.#verb(res, async () => {
           const b = await this.#body(req)
           const name = words(b.name, 'a GitHub App name')
-          const redirectUrl = `https://${String(req.headers.host ?? '')}/api/github-app/complete`
+          // The redirect is THIS surface's own address, composed from curia's
+          // own records (#68) rather than from the request headers. GitHub
+          // sends the conversion code back to this URL, so a caller-named
+          // redirect would be a way to send that code somewhere else. The
+          // `Host` header is whatever the caller wrote; `link()` is what
+          // tailscale says this box is.
+          const redirectUrl = new URL('api/github-app/complete', await this.link()).toString()
           return this.#daemon({
             method: 'POST', path: '/github-app/start', body: { name, redirect_url: redirectUrl }, accept: [200, 400],
           })

--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -281,7 +281,16 @@ export class GitHubAppSetup {
     } catch {
       throw new Error('the GitHub App redirect URL is not a URL')
     }
+    // GitHub sends the one-use conversion code back to this URL, so what it
+    // may look like is worth naming. The daemon holds no record of its own
+    // public address - the sidecar composes the URL from curia's own records
+    // (#68), and that is where the host is decided. What this side can still
+    // check is the shape: HTTPS, and none of the parts a redirect for this
+    // flow has no use for. Credentials, a query, or a fragment in a manifest
+    // redirect are all signs the URL came from somewhere other than curia.
     if (redirect.protocol !== 'https:') throw new Error('the GitHub App redirect URL must use HTTPS')
+    if (redirect.username || redirect.password) throw new Error('the GitHub App redirect URL must carry no credentials')
+    if (redirect.search || redirect.hash) throw new Error('the GitHub App redirect URL must carry no query or fragment')
     const state = Buffer.from(this.randomBytes(32)).toString('hex')
     const expires = this.now() + APP_SETUP_TTL_MS
     this.#writeState({ state, expires_at: expires, status: 'pending' })

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -784,6 +784,7 @@ describe('the operator verbs (#266)', () => {
         fetchOverview: async () => ({ daemon: { port: 4271 } }),
         assertServe: async () => {},
         serveOff: async () => {},
+        attachBase: async () => 'box.tail1234.ts.net',
         tailnetSelf: async () => ({ dnsName: 'box.tail1234.ts.net', ips: ['100.98.118.33'] }),
       },
     })
@@ -845,6 +846,9 @@ describe('the operator verbs (#266)', () => {
   test('GitHub App setup keeps conversion inside the daemon', async () => {
     const started = await press('/api/github-app/start', { name: 'curia-box' })
     assert.equal(started.status, 200)
+    // The redirect is composed from curia's own records - `attachBase()` and
+    // the serve port - not from anything the caller sent.
+    assert.equal(await surface.link(), 'https://box.tail1234.ts.net:8445/')
     assert.deepEqual(sent('/github-app/start').body, {
       name: 'curia-box',
       redirect_url: 'https://box.tail1234.ts.net:8445/api/github-app/complete',
@@ -853,6 +857,23 @@ describe('the operator verbs (#266)', () => {
     const completed = await req(surface.port, '/api/github-app/complete?code=one-use&state=expected', { headers: served() })
     assert.equal(completed.status, 303)
     assert.equal(completed.text.includes('PRIVATE KEY'), false)
+  })
+
+  // GitHub sends the one-use conversion code to the redirect URL, so a caller
+  // who could name the redirect could name where that code lands. `Host` is
+  // caller-written text, and it does not move this URL. The first press uses a
+  // name this box does answer to, because that is the one the identity gate
+  // lets through - the gate refuses the rest, which the second press shows.
+  test('a caller-written Host header does not move the setup redirect', async () => {
+    await press('/api/github-app/start', { name: 'curia-box' }, { host: '100.98.118.33:8445' })
+    assert.equal(
+      sent('/github-app/start').body.redirect_url,
+      'https://box.tail1234.ts.net:8445/api/github-app/complete',
+    )
+    calls = []
+    const outside = await press('/api/github-app/start', { name: 'curia-box' }, { host: 'evil.example.com' })
+    assert.equal(outside.status, 403)
+    assert.equal(sent('/github-app/start'), undefined, 'nothing reached the daemon at all')
   })
 
   // The Credentials screen's one press (#661), and the reason that screen


### PR DESCRIPTION
## What this fixes

`/api/github-app/start` in `daemon/src/dashboard.mjs` composed the GitHub App manifest redirect URL from the request's `Host` header:

```js
const redirectUrl = `https://${String(req.headers.host ?? '')}/api/github-app/complete`
```

GitHub sends the one-use manifest conversion code back to that URL. A caller who can name the redirect can name where that code lands, and the code converts into the App's private key.

#694 built the other manifest-setup relay and wrote the boundary down in a comment beside `/api/appsetup/begin`: the redirect is composed from curia's own records, never from anything the browser said, because GitHub sends the conversion code to it. #738 added this second implementation, and the rule didn't come across. `daemon/test/dashboard.test.mjs` then pinned the weaker behavior, because its assertion derived the expected value from the test's own `host` header.

## How bad is it

Not an open door. Two things stand between this and a real code theft:

- The sidecar sits behind the Tailscale identity gate, and `identityRefusal()` checks `Host` against the set of names this box actually answers to. A `Host` of `evil.example.com` is refused with 403 before the route runs.
- Browsers can't set `Host` on a `fetch`.

So what shipped is a defense-in-depth regression: the boundary #694 established stopped being enforced on the route the Settings screen actually calls, and only the identity gate was left holding it. The narrowest thing an admitted caller could still do was swap in one of this box's other served names, such as its tailnet IP, and move the redirect. Worth fixing on its own terms, and worth fixing before the identity gate's host set ever widens.

## The change

- `/api/github-app/start` composes the redirect with `new URL('api/github-app/complete', await this.link())`. `link()` is `attachBase()` plus the serve port, which is what tailscale says this box is. Same source #694's route uses.
- `GitHubAppSetup.start()` in `daemon/src/githubapp.mjs` now also rejects a redirect URL carrying credentials, a query, or a fragment. The daemon holds no record of its own public address, so the host is still the sidecar's call - what this side can verify is the shape, and none of those parts belong in a manifest redirect. I didn't add an allowed-host check there, because verifying it would mean giving that module a tailscale dependency it doesn't have, which is a bigger change than this fix.
- The test that asserted the header-derived value now asserts the records-derived one, and checks `surface.link()` alongside it so the source is visible.
- A new test presses `/api/github-app/start` with a caller-chosen `Host`. The first press uses a name this box does answer to, so it passes the identity gate, and the redirect doesn't move. The second uses an outside name, gets 403, and nothing reaches the daemon.

Nothing else moved. Neither setup implementation was restructured, the dead one is still there, and the Settings UI is untouched.

## Tests

`npm test` in `daemon/`:

- Baseline on `origin/main` (241a525): 3607 passing, 0 failing, 0 cancelled.
- This branch: 3608 passing, 0 failing, 0 cancelled. The one added test is the hostile-`Host` case.

## Filed, not fixed

Two things I found while reading this, both now sub-issues of #685:

- #764 - two GitHub App setup stacks ship side by side, and the #694 one is unreachable from any UI. This bug is what having two of them costs.
- #765 - the aistack sync runs twice on two clocks, and the #738 copy's status is unjournalled, so a registered box reports itself unregistered after every daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVfowZpiXbropy8XjKb7t5
