### PR TITLE
Open the terminal inside Atlas Chat (alp82/curia#714)

### DIFF
--- a/config/curia.yaml
+++ b/config/curia.yaml
@@ -33,6 +33,9 @@ dispatch:
 
 attach:
   ttyd_port: 7681
+  # Retired by #714: the terminal is embedded in Atlas Chat through the
+  # sidecar's same-origin /terminal/ route. The daemon only withdraws the
+  # standalone Serve rule an older daemon asserted here. Defaults to 8443.
   serve_port: 8443
   # #70, landing #69: the attach page is an owned, BUILT asset, not whatever
   # index ttyd happens to ship. It carries the viewport meta (no flag can set

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -709,8 +709,21 @@
   .composer-row { display: flex; gap: 6px; align-items: center; margin-top: 6px; }
   .composer-row .grow { flex: 1; }
   .composer.ended { font-size: 13px; padding: 10px 0; }
-  .terminal-pane { margin: 0 0 14px; border: 1px solid var(--line); border-radius: 9px; overflow: hidden; background: #111; }
-  .terminal-pane iframe { display: block; width: 100%; height: min(68vh, 720px); border: 0; }
+  /* The terminal dock (#714). It lives OUTSIDE #app on purpose: the poll
+     rewrites #app's innerHTML every few seconds, and an iframe that is moved
+     or rebuilt reconnects its WebSocket, so the frame that carries ttyd has
+     to sit where the redraw never reaches. Same origin, one route: the
+     sidecar proxies /terminal/ to ttyd behind the Atlas identity check. */
+  .terminal-dock { position: fixed; left: 0; right: 0; bottom: 0; z-index: 30; display: flex; flex-direction: column; height: min(60vh, 640px); background: #111; border-top: 1px solid var(--line); box-shadow: 0 -8px 24px rgba(0,0,0,.35); }
+  .terminal-dock .dock-head { display: flex; align-items: center; gap: 8px; padding: 4px 10px; background: var(--bg-raise); color: var(--ink-dim); font-size: 12px; border-bottom: 1px solid var(--line); }
+  .terminal-dock .dock-head .grow { flex: 1; }
+  .terminal-dock iframe { display: block; flex: 1; width: 100%; border: 0; background: #111; }
+  @media (max-width: 760px) {
+    /* On a phone the dock stops at the notch bar, and ttyd's own touch key
+       row rides inside the frame: the attach page shows it on a coarse
+       pointer and hides it on a desktop, so Atlas adds no second row. */
+    .terminal-dock { height: 55vh; height: 55dvh; bottom: calc(70px + env(safe-area-inset-bottom)); }
+  }
 
   /* ---------- the screens that land later ---------- */
   .later {
@@ -3407,7 +3420,7 @@ function chatFresh(session) {
   return {
     session, conn: "connecting", file: null, harness: null, ended: null, clients: 0,
     items: [], open: [], history: [], parse: null, dialog: null, receipt: null,
-    draft: "", mirror: false, notes: [], lastEdit: 0, stick: true,
+    draft: "", mirror: false, notes: [], lastEdit: 0, stick: true, terminal: false,
     client: Math.random().toString(36).slice(2, 8), es: null,
   };
 }
@@ -3420,6 +3433,7 @@ function applyChatRoute(parts) {
   if (session === chat.session) return;
   chatClose();
   chat = chatFresh(session);
+  chatMountTerminal();
   chatConnect();
 }
 function chatClose() {
@@ -3496,23 +3510,40 @@ function screenChat(p) {
 function chatPicker(p) {
   const down = p && !p.daemon_up;
   const count = conversations?.conversations?.length ?? null;
-  const tools = `<button class="btn sm" type="button" onclick="toggleTerminal()">Terminal</button>${count == null ? "" : `<span class="dim-note num">${count} conversation${count === 1 ? "" : "s"}</span>`}`;
+  const tools = count == null ? "" : `<span class="dim-note num">${count} conversation${count === 1 ? "" : "s"}</span>`;
   return `${head(p, "Chat", tools)}
-    <div id="terminal-pane" class="terminal-pane" hidden></div>
     ${down ? `<p class="unread">The chat is down while the daemon restarts. Your message reaches every conversation through it.</p>` : ""}
     ${chatList()}`;
 }
 
-function toggleTerminal() {
-  const pane = document.getElementById("terminal-pane");
-  if (!pane) return;
-  pane.hidden = !pane.hidden;
-  if (!pane.hidden && !pane.firstChild) {
-    const frame = document.createElement("iframe");
-    frame.src = "/terminal/";
-    frame.title = "Curia terminal";
-    pane.appendChild(frame);
-  }
+/* ---- the terminal (#714) ----
+   The room's header opens the live terminal for ITS conversation, and only
+   for one that still runs: an ended agent has no pane to show. The dock is
+   one element under document.body, mounted once per opening and removed on
+   close or on leaving the room, so the attached tmux client goes away with
+   it rather than holding a stale size on the shared window. */
+const terminalSrc = (session) => `/terminal/?arg=${encodeURIComponent(session)}`;
+function terminalDock() {
+  if (!chat.terminal || !chat.session) return "";
+  return `<div class="dock-head mono"><span class="grow">terminal · ${esc(chat.session)}</span>
+      <button class="btn sm" type="button" onclick="chatToggleTerminal()">Close</button></div>
+    <iframe src="${terminalSrc(chat.session)}" title="Terminal for ${esc(chat.session)}"></iframe>`;
+}
+function chatToggleTerminal() {
+  chat.terminal = !chat.terminal && !chatEnded();
+  chatMountTerminal();
+  render();
+}
+function chatMountTerminal() {
+  if (typeof document.createElement !== "function" || !document.body) return;
+  let dock = document.getElementById("terminal-dock");
+  if (!chat.terminal) { dock?.remove(); return; }
+  if (dock) return;
+  dock = document.createElement("div");
+  dock.id = "terminal-dock";
+  dock.className = "terminal-dock";
+  dock.innerHTML = terminalDock();
+  document.body.appendChild(dock);
 }
 
 /* Null is not empty, the second rule of this page. A list curia could not be
@@ -3614,8 +3645,8 @@ function chatRoom(p) {
   const ended = chatEnded();
   const conn = c.conn === "live" ? `<span class="chat-conn ok">live</span>` : `<span class="chat-conn bad">${esc(c.conn)}</span>`;
   const watching = c.clients > 1 ? `<span class="dim-note">${c.clients} devices watching</span>` : "";
-  const terminal = role === "ticket" && !ended
-    ? `<a class="btn sm" href="/terminal/?arg=${encodeURIComponent(c.session)}" target="_blank">Terminal</a>` : "";
+  const terminal = ended ? ""
+    : `<button class="btn sm ${c.terminal ? "on" : ""}" type="button" onclick="chatToggleTerminal()">${c.terminal ? "Hide terminal" : "Terminal"}</button>`;
   const tools = `<a class="btn sm" href="#chat">← Chat</a>${terminal}`;
   return `${head(p, title, tools)}
     <div class="room" data-role="${role}">

--- a/daemon/src/config.mjs
+++ b/daemon/src/config.mjs
@@ -221,6 +221,13 @@ export function loadCuriaConfig(file, { checkPaths = true, localFile, env = proc
 
   const a = cfg.attach
   if (!a || typeof a !== 'object') fail(src, '`attach` section missing')
+  // `serve_port` retired with #714: Atlas serves the terminal on its own
+  // address, and the only thing the daemon does with this port is withdraw
+  // the standalone rule an older daemon asserted. Optional with the port that
+  // rule always used, so a config that drops the line still withdraws it. It
+  // stays in the collision check, because withdrawing a port another surface
+  // is published on would take that surface down.
+  a.serve_port = a.serve_port ?? 8443
   for (const key of ['ttyd_port', 'serve_port']) {
     if (!(Number.isInteger(a[key]) && a[key] > 0 && a[key] < 65536)) fail(src, `attach.${key} must be a port number`)
   }

--- a/daemon/test/attach.test.mjs
+++ b/daemon/test/attach.test.mjs
@@ -88,6 +88,15 @@ describe('the built index asset (#70)', () => {
   }
   const stampFor = (ttyd, chrome) => stampMeta({ ttyd, chrome: sha256(chrome) })
 
+  test('#714: the shipped index carries the touch key row, shown on a coarse pointer only', () => {
+    // The embedded terminal in Atlas Chat is this page in an iframe. A phone
+    // gets its Esc, Tab and arrows from here, and a desktop gets no second
+    // row, so Atlas draws none of its own.
+    const built = fs.readFileSync(DEFAULT_INDEX, 'utf8')
+    assert.match(built, /pointer:fine/)
+    assert.match(fs.readFileSync(path.join(path.dirname(DEFAULT_INDEX), CHROME_BASENAME), 'utf8'), /function coarse\(\)/)
+  })
+
   test('the shipped asset is a real built index, and the daemon accepts it', () => {
     // Not a mock: this is the file ttyd is actually spawned with. If the
     // committed asset ever goes stale against the committed chrome source,

--- a/daemon/test/config.test.mjs
+++ b/daemon/test/config.test.mjs
@@ -574,6 +574,13 @@ describe('timeline config (#74)', () => {
     )
   })
 
+  test('#714: attach.serve_port is optional now — it names only the retired rule to withdraw', () => {
+    const file = writeConfig('')
+    const text = fs.readFileSync(file, 'utf8').replace(/^  serve_port: 8443\n/m, '')
+    fs.writeFileSync(file, text)
+    assert.equal(loadCuriaConfig(file).attach.serve_port, 8443)
+  })
+
   test('a port collision with attach refuses the boot — one surface must not shadow another', () => {
     assert.throws(
       () => loadCuriaConfig(writeConfig(['timeline:', '  serve_port: 8443'].join('\n'))),

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2674,6 +2674,40 @@ describe('the chat screen (#267, the picker of #333)', () => {
       assert.match(t, /waiting on you — question \(esc-8\) Ship it\?/)
     })
 
+    // The terminal (#714). The header opens it for THIS conversation, in a
+    // dock the page mounts outside #app, and only while the agent runs.
+    test('the header opens the same-origin terminal for the current conversation, and hides it again', () => {
+      let html = page.screenChat(payload())
+      assert.match(html, /onclick="chatToggleTerminal\(\)"/)
+      assert.doesNotMatch(html, /target="_blank"/, 'no separate terminal address')
+      assert.equal(page.terminalDock(), '', 'closed until the header opens it')
+      page.chatToggleTerminal()
+      assert.equal(page.chat.terminal, true)
+      const dock = page.terminalDock()
+      assert.match(dock, /<iframe src="\/terminal\/\?arg=curia-684"/)
+      assert.doesNotMatch(dock, /touch|Esc|Tab/, 'Atlas adds no key row of its own; ttyd\'s page carries it on a coarse pointer')
+      html = page.screenChat(payload())
+      assert.match(text(html), /Hide terminal/)
+      page.chatToggleTerminal()
+      assert.equal(page.chat.terminal, false)
+      assert.equal(page.terminalDock(), '')
+    })
+
+    test('leaving the room closes its terminal, and the next room starts with it closed', () => {
+      page.chatToggleTerminal()
+      assert.equal(page.chat.terminal, true)
+      page.applyChatRoute(['chat', 'curia-console-2'])
+      assert.equal(page.chat.terminal, false)
+      assert.equal(page.terminalDock(), '')
+    })
+
+    test('an ended agent offers no terminal', () => {
+      page.chatReceive('hello', { session: 'curia-684', file: null, harness: 'claude', clients: 1, draft: '', ended: true })
+      assert.doesNotMatch(page.screenChat(payload()), /chatToggleTerminal/)
+      page.chatToggleTerminal()
+      assert.equal(page.chat.terminal, false, 'the toggle refuses too')
+    })
+
     test('an open choice in the room is the same typed card Home draws, answered in place (#712)', () => {
       page.chatReceive('escalations', [{
         id: 'esc-9', kind: 'choice', prompt: '**Which branch?**', typed: true, recommended: false,


### PR DESCRIPTION
Closes #714.

## What changed

- The Chat room's header has a **Terminal** button. It opens the live terminal for the current conversation in a dock at the bottom of the page. The dock is one element under `document.body`, outside `#app`, because the poll rewrites `#app` every few seconds and a rebuilt iframe reconnects ttyd. **Hide terminal** or leaving the room removes the frame, so the attached tmux client goes away with it.
- An ended agent offers no terminal, and the toggle refuses for one.
- The picker's session-less **Terminal** toggle and the room's new-tab link are gone. Every terminal is same-origin through the sidecar's `/terminal/?arg=<session>` route.
- On a phone, ttyd's own attach page carries the touch key row inside the frame, shown on a coarse pointer only. Atlas adds no second row. A test pins that rule in the shipped `attach-index.html`.
- `attach.serve_port` is optional and defaults to 8443. The daemon only withdraws the standalone rule an older daemon asserted there. The collision check keeps the port, because withdrawing a port another surface is published on would take that surface down.

## What was measured

The daemon suite: 3702 tests, 0 failed, 0 cancelled. The sidecar's HTTP and WebSocket proxy tests from the earlier landing still pass. The room's toggle, the route change, and the ended refusal each have a page test in the vm.

Not measured against a live box: the dock's layout on a real phone, and the reconnect behavior of ttyd inside the dock across a redraw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
