### PR TITLE
Deliver composite sends on Discord and Atlas (alp82/curia#716)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -403,7 +403,7 @@ The named fields an agent fills instead of one prose string (#413). One vocabula
 _Avoid_: structured payload, card schema.
 
 **Composite send**:
-One agent call that returns an ordered array of messages (#622). Each entry renders as its own Discord message, with its own typed format and its own optional attachments. At most one message decides, and it posts last, so the buttons sit at the thread bottom. A send carries at most four messages, a `curia.yaml` default with a settings row. The prose message holds the answer to an operator note at up to 1600 characters, and a question of a round may carry a 600-character background block. A message exists when a reader would want to skip it on its own (#640). See [ADR-0026](docs/adr/0026-the-composite-send.md).
+One agent call that returns an ordered array of messages (#622). Each entry renders as its own Discord message, with its own typed format and its own optional attachments. At most one message decides, and it posts last, so the buttons sit at the thread bottom. A send carries at most four messages, a `curia.yaml` default with a settings row. The prose message holds the answer to an operator note at up to 1600 characters, and a question of a round may carry a 600-character background block. A message exists when a reader would want to skip it on its own (#640). `send.mjs` is the contract, `composite.mjs` is the one renderer, and both surfaces read it: Discord posts each rendered message, and Atlas Chat draws the same sequence from the call the transcript carries, with the deciding message drawn as the card from the record (#716). A prose message leads with its conclusion in bold. See [ADR-0026](docs/adr/0026-the-composite-send.md).
 _Avoid_: multi-part response, message batch.
 
 **The rail**:

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -686,6 +686,11 @@
   .chat-log .tool .res { display: block; color: var(--ink-dim); margin-top: 3px; }
   .chat-log .tool .res.err { color: var(--warn); }
   .chat-log .tool .full { display: block; white-space: pre-wrap; margin-top: 4px; font: 13px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  .chat-log .tool .send { display: block; margin-top: 4px; font: 13px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  .chat-log .tool .send-msg { padding: 6px 0; border-top: 1px solid var(--line); }
+  .chat-log .tool .send-msg:first-child { border-top: 0; padding-top: 0; }
+  .chat-log .tool .send-msg .rail { display: block; color: var(--ink-dim); font-size: 11.5px; margin-bottom: 2px; }
+  .chat-log .tool .send-msg.deciding .dim-note { font-size: 12px; }
   .chat-log .note { color: var(--ink-dim); font-size: 12px; text-align: center; }
   .chat-log .note.warn { color: var(--warn); }
   .chat-log .at { color: var(--ink-faint); font-size: 11px; margin-right: 5px; }
@@ -3702,8 +3707,11 @@ function chatItem(it) {
   if (it.kind === "tool") {
     const name = String(it.name ?? "").replace("mcp__curia__", "curia.");
     /* Full curia prose replaces the one-line brief (#108 item 1); ask_human
-       stays a brief here — its escalation card carries the full body. */
-    const body = it.text && !/ask_human$/.test(it.name ?? "")
+       stays a brief here — its escalation card carries the full body. A
+       composite send (#716) draws its sequence under the same rails Discord
+       posts, and its deciding message is the card, drawn from the record. */
+    const body = it.send ? chatSend(it.send)
+      : it.text && !/ask_human$/.test(it.name ?? "")
       ? `<span class="full">${esc(it.text)}</span>` : `<span class="brief">${esc(it.brief ?? "")}</span>`;
     const r = it.result;
     const res = r ? `<span class="res ${r.ok ? "" : "err"}">${r.ok ? "→ " : "✗ "}${esc(r.brief)}${r.lines > 1 ? ` (${r.lines} lines)` : ""}</span>` : "";
@@ -3711,6 +3719,17 @@ function chatItem(it) {
   }
   if (it.kind === "result") return `<div class="item tool">${it.ok ? "→ " : "✗ "}${esc(it.brief)}</div>`;
   return `<div class="item note">${esc(it.text ?? "")}</div>`;
+}
+/* The messages of one send, in the order the reader reads them. The rail is
+   curia's count and the agent's label; a send of one carries none. The
+   deciding message posts last and is the card, so here it is only named. */
+function chatSend(send) {
+  const rows = send.map((m) => {
+    const rail = m.rail ? `<span class="rail">${esc(String(m.rail).replace(/^-# /, ""))}</span>` : "";
+    if (m.deciding) return `<div class="send-msg deciding">${rail}<span class="dim-note">the card follows</span></div>`;
+    return `<div class="send-msg">${rail}<div class="pre">${esc(m.body ?? "")}</div></div>`;
+  });
+  return `<div class="send">${rows.join("")}</div>`;
 }
 function chatHistoryCard(r) {
   const options = r.options?.length ? `<div class="meta">options: ${esc(r.options.join(" | "))}</div>` : "";

--- a/daemon/src/composite.mjs
+++ b/daemon/src/composite.mjs
@@ -1,22 +1,24 @@
-// The pure composite-send contract (#691, ADR-0026).
+// The composite send, rendered (#716, ADR-0026).
 //
-// This module knows the payload and nothing about Discord, Atlas, tools, or
-// journals. Callers keep the proposed messages unchanged when this returns
-// faults. A refusal must never turn five authored messages into four delivered
-// messages.
+// `send.mjs` is the CONTRACT: how many messages a send carries, which one may
+// decide, where it sits, and which fields each format takes. This module is
+// the one renderer over that contract, and both operator surfaces read it.
+// Discord posts each rendered message as its own post, and Atlas Chat draws
+// the same sequence from the call the transcript carries, so neither surface
+// infers a message's intent on its own.
+//
+// Callers keep the proposed messages unchanged when the contract returns
+// faults. A refusal must never turn five authored messages into four
+// delivered ones.
 
-import { CAPS, gradeA, gradeB, lintAskHuman, lintVisual } from './lint.mjs'
 import { composeCard, visualBlock } from './card.mjs'
 import { smallPrint } from './messaging.mjs'
+import {
+  MESSAGES_PER_SEND, MESSAGE_FORMATS, DECIDING_FORMATS, sendFloorFaults, lintSend,
+} from './send.mjs'
 
-export const MAX_MESSAGES_PER_SEND = 4
-export const MESSAGE_LABEL_CAP = 20
-export const PROSE_CAP = 1600
-export const QUESTION_BACKGROUND_CAP = 600
-export const MESSAGE_FORMATS = [
-  'prose', 'round', 'choice', 'approve-reject', 'preview-review', 'visual', 'files',
-]
-export const DECIDING_FORMATS = ['round', 'choice', 'approve-reject', 'preview-review']
+export const MAX_MESSAGES_PER_SEND = MESSAGES_PER_SEND
+export { MESSAGE_FORMATS, DECIDING_FORMATS }
 
 const FORMAT_KIND = {
   round: 'free-text',
@@ -25,249 +27,86 @@ const FORMAT_KIND = {
   'preview-review': 'preview-review',
 }
 
-const COMMON_FIELDS = ['format', 'label', 'attachments', 'picture', 'table', 'diagram']
-const FORMAT_FIELDS = {
-  prose: ['text'],
-  round: ['headline', 'questions', 'detail', 'timeline'],
-  choice: ['headline', 'options', 'detail', 'timeline'],
-  'approve-reject': ['headline', 'options', 'detail', 'timeline'],
-  'preview-review': ['headline', 'options', 'detail', 'timeline', 'preview_url'],
-  visual: [],
-  files: ['caption'],
+// The floor of a send: a missing or misplaced field, the cap, and the place of
+// the deciding message. It is the schema path of ADR-0005, read by `send.mjs`.
+export function compositeSendSchemaFaults(messages, { maxMessages = MESSAGES_PER_SEND } = {}) {
+  return sendFloorFaults(messages, { cap: maxMessages })
 }
 
-const present = (value) => value !== undefined && value !== null && String(value).trim() !== ''
-
-function contentSchemaFaults(message, i) {
-  const at = `messages[${i}]`
-  const faults = []
-  const format = message.format
-  if (!MESSAGE_FORMATS.includes(format)) return faults
-  const allowed = new Set([...COMMON_FIELDS, ...FORMAT_FIELDS[format], 'visual', 'images'])
-  for (const field of Object.keys(message)) {
-    if (!allowed.has(field)) faults.push(`${at}.${field}: not permitted on the ${format} format.`)
-  }
-  const textField = (target, field, fieldAt = at) => {
-    if (target[field] !== undefined && typeof target[field] !== 'string') faults.push(`${fieldAt}.${field}: expected text.`)
-  }
-  for (const field of ['text', 'headline', 'detail', 'preview_url', 'caption']) textField(message, field)
-  if (message.timeline !== undefined && typeof message.timeline !== 'boolean') faults.push(`${at}.timeline: expected true or false.`)
-  if (format === 'prose' && !present(message.text)) faults.push(`${at}.text: missing. A prose message needs its prose.`)
-  if (format === 'round') {
-    if (!present(message.headline)) faults.push(`${at}.headline: missing.`)
-    if (!Array.isArray(message.questions) || !message.questions.length) {
-      faults.push(`${at}.questions: missing. A round needs one question or more.`)
-    } else {
-      message.questions.forEach((question, j) => {
-        const qAt = `${at}.questions[${j}]`
-        if (!question || typeof question !== 'object' || Array.isArray(question)) {
-          faults.push(`${qAt}: expected a question object.`)
-          return
-        }
-        for (const field of Object.keys(question)) {
-          if (!['text', 'background', 'recommendation'].includes(field)) faults.push(`${qAt}.${field}: not permitted on a question.`)
-        }
-        if (!present(question.text)) faults.push(`${qAt}.text: missing.`)
-        for (const field of ['text', 'background', 'recommendation']) textField(question, field, qAt)
-      })
-    }
-  }
-  if (format === 'choice') {
-    if (!present(message.headline)) faults.push(`${at}.headline: missing.`)
-    if (!Array.isArray(message.options) || message.options.length < 2) {
-      faults.push(`${at}.options: a choice needs two options or more.`)
-    } else {
-      message.options.forEach((option, j) => {
-        const oAt = `${at}.options[${j}]`
-        if (!option || typeof option !== 'object' || Array.isArray(option)) {
-          faults.push(`${oAt}: expected an option object.`)
-          return
-        }
-        for (const field of Object.keys(option)) {
-          if (!['label', 'handle', 'consequence', 'example', 'recommended'].includes(field)) faults.push(`${oAt}.${field}: not permitted on an option.`)
-        }
-        if (!present(option.label)) faults.push(`${oAt}.label: missing.`)
-        for (const field of ['label', 'handle', 'consequence', 'example']) textField(option, field, oAt)
-        if (!present(option.handle)) faults.push(`${oAt}.handle: missing. A choice button needs a short handle.`)
-        else if (typeof option.handle !== 'string') faults.push(`${oAt}.handle: expected one line of text.`)
-        if (!present(option.consequence)) faults.push(`${oAt}.consequence: missing.`)
-        if (option.recommended !== undefined && typeof option.recommended !== 'boolean') faults.push(`${oAt}.recommended: expected true or false.`)
-      })
-    }
-  }
-  if (format === 'approve-reject' || format === 'preview-review') {
-    if (!present(message.headline)) faults.push(`${at}.headline: missing.`)
-    if (message.options !== undefined) {
-      if (!Array.isArray(message.options) || message.options.length !== 2) {
-        faults.push(`${at}.options: approve and reject take exactly two options.`)
-      } else {
-        message.options.forEach((option, j) => {
-          const oAt = `${at}.options[${j}]`
-          if (!option || typeof option !== 'object' || Array.isArray(option)) {
-            faults.push(`${oAt}: expected an option object.`)
-            return
-          }
-          for (const field of Object.keys(option)) {
-            if (!['consequence', 'example'].includes(field)) faults.push(`${oAt}.${field}: not permitted on an approve-reject option.`)
-          }
-          for (const field of ['consequence', 'example']) textField(option, field, oAt)
-          if (!present(option.consequence)) faults.push(`${oAt}.consequence: missing.`)
-        })
-      }
-    }
-  }
-  if (format === 'preview-review' && !present(message.preview_url)) faults.push(`${at}.preview_url: missing.`)
-  if (format === 'visual' && !['picture', 'table', 'diagram'].some((field) => present(message[field]))) {
-    faults.push(`${at}: a visual message needs a picture, table, or diagram.`)
-  }
-  if (format === 'files') {
-    if (!present(message.caption)) faults.push(`${at}.caption: missing.`)
-    if (!Array.isArray(message.attachments) || !message.attachments.length) {
-      faults.push(`${at}.attachments: missing. A files message needs one file or more.`)
-    }
-  }
-  return faults
-}
-
-export function compositeSendSchemaFaults(messages, { maxMessages = MAX_MESSAGES_PER_SEND } = {}) {
-  if (!Array.isArray(messages)) return ['messages: missing. A send is an ordered array of typed messages.']
-  const faults = []
-  if (!messages.length) faults.push('messages: empty. A send needs one typed message or more.')
-  if (messages.length > maxMessages) {
-    faults.push(`messages: ${messages.length} messages over the ${maxMessages} message cap. Compose another send. Curia refuses the send, it never drops a message.`)
-  }
-  for (const [i, message] of messages.entries()) {
-    if (!message || typeof message !== 'object' || Array.isArray(message)) {
-      faults.push(`messages[${i}]: expected a typed message object.`)
-      continue
-    }
-    const format = message?.format
-    if (!MESSAGE_FORMATS.includes(format)) {
-      faults.push(`messages[${i}].format: ${JSON.stringify(format)} is not supported. Use ${MESSAGE_FORMATS.join(', ')}.`)
-    }
-    const at = `messages[${i}]`
-    if (typeof message?.label !== 'string' || !message.label.trim()) {
-      faults.push(`${at}.label: missing. Every typed message needs a short rail label.`)
-    }
-    if (message?.attachments !== undefined) {
-      if (!Array.isArray(message.attachments)) {
-        faults.push(`${at}.attachments: expected an array of file paths.`)
-      } else {
-        message.attachments.forEach((attachment, j) => {
-          if (typeof attachment !== 'string' || !attachment.trim()) {
-            faults.push(`${at}.attachments[${j}]: expected a file path.`)
-          }
-        })
-      }
-    }
-    for (const field of ['picture', 'table', 'diagram']) {
-      if (message?.[field] !== undefined && typeof message[field] !== 'string') {
-        faults.push(`${at}.${field}: expected a string.`)
-      }
-    }
-    if (message?.visual !== undefined) {
-      faults.push(`${at}.visual: retired. Put the content in picture, table, or diagram.`)
-    }
-    if (message?.images !== undefined) {
-      faults.push(`${at}.images: retired. Put file paths in attachments.`)
-    }
-    faults.push(...contentSchemaFaults(message, i))
-  }
-  const decisions = messages
-    .map((message, i) => DECIDING_FORMATS.includes(message?.format) ? i : null)
-    .filter((i) => i !== null)
-  if (decisions.length > 1) {
-    faults.push(`messages: ${decisions.length} deciding messages. A send carries at most one deciding message.`)
-  }
-  if (decisions.length && decisions.at(-1) !== messages.length - 1) {
-    faults.push(`messages: the deciding message at messages[${decisions.at(-1)}] must be last.`)
-  }
-  return faults
-}
-
-const namedVisualFaults = (field, value) => lintVisual(value)
-  .map((fault) => fault.replace(/^visual:/, `${field}:`))
-
-export function lintCompositeSend(messages) {
-  if (!Array.isArray(messages)) return []
-  const faults = []
-  for (const [i, message] of messages.entries()) {
-    if (!message || typeof message !== 'object') continue
-    const at = `messages[${i}]`
-    if (typeof message.label === 'string' && message.label.trim()) {
-      faults.push(...gradeA(`${at}.label`, message.label, MESSAGE_LABEL_CAP))
-    }
-    if (message.format === 'prose' && typeof message.text === 'string') {
-      const proseFaults = gradeB(`${at}.text`, message.text, PROSE_CAP)
-      faults.push(...proseFaults.map((fault) => fault.includes(`over the ${PROSE_CAP} cap`)
-        ? `${fault} Compose a second prose message where the meaning breaks.`
-        : fault))
-    }
-    const cardKind = message.format === 'round' ? 'free-text' : message.format
-    if (DECIDING_FORMATS.includes(message.format)) {
-      faults.push(...lintAskHuman(cardKind, message).map((fault) => `${at}.${fault}`))
-    }
-    if (message.format === 'choice') {
-      for (const [j, option] of (message.options ?? []).entries()) {
-        if (typeof option?.handle === 'string') {
-          faults.push(...gradeA(`${at}.options[${j}].handle`, option.handle, CAPS.option))
-        }
-      }
-    }
-    if (message.format === 'files' && typeof message.caption === 'string') {
-      faults.push(...gradeA(`${at}.caption`, message.caption, CAPS.headline))
-    }
-    for (const [j, question] of (message.questions ?? []).entries()) {
-      if (typeof question?.background === 'string') {
-        faults.push(...gradeB(`${at}.questions[${j}].background`, question.background, QUESTION_BACKGROUND_CAP))
-      }
-    }
-    if (typeof message.table === 'string') faults.push(...namedVisualFaults(`${at}.table`, message.table))
-    if (typeof message.diagram === 'string') faults.push(...namedVisualFaults(`${at}.diagram`, message.diagram))
-  }
-  return faults
-}
+// The words of a send, by the grade each field already had.
+export const lintCompositeSend = (messages) => lintSend(messages)
 
 export function compositeSendFaults(messages, options) {
   return [...compositeSendSchemaFaults(messages, options), ...lintCompositeSend(messages)]
 }
 
-// One rendering description feeds both operator surfaces. Discord turns the
-// description into posts and components. Atlas keeps the same fields in its
-// conversation event, so neither surface has to infer a message's intent.
+// The rail (#640): its number in the send, then the agent's label. curia writes
+// the count, so the reader knows how far the send runs before it asks. A send
+// of one message carries no rail, because there is nothing to count.
 export function compositeRail(message, index, count) {
   if (count <= 1) return ''
-  return smallPrint(`${index + 1} of ${count} · ${String(message.label).trim()}`)
+  return smallPrint(`${index + 1} of ${count} · ${String(message.label ?? '').trim()}`)
+}
+
+// The fields a deciding message hands the escalation record, in the shape the
+// single-message `ask_human` gate already stores.
+function cardPayload(message) {
+  return {
+    headline: message.headline,
+    questions: message.questions,
+    options: message.options,
+    detail: message.detail,
+    picture: message.picture,
+    table: message.table,
+    diagram: message.diagram,
+    timeline: message.timeline,
+    preview_url: message.preview_url,
+  }
+}
+
+const present = (value) => value !== undefined && value !== null && String(value).trim() !== ''
+
+const blocks = (message) => ['table', 'diagram']
+  .filter((field) => present(message[field]))
+  .map((field) => visualBlock(message[field]))
+
+const detailLine = (message) => (present(message.detail) ? [`Details: ||${String(message.detail).trim()}||`] : [])
+
+// The body of one message, without its rail. A prose message is its prose, a
+// deciding one is the card `card.mjs` composes, a visual is its block, and a
+// files message is its caption.
+function messageBody(message) {
+  const kind = FORMAT_KIND[message.format] ?? null
+  if (kind) return composeCard(kind, cardPayload(message))
+  if (message.format === 'prose') {
+    return [String(message.prose ?? '').trim(), ...blocks(message), ...detailLine(message)].join('\n\n')
+  }
+  if (message.format === 'visual') {
+    const shown = blocks(message)
+    if (!shown.length && present(message.picture)) shown.push(smallPrint('Picture attached.'))
+    return [...shown, ...detailLine(message)].join('\n\n')
+  }
+  if (message.format === 'files') return String(message.caption ?? '').trim()
+  return ''
 }
 
 export function renderCompositeMessage(message, index, count) {
   const kind = FORMAT_KIND[message.format] ?? null
   const rail = compositeRail(message, index, count)
-  const visual = message.table ?? message.diagram
-  let body = ''
-
-  if (message.format === 'prose') body = String(message.text ?? '').trim()
-  else if (kind) body = composeCard(kind, { ...message, visual })
-  else if (message.format === 'visual') {
-    const textVisual = message.table ?? message.diagram
-    if (textVisual) body = visualBlock(textVisual)
-    else if (message.picture) body = smallPrint('Picture attached.')
-  } else if (message.format === 'files') {
-    body = String(message.caption ?? '').trim()
-  }
-
+  const body = messageBody(message)
   // A picture is looked at in place. Other attachments remain downloads. The
   // transport receives one ordered list because both use Discord file slots.
   const attachments = [message.picture, ...(message.attachments ?? [])].filter(Boolean)
   return {
     format: message.format,
-    label: message.label,
+    label: message.label ?? null,
     kind,
     deciding: Boolean(kind),
+    rail,
+    body,
     content: [rail, body].filter(Boolean).join('\n'),
     attachments,
-    rail,
-    payload: kind ? { ...message, visual } : null,
+    payload: kind ? cardPayload(message) : null,
   }
 }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -95,6 +95,7 @@ import { githubSearchSource, journalSearchSource, transcriptSearchSource } from 
 import {
   compositeSendFaults, compositeSendSchemaFaults, renderCompositeSend,
 } from './composite.mjs'
+import { sendSchema, sendHasText, decidingIndex, SEND_HINT } from './send.mjs'
 import { trackerWriteWaves } from './trackerwrites.mjs'
 import {
   AccountUsage, AnthropicCredentialHealth, ModelWindows,
@@ -866,24 +867,42 @@ function askHumanGate(agentName, kind, raw) {
   return { open, flags: verdict.flags ?? null, note: verdict.note ?? null }
 }
 
-function compositeAskHumanGate(agentName, messages, maxMessages) {
+// The composite gate (#716, ADR-0026). One pass over a `messages` array, on
+// its own lint key per tool, so a refused send and a refused single card never
+// spend each other's attempts. `send.mjs` is the contract and `composite.mjs`
+// renders each message; the gate adds only what the TOOL decides: an
+// `ask_human` send decides once, last, and a `notify` send decides nothing.
+function compositeGate(agentName, tool, messages, maxMessages) {
   const schemaFaults = compositeSendSchemaFaults(messages, { maxMessages })
   const rendered = Array.isArray(messages) ? renderCompositeSend(messages) : []
   const deciding = rendered.at(-1)
-  const decisionFaults = deciding?.deciding
-    ? []
-    : ['messages: `ask_human` needs one deciding message last. Use `notify` when no answer blocks the work.']
+  const decisionFaults = []
+  if (tool === 'ask_human' && !deciding?.deciding) {
+    decisionFaults.push('messages: `ask_human` needs one deciding message last. Use `notify` when no answer blocks the work.')
+  }
+  const decides = Array.isArray(messages) ? decidingIndex(messages) : -1
+  if (tool === 'notify' && decides >= 0) {
+    decisionFaults.push(`messages: \`notify\` decides nothing, and message ${decides + 1} is a ${messages[decides].format}. Use \`ask_human\` when an answer blocks the work.`)
+  }
   const faults = [...compositeSendFaults(messages, { maxMessages }), ...decisionFaults]
   const verdict = lintGate.judge({
     agent: agentName,
-    kind: 'composite-ask',
+    kind: `composite-${tool === 'ask_human' ? 'ask' : 'notify'}`,
     faults,
     schema: schemaFaults.length > 0 || decisionFaults.length > 0,
-    hasText: Boolean(deciding?.deciding && rendered.some((message) => message.content)),
+    hasText: sendHasText(messages) && decisionFaults.length === 0,
     prompt: deciding?.content ?? null,
     payload: Array.isArray(messages) ? { messages } : null,
   })
   if (verdict.reject || verdict.refuse) return { stop: verdict.reject ?? verdict.refuse }
+  return { rendered, flags: verdict.flags ?? null, note: verdict.note ?? null }
+}
+
+function compositeAskHumanGate(agentName, messages, maxMessages) {
+  const gated = compositeGate(agentName, 'ask_human', messages, maxMessages)
+  if (gated.stop) return gated
+  const { rendered, flags, note } = gated
+  const deciding = rendered.at(-1)
 
   const payload = deciding.payload
   return {
@@ -897,8 +916,8 @@ function compositeAskHumanGate(agentName, messages, maxMessages) {
     },
     preludes: rendered.slice(0, -1),
     attachments: deciding.attachments,
-    flags: verdict.flags ?? null,
-    note: verdict.note ?? null,
+    flags,
+    note,
   }
 }
 
@@ -1828,11 +1847,53 @@ function buildMcpServer(agent, ticket) {
   // `progress` means neither. A set built on the agent's own weighting would be
   // a claim the payload cannot check, which is the fault ADR-0019 retired the
   // `recommended` boolean over.
+  // A composite `notify` (#716): every message of the send posts in order,
+  // each under its rail, each with its own files, and the whole send journals
+  // once so Atlas and the timeline read the same sequence Discord did. It
+  // carries none of the single-call fields: a status line and a send are two
+  // shapes, and a call that mixes them is refused before either goes out.
+  async function notifyComposite(messages, attachments, raw) {
+    const mixed = Object.entries(raw).filter(([, v]) => v !== undefined && v !== null).map(([k]) => k)
+    if (attachments?.length) mixed.push('attachments')
+    if (mixed.length) {
+      return { content: [{ type: 'text', text: `❌ curia refused this call. A composite \`notify\` carries only \`messages\`, and this one also carries ${mixed.join(', ')}. Put each file path in the \`attachments\` of the message it belongs to, and send a status line as its own call.` }] }
+    }
+    const gated = compositeGate(agent, 'notify', messages, curiaConfig.dispatch.messages_per_send ?? 4)
+    if (gated.stop) return { content: [{ type: 'text', text: gated.stop }] }
+    const { rendered, flags, note } = gated
+    const posts = rendered.map((message) => ({ message, ...outboundFiles(agent, message.attachments) }))
+    const refusals = posts.flatMap((p) => p.refusals)
+    reduction.journal('composite_send', {
+      agent, ticket, tool: 'notify', messages,
+      attachments: posts.flatMap((p) => p.files.map((f) => f.attachment)), refusals,
+      ...(flags ? { lint_flags: flags } : {}),
+    })
+    if (bridge) {
+      let sends = Promise.resolve()
+      for (const { message, files } of posts) {
+        sends = sends.then(() => bridge.notify(ticket, message.content, { files, as: speaker }))
+      }
+      if (flags?.length) {
+        sends = sends.then(() => bridge.notify(ticket, smallPrint([
+          `⚠️ curia sent this after ${flags.length} lint fault(s) the agent did not fix:`,
+          ...flags,
+        ].join('\n'))))
+      }
+      sends.catch(() => {})
+    } else {
+      for (const { message } of posts) log(`[notify ticket-${ticket}] ${message.content}`)
+    }
+    const said = refusals.length ? `ok (${refusals.length} file(s) refused)\n${refusals.join('\n')}` : 'ok'
+    const flagNote = note ? [{ type: 'text', text: flaggedNotifyText(flags) }] : []
+    return { content: [...flagNote, { type: 'text', text: said }, ...drainNotes()] }
+  }
+
   server.tool(
     'notify',
     'Fire-and-forget opening, working phase, or milestone for the human. Returns immediately.'
     + ' `kind` says what the operator must DO: `progress` needs nothing from them, `look` puts a file or a page in front of their eyes now, and `ask` wants a reply they can send whenever they get to it.'
     + ' An `ask` blocks nothing — use `ask_human` when you cannot go on without the answer.'
+    + ` An answer that does not fit the status line is a SEND: put it in \`messages\` alone, with a prose message that leads with its conclusion in bold. ${SEND_HINT} A notify send decides nothing.`
     + ' READ WHAT THIS CALL RETURNS. Curia lints your words and refuses the call when they break a rule. Rewrite the named field and call again. You get three attempts, and the fourth text goes out flagged.',
     {
       // Off zod for the reason the gate's `summary` is (#438): a -32602 dies in
@@ -1855,11 +1916,16 @@ function buildMcpServer(agent, ticket) {
       ]).optional().describe('Edit routine progress into the live status line without adding a thread message.'),
       label: z.string().optional().describe('What you are doing now, in one line of at most 20 characters.'),
       ...ATTACHMENT_SHAPE,
+      // The composite send (#716, ADR-0026), with NO deciding message: a prose
+      // message carries the answer that never fit the 600-character status
+      // line, and an image or a file rides the message it belongs to.
+      messages: sendSchema,
     },
-    async ({ attachments, ...raw }) => {
+    async ({ attachments, messages, ...raw }) => {
       if (raw.opening && reduction.hasAgentOpening(agent)) {
         return { content: [{ type: 'text', text: 'opening: already sent for this dispatch.' }] }
       }
+      if (messages) return notifyComposite(messages, attachments, raw)
       // The same gate as the other surfaces, on its own key, so a rejected
       // status line and a rejected question never spend each other's attempts.
       const floor = notifyFloorFaults(raw)
@@ -2050,6 +2116,7 @@ function buildMcpServer(agent, ticket) {
     + ' Every call needs a `headline`. The untyped `prompt` is retired, and curia refuses a call that carries it.'
     + ' free-text is a ROUND — put every question in `questions`, give each a `recommendation`, and curia adds the ✅ All as recommended button when every one of them has it.'
     + ' choice takes `options`, each with a `label` and the `consequence` of picking it.'
+    + ` A decision that needs an answer or a picture in front of it is a SEND: put the whole sequence in \`messages\` alone, the deciding message last. ${SEND_HINT}`
     + ' READ WHAT THIS CALL RETURNS. Curia lints your words and refuses the call when they break a rule, and the refusal names the rule and quotes the text. Rewrite the named field and call again. You get three attempts, and the fourth text goes out flagged.',
     {
       // The two RETIRED fields (#422). They stay in the schema so that curia
@@ -2085,7 +2152,10 @@ function buildMcpServer(agent, ticket) {
       timeline: z.boolean().optional().describe('Point the operator at the timeline for the reasoning. Curia composes the link.'),
       preview_url: z.string().optional(),
       ...ATTACHMENT_SHAPE,
-      messages: z.array(z.record(z.string(), z.any())).optional().describe('One ordered composite send. Each entry has its own `format`, `label`, content fields, and `attachments`. At most four messages. Put the one deciding message last.'),
+      // The composite send (#716, ADR-0026): the array `send.mjs` types, with
+      // the deciding message last. The single-card fields above stay for a
+      // call of one card, and a call carries one shape or the other.
+      messages: sendSchema,
     },
     // `attachments` is bound aside, because the ANSWER carries a field of that
     // name too (#34): the files the human replied with.
@@ -2143,7 +2213,7 @@ function buildMcpServer(agent, ticket) {
         }
       }
       const preludeRefusals = []
-      if (messages) reduction.journal('composite_send', { agent, ticket, messages })
+      if (messages) reduction.journal('composite_send', { agent, ticket, tool: 'ask_human', messages })
       if (gated.preludes?.length) {
         for (const prelude of gated.preludes) {
           const outbound = outboundFiles(agent, prelude.attachments)

--- a/daemon/src/send.mjs
+++ b/daemon/src/send.mjs
@@ -167,12 +167,26 @@ export function sendFloorFaults(messages, { cap = MESSAGES_PER_SEND } = {}) {
 
 // ---- the words ----------------------------------------------------------------
 
+// A prose message opens with one bold line, and the body comes after it.
+export const leadsWithConclusion = (prose) => /^\*\*[^*\n]+\*\*/.test(String(prose ?? '').trim())
+
 function messageLint(m, prefix) {
   const faults = []
   if (present(m?.label)) faults.push(...gradeA(`${prefix}label`, m.label, CAPS.label))
   // The prose message. Past the cap the agent composes a SECOND prose message,
-  // and `gradeB` names the cap while the send-level guidance names that path.
-  if (present(m?.prose)) faults.push(...gradeB(`${prefix}prose`, m.prose, CAPS.prose))
+  // and the refusal names that path rather than only the number: an agent that
+  // hears the number alone spends its attempts squeezing.
+  if (present(m?.prose)) {
+    faults.push(...gradeB(`${prefix}prose`, m.prose, CAPS.prose).map((f) => (
+      f.includes(`over the ${CAPS.prose} cap`) ? `${f} Compose a second prose message, and break where the meaning breaks.` : f
+    )))
+    // The conclusion leads, in bold (#640). It is the shape the ending report
+    // and the verdict already take, and it survives being read halfway, which
+    // is what a phone does to a long block.
+    if (!leadsWithConclusion(m.prose)) {
+      faults.push(`${prefix}prose: lead with the conclusion, in bold, on the first line: **The cap holds.** The body follows it.`)
+    }
+  }
   if (present(m?.caption)) faults.push(...gradeA(`${prefix}caption`, m.caption, CAPS.caption))
   if (present(m?.detail)) faults.push(...gradeA(`${prefix}detail`, m.detail, CAPS.detail))
   faults.push(...lintVisualFields(m ?? {}, prefix))

--- a/daemon/src/transcript.mjs
+++ b/daemon/src/transcript.mjs
@@ -27,6 +27,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { renderCompositeSend } from './composite.mjs'
 
 export const TRANSCRIPT_HARNESSES = ['claude', 'codex']
 
@@ -244,6 +245,7 @@ function claudeToolBrief(name, input = {}) {
   if (name === 'Grep' || name === 'Glob') return `${input.pattern ?? ''} ${input.path ?? ''}`.trim()
   if (name === 'TodoWrite') return `${input.todos?.length ?? 0} items`
   if (name?.startsWith('mcp__curia__')) {
+    if (isCuriaSend(input)) return curiaSendBrief(input)
     return firstLine(input.prompt ?? input.summary ?? input.message ?? JSON.stringify(input))
   }
   if (name === 'Task' || name === 'Agent') return firstLine(input.description ?? input.prompt)
@@ -258,6 +260,30 @@ function curiaToolText(input = {}) {
   const t = input.prompt ?? input.message ?? input.summary
   return typeof t === 'string' && t.trim() ? t : null
 }
+
+// The composite send a curia call carries (#716, ADR-0026), rendered by the
+// one renderer Discord posts from, so Atlas Chat draws the same sequence under
+// the same rails. The deciding message is marked rather than dropped: the
+// page draws it from the daemon's escalation record, as it draws every card.
+// A `messages` value the renderer cannot read is no sequence, and the brief
+// stands alone, because a transcript line must never break the room.
+function curiaToolSend(input = {}) {
+  if (!Array.isArray(input.messages) || !input.messages.length) return null
+  try {
+    return renderCompositeSend(input.messages)
+      .map(({ rail, body, deciding, format, label }) => ({ rail, body, deciding, format, label }))
+  } catch {
+    return null
+  }
+}
+
+// One line for a send: how many messages, and their labels in order.
+function curiaSendBrief(input = {}) {
+  const labels = input.messages.map((m) => String(m?.label ?? m?.format ?? '?').trim())
+  return `send of ${input.messages.length}: ${labels.join(' · ')}`
+}
+
+const isCuriaSend = (input) => Array.isArray(input?.messages) && input.messages.length > 0
 
 function claudeResultText(content) {
   if (typeof content === 'string') return content
@@ -282,6 +308,8 @@ function claudeItems(e) {
         if (c.name?.startsWith('mcp__curia__')) {
           const text = curiaToolText(c.input)
           if (text) item.text = text
+          const send = curiaToolSend(c.input)
+          if (send) item.send = send
         }
         out.push(item)
       }
@@ -355,6 +383,7 @@ function codexToolBrief(name, args) {
   if (name === 'exec_command' || name === 'shell') return firstLine(args.cmd ?? args.command)
   if (name === 'write_stdin') return firstLine(args.chars)
   if (name === 'ask_human' || name === 'notify' || name === 'report_result' || name === 'request_review') {
+    if (isCuriaSend(args)) return curiaSendBrief(args)
     return firstLine(args.prompt ?? args.message ?? args.summary ?? JSON.stringify(args))
   }
   return firstLine(JSON.stringify(args), 160)
@@ -411,6 +440,8 @@ function codexItems(e) {
       if (String(p.namespace ?? '').startsWith('mcp__curia')) {
         const text = curiaToolText(args)
         if (text) item.text = text
+        const send = curiaToolSend(args)
+        if (send) item.send = send
       }
       return [item]
     }

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -2154,6 +2154,11 @@ export function writePrompt(cfgDir, issue, {
     '  blocks nothing, so use `ask_human` when you cannot go on without the answer.',
     '  Set `phase` for routine progress. Curia edits the live status line instead of posting another message.',
     '- Start with one `notify` message. Put your goal first, then your first step. Use at most two lines.',
+    '- **A SEND is `messages` on either tool** (ADR-0026): an ordered array, each entry its own typed',
+    '  message with a `format`, a rail `label`, and its own `attachments`. A message exists when a reader',
+    '  would want to skip it on its own; anything read together stays one message. A prose message leads',
+    '  with its conclusion in bold, and past 1600 characters you write a second one. At most one message',
+    '  decides, and it goes last, only on `ask_human`. Curia writes the count, and refuses a send over the cap.',
     ...(newMap ? [
       '- `map_created` — tell curia the number of the map you created, the moment it exists. curia checks',
       '  the issue is really an open `wayfinder:map` in this repo, then takes it as this session\'s map:',
@@ -2185,6 +2190,11 @@ export function writePrompt(cfgDir, issue, {
     '  blocks nothing, so use `ask_human` when you cannot go on without the answer.',
     '  Set `phase` for routine progress. Curia edits the live status line instead of posting another message.',
     '- Start with one `notify` message. Put your goal first, then your first step. Use at most two lines.',
+    '- **A SEND is `messages` on either tool** (ADR-0026): an ordered array, each entry its own typed',
+    '  message with a `format`, a rail `label`, and its own `attachments`. A message exists when a reader',
+    '  would want to skip it on its own; anything read together stays one message. A prose message leads',
+    '  with its conclusion in bold, and past 1600 characters you write a second one. At most one message',
+    '  decides, and it goes last, only on `ask_human`. Curia writes the count, and refuses a send over the cap.',
     ...(portLines.length ? [
       '- `publish_preview` — publish a dev server you have started as an HTTPS link. Start the server FIRST,',
       `  bound to \`0.0.0.0\` on one of your three ports (${ports.join(', ')}), then call this with that port`,

--- a/daemon/test/composite.test.mjs
+++ b/daemon/test/composite.test.mjs
@@ -1,12 +1,18 @@
+// Tests for src/composite.mjs (#716): the one renderer over the ADR-0026
+// contract that `send.mjs` types. The contract's own rules are pinned in
+// send.test.mjs; this file pins that the renderer reads that contract rather
+// than a second one, and what each message comes out as.
+
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   compositeSendFaults, compositeSendSchemaFaults, lintCompositeSend,
-  renderCompositeSend,
+  renderCompositeSend, compositeRail, MAX_MESSAGES_PER_SEND,
 } from '../src/composite.mjs'
+import { MESSAGES_PER_SEND } from '../src/send.mjs'
 
-const prose = (label, text = 'The result is ready.') => ({
-  format: 'prose', label, text, attachments: [],
+const prose = (label, text = '**The result is ready.** The journal owns the record.') => ({
+  format: 'prose', label, prose: text, attachments: [],
 })
 
 const choice = () => ({
@@ -20,156 +26,51 @@ const choice = () => ({
   attachments: [],
 })
 
-describe('the composite send contract', () => {
-  test('one send carries no more than four typed messages', () => {
-    assert.deepEqual(compositeSendFaults([prose('answer'), choice()]), [])
+describe('the renderer reads the one contract', () => {
+  test('the cap is the contract\'s cap', () => {
+    assert.equal(MAX_MESSAGES_PER_SEND, MESSAGES_PER_SEND)
+  })
 
+  test('a send over the cap is refused whole, and the messages come back untouched', () => {
+    assert.deepEqual(compositeSendFaults([prose('answer'), choice()]), [])
     const messages = [1, 2, 3, 4, 5].map((n) => prose(`part ${n}`))
     const before = structuredClone(messages)
-    const faults = compositeSendFaults(messages)
-
-    assert.match(faults.join(' | '), /5 messages over the 4 message cap/)
+    assert.match(compositeSendFaults(messages).join(' | '), /5 messages over the 4 cap/)
     assert.deepEqual(messages, before, 'a refusal must not drop the fifth message')
+    assert.deepEqual(compositeSendFaults([prose('a'), prose('b'), prose('c')], { maxMessages: 2 }).length, 1)
   })
 
-  test('one deciding message is allowed, and it must be last', () => {
-    const twoDecisions = [choice(), { ...choice(), label: 'second decision' }]
-    assert.match(compositeSendFaults(twoDecisions).join(' | '), /at most one deciding message/)
-
-    const decisionFirst = [choice(), prose('follow-up')]
-    assert.match(compositeSendFaults(decisionFirst).join(' | '), /deciding message at messages\[0\] must be last/)
-
-    assert.deepEqual(compositeSendFaults([prose('answer'), choice()]), [])
+  test('the deciding message is last, and there is at most one', () => {
+    assert.match(compositeSendFaults([choice(), prose('follow-up')]).join(' | '), /deciding message is 1 of 2\. It posts last/)
+    assert.match(compositeSendFaults([choice(), { ...choice(), label: 'second' }]).join(' | '), /2 deciding messages/)
   })
 
-  test('every entry names one supported format', () => {
-    const formats = ['prose', 'round', 'choice', 'approve-reject', 'preview-review', 'visual', 'files']
-    for (const format of formats) {
-      assert.doesNotMatch(
-        compositeSendFaults([{ format, label: format, attachments: [] }]).join(' | '),
-        /\.format:/,
-      )
-    }
-
-    const faults = compositeSendFaults([{ format: 'markdown', label: 'answer', attachments: [] }])
-    assert.match(faults.join(' | '), /messages\[0\]\.format: "markdown" is not supported/)
+  test('the fields are the contract\'s: `prose` carries the prose, and `text` is named', () => {
+    const faults = compositeSendSchemaFaults([{ format: 'prose', label: 'answer', text: 'words' }]).join(' | ')
+    assert.match(faults, /messages\[0\]\.text: a `prose` message does not carry it/)
+    assert.match(faults, /messages\[0\]\.prose: missing/)
   })
 
-  test('labels cap at 20 characters, and attachments are path strings', () => {
-    assert.deepEqual(compositeSendFaults([prose('x'.repeat(20))]), [])
-    assert.match(compositeSendFaults([prose('x'.repeat(21))]).join(' | '), /label: 21 characters over the 20 cap/)
-    assert.match(compositeSendFaults([{ ...prose('answer'), attachments: 'answer.md' }]).join(' | '), /attachments: expected an array of file paths/)
-    assert.match(compositeSendFaults([{ ...prose('answer'), attachments: ['answer.md', 2] }]).join(' | '), /attachments\[1\]: expected a file path/)
+  test('the words take the grades they already had', () => {
+    const faults = lintCompositeSend([prose('x'.repeat(21)), choice()]).join(' | ')
+    assert.match(faults, /messages\[0\]\.label: 21 characters over the 20 cap/)
+    assert.match(lintCompositeSend([prose('answer', 'No bold lead.')]).join(' | '), /lead with the conclusion, in bold/)
   })
+})
 
-  test('the new visual and attachment names are accepted without losing retired fields', () => {
-    const accepted = {
-      ...prose('answer'), picture: '/workspace/chart.png', table: 'A  B\n1  2', diagram: 'A -> B',
-      attachments: ['/workspace/details.md'],
-    }
-    assert.deepEqual(compositeSendFaults([accepted]), [])
-
-    const retired = [{ ...prose('answer'), visual: 'A -> B', images: ['/workspace/chart.png'] }]
-    const before = structuredClone(retired)
-    const faults = compositeSendFaults(retired).join(' | ')
-    assert.match(faults, /visual: retired.*table.*diagram/)
-    assert.match(faults, /images: retired.*attachments/)
-    assert.deepEqual(retired, before)
+describe('the rail', () => {
+  test('curia writes the count, and a send of one carries none', () => {
+    assert.equal(compositeRail({ label: 'answer' }, 0, 3), '-# 1 of 3 · answer')
+    assert.equal(compositeRail({ label: 'answer' }, 0, 1), '')
+    assert.equal(renderCompositeSend([prose('answer')])[0].content, '**The result is ready.** The journal owns the record.')
+    assert.equal(renderCompositeSend([prose('answer')])[0].rail, '')
   })
+})
 
-  test('prose caps at 1600 and tells the author to compose another message', () => {
-    assert.deepEqual(lintCompositeSend([prose('answer', 'x'.repeat(1600))]), [])
-    const faults = lintCompositeSend([prose('answer', 'x'.repeat(1601))]).join(' | ')
-    assert.match(faults, /messages\[0\]\.text: 1601 characters over the 1600 cap/)
-    assert.match(faults, /Compose a second prose message/)
-  })
-
-  test('question background is grade B prose capped at 600 characters', () => {
-    const round = {
-      format: 'round', label: 'decision', headline: 'Which limit should apply?', attachments: [],
-      questions: [{ text: 'How many messages?', background: 'x'.repeat(600), recommendation: 'Four.' }],
-    }
-    assert.deepEqual(compositeSendSchemaFaults([round]), [])
-    assert.deepEqual(lintCompositeSend([round]), [])
-
-    round.questions[0].background += 'x'
-    assert.match(lintCompositeSend([round]).join(' | '), /background: 601 characters over the 600 cap/)
-  })
-
-  test('each format enforces its own content floor', () => {
-    const valid = [
-      prose('answer'),
-      {
-        format: 'round', label: 'questions', headline: 'Choose the limits.',
-        questions: [{ text: 'How many?', recommendation: 'Four.' }], attachments: [],
-      },
-      choice(),
-      { format: 'approve-reject', label: 'approval', headline: 'Ship the change?', attachments: [] },
-      { format: 'preview-review', label: 'preview', headline: 'Does the page read well?', preview_url: 'https://preview.invalid', attachments: [] },
-      { format: 'visual', label: 'flow', diagram: 'input -> output', attachments: [] },
-      { format: 'files', label: 'patch', caption: 'The complete patch.', attachments: ['/workspace/fix.patch'] },
-    ]
-    for (const message of valid) assert.deepEqual(compositeSendSchemaFaults([message]), [], message.format)
-
-    assert.match(compositeSendSchemaFaults([{ format: 'prose', label: 'answer' }]).join(' | '), /text: missing/)
-    assert.match(compositeSendSchemaFaults([{ format: 'visual', label: 'flow' }]).join(' | '), /picture, table, or diagram/)
-    assert.match(compositeSendSchemaFaults([{ format: 'files', label: 'patch', caption: 'Patch.' }]).join(' | '), /attachments: missing/)
-  })
-
-  test('choice options require an explicit short button handle', () => {
-    const without = choice()
-    delete without.options[0].handle
-    assert.match(compositeSendSchemaFaults([without]).join(' | '), /options\[0\]\.handle: missing/)
-
-    const bad = choice()
-    bad.options[0].handle = { text: 'journal' }
-    assert.match(compositeSendSchemaFaults([bad]).join(' | '), /options\[0\]\.handle: expected one line of text/)
-  })
-
-  test('a format refuses content fields that belong to another format', () => {
-    const payload = [{ ...prose('answer'), questions: [{ text: 'Hidden question?' }] }]
-    const before = structuredClone(payload)
-    assert.match(compositeSendSchemaFaults(payload).join(' | '), /questions: not permitted on the prose format/)
-    assert.deepEqual(payload, before)
-  })
-
-  test('typed card fields and handles keep their existing lint grades', () => {
-    const message = choice()
-    message.options[0].handle = 'journal\nnow'
-    assert.match(lintCompositeSend([message]).join(' | '), /options\[0\]\.handle: a newline/)
-
-    message.options[0].handle = 'journal'
-    message.options[0].consequence = 'A robust record.'
-    assert.match(lintCompositeSend([message]).join(' | '), /options\[0\]\.consequence: the marketing adjective "robust"/)
-  })
-
-  test('tables and diagrams keep the phone geometry limit', () => {
-    const table = { ...prose('answer'), table: 'x'.repeat(43) }
-    const diagram = { ...prose('answer'), diagram: Array(21).fill('row').join('\n') }
-    const faults = lintCompositeSend([table, diagram]).join(' | ')
-    assert.match(faults, /messages\[0\]\.table: 43 columns over the 42 cap/)
-    assert.match(faults, /messages\[1\]\.diagram: 21 lines over the 20 cap/)
-  })
-
-  test('a send and each typed field keep their declared types', () => {
-    assert.match(compositeSendSchemaFaults([]).join(' | '), /messages: empty/)
-    assert.match(compositeSendSchemaFaults(['answer']).join(' | '), /messages\[0\]: expected a typed message object/)
-
-    const bad = choice()
-    bad.headline = 42
-    bad.timeline = 'yes'
-    bad.options[0].recommended = 'yes'
-    const before = structuredClone(bad)
-    const faults = compositeSendSchemaFaults([bad]).join(' | ')
-    assert.match(faults, /headline: expected text/)
-    assert.match(faults, /timeline: expected true or false/)
-    assert.match(faults, /options\[0\]\.recommended: expected true or false/)
-    assert.deepEqual(bad, before)
-  })
-
+describe('the rendered sequence', () => {
   test('one renderer gives every surface the same ordered message sequence', () => {
     const messages = [
-      { ...prose('answer', 'The journal owns the record.'), picture: '/workspace/chart.png' },
+      { ...prose('answer', '**The journal owns the record.** It survives a restart.'), picture: '/workspace/chart.png' },
       {
         format: 'round', label: 'decision', headline: 'Choose the limits.', attachments: ['/workspace/limits.md'],
         questions: [{ text: 'How many messages?', background: 'Discord keeps the deciding message last.', recommendation: 'Four.' }],
@@ -178,17 +79,37 @@ describe('the composite send contract', () => {
 
     const rendered = renderCompositeSend(messages)
     assert.equal(rendered.length, 2)
-    assert.match(rendered[0].content, /^-# 1 of 2 · answer\nThe journal owns the record\.$/)
+    assert.equal(rendered[0].rail, '-# 1 of 2 · answer')
+    assert.match(rendered[0].content, /^-# 1 of 2 · answer\n\*\*The journal owns the record\.\*\* It survives a restart\.$/)
     assert.deepEqual(rendered[0].attachments, ['/workspace/chart.png'])
     assert.equal(rendered[0].deciding, false)
+    assert.equal(rendered[0].payload, null)
     assert.match(rendered[1].content, /^-# 2 of 2 · decision\n\*\*Choose the limits\.\*\*/)
-    assert.match(rendered[1].content, /-# 💡 Discord keeps the deciding message last\./)
+    // The question background: small print, behind 💡, under its line.
+    assert.match(rendered[1].content, /\*\*1\.\*\* How many messages\?\n-# 💡 Discord keeps the deciding message last\.\n↳ Four\./)
     assert.deepEqual(rendered[1].attachments, ['/workspace/limits.md'])
     assert.equal(rendered[1].kind, 'free-text')
     assert.equal(rendered[1].deciding, true)
+    assert.equal(rendered[1].payload.headline, 'Choose the limits.')
+    assert.equal(rendered[1].payload.questions[0].background, 'Discord keeps the deciding message last.')
+    assert.equal('visual' in rendered[1].payload, false, 'the retired field is not reborn on the record')
   })
 
-  test('a single message carries no rail', () => {
-    assert.equal(renderCompositeSend([prose('answer')])[0].content, 'The result is ready.')
+  test('a visual message is its fenced block, a picture-only one says so, and a files message is its caption', () => {
+    const rendered = renderCompositeSend([
+      { format: 'visual', label: 'flow', diagram: 'a -> b', attachments: [] },
+      { format: 'visual', label: 'mock', picture: '/workspace/mock.png', attachments: [] },
+      { format: 'files', label: 'patch', caption: 'The complete patch.', attachments: ['/workspace/fix.patch'] },
+    ])
+    assert.equal(rendered[0].body, '```\na -> b\n```')
+    assert.equal(rendered[1].body, '-# Picture attached.')
+    assert.deepEqual(rendered[1].attachments, ['/workspace/mock.png'])
+    assert.equal(rendered[2].body, 'The complete patch.')
+    assert.equal(rendered[2].content, '-# 3 of 3 · patch\nThe complete patch.')
+  })
+
+  test('a prose message keeps its table and its facts under the prose', () => {
+    const [m] = renderCompositeSend([{ ...prose('cost'), table: 'a  b\n1  2', detail: 'Measured on the box.' }])
+    assert.equal(m.body, '**The result is ready.** The journal owns the record.\n\n```\na  b\n1  2\n```\n\nDetails: ||Measured on the box.||')
   })
 })

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2665,6 +2665,36 @@ describe('the chat screen (#267, the picker of #333)', () => {
       assert.match(text(page.screenChat(payload())), /def\.jsonl/)
     })
 
+    // The composite send (#716). The room draws every message of the sequence
+    // under its rail, and the deciding one is only named, because the card
+    // from the record carries it.
+    test('a composite send draws its sequence under the rails, and the deciding message is the card', () => {
+      page.chatReceive('items', [{
+        kind: 'tool', id: 't2', name: 'mcp__curia__ask_human', brief: 'send of 3: answer · the run · decision', at: at(200),
+        send: [
+          { rail: '-# 1 of 3 · answer', body: '**The cap held.** Cooling ran to 14:20.', deciding: false, format: 'prose', label: 'answer' },
+          { rail: '-# 2 of 3 · the run', body: '```\nboot -> cap\n```', deciding: false, format: 'visual', label: 'the run' },
+          { rail: '-# 3 of 3 · decision', body: '**Keep the cap?**', deciding: true, format: 'choice', label: 'decision' },
+        ],
+      }])
+      const html = page.screenChat(payload())
+      const t = text(html)
+      assert.match(t, /1 of 3 · answer \*\*The cap held\.\*\* Cooling ran to 14:20\./)
+      assert.match(t, /2 of 3 · the run ``` boot -&gt; cap ```/)
+      assert.match(t, /3 of 3 · decision the card follows/)
+      assert.doesNotMatch(t, /Keep the cap\?/, 'the deciding body is the card, drawn from the record')
+      assert.doesNotMatch(html, /-# /, 'the rail loses the Discord small-print mark')
+      assert.equal((html.match(/class="send-msg/g) ?? []).length, 3)
+
+      page.chatReceive('items', [{
+        kind: 'tool', id: 't3', name: 'mcp__curia__notify', brief: 'send of 1: answer', at: at(100),
+        send: [{ rail: '', body: '**One message.** No rail.', deciding: false, format: 'prose', label: 'answer' }],
+      }])
+      const one = page.screenChat(payload())
+      assert.match(text(one), /\*\*One message\.\*\* No rail\./)
+      assert.doesNotMatch(one, /class="rail"[^<]*<\/span>[^<]*One message/)
+    })
+
     test('the daemon\'s escalation record interleaves with the transcript, and an open one is a banner', () => {
       page.chatReceive('items', [{ kind: 'say', text: 'first', at: at(300) }, { kind: 'say', text: 'third', at: at(100) }])
       page.chatReceive('esc_history', [{ id: 'esc-7', kind: 'question', prompt: 'Which branch?', options: ['a', 'b'], opened_at: at(200), closed_at: at(150), status: 'answered', answer: 'a', answered_by: 'alp', answered_via: 'dashboard' }])

--- a/daemon/test/send.test.mjs
+++ b/daemon/test/send.test.mjs
@@ -16,7 +16,7 @@ import { CAPS } from '../src/lint.mjs'
 
 const names = (faults) => faults.join(' | ')
 
-const prose = (label, text = 'The cap landed at 09:00 and cooling ran to 14:20.') => ({
+const prose = (label, text = '**The cap held.** It landed at 09:00 and cooling ran to 14:20.') => ({
   format: 'prose', label, prose: text,
 })
 const round = (label = 'decision') => ({
@@ -127,11 +127,20 @@ describe('the field vocabulary per format', () => {
     assert.match(names(sendFloorFaults([{ format: 'prose', label: 'answer' }])), /messages\[0\]\.prose: missing/)
   })
 
-  test('prose caps at 1600, not at the block cap', () => {
-    assert.deepEqual(lintSend([{ format: 'prose', label: 'answer', prose: 'Short words. '.repeat(100) }]), [])
-    const long = 'Short words here. '.repeat(100)
+  test('prose caps at 1600, not at the block cap, and the refusal names the second message', () => {
+    assert.deepEqual(lintSend([{ format: 'prose', label: 'answer', prose: `**Short.** ${'Short words. '.repeat(100)}` }]), [])
+    const long = `**Long.** ${'Short words here. '.repeat(100)}`
     assert.ok(long.length > CAPS.prose)
-    assert.match(names(lintSend([{ format: 'prose', label: 'answer', prose: long }])), new RegExp(`messages\\[0\\]\\.prose: ${long.length} characters over the ${CAPS.prose} cap`))
+    const faults = names(lintSend([{ format: 'prose', label: 'answer', prose: long }]))
+    assert.match(faults, new RegExp(`messages\\[0\\]\\.prose: ${long.length} characters over the ${CAPS.prose} cap`))
+    assert.match(faults, /Compose a second prose message/)
+  })
+
+  test('prose leads with its conclusion, in bold (#716)', () => {
+    assert.deepEqual(lintSend([prose('answer', '**The cap holds.**\nThe body follows.')]), [])
+    const faults = names(lintSend([prose('answer', 'The cap holds. The body follows.')]))
+    assert.match(faults, /messages\[0\]\.prose: lead with the conclusion, in bold/)
+    assert.match(names(lintSend([prose('answer', 'Some words **and bold later**.')])), /lead with the conclusion/)
   })
 
   test('a visual message shows one of the three', () => {

--- a/daemon/test/theflip.test.mjs
+++ b/daemon/test/theflip.test.mjs
@@ -227,7 +227,7 @@ describe('an untyped ask_human is refused since the flip (#422, real boot)', () 
   test('a composite ask keeps its order and opens only its last decision', async () => {
     const c = await client('curia-422-composite', '422')
     const messages = [
-      { format: 'prose', label: 'answer', text: 'The shared contract is ready.', attachments: [] },
+      { format: 'prose', label: 'answer', prose: '**The shared contract is ready.** One module types it.', attachments: [] },
       {
         format: 'choice', label: 'decision', headline: 'Which surface should answer?', attachments: [],
         options: [
@@ -250,7 +250,42 @@ describe('an untyped ask_human is refused since the flip (#422, real boot)', () 
       body: JSON.stringify({ id: open.id, answer: 'Use Atlas.' }),
     })
     assert.match((await call).content.map((part) => part.text ?? '').join('\n'), /Use Atlas\./)
+    assert.equal(send.tool, 'ask_human')
     await c.close().catch(() => {})
+  })
+
+  // The composite notify (#716). It decides nothing, it posts every message
+  // in order, and it journals once with the tool that sent it.
+  test('a composite notify posts its sequence, decides nothing, and refuses a deciding message', async () => {
+    const c = await client('curia-422-notify', '422')
+    const notify = async (args) => {
+      const r = await c.callTool({ name: 'notify', arguments: args }, undefined, { timeout: 30_000 })
+      return r.content.map((x) => x.text ?? '').join('\n')
+    }
+    try {
+      const messages = [
+        { format: 'prose', label: 'answer', prose: '**The cap held.** Cooling ran to 14:20.', attachments: [] },
+        { format: 'visual', label: 'the run', diagram: 'boot -> cap -> cool', attachments: [] },
+      ]
+      assert.equal(await notify({ messages }), 'ok')
+      const send = journalEvents(path.join(tmp, 'data')).find((event) => event.type === 'composite_send' && event.agent === 'curia-422-notify')
+      assert.deepEqual(send.messages, messages)
+      assert.equal(send.tool, 'notify')
+      assert.deepEqual(await openEscalations(port), [], 'a notify send opens no card')
+
+      const refused = await notify({ messages: [messages[0], {
+        format: 'choice', label: 'decision', headline: 'Which one?', attachments: [],
+        options: [
+          { label: 'The cap.', handle: 'cap', consequence: 'The cap stands.' },
+          { label: 'No cap.', handle: 'none', consequence: 'The cap goes.' },
+        ],
+      }] })
+      assert.match(refused, /`notify` decides nothing, and message 2 is a choice/)
+      assert.match(await notify({ messages, message: 'and a status line' }), /carries only `messages`, and this one also carries message/)
+      assert.match(await notify({ messages: [{ format: 'prose', label: 'answer', prose: 'No bold lead.' }] }), /lead with the conclusion, in bold/)
+    } finally {
+      await c.close().catch(() => {})
+    }
   })
 
   test('a bare string option is refused, and it is named once rather than per field', async () => {

--- a/daemon/test/transcriptbranch.test.mjs
+++ b/daemon/test/transcriptbranch.test.mjs
@@ -75,3 +75,50 @@ test('the journal keeps the landing point through a restart', () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+// The composite send on the Chat stream (#716). The one renderer Discord
+// posts from gives the transcript item its sequence, so Atlas draws the same
+// rails. The deciding message is marked, because the page draws it as the
+// card from the daemon's record.
+const SEND = [
+  { format: 'prose', label: 'answer', prose: '**The cap held.** Cooling ran to 14:20.' },
+  { format: 'choice', label: 'decision', headline: 'Keep the cap?', options: [
+    { label: 'Keep it.', handle: 'keep', consequence: 'The cap stands.' },
+    { label: 'Drop it.', handle: 'drop', consequence: 'The cap goes.' },
+  ] },
+]
+
+test('a composite curia call carries its rendered sequence, on the claude harness', () => {
+  const line = JSON.stringify({
+    type: 'assistant', uuid: 'a1', parentUuid: null, timestamp: '2026-08-26T09:00:00.000Z',
+    message: { content: [{ type: 'tool_use', id: 't1', name: 'mcp__curia__ask_human', input: { messages: SEND } }] },
+  })
+  const [item] = readActiveMessages('claude', [line]).items
+  assert.equal(item.kind, 'tool')
+  assert.equal(item.brief, 'send of 2: answer · decision')
+  assert.equal(item.text, undefined)
+  assert.deepEqual(item.send.map((m) => [m.rail, m.deciding]), [['-# 1 of 2 · answer', false], ['-# 2 of 2 · decision', true]])
+  assert.equal(item.send[0].body, '**The cap held.** Cooling ran to 14:20.')
+  assert.match(item.send[1].body, /^\*\*Keep the cap\?\*\*/)
+})
+
+test('a composite curia call carries its rendered sequence, on the codex harness', () => {
+  const line = JSON.stringify({
+    type: 'response_item', timestamp: '2026-08-26T09:00:00.000Z',
+    payload: { type: 'function_call', call_id: 'c1', name: 'notify', namespace: 'mcp__curia', arguments: JSON.stringify({ messages: [SEND[0]] }) },
+  })
+  const [item] = readActiveMessages('codex', [line]).items
+  assert.equal(item.name, 'curia.notify')
+  assert.equal(item.brief, 'send of 1: answer')
+  assert.deepEqual(item.send, [{ rail: '', body: '**The cap held.** Cooling ran to 14:20.', deciding: false, format: 'prose', label: 'answer' }])
+})
+
+test('a `messages` value the renderer cannot read leaves the brief alone', () => {
+  const line = JSON.stringify({
+    type: 'assistant', uuid: 'a2', parentUuid: null, timestamp: '2026-08-26T09:00:00.000Z',
+    message: { content: [{ type: 'tool_use', id: 't2', name: 'mcp__curia__notify', input: { messages: [null, 'x'] } }] },
+  })
+  const [item] = readActiveMessages('claude', [line]).items
+  assert.equal(item.send, undefined)
+  assert.equal(item.brief, 'send of 2: ? · ?')
+})


### PR DESCRIPTION
Closes #716.

## What changed

- One contract, one renderer. `send.mjs` (#691) is the composite-send contract, and `composite.mjs` now renders over it instead of carrying a second floor and lint of its own. The prose field is `prose`, as ADR-0026 says, and a `text` field is named rather than read. A send of one message needs no label.
- `notify` takes a send. A `messages` array with no deciding message posts each message in order under its rail, each with its own files, and journals one `composite_send` event with `tool: notify`. A deciding message on a notify send is refused by its position and format, and a call that mixes a send with a status line is refused before either goes out.
- Both tools declare `sendSchema`, so every message field is typed, optional to zod, and refused in words. The tool descriptions carry the one rule, with no shape catalog.
- Prose leads with its conclusion in bold. A prose message that does not open with a bold line gets a lint fault, and the 1600 cap refusal names the second prose message.
- Atlas Chat draws the sequence. The transcript reader renders a curia call that carries `messages` through the same renderer Discord posts from, and the room draws each message under its rail. The deciding message is only named there, because the card from the record carries it. A `messages` value the renderer cannot read leaves the brief alone.
- The question background renders as small print behind 💡, and the test pins it. The settings row `dispatch.messages_per_send` already existed and is unchanged.
- The standing orders name the send, and `CONTEXT.md` says where the contract and the renderer live.

## What was measured

The daemon suite: 3704 tests, 0 failed, 0 cancelled. The composite ask and the composite notify run on a real daemon boot, and the journal, the refusals, and the empty escalation list are read back. The rendered sequence runs through the transcript reader on both harnesses and through the page in a vm.

Not measured: a live Discord post of a send, and a real browser reading the room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
