### PR TITLE
Answer native pane dialogs through a typed Chat card (alp82/curia#715)

### DIFF
--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2775,6 +2775,50 @@ describe('the chat screen (#267, the picker of #333)', () => {
       assert.doesNotMatch(html, /doDialogAnswer/)
     })
 
+    test('an unparsed native dialog keeps the guard banner and the terminal link', () => {
+      page.chatReceive('dialog', { up: true, hint: 'Enter to select', reason: 'curia could not parse options from the native claude dialog', card: null })
+      const html = page.screenChat(payload())
+      assert.match(text(html), /A native dialog owns the terminal\. curia could not parse options from the native claude dialog/)
+      assert.match(html, /href="\/terminal\/\?arg=curia-684"/, 'the terminal is the way through')
+      assert.match(text(html), /Chat sends stay blocked while this dialog is open/)
+      assert.doesNotMatch(html, /doDialogAnswer/, 'no control answers a card curia could not measure')
+      page.chatReceive('dialog', { up: false })
+      assert.doesNotMatch(text(page.screenChat(payload())), /native dialog/)
+    })
+
+    // The tap is the whole seam between the card and the daemon: it sends the
+    // option index for the card the page holds, and a second tap gets the
+    // first receipt (#712's rule) rather than a second answer.
+    test('a tap posts the measured option index, and a second tap shows the first receipt', async () => {
+      const posts = []
+      const receipt = { dialog: 'native-3', index: 2, marker: 'B', answer: 'Preview', by: 'phone', at: at(1) }
+      let answered = false
+      const room = loadPage({ fetchImpl: async (url, init) => {
+        posts.push({ url, body: JSON.parse(init.body) })
+        const first = !answered
+        answered = true
+        return { json: async () => (first ? { ok: true, receipt } : { error: 'this native dialog already has an answer', receipt }) }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chatReceive('dialog', { up: true, hint: 'Enter to select', card: { id: 'native-3', kind: 'choice', headline: 'Which branch?', selected_index: 1, options: [{ index: 1, marker: 'A', label: 'Stable' }, { index: 2, marker: 'B', label: 'Preview' }] } })
+      await room.doDialogAnswer('native-3', 2)
+      assert.equal(posts.length, 1)
+      assert.equal(posts[0].url, '/dialog-answer')
+      assert.equal(posts[0].body.session, 'curia-684')
+      assert.equal(posts[0].body.dialog, 'native-3')
+      assert.equal(posts[0].body.index, 2, 'the index, not the words')
+      assert.match(text(room.screenChat(payload())), /answered · phone .* B · Preview/)
+
+      room.chat.receipt = null
+      room.chatReceive('dialog', { up: true, hint: 'Enter to select', card: { id: 'native-3', kind: 'choice', headline: 'Which branch?', selected_index: 1, options: [{ index: 1, marker: 'A', label: 'Stable' }, { index: 2, marker: 'B', label: 'Preview' }] } })
+      await room.doDialogAnswer('native-3', 1)
+      assert.equal(posts.length, 2)
+      const html = room.screenChat(payload())
+      assert.match(text(html), /answered · phone .* B · Preview/, 'the first receipt, not an error')
+      assert.doesNotMatch(html, /doDialogAnswer/)
+      room.applyChatRoute([])
+    })
+
     test('a parse failure is a banner, never silence', () => {
       page.chatReceive('parse', { reason: 'unknown line shape', file: 'x', dropped: 3 })
       assert.match(text(page.screenChat(payload())), /INCOMPLETE — unknown line shape \(3 lines dropped\)/)


### PR DESCRIPTION
Closes #715.

## What changed

- The behavior this ticket asks for was already on main. PR #738 taught the timeline to parse a native dialog from the pane on the daemon side, send it as one `dialog` stream event, answer it through `/dialog-answer` with the measured option index, and keep first-answer-wins with one receipt. PR #775 drew the card in the Atlas Chat room. The `multiSelect` free-text path stays behind its guard with a named reason, and the review screen without footer chrome clears the guard.
- This PR closes the one gap: the page seam had no test. Two page tests now drive it in a vm. A tap posts the card id and the option index, not the words, to `/dialog-answer`, and a second tap on the same card shows the first receipt instead of an error. An unparsed dialog keeps the guard banner, names its reason, links the terminal, and offers no answer control.

## What was measured

The daemon suite: 3704 tests, 0 failed, 0 cancelled. The parser, the option send, the receipt, and the sidecar relay were already pinned in `timeline.test.mjs`, `tmux.test.mjs`, and `dashboard.test.mjs`.

Not measured: a live Claude or Codex pane. The `multiSelect` free-text path remains disabled until an integration check against a real pane passes, which is the map's standing admission for the whole pane stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
