### PR TITLE
Render global search and its landing routes in Atlas (alp82/curia#713)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -627,7 +627,7 @@ A browser conversation number that is used up. The daemon journals every key it 
 One query over the four indexed sources: the GitHub facts, the decisions a map records under `## Decisions so far`, the journal, and the local chat transcripts. Discord thread bodies stay out of the first index, because Discord is the alert surface and its text is a copy of what the journal and the transcripts already hold. The lens button in every screen header opens it. See [#589](https://github.com/alp82/curia/issues/589) and `daemon/src/search.mjs`.
 
 **Landing target**:
-Where a search result opens, as typed data rather than a URL. A ticket hit and a chat hit land on `chat`, a map hit on `maps`, a journal hit on `feed`, and a decision hit on `github`, at its resolution comment. The query names the surface and its key, and the screen does the routing.
+Where a search result opens, as typed data rather than a URL. A ticket hit and a chat hit land on `chat`, a map hit on `maps`, a journal hit on `feed`, and a decision hit on `github`, at its resolution comment. The query names the surface and its key, and the screen does the routing. A result row shows its kind, a two-line snippet, its age, and its landing word, and the lens overlay takes no navigation slot. A row that asks something of the operator (`needs_you`, the tracker's `ready-for-human` and `needs-info` labels, the journal's `warning`) shows that attention word in place of its kind. `open` and `closed` are not attention, so those rows keep their kind. See [#713](https://github.com/alp82/curia/issues/713).
 
 **Preview**:
 A tailnet HTTPS link to an agent's running dev server. The daemon allocates the public port and composes the link.

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1103,12 +1103,29 @@ function searchMark(value, query) {
   return source.replace(re, (hit) => `<mark>${hit}</mark>`);
 }
 
+/* Where a row lands (#713). The wire names the surface and its key; this is
+   the whole routing table, and every row shows its landing word. A ticket and
+   a chat hit open the Chat room, a map hit opens the Maps detail route, a
+   journal hit opens the Feed on that event, and a decision opens its
+   resolution comment on GitHub in a new tab, so the search stays behind it. */
 function searchLanding(row) {
   const landing = row.landing ?? {};
-  if (landing.surface === "chat") return { href: chatHref(landing.conversation), word: "Chat" };
+  if (landing.surface === "chat") return { href: chatHref(landing.conversation), word: "Chat", action: `searchGo('chat','${js(landing.conversation)}')` };
   if (landing.surface === "maps") return { href: "#maps", word: "Maps", action: `searchGo('maps','${js(landing.map)}')` };
   if (landing.surface === "feed") return { href: "#feed", word: "Feed", action: `searchGo('feed','${js(landing.event)}')` };
-  return { href: landing.url ?? "#", word: "GitHub" };
+  return { href: landing.url ?? "#", word: "GitHub", external: true };
+}
+
+/* The attention word a row shows instead of its kind (#713). The sources hand
+   over what they know: the search module's `needs_you`, the tracker's own
+   `needs-info` and `ready-for-human` labels, and the journal's `warning`. Only
+   a state that asks something of the operator replaces the kind word. `open`
+   and `closed` are not attention, so those rows keep their kind. */
+const SEARCH_ATTENTION_WORDS = {
+  needs_you: "needs you", "ready-for-human": "needs you", "needs-info": "needs info", warning: "warning",
+};
+function searchAttentionWord(row) {
+  return SEARCH_ATTENTION_WORDS[String(row.attention ?? "")] ?? null;
 }
 
 function searchOverlay() {
@@ -1122,8 +1139,10 @@ function searchOverlay() {
     if (rows === null) body = `<div class="unread">Search could not reach Curia.</div>`;
     else body = rows.length ? `<div class="search-results">${rows.map((row) => {
       const landing = searchLanding(row);
-      const kind = row.attention || row.kind;
-      return `<a class="search-result" href="${esc(landing.href)}"${landing.action ? ` onclick="${landing.action};return false"` : ""}><span class="kind${row.attention ? " needs" : ""}">${esc(kind)}</span>
+      const attention = searchAttentionWord(row);
+      const kind = attention || row.kind;
+      const opens = landing.action ? ` onclick="${landing.action};return false"` : landing.external ? ` target="_blank" rel="noopener"` : "";
+      return `<a class="search-result" href="${esc(landing.href)}"${opens}><span class="kind${attention ? " needs" : ""}">${esc(kind)}</span>
         <span><span class="title">${searchMark(row.title, state.q)}</span><span class="snippet">${searchMark(row.snippet, state.q)}</span></span>
         <span class="meta"><span>${esc(dur(row.age_s))}</span><span>${esc(landing.word)}</span></span></a>`;
     }).join("")}</div>` : `<div class="empty">Nothing matches.</div>`;
@@ -1161,7 +1180,12 @@ function searchGo(surface, ref) {
   if (surface === "feed") UI.feed.focus = { id: String(ref), query: UI.search.q.trim().toLowerCase() };
   UI.search.open = false;
   enter(surface);
-  location.hash = surface;
+  if (surface === "chat" && ref) {
+    applyChatRoute(["chat", encodeURIComponent(String(ref))]);
+    location.hash = chatRoute(String(ref));
+  } else {
+    location.hash = surface;
+  }
   render();
   return false;
 }

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1357,7 +1357,7 @@ describe('the read screens (#264)', () => {
       page.UI.search = {
         open: true, q: 'atlas', loading: false, error: null,
         result: { query: 'atlas', errors: [], results: [
-          { kind: 'ticket', title: 'Build Atlas', snippet: 'One Atlas address', age_s: 60, attention: 'needs you', landing: { surface: 'chat', conversation: 'curia-684' } },
+          { kind: 'ticket', title: 'Build Atlas', snippet: 'One Atlas address', age_s: 60, attention: 'needs_you', landing: { surface: 'chat', conversation: 'curia-684' } },
           { kind: 'map', title: 'Atlas map', snippet: 'The route', age_s: 120, attention: null, landing: { surface: 'maps', map: 244 } },
           { kind: 'journal', title: 'Agent started', snippet: 'Atlas work began', age_s: 180, attention: null, landing: { surface: 'feed', event: 'event-4' } },
           { kind: 'decision', title: 'Keep one spec', snippet: 'Atlas and Discord', age_s: 240, attention: null, landing: { surface: 'github', url: 'https://github.com/alp82/curia/issues/685' } },
@@ -1381,6 +1381,73 @@ describe('the read screens (#264)', () => {
       page.UI.search.q = 'notes'
       page.searchGo('feed', 'event-4')
       assert.match(page.atlasFeed(page.payload.overview), /class="feed-news needs focus"/)
+    })
+
+    test('a ticket or chat hit opens the Chat room for that conversation', () => {
+      page.payload = payload()
+      page.UI.search = { open: true, q: 'atlas', loading: false, error: null, result: { query: 'atlas', errors: [], results: [
+        { kind: 'chat', title: 'Chat curia-684', snippet: 'One Atlas address', age_s: 5, attention: null, landing: { surface: 'chat', conversation: 'curia-684' } },
+      ] } }
+      assert.match(page.searchOverlay(), /href="#chat\/curia-684"[^>]*onclick="searchGo\('chat','curia-684'\)/)
+
+      page.searchGo('chat', 'curia-684')
+
+      assert.equal(page.UI.screen, 'chat')
+      assert.equal(page.location.hash, 'chat/curia-684')
+      assert.equal(page.chat.session, 'curia-684')
+      assert.equal(page.UI.search.open, false)
+    })
+
+    test('only a state that asks for the operator replaces the kind word', () => {
+      page.UI.search = { open: true, q: 'x', loading: false, error: null, result: { query: 'x', errors: [], results: [
+        { kind: 'ticket', title: 'A', snippet: 's', age_s: 1, attention: 'ready-for-human', landing: { surface: 'chat', conversation: 'curia-1' } },
+        { kind: 'ticket', title: 'B', snippet: 's', age_s: 1, attention: 'needs-info', landing: { surface: 'chat', conversation: 'curia-2' } },
+        { kind: 'ticket', title: 'C', snippet: 's', age_s: 1, attention: 'needs_you', landing: { surface: 'chat', conversation: 'curia-3' } },
+        { kind: 'journal', title: 'D', snippet: 's', age_s: 1, attention: 'warning', landing: { surface: 'feed', event: 'e' } },
+        { kind: 'ticket', title: 'E', snippet: 's', age_s: 1, attention: 'open', landing: { surface: 'chat', conversation: 'curia-4' } },
+        { kind: 'map', title: 'F', snippet: 's', age_s: null, attention: 'closed', landing: { surface: 'maps', map: 9 } },
+      ] } }
+      const html = page.searchOverlay()
+      const t = text(html)
+      assert.match(t, /needs you A s/)
+      assert.match(t, /needs info B s/)
+      assert.match(t, /needs you C s/)
+      assert.match(t, /warning D s/)
+      assert.match(t, /ticket E s/)
+      assert.match(t, /map F s/)
+      assert.equal((html.match(/class="kind needs"/g) ?? []).length, 4)
+    })
+
+    test('a decision opens GitHub in a new tab and a map missing from the snapshot still lands on Maps', () => {
+      page.payload = payload()
+      page.UI.search = { open: true, q: 'x', loading: false, error: null, result: { query: 'x', errors: [], results: [
+        { kind: 'decision', title: 'Keep one spec', snippet: 's', age_s: 1, attention: null, landing: { surface: 'github', url: 'https://github.com/alp82/curia/issues/685#issuecomment-1' } },
+      ] } }
+      assert.match(page.searchOverlay(), /href="https:\/\/github\.com\/alp82\/curia\/issues\/685#issuecomment-1" target="_blank" rel="noopener"/)
+
+      page.searchGo('maps', '999999')
+
+      assert.equal(page.UI.screen, 'maps')
+      assert.equal(page.location.hash, 'maps')
+      assert.equal(page.UI.search.open, false)
+    })
+
+    test('the lens sits in every page header and takes no navigation slot', () => {
+      page.payload = payload()
+      page.UI.search = { open: false, q: '', loading: false, error: null, result: null }
+      const screens = { home: 'screenHome', maps: 'screenMaps', agents: 'screenAgents', feed: 'screenFeed', chat: 'screenChat', credentials: 'screenCredentials', settings: 'screenSettings' }
+      for (const [name, fn] of Object.entries(screens)) {
+        page.UI.screen = name
+        const html = page[fn](page.payload)
+        assert.match(html, /class="search-lens" onclick="openSearch\(\)"/, `${name} has no lens`)
+      }
+      page.UI.screen = 'home'
+      for (const nav of [page.desktopNav(0, ''), page.mobileNav(0, '')]) {
+        assert.doesNotMatch(nav, /search/i)
+      }
+      assert.equal(page.searchOverlay(), '')
+      page.openSearch()
+      assert.match(page.searchOverlay(), /class="search-sheet" role="dialog"/)
     })
 
     test('an older response cannot replace results for a newer query', async () => {


### PR DESCRIPTION
Closes #713.

## What changed

Most of this ticket was already on main: #738 drew the lens overlay and #742 built the query behind `/api/search`. This pull request finishes the routes and the words the acceptance criteria name.

- A ticket or chat hit opens the Chat room for its conversation. `searchGo('chat', conversation)` applies the chat route in page state, so the room connects without waiting for a hash change, and the hash lands on `#chat/<session>`.
- A decision opens its GitHub comment in a new tab, so the search stays behind it.
- Only a state that asks something of the operator replaces the kind word. The wire hands the page `needs_you`, the tracker's `ready-for-human` and `needs-info` labels, or the journal's `warning`, and the page renders "needs you", "needs info", or "warning" in amber. `open` and `closed` are not attention, so those rows keep their kind. Before this change every raw label string replaced the kind word verbatim.
- `CONTEXT.md` states the row shape and the attention rule under Landing target.

## What was measured

The daemon suite: 3697 tests, 0 failed, 0 cancelled. New page tests cover the Chat landing, the attention words, the GitHub target, a map hit absent from the snapshot, the lens in all seven screen headers, and the absence of a search slot in both the drawer and the notch bar. The phone-width layout is CSS under `max-width: 620px`, and the sidecar forwarding test from #742 stands.

Not measured: a real browser at phone width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
