### PR TITLE
Answer the same typed card from Atlas or Discord (alp82/curia#712)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -473,7 +473,16 @@ A builder idle inside its own `request_review` or `report_result` call while a c
 The message curia queues at the builder the moment a reviewer spawns. It names the reviewer and holds the ending: no resolve, no merge and no `report_result` until the verdict lands. A cross-check pressed at the gate sends none, because the builder is already parked.
 
 **First-valid-wins**:
-The answer rule. The first valid answer closes the escalation atomically. Any device may answer. Later answers get a refusal.
+The answer rule. The first valid answer closes the escalation atomically. Any device may answer. Later answers get a refusal that carries the first **Answer receipt**, so the surface that lost the race shows the mark and never a second question (#712).
+
+**Answer receipt**:
+The one mark an answered card carries on every surface: who answered, on which surface, when, and the answer's own words. The Discord card edits it on, the Chat room and Home read it from the record, and a second answer gets it back in place of an error. See [ADR-0025](docs/adr/0025-the-cards-under-the-one-voice.md) and [#712](https://github.com/alp82/curia/issues/712).
+
+**Option band**:
+Which control a choice card earns from its option count, the same on Discord and Atlas: two to four options are buttons that say the marker and the per-option handle, five to 25 are one select, and past 25 the numbered list stays and a reply names a marker. Every control sends the option index, and the daemon resolves the index to the option's own words, so a typed reply, a Discord press and an Atlas tap record one answer. The card body keeps every consequence. See [ADR-0025](docs/adr/0025-the-cards-under-the-one-voice.md) and [#712](https://github.com/alp82/curia/issues/712).
+
+**Reply files**:
+The files an answer carries. Every card names the path they land in, `data/attachments/<escalation id>/`, whether the reply came from a Discord thread or a browser. A browser reply sends them inline through the sidecar, the daemon writes them under the bridge's own naming, and the paths ride the answer as the agent's readable form. See [#712](https://github.com/alp82/curia/issues/712).
 
 **Supersede**:
 A re-asked question closes the older record and routes late answers to the live one. The key is the agent and the kind, never the wording (#336). A re-send that explains itself in its own words is the same call, so it closes the original at birth. A confirm keys on the target instance instead. It reaches OPEN records only, so a question that is already answered is handled by the recorded answer (#369).

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -38,7 +38,7 @@
      2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
         nobody has computed is not an empty frontier. Every section that can fail
         on its own says which of the two it is. -->
-<meta name="curia-dashboard" content="proto=13">
+<meta name="curia-dashboard" content="proto=14">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark light">
 <title>Atlas · Curia</title>
@@ -694,6 +694,9 @@
   .chat-esc .q { white-space: pre-wrap; }
   .chat-esc .meta { color: var(--ink-dim); font-size: 12px; }
   .chat-esc .ans { white-space: pre-wrap; border-top: 1px solid var(--line); margin-top: 5px; padding-top: 5px; }
+  .opts.numbered { margin: 4px 0 0 18px; padding: 0; font-size: 12.5px; }
+  .act-row.files input[type=file] { font-size: 12px; max-width: 100%; }
+  .act-row select { font: inherit; font-size: 12.5px; max-width: 100%; }
   .chat-dialog { border: 1px solid var(--warn); border-radius: 9px; padding: 7px 10px; margin: 0 0 8px; font-size: 13px; }
   .chat-dialog.card { border-color: var(--line); background: var(--bg-raise); }
   .chat-dialog .dialog-kind { color: var(--ink-dim); font-size: 11.5px; font-weight: 600; }
@@ -924,11 +927,13 @@ async function verb(key, path, body) {
       body: JSON.stringify(body),
     });
     const b = await res.json().catch(() => ({}));
-    if (!res.ok) throw new Error(b.error || ("the console answered " + res.status));
+    if (!res.ok) throw Object.assign(new Error(b.error || ("the console answered " + res.status)), { receipt: b.receipt ?? null });
     out = b;
     UI.act.said = { key, text: outcome(b), ok: b.ok !== false };
   } catch (e) {
-    UI.act.said = { key, text: e.message, ok: false };
+    /* A second answer shows the first receipt (#712, ADR-0025): the same
+       mark the card carries, in place of a second question or an error. */
+    UI.act.said = { key, text: e.receipt ? receiptLine(e.receipt) : e.message, ok: false };
   }
   UI.act.busy = null;
   render();
@@ -938,6 +943,13 @@ async function verb(key, path, body) {
 function refuse(key, text) {
   UI.act.said = { key, text, ok: false };
   render();
+}
+
+/* The one receipt, in the words the Discord mark uses (ADR-0025). */
+function receiptLine(x) {
+  const via = x.via ? ` via ${x.via}` : "";
+  const at = x.at ? ` ${clock(x.at)}` : "";
+  return `✅ answered by ${x.by ?? "someone"}${via}${at}: ${x.answer ?? ""}`;
 }
 
 function outcome(b) {
@@ -975,12 +987,74 @@ function typed(id) {
 /* ---- the verbs themselves ---- */
 
 const startTicket = (repo, ticket) => verb(`start:${repo}#${ticket}`, "/api/start", { repo, ticket: String(ticket) });
-const answerEsc = (id, answer) => verb("esc:" + id, "/api/answer", { id, answer });
+/* One answer, three shapes (#712, ADR-0025): words, an option index, or
+   files. The index is what a button, a select and a numbered reply all send,
+   so a Discord press and an Atlas tap resolve the same option. Files ride the
+   answer inline, and the daemon writes them where the card said they land. */
+async function answerEsc(id, body) {
+  if (anyBusy()) return null;
+  const answer = typeof body === "string" ? { answer: body } : { ...body };
+  try {
+    answer.files = await replyFilesOf("files-" + id);
+  } catch (e) {
+    return refuse("esc:" + id, e.message);
+  }
+  return verb("esc:" + id, "/api/answer", { id, ...answer });
+}
+function answerIndex(id, index) { return answerEsc(id, { index: Number(index) }); }
+function answerSelect(id, field) {
+  const el = document.getElementById(field);
+  const v = el ? String(el.value ?? "") : "";
+  if (!/^\d+$/.test(v)) return refuse("esc:" + id, "Pick an option first.");
+  answerIndex(id, Number(v));
+}
 
-function answerTyped(id, field) {
+/* The marker every surface prints beside an option (card.mjs marker): a typed
+   card marks with letters, and an untyped card counts. A reply of one marker
+   resolves to the index, so `B` and `2` answer the same way here as in a
+   Discord thread. */
+const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const optMarker = (r, i) => (r.typed && i < LETTERS.length ? LETTERS[i] : String(i + 1));
+function markerIndex(r, text) {
+  if (r.kind !== "choice" || !r.options?.length) return null;
+  const t = String(text).trim();
+  if (/^\d+$/.test(t) && r.options[Number(t) - 1] !== undefined) return Number(t) - 1;
+  if (r.typed && /^[a-z]$/i.test(t)) {
+    const i = LETTERS.indexOf(t.toUpperCase());
+    return r.options[i] !== undefined ? i : null;
+  }
+  return null;
+}
+
+/* The files a reply carries, read from the card's own input as base64. The
+   size cap is the daemon's, said here before the upload rather than after. */
+const MAX_REPLY_FILE_BYTES = 8 * 1024 * 1024;
+function replyFilesOf(field) {
+  const el = document.getElementById(field);
+  const list = el && el.files ? [...el.files] : [];
+  if (!list.length) return Promise.resolve([]);
+  const total = list.reduce((n, f) => n + f.size, 0);
+  if (total > MAX_REPLY_FILE_BYTES) return Promise.reject(new Error(`A reply carries at most ${MAX_REPLY_FILE_BYTES / 1048576} MB of files.`));
+  return Promise.all(list.map((f) => new Promise((ok, no) => {
+    const rd = new FileReader();
+    rd.onload = () => ok({ name: f.name, data: String(rd.result).replace(/^data:[^,]*,/, "") });
+    rd.onerror = () => no(new Error(`Could not read ${f.name}.`));
+    rd.readAsDataURL(f);
+  })));
+}
+
+function answerTyped(id, field, r) {
   const v = typed(field);
   if (!v) return refuse("esc:" + id, "Type the answer first — an empty reply answers nothing.");
+  const i = r ? markerIndex(r, v) : null;
+  if (i !== null) return answerIndex(id, i);
   answerEsc(id, v);
+}
+/* The record the typed answer resolves its marker against: the open list on
+   Home, or the Chat room's own open list. */
+function escRecord(id) {
+  const home = (payload?.overview?.escalations ?? []).find((r) => r.id === id);
+  return home ?? (chat.open ?? []).find((r) => r.id === id) ?? null;
 }
 /* A rejection IS feedback (#48): the agent gets the operator's own words and
    fixes what they name. So an empty one is refused here rather than sent as a
@@ -1314,9 +1388,43 @@ function answerButtons(r) {
     b.push(btn("✅ Approve", APPROVE, "primary"), btn("❌ Reject", REJECT, "danger"));
   }
   if (r.kind === "confirm") b.push(btn("✅ Approve", APPROVE, "danger"), btn("❌ Decline", REJECT));
-  if (r.kind === "choice") for (const [i, o] of (r.options ?? []).entries()) b.push(btn(snip(r.option_handles?.[i] || o, 80), o));
   if (r.kind === "free-text" && r.recommended) b.push(btn("✅ All as recommended", ALL_AS_RECOMMENDED, "primary"));
-  return b.length ? `<div class="act-row">${b.join("")}</div>` : "";
+  const rows = [];
+  if (b.length) rows.push(`<div class="act-row">${b.join("")}</div>`);
+  if (r.kind === "choice") rows.push(choiceControls(r));
+  return rows.join("");
+}
+
+/* The option bands (ADR-0025): two to four options are buttons, five to 25 are
+   one select, and past 25 the numbered list stays and a reply names a number.
+   Every control sends the INDEX, and the button says the marker and the
+   handle while the card body keeps the consequence. */
+const MAX_BUTTON_OPTIONS = 4, MAX_SELECT_OPTIONS = 25;
+function choiceControls(r) {
+  const opts = r.options ?? [];
+  if (!opts.length) return "";
+  const handle = (i) => r.option_handles?.[i] || opts[i];
+  const label = (i) => `${optMarker(r, i)} · ${snip(handle(i), 80)}`;
+  if (opts.length <= MAX_BUTTON_OPTIONS) {
+    return `<div class="act-row">${opts.map((_, i) => `<button class="btn sm" ${anyBusy() ? "disabled" : ""}
+      onclick="answerIndex('${js(r.id)}',${i})">${esc(label(i))}</button>`).join("")}</div>`;
+  }
+  if (opts.length <= MAX_SELECT_OPTIONS) {
+    const id = "sel-" + r.id;
+    return `<div class="act-row"><select id="${esc(id)}" ${anyBusy() ? "disabled" : ""}>
+      <option value="">pick one…</option>${opts.map((_, i) => `<option value="${i}">${esc(label(i))}</option>`).join("")}</select>
+      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerSelect('${js(r.id)}','${js(id)}')">Answer</button></div>`;
+  }
+  return `<ol class="opts numbered">${opts.map((o, i) => `<li><b>${esc(optMarker(r, i))}.</b> ${esc(snip(handle(i), 120))}</li>`).join("")}</ol>
+    <div class="dim">Reply with ${r.typed ? "a letter or " : ""}a number.</div>`;
+}
+
+/* Every card names the file path (ADR-0025): a reply may carry files, and
+   this line says where they land. */
+function replyFilesRow(r) {
+  const where = r.files_dir ? ` They land under <code>${esc(r.files_dir)}/</code> and reach the agent as paths.` : "";
+  return `<div class="act-row files"><input type="file" id="files-${esc(r.id)}" multiple ${anyBusy() ? "disabled" : ""}>
+    <span class="dim">A reply may carry files.${where}</span></div>`;
 }
 
 /* Free-form, on every kind. A choice can be answered in words the options do
@@ -1326,8 +1434,8 @@ function answerField(r) {
   const id = "ans-" + r.id;
   return `<div class="act-row">
     <input type="text" id="${esc(id)}" placeholder="answer in your own words…" ${anyBusy() ? "disabled" : ""}>
-    <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}')">Answer</button>
-  </div>`;
+    <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}',escRecord('${js(r.id)}'))">Answer</button>
+  </div>${replyFilesRow(r)}`;
 }
 
 function escCard(r) {
@@ -3498,13 +3606,15 @@ function chatRoom(p) {
     </div>`;
 }
 
+/* The open question is the same typed card Home and Discord draw (#712,
+   ADR-0025): one payload, the same markers, and the answer controls in the
+   room. The composer below still queues a message; the card answers. */
 function chatOpenEscalation(r) {
   const bits = [`since ${clock(r.opened_at)}`];
-  if (r.options?.length) bits.push(`options: ${r.options.join(" | ")}`);
   if (r.preview_url) bits.push(r.preview_url);
-  bits.push("answer it on Home or in Discord — the composer below queues a message, it does not answer this");
   return `<div class="chat-esc"><div class="kind">⏳ waiting on you — ${esc(r.kind)} (${esc(r.id)})</div>
-    <div class="q">${esc(r.prompt ?? "")}</div><div class="meta">${esc(bits.join(" · "))}</div></div>`;
+    <div class="q">${esc(r.prompt ?? "")}</div><div class="meta">${esc(bits.join(" · "))}</div>
+    ${answerButtons(r)}${answerField(r)}${said("esc:" + r.id)}</div>`;
 }
 
 /* The transcript items and the daemon's own escalation record, interleaved by
@@ -3551,9 +3661,7 @@ function chatHistoryCard(r) {
   const options = r.options?.length ? `<div class="meta">options: ${esc(r.options.join(" | "))}</div>` : "";
   let ans;
   if (r.status === "answered") {
-    const who = r.answered_by ? ` by ${r.answered_by}` : "";
-    const via = r.answered_via ? ` (${r.answered_via})` : "";
-    ans = `<div class="ans">✔ answered${esc(who)}${esc(via)} ${clock(r.closed_at)}: ${esc(r.answer ?? "")}</div>`;
+    ans = `<div class="ans">${esc(receiptLine({ by: r.answered_by, via: r.answered_via, at: r.closed_at, answer: r.answer }))}</div>`;
   } else if (r.status === "open") {
     ans = `<div class="meta">waiting on you</div>`;
   } else {

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -1271,6 +1271,11 @@ export class DiscordBridge {
     return rows
   }
 
+  // The path a reply file lands in, as one small-print line (#712).
+  #replyFilesLine(record) {
+    return smallPrint(`A reply here may carry files. They land under \`${path.join(this.dataDir, 'attachments', record.id)}/\` and reach the agent as paths.`)
+  }
+
   #escalationBody(record, files = []) {
     if (record.kind === CONFIRM_KIND) {
       // Every confirm but one is about a live agent and lapses with it. The
@@ -1295,6 +1300,7 @@ export class DiscordBridge {
         '',
         '_✅ Approve to merge and resolve. A reply is a rejection, and I take your words as the change list._',
         '_🔎 Cross-check answers neither. It starts a reviewer on the other provider, and I wait for its verdict._',
+        this.#replyFilesLine(record),
         `-# ${record.id}`,
       ].join('\n')
     }
@@ -1344,6 +1350,11 @@ export class DiscordBridge {
     } else if (record.kind === 'preview-review') {
       parts.push(`Preview: ${record.preview_url}`, '_Approve/Reject, or reply in this thread with comments._')
     }
+    // Every card names the file path (#712, ADR-0025): one small-print line
+    // says a reply may carry files, and where they land. The directory is the
+    // one `#downloadAttachments` writes and the one a browser reply writes, so
+    // the agent reads one shape whichever surface answered.
+    parts.push(this.#replyFilesLine(record))
     // A flagged send (#416, ADR-0005): the agent used up its three rejections
     // and curia sent the text as it stands. The operator sees which rule it
     // broke, beside the text that broke it — a flagged question still reaches
@@ -1800,7 +1811,13 @@ export class DiscordBridge {
           }).catch(() => {})
         }
       } else {
-        await i.reply({ content: `⚠️ not open — ${result.reason}${result.record?.answer ? ` (answer was \`${result.record.answer}\`)` : ''}`, ephemeral: true })
+        // A second press shows the first receipt (#712, ADR-0025): the same
+        // mark the card carries, and no second journal answer behind it.
+        const r = result.record
+        const receipt = result.reason === 'answered' && r
+          ? `✅ **answered** by <@${r.answered_by}> via ${r.answered_via}: \`${String(r.answer ?? '').slice(0, 200)}\``
+          : `⚠️ not open — ${result.reason}${r?.answer ? ` (answer was \`${r.answer}\`)` : ''}`
+        await i.reply({ content: receipt, ephemeral: true })
       }
     }
   }

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -85,7 +85,7 @@ export const daemonPort = () => Number(process.env.PORT ?? DEFAULT_DAEMON_PORT)
 // the `#chat/<session>` route, the page reads the six timeline routes through
 // this sidecar, and it draws an ended agent from the `live` field of
 // `/api/console`, which a proto-12 daemon does not carry.
-export const DASHBOARD_PROTO = 13
+export const DASHBOARD_PROTO = 14
 
 // The Credentials screen's own hash (#661). It is here rather than in the
 // daemon that links to it, because the page's screen names are this file's half
@@ -241,6 +241,9 @@ export const DIFF_TIMEOUT_MS = 30_000
 // The biggest settings patch this surface will read. The screen writes a watch
 // list and a handful of numbers, so anything near this is not a settings save.
 export const MAX_BODY = 256 * 1024
+// An answer may carry files inline as base64 (#712): 8 MB of files is about
+// 11 MB on the wire, and the daemon caps the decoded bytes at 8 MB.
+export const MAX_ANSWER_BODY = 12 * 1024 * 1024
 
 // What the page may name on a verb route (#266).
 //
@@ -313,6 +316,16 @@ function field(value, re, what) {
   if (!re.test(s)) throw refuse(`"${s}" is not ${what}`)
   return s
 }
+// A reply's files, as the page sends them (#712): `{name, data}` with base64
+// data. The names are the operator's own and the daemon makes them safe; this
+// surface only keeps the shape honest and the count small.
+const MAX_REPLY_FILES = 10
+function replyFiles(value) {
+  if (!Array.isArray(value)) return []
+  if (value.length > MAX_REPLY_FILES) throw refuse(`a reply carries at most ${MAX_REPLY_FILES} files`)
+  return value.map((f) => ({ name: String(f?.name ?? ''), data: String(f?.data ?? '') }))
+}
+
 function words(value, what) {
   const s = String(value ?? '').trim()
   if (!s) throw refuse(`${what} with no words is not ${what}`)
@@ -615,15 +628,15 @@ export class DashboardSurface {
 
   // A JSON body, bounded. `readBody` on the daemon side is the same shape; this
   // one is separate because the sidecar imports no daemon internals.
-  #body(req) {
+  #body(req, limit = MAX_BODY) {
     return new Promise((resolve, reject) => {
       const chunks = []
       let size = 0
       req.on('data', (c) => {
         size += c.length
-        if (size > MAX_BODY) {
+        if (size > limit) {
           req.destroy()
-          return reject(new Error(`a settings save may not exceed ${MAX_BODY} bytes`))
+          return reject(new Error(`a ${limit === MAX_BODY ? 'settings save' : 'reply with files'} may not exceed ${limit} bytes`))
         }
         chunks.push(c)
       })
@@ -651,7 +664,7 @@ export class DashboardSurface {
       (e) => {
         if (e?.refusal) {
           this.log(`dashboard: the save was refused — ${e.message}`)
-          return this.#json(res, 409, { error: e.message, refused: true })
+          return this.#json(res, 409, { error: e.message, refused: true, ...(e.receipt ? { receipt: e.receipt } : {}) })
         }
         this.log(`dashboard: the save failed — ${e.message}`)
         return this.#json(res, 500, { error: e.message })
@@ -965,13 +978,23 @@ export class DashboardSurface {
       // reason, and the page says which.
       if (url.pathname === '/api/answer') {
         return this.#verb(res, async () => {
-          const b = await this.#body(req)
+          const b = await this.#body(req, MAX_ANSWER_BODY)
           const id = field(b.id, VERB_ESC_RE, 'an escalation id')
-          const answer = words(b.answer, 'an answer')
+          // An answer is words, an option index, or files (#712): a button and
+          // a select send the index every surface shares, a numbered reply
+          // sends words the page resolved, and a reply may carry files as
+          // inline base64. Any one of the three is an answer.
+          const index = Number.isInteger(b.index) && b.index >= 0 ? b.index : null
+          const files = replyFiles(b.files)
+          const answer = index === null && !files.length ? words(b.answer, 'an answer') : String(b.answer ?? '').trim().slice(0, MAX_WORDS)
           const out = await this.#daemon({
-            method: 'POST', path: '/answer', body: { id, answer, by, via: 'dashboard' }, accept: [200, 409],
+            method: 'POST', path: '/answer', body: { id, answer, index, files, by, via: 'dashboard' }, accept: [200, 400, 409],
           })
-          if (out.ok === false) throw refuse(ANSWER_REFUSAL[out.reason] ?? `that question is ${out.reason}`)
+          if (out.ok === false) {
+            // The first receipt rides the refusal, so the page shows the mark
+            // rather than an error (#712, ADR-0025).
+            throw Object.assign(refuse(out.error ?? ANSWER_REFUSAL[out.reason] ?? `that question is ${out.reason}`), { receipt: out.receipt ?? null })
+          }
           return out
         })
       }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -34,7 +34,7 @@ import { DiscordBridge } from './bridge.mjs'
 import { installCrashGuard } from './health.mjs'
 import { sayGoodbye, questionGoodbye, deathWasSilent, DAEMON_BOOT } from './goodbye.mjs'
 import { readable } from './logline.mjs'
-import { resolveOutboundFiles, inboundContent, ALLOWED_EXTENSIONS } from './attachments.mjs'
+import { resolveOutboundFiles, inboundContent, ALLOWED_EXTENSIONS, safeLeaf } from './attachments.mjs'
 import { PreviewRegistry } from './preview.mjs'
 import { loadCuriaConfig, loadRoutingConfig, overrideSummary } from './config.mjs'
 import { PROBE_MARK, PROBE_PATH, GUEST_DAEMON_HOST, GUEST_WT, dockerGateway, probeSideChannel } from './sandbox.mjs'
@@ -72,7 +72,7 @@ import {
 import { probeOverseer } from './overseerservice.mjs'
 import { replayKilledTurns, replayLine } from './overseerreplay.mjs'
 import { LIVE_PATHS, DISPATCH_KEYS, liveSettings, liveDiff, frozenDifference } from './settings.mjs'
-import { TimelineSurface } from './timeline.mjs'
+import { TimelineSurface, cardFields } from './timeline.mjs'
 import { identityRefusal, hostsForPorts, tailnetSelf } from './identity.mjs'
 import { detectHarness, findTranscript } from './transcript.mjs'
 import { promptTitle, elapsedLabel, speakerName, smallPrint, handOffLine } from './messaging.mjs'
@@ -130,6 +130,52 @@ const PORT = Number(process.env.PORT ?? 4271)
 // CURIA_DATA_DIR mirrors CURIA_CONFIG_DIR: the boot test points both at a
 // fixture dir so a test run never writes into the real journal.
 const DATA = process.env.CURIA_DATA_DIR ?? path.join(ROOT, 'data')
+
+// Where a reply file lands, per question (#712, ADR-0025). The Discord bridge
+// has written downloaded thread attachments here since #34; a browser answer
+// writes the same directory, so every card names one path and the agent reads
+// one shape. Named on the card, so the path is a fact the operator can see.
+// The one receipt (#712, ADR-0025): the same four facts the card's mark, the
+// Chat room and the record read, so every surface says one sentence.
+const answerReceipt = (record) => ({
+  by: record.answered_by ?? null, via: record.answered_via ?? null,
+  at: record.closed_at ?? null, answer: record.answer ?? null,
+})
+
+const replyFilesDir = (id) => path.join(DATA, 'attachments', String(id))
+
+// A browser reply's files, sent inline as base64 (#712). They are written under
+// the question's own directory with the bridge's naming, and a file whose type
+// curia would refuse on the way out is refused on the way in, by name. The cap
+// is per answer, and it is generous for a screenshot and mean for a tarball.
+const MAX_REPLY_FILE_BYTES = 8 * 1024 * 1024
+function writeReplyFiles(id, files) {
+  const paths = []
+  const refusals = []
+  if (!Array.isArray(files) || !files.length) return { paths, refusals }
+  const dir = replyFilesDir(id)
+  let total = 0
+  let n = 0
+  for (const file of files) {
+    const leaf = safeLeaf(file?.name, 'reply')
+    const ext = path.extname(leaf).toLowerCase()
+    if (!ALLOWED_EXTENSIONS.includes(ext)) {
+      refusals.push(`${leaf}: refused — curia cannot take that file type (allowed: ${ALLOWED_EXTENSIONS.join(', ')})`)
+      continue
+    }
+    const bytes = Buffer.from(String(file?.data ?? ''), 'base64')
+    total += bytes.length
+    if (!bytes.length || total > MAX_REPLY_FILE_BYTES) {
+      refusals.push(`${leaf}: refused — ${bytes.length ? `a reply carries at most ${MAX_REPLY_FILE_BYTES / 1048576} MB of files` : 'the file is empty'}`)
+      continue
+    }
+    fs.mkdirSync(dir, { recursive: true })
+    const dest = path.join(dir, `${leaf.slice(0, leaf.length - ext.length)}-${++n}${ext}`)
+    fs.writeFileSync(dest, bytes)
+    paths.push(dest)
+  }
+  return { paths, refusals }
+}
 // The command channel. The bridge opens it; the dispatcher names it, because a
 // confirm typed outside any thread renders there (#218).
 const CHANNEL = process.env.CURIA_CHANNEL ?? 'curia'
@@ -1536,6 +1582,7 @@ const timeline = new TimelineSurface({
     composerFor: (harness) => routingConfig.harnesses[harness]?.readyRe ?? null,
     escalationsFor: (session) => reduction.openEscalations().filter((r) => r.agent === session),
     escalationHistoryFor: (session) => reduction.escalationsForAgent(session),
+    filesDirFor: replyFilesDir,
     landingFor: (session) => reduction.transcriptLanding(session),
     takeBack: (request) => conversationRuntime.takeBack(request),
     correct: (request) => conversationRuntime.correct(request),
@@ -2431,14 +2478,13 @@ const wireEscalation = (r) => ({
   kind: r.kind,
   prompt: r.prompt,
   options: r.options ?? null,
-  option_handles: r.payload?.options?.map((option, index) => String(option?.handle ?? r.options?.[index] ?? '')) ?? null,
+  ...cardFields(r, { filesDirFor: replyFilesDir }),
   preview_url: r.preview_url ?? null,
   // #266: the console draws the same buttons the Discord card draws, so it
   // needs the one field that decides whether a free-text round carries the ✅
   // All as recommended tap (#285). Without it the console would offer a
   // recommended round a plain text box, and the operator would have to type
   // the fixed word the button sends.
-  recommended: Boolean(r.recommended),
   opened_at: r.opened_at,
   agent_died: Boolean(r.agent_died),
   rendered: Boolean(r.discord),
@@ -3079,11 +3125,24 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   }
 
   if (url.pathname === '/answer' && req.method === 'POST') {
-    const { id, answer, attachments, by, via } = await readBody(req)
+    const body = await readBody(req)
+    const { id, attachments, by, via, index, files: inline } = body
+    let answer = String(body.answer ?? '')
+    // An option index is the same answer a Discord button sends (#712,
+    // ADR-0025): every surface resolves a pick to the option's own words, so
+    // the record and the agent read one text whichever control was pressed.
+    const live = reduction.resolveLive(String(id ?? '')).record
+    const picked = Number.isInteger(index) ? live?.options?.[index] : undefined
+    if (picked !== undefined) answer = String(picked)
+    // A browser reply's files (#712) are written first, then walk the same
+    // containment gate the bridge's downloads walk, so one path reads them.
+    const written = live?.status === 'open' ? writeReplyFiles(live.id, inline) : { paths: [], refusals: [] }
+    if (written.refusals.length) return json(400, { ok: false, reason: 'files', error: written.refusals.join('; ') })
     // Attachment paths get read and inlined into an agent's context, so they
     // pass the same containment gate as outbound attachments rather than being
     // trusted because the caller reached loopback.
-    const { files } = outboundFiles('rest', attachments)
+    const { files } = outboundFiles('rest', [...(attachments ?? []), ...written.paths])
+    if (written.paths.length) answer = [answer, ...written.paths.map((p) => `[attachment: ${p}]`)].filter(Boolean).join('\n')
     // #266: the console names the operator who pressed and the surface they
     // pressed on, so the journal and the feed say `answered by <login> via
     // dashboard` rather than attributing every browser answer to `rest`. The
@@ -3091,6 +3150,10 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
     const result = gate.answer(id, {
       answer: String(answer), attachments: files.map((f) => f.attachment), by: named(by), via: named(via),
     })
+    // A second answer gets the first receipt (#712, ADR-0025): the refusal
+    // carries who answered, where, when and what, so the surface that lost the
+    // race shows the mark and never a second question. Nothing is journalled.
+    if (!result.ok && result.record?.status === 'answered') result.receipt = answerReceipt(result.record)
     return json(result.ok ? 200 : 409, result)
   }
 

--- a/daemon/src/send.mjs
+++ b/daemon/src/send.mjs
@@ -245,6 +245,7 @@ export const messageSchema = z.object({
   })).optional().describe('round only: one entry per question. Curia numbers them.'),
   options: z.array(z.object({
     label: z.string().optional().describe('The choice, by its name. One line, 80 characters.'),
+    handle: z.string().optional().describe('Short button text. One line, 20 characters. The card body keeps the full label and consequence.'),
     consequence: z.string().optional().describe('What picking this option costs. One line, 300 characters.'),
     example: z.string().optional().describe('One concrete case for this option. Block prose, 300 characters.'),
     recommended: z.boolean().optional(),

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -48,6 +48,20 @@ import { detectHarness, findTranscript, transcriptForSession, readActiveTranscri
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 
+// The card fields every answer surface renders from one payload (#712,
+// ADR-0025): the per-option handle for a short control, whether the card is
+// typed (letters mark its options; an untyped card counts), whether a round
+// carries the one ✅ tap, and the directory a reply file lands in. The wire on
+// Home carries the same four, composed by index.mjs.
+export function cardFields(r, deps = {}) {
+  return {
+    option_handles: r.payload?.options?.map((option, index) => String(option?.handle ?? r.options?.[index] ?? '')) ?? null,
+    typed: Boolean(r.payload),
+    recommended: Boolean(r.recommended),
+    files_dir: deps.filesDirFor?.(r.id) ?? null,
+  }
+}
+
 export const DEFAULT_TIMELINE_INDEX = path.resolve(DIR, '..', 'assets', 'timeline.html')
 
 // The page and this server are two halves of one protocol (SSE event names,
@@ -553,8 +567,12 @@ export class TimelineSurface {
   // supersede and nudge all just change the snapshot.
   #pumpEscalations(name) {
     const s = this.#state(name)
+    // The typed-card fields ride here too (#712): the Chat room draws the
+    // same card Home and Discord draw, so it needs the handles, whether the
+    // markers are letters, the round's one tap, and where a reply file lands.
     const open = this.deps.escalationsFor(name).map((r) => ({
       id: r.id, kind: r.kind, prompt: r.prompt, options: r.options ?? null,
+      ...cardFields(r, this.deps),
       preview_url: r.preview_url ?? null, opened_at: r.opened_at, nudges: r.nudges,
     }))
     const snapshot = JSON.stringify(open)
@@ -568,6 +586,7 @@ export class TimelineSurface {
     // the transcript's tool line is a clipped brief on both harnesses.
     const history = this.deps.escalationHistoryFor(name).map((r) => ({
       id: r.id, kind: r.kind, prompt: r.prompt, options: r.options ?? null,
+      ...cardFields(r, this.deps),
       preview_url: r.preview_url ?? null, opened_at: r.opened_at,
       closed_at: r.closed_at ?? null, status: r.status,
       answer: r.answer ?? null, answered_by: r.answered_by ?? null,

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -1157,6 +1157,42 @@ describe('the operator verbs (#266)', () => {
     }
   })
 
+  test('an index and files ride to the daemon as they are, and words are not owed beside them (#712)', async () => {
+    const res = await press('/api/answer', { id: 'esc-7', index: 1, files: [{ name: 'shot.png', data: 'cG5n' }] })
+    assert.equal(res.status, 200)
+    const body = sent('/answer').body
+    assert.equal(body.index, 1)
+    assert.equal(body.answer, '')
+    assert.deepEqual(body.files, [{ name: 'shot.png', data: 'cG5n' }])
+    calls = []
+    await press('/api/answer', { id: 'esc-7', answer: 'B', index: 'x' })
+    assert.equal(sent('/answer').body.index, null, 'a shape that is no index is no index')
+    assert.deepEqual(sent('/answer').body.files, [])
+  })
+
+  test('a reply of more than ten files is refused before the daemon is asked', async () => {
+    const res = await press('/api/answer', { id: 'esc-7', files: Array.from({ length: 11 }, (_, i) => ({ name: `f${i}.txt`, data: 'eA==' })) })
+    assert.equal(res.status, 409)
+    assert.match(JSON.parse(res.text).error, /at most 10 files/)
+    assert.deepEqual(calls, [])
+  })
+
+  test('a second answer carries the first receipt back to the page (#712)', async () => {
+    reply['/answer'] = [409, { ok: false, reason: 'answered', receipt: { by: 'alp', via: 'button', at: 'T', answer: 'Preview' } }]
+    const res = await press('/api/answer', { id: 'esc-7', answer: 'Stable' })
+    assert.equal(res.status, 409)
+    const body = JSON.parse(res.text)
+    assert.equal(body.refused, true)
+    assert.deepEqual(body.receipt, { by: 'alp', via: 'button', at: 'T', answer: 'Preview' })
+  })
+
+  test('a file refusal from the daemon reads as the daemon wrote it', async () => {
+    reply['/answer'] = [400, { ok: false, reason: 'files', error: 'tool.exe: refused — curia cannot take that file type' }]
+    const res = await press('/api/answer', { id: 'esc-7', answer: 'x', files: [{ name: 'tool.exe', data: 'TVo=' }] })
+    assert.equal(res.status, 409)
+    assert.match(JSON.parse(res.text).error, /tool\.exe: refused/)
+  })
+
   test('a reason nobody wrote a sentence for still reads, rather than rendering blank', async () => {
     reply['/answer'] = [409, { ok: false, reason: 'something-new' }]
     assert.match(JSON.parse((await press('/api/answer', { id: 'esc-7', answer: 'x' })).text).error, /something-new/)

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2038,27 +2038,107 @@ describe('the operator verbs (#266)', () => {
   // ---- answer --------------------------------------------------------------
 
   describe('an answer, on the one answer surface', () => {
-    test('a choice offers its own options, and the button sends the option verbatim', () => {
+    test('a choice offers its own options, and the button sends the option INDEX every surface shares (#712)', () => {
       const html = page.screenHome(payload())
-      assert.match(html, /answerEsc\('esc-7','Drop the older note'\)/)
-      assert.match(html, /answerEsc\('esc-7','Post both with stamps'\)/)
+      assert.match(html, /answerIndex\('esc-7',0\)/)
+      assert.match(html, /answerIndex\('esc-7',1\)/)
+      assert.match(text(html), /1 · Drop the older note/, 'an untyped card counts its options')
+      assert.match(text(html), /2 · Post both with stamps/)
+    })
+
+    // The typed card (#712, ADR-0025): the button says the letter and the
+    // handle, the body keeps the consequence, and the band picks the control.
+    describe('the typed card, one payload on every surface (#712)', () => {
+      const typedCard = (n, { handles = true } = {}) => {
+        const p = payload()
+        const options = Array.from({ length: n }, (_, i) => `Option ${i + 1}, with its whole consequence spelled out`)
+        Object.assign(p.overview.escalations[0], {
+          typed: true, options,
+          option_handles: handles ? options.map((_, i) => `opt${i + 1}`) : null,
+          files_dir: '/box/data/attachments/esc-7',
+        })
+        return p
+      }
+
+      test('two to four options are buttons that say the letter and the handle', () => {
+        const html = page.screenHome(typedCard(3))
+        assert.match(html, /answerIndex\('esc-7',2\)/)
+        assert.match(text(html), /A · opt1/)
+        assert.match(text(html), /C · opt3/)
+        assert.doesNotMatch(html, /<select id="sel-esc-7"/)
+        assert.doesNotMatch(text(html), /whole consequence spelled out/, 'the button never repeats the body')
+      })
+
+      test('five to 25 options are one select, and its Answer sends the picked index', () => {
+        const html = page.screenHome(typedCard(5))
+        assert.match(html, /<select id="sel-esc-7"/)
+        assert.match(html, /<option value="4">E · opt5<\/option>/)
+        assert.match(html, /answerSelect\('esc-7','sel-esc-7'\)/)
+        assert.doesNotMatch(html, /answerIndex\('esc-7',0\)/, 'no button row beside the menu')
+        assert.match(page.screenHome(typedCard(25)), /<select id="sel-esc-7"/)
+      })
+
+      test('past 25 the numbered list stays, and a reply of a marker resolves to the index', () => {
+        const p = typedCard(27)
+        const html = page.screenHome(p)
+        assert.doesNotMatch(html, /<select id="sel-esc-7"/)
+        assert.doesNotMatch(html, /answerIndex\('esc-7',0\)/)
+        assert.match(text(html), /A\. opt1/)
+        assert.match(text(html), /27\. opt27/, 'the 27th marker is a number, as card.mjs marks it')
+        assert.match(text(html), /Reply with a letter or a number\./)
+        const r = p.overview.escalations[0]
+        assert.equal(page.markerIndex(r, 'b'), 1)
+        assert.equal(page.markerIndex(r, '27'), 26)
+        assert.equal(page.markerIndex(r, '28'), null, 'a marker no option carries is words')
+        assert.equal(page.markerIndex({ ...r, typed: false }, 'B'), null, 'an untyped card has no letters')
+      })
+
+      test('a card with no handles falls back to the label, so no button is blank', () => {
+        assert.match(text(page.screenHome(typedCard(2, { handles: false }))), /A · Option 1, with its whole/)
+      })
+
+      test('every card names the file path, and the reply carries files from its own input', () => {
+        const html = page.screenHome(typedCard(2))
+        assert.match(html, /<input type="file" id="files-esc-7" multiple/)
+        assert.match(text(html), /A reply may carry files\. They land under \/box\/data\/attachments\/esc-7\/ and reach the agent as paths\./)
+        const p = payload()
+        assert.match(text(page.screenHome(p)), /A reply may carry files\./, 'an untyped card names it too')
+      })
+
+      test('a second answer shows the first receipt, in the words the Discord mark uses', async () => {
+        const p = typedCard(2)
+        let posted = null
+        const local = loadPage({
+          fetchImpl: async (url, init) => {
+            posted = { url, body: JSON.parse(init.body) }
+            return { ok: false, status: 409, json: async () => ({ error: 'that question was already answered — the first valid answer wins', refused: true, receipt: { by: 'alp', via: 'button', at: at(60), answer: 'Option 1, with its whole consequence spelled out' } }) }
+          },
+        })
+        local.payload = p
+        await local.answerIndex('esc-7', 1)
+        assert.equal(posted.url, '/api/answer')
+        assert.deepEqual(posted.body, { id: 'esc-7', index: 1, files: [] })
+        const t = text(local.screenHome(p))
+        assert.match(t, /✅ answered by alp via button .*: Option 1, with its whole/)
+        assert.doesNotMatch(t, /already answered/, 'the receipt, not the refusal')
+      })
     })
 
     // An option is an AGENT's own words, and it lands inside an onclick
     // handler. A quote in it would close the JS string and open code, which
     // makes it the one value on this page that could ever do that.
-    test('an option carrying a quote is escaped for the handler it sits in, not only for the html', () => {
+    test('an option carrying a quote never reaches a handler: the control sends the index, and the label is html-escaped', () => {
       const raw = "x'),alert(1),('"
       const p = payload()
       p.overview.escalations[0].options = ["it's fine", raw]
       const html = page.screenHome(p)
-      assert.ok(html.includes("answerEsc('esc-7','it\\'s fine')"), 'the quote is escaped, and the label still reads')
-      assert.equal(html.includes(`,'${raw}')`), false, 'the raw option never reaches the handler')
-      assert.ok(html.includes("x\\'),alert(1),(\\'"), 'every quote in it stays inside the string it was given')
+      assert.doesNotMatch(html, /onclick="[^"]*alert/, 'the option is inside no handler')
+      assert.match(text(html), /2 · x'\),alert\(1\),\('/, 'the label still reads')
+      assert.match(html, /answerIndex\('esc-7',1\)/)
     })
 
     test('every kind still takes words: an option list is not the only way to answer', () => {
-      assert.match(page.screenHome(payload()), /answerTyped\('esc-7','ans-esc-7'\)/)
+      assert.match(page.screenHome(payload()), /answerTyped\('esc-7','ans-esc-7',escRecord\('esc-7'\)\)/)
     })
 
     test('an approve-reject pair sends the two literals the daemon classifies', () => {
@@ -2523,8 +2603,25 @@ describe('the chat screen (#267, the picker of #333)', () => {
       page.chatReceive('esc_history', [{ id: 'esc-7', kind: 'question', prompt: 'Which branch?', options: ['a', 'b'], opened_at: at(200), closed_at: at(150), status: 'answered', answer: 'a', answered_by: 'alp', answered_via: 'dashboard' }])
       page.chatReceive('escalations', [{ id: 'esc-8', kind: 'question', prompt: 'Ship it?', options: null, opened_at: at(50), nudges: 0 }])
       const t = text(page.screenChat(payload()))
-      assert.match(t, /first .*Which branch\?.*answered by alp \(dashboard\).*third/s)
+      assert.match(t, /first .*Which branch\?.*✅ answered by alp via dashboard.*third/s)
       assert.match(t, /waiting on you — question \(esc-8\) Ship it\?/)
+    })
+
+    test('an open choice in the room is the same typed card Home draws, answered in place (#712)', () => {
+      page.chatReceive('escalations', [{
+        id: 'esc-9', kind: 'choice', prompt: '**Which branch?**', typed: true, recommended: false,
+        options: ['Stable, and wait for the fix', 'Preview, and take the risk'], option_handles: ['stable', 'preview'],
+        files_dir: '/box/data/attachments/esc-9', opened_at: at(50), nudges: 0,
+      }])
+      const html = page.screenChat(payload())
+      assert.match(html, /answerIndex\('esc-9',0\)/)
+      assert.match(text(html), /A · stable/)
+      assert.match(text(html), /B · preview/)
+      assert.match(html, /answerTyped\('esc-9','ans-esc-9',escRecord\('esc-9'\)\)/)
+      assert.match(html, /<input type="file" id="files-esc-9" multiple/)
+      assert.match(text(html), /They land under \/box\/data\/attachments\/esc-9\//)
+      assert.doesNotMatch(text(html), /answer it on Home/)
+      assert.equal(page.escRecord('esc-9').id, 'esc-9', 'the typed answer resolves its marker against the room\'s own record')
     })
 
     test('an ended agent stays readable and refuses new input with one sentence', () => {

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -935,6 +935,54 @@ describe('the console verbs on the loopback surface (#266, real boot)', () => {
     assert.equal(JSON.parse(res.body).reason, 'unknown')
   })
 
+  // The typed card from a browser (#712, ADR-0025): an index is the option's
+  // own words, a reply file lands where the card said, and the second answer
+  // gets the first receipt and no second journal line.
+  describe('one answer, from any surface (#712)', () => {
+    let id
+    before(async () => {
+      const res = await post('/escalate', { agent: 'curia-1', ticket: '1', kind: 'choice', prompt: 'which?', options: ['Stable', 'Preview'] })
+      id = JSON.parse(res.body).id
+    })
+
+    test('an option index resolves to the option\'s words, and the files land under the question\'s own directory', async () => {
+      const data = Buffer.from('a: 1\n').toString('base64')
+      const res = await post('/answer', {
+        id, index: 1, answer: '', by: 'alp@example.com', via: 'dashboard',
+        files: [{ name: '../../notes.txt', data }, { name: 'shot.png', data: Buffer.from('png').toString('base64') }],
+      })
+      assert.equal(res.status, 200, res.body)
+      const answered = journal().filter((e) => e.type === 'esc_answer' && e.id === id)
+      assert.equal(answered.length, 1)
+      const dir = path.join(dataDir, 'attachments', id)
+      assert.deepEqual(fs.readdirSync(dir).sort(), ['notes-1.txt', 'shot-2.png'], 'the names are made safe and numbered like a Discord download')
+      assert.match(answered[0].answer, /^Preview\n\[attachment: .*notes-1\.txt\]\n\[attachment: .*shot-2\.png\]$/)
+      assert.deepEqual(answered[0].attachments, [path.join(dir, 'notes-1.txt'), path.join(dir, 'shot-2.png')])
+      assert.equal(fs.readFileSync(path.join(dir, 'notes-1.txt'), 'utf8'), 'a: 1\n')
+    })
+
+    test('a second answer is refused with the first receipt, and journals nothing', async () => {
+      const res = await post('/answer', { id, index: 0, by: 'other@example.com', via: 'dashboard', files: [{ name: 'late.txt', data: Buffer.from('x').toString('base64') }] })
+      assert.equal(res.status, 409)
+      const body = JSON.parse(res.body)
+      assert.equal(body.reason, 'answered')
+      assert.equal(body.receipt.by, 'alp@example.com')
+      assert.equal(body.receipt.via, 'dashboard')
+      assert.match(body.receipt.answer, /^Preview/)
+      assert.ok(body.receipt.at)
+      assert.equal(journal().filter((e) => e.type === 'esc_answer' && e.id === id).length, 1)
+      assert.equal(fs.existsSync(path.join(dataDir, 'attachments', id, 'late-1.txt')), false, 'a late reply writes no file')
+    })
+
+    test('a file type curia would refuse on the way out is refused on the way in, by name', async () => {
+      const open = JSON.parse((await post('/escalate', { agent: 'curia-2', ticket: '2', kind: 'free-text', prompt: 'notes?' })).body)
+      const res = await post('/answer', { id: open.id, answer: 'here', files: [{ name: 'tool.exe', data: Buffer.from('MZ').toString('base64') }] })
+      assert.equal(res.status, 400)
+      assert.match(JSON.parse(res.body).error, /tool\.exe: refused/)
+      assert.equal(journal().filter((e) => e.type === 'esc_answer' && e.id === open.id).length, 0)
+    })
+  })
+
   // ---- the browser conversations (#333, ADR-0016) ----------------------------
   //
   // Live, on the real daemon, because the rule that matters is durable: a

--- a/daemon/test/onevoice.test.mjs
+++ b/daemon/test/onevoice.test.mjs
@@ -76,12 +76,22 @@ describe('a press on an escalation button says nothing beside the card (#253)', 
   // A refusal is the other case: nothing happened, so there is no mark on the
   // card to read. The presser is told privately.
   test('a refusal still replies, and only to the presser', async () => {
-    result = { ok: false, reason: 'already answered', record: { id: 'esc-12', answer: 'navy' } }
+    result = { ok: false, reason: 'cancelled', record: { id: 'esc-12', answer: 'navy' } }
     await press('esc|esc-12|opt|approve')
     assert.equal(replies.length, 1)
     assert.equal(replies[0].ephemeral, true)
     assert.match(replies[0].content, /not open/)
     assert.match(replies[0].content, /navy/)
+  })
+
+  // A second press shows the first receipt (#712, ADR-0025): the same mark
+  // the card carries, to the presser alone, and nothing is journalled.
+  test('a second press on an answered card shows the first receipt', async () => {
+    result = { ok: false, reason: 'answered', record: { id: 'esc-12', answer: 'navy', answered_by: 'u-1', answered_via: 'button' } }
+    await press('esc|esc-12|idx|1')
+    assert.equal(replies.length, 1)
+    assert.equal(replies[0].ephemeral, true)
+    assert.equal(replies[0].content, '✅ **answered** by <@u-1> via button: `navy`')
   })
 })
 

--- a/daemon/test/send.test.mjs
+++ b/daemon/test/send.test.mjs
@@ -26,6 +26,14 @@ const round = (label = 'decision') => ({
   questions: [{ text: 'Should cooling re-arm at boot?', recommendation: 'Yes, from the stored cap.' }],
 })
 
+describe('the per-option handle on a composite choice (#712)', () => {
+  test('the message schema keeps a handle, so the button can be short while the body keeps the words', () => {
+    const parsed = messageSchema.parse({ format: 'choice', headline: 'Which?', options: [{ label: 'Stable, and wait', handle: 'stable' }, { label: 'Preview' }] })
+    assert.equal(parsed.options[0].handle, 'stable')
+    assert.equal(parsed.options[1].handle, undefined)
+  })
+})
+
 describe('the catalog', () => {
   test('the seven formats of ADR-0026, and the four that decide', () => {
     assert.deepEqual(MESSAGE_FORMATS, ['prose', 'round', 'choice', 'approve-reject', 'preview-review', 'visual', 'files'])

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -922,6 +922,24 @@ describe('TimelineSurface', () => {
     }
   })
 
+  test('the open card carries the typed-card fields the room renders from (#712)', async () => {
+    escalations = [{
+      id: 'esc-8', kind: 'choice', prompt: '**Which?**', options: ['Stable, and wait', 'Preview, and risk it'],
+      payload: { options: [{ label: 'Stable, and wait', handle: 'stable' }, { label: 'Preview, and risk it' }] },
+      preview_url: null, opened_at: 'T',
+    }]
+    try {
+      const { events } = await sse(port, 'session=curia-9')
+      const r = events.filter((e) => e.event === 'escalations').at(-1).data[0]
+      assert.deepEqual(r.option_handles, ['stable', 'Preview, and risk it'], 'a missing handle falls back to the label')
+      assert.equal(r.typed, true)
+      assert.equal(r.recommended, false)
+      assert.equal(r.files_dir, null, 'this fixture names no files directory, and the field says so rather than inventing one')
+    } finally {
+      escalations = []
+    }
+  })
+
   test('the full escalation history reaches the page — question, options, answer, who answered (#108 item 1)', async () => {
     escHistory = [{
       id: 'esc-3', agent: 'curia-9', kind: 'choice',

--- a/daemon/test/typedcard.test.mjs
+++ b/daemon/test/typedcard.test.mjs
@@ -183,6 +183,7 @@ describe('a typed choice past the button band', () => {
     // body already IS that list, so printing it again is the scroll #431 named.
     assert.equal((msg.content.match(/option 1/g) ?? []).length, 1)
     assert.match(msg.content, /_Pick from the menu below\._/)
+    assert.match(msg.content, /-# A reply here may carry files\. They land under `\S+\/attachments\/esc-[^`]+\/` and reach the agent as paths\./, 'every card names the file path (#712)')
   })
 
   test('past the menu band the card asks for a letter or a number', async () => {


### PR DESCRIPTION
Closes #712.

## What changed

- The Atlas Chat room draws an open question as the same typed card Home draws, and answers it in place. The stream's `escalations` and `esc_history` events carry `option_handles`, `typed`, `recommended`, and `files_dir`, composed by one `cardFields` helper that Home's wire shares.
- The option bands apply on Atlas as on Discord. Two to four options are buttons that say the marker and the handle. Five to 25 are one select. Past 25 the numbered list stays, and a reply of a letter or a number resolves to the index. Every control sends the index to `/api/answer`, and the daemon resolves the index to the option's own words, so a Discord press and an Atlas tap record one answer.
- Every card names the reply-file path. The Discord card gains one small-print line naming `data/attachments/<id>/`. The Atlas card carries a file input, sends the files inline as base64, and the daemon writes them under the bridge's naming. A type curia would refuse on the way out is refused on the way in, by name, and the reply journals nothing.
- A second answer shows the first receipt. The daemon's 409 carries `receipt` (who, where, when, what), the sidecar passes it through, the page shows it in the Discord mark's words, and a second Discord press gets the same mark ephemerally. No second journal answer is written.
- The composite send schema accepts the per-option `handle` that `ask_human` already accepts.
- `CONTEXT.md` gains Answer receipt, Option band, and Reply files. The dashboard proto is 14.

## What was measured

The daemon suite: 3693 tests, 0 failed, 0 cancelled. The index resolution, the file write, the refusal by type, and the second-answer receipt run on a real daemon boot. The bands, the path line, the marker resolution, and the receipt render run through the page in a vm and through the sidecar.

Not measured: a real browser reading a file input, and a live Discord press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
