### PR TITLE
Switch a live agent's model from the Discord status line (alp82/curia#717)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,6 +120,9 @@ A key under `models:` in `routing.yaml`. It is the dispatch vocabulary that `mod
 **Model name**:
 What curia tells a human is running. The status line uses the transcript model, then `models.<label>.id`, then the routing label. Cooling, fallback, and `status` keep the routing label.
 
+**Model switch**:
+The operator's move of a live agent to another routing label, from the `model` button on the Discord status line or the `model <n> <label>` command ([#717](https://github.com/alp82/curia/issues/717), on the [#561](https://github.com/alp82/curia/issues/561) evidence). The daemon refuses a cooled or cross-harness target before the pane is touched, and it names the hold and its reset. The composer is cut first and pasted back after, on every lane. claude switches in its own pane by `/model <id>` plus one confirm, so the process and the transcript stay; codex switches by a kill and `resume -m <id>`, because its picker lists only the built-in catalog. The effort belongs to the ticket type and survives the switch. The switch journals a whole spawn line (`agent_model_switched`), so a restart and a stall respawn read the model the agent is on.
+
 **Harness**:
 The program an agent runs under: claude or codex. It is a function of the model: `models.<x>.harness` states one value, and no command overrides it. A pin that disagreed with the model built `codex --model opus`, which is not a model.
 _Avoid_: backend, lane.

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -1611,7 +1611,38 @@ export class DiscordBridge {
     } catch (e) {
       this.log(`status links for ${ticket} failed: ${e.message}`)
     }
-    return DiscordBridge.linkRow(links)
+    const rows = DiscordBridge.linkRow(links.slice(0, 4))
+    // The model button (#717, the #553 shape): one more button beside the
+    // links while the agent lives. It opens an ephemeral pick of routing
+    // labels, so the thread carries no menu and no second line for the press.
+    if (!settled && this.handlers.modelChoices) {
+      const button = new ButtonBuilder().setStyle(ButtonStyle.Secondary).setLabel('model').setCustomId(`model|${ticket}|open`)
+      if (rows.length) rows[0].addComponents(button)
+      else rows.push(new ActionRowBuilder().addComponents(button))
+    }
+    return rows
+  }
+
+  // The ephemeral pick a press on the model button opens (#717). The labels
+  // are the routing vocabulary `/start` speaks; the small print under each is
+  // `models.<label>.id`, the name the harness is asked for, and the hold a
+  // cooled label carries. The cooled and cross-harness labels stay in the
+  // menu: the refusal names the hold, which is what the operator learns from.
+  static modelMenu(ticket, choices) {
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId(`model|${ticket}|sel`)
+      .setPlaceholder('Pick a model…')
+    for (const c of choices.slice(0, MAX_SELECT_OPTIONS)) {
+      const note = c.hold
+        ? `cooling${c.hold.reset_at ? ` until ${new Date(c.hold.reset_at).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}` : ''} (${c.hold.name})`
+        : c.crossHarness ? `on the ${c.harness} harness` : null
+      menu.addOptions({
+        label: `${c.label}${c.running ? ' - running now' : ''}`.slice(0, 100),
+        value: c.label,
+        description: [c.id, note].filter(Boolean).join(' · ').slice(0, 100),
+      })
+    }
+    return [new ActionRowBuilder().addComponents(menu)]
   }
 
   async postStatus(ticket, text, { settled = false } = {}) {
@@ -1767,6 +1798,40 @@ export class DiscordBridge {
         content: interruptedReceipt(i.message.content, { by: i.user.id, session: res.session, graceMs: res.graceMs }),
         components: [],
       }).catch(() => {})
+      return
+    }
+
+    // The model switch from the status line (#717). The press opens an
+    // ephemeral menu; the pick runs the switch and rewrites that same ephemeral
+    // message with the verdict. The thread itself stays quiet: the status line
+    // redraws off the journal, and a refusal is the presser's to read.
+    if (i.isButton() && i.customId.startsWith('model|')) {
+      const [, ticket, action] = i.customId.split('|')
+      if (action !== 'open') return
+      let choices = null
+      try {
+        choices = await this.handlers.modelChoices?.(ticket)
+      } catch (e) {
+        this.log(`model choices for ${ticket} failed: ${e.message}`)
+      }
+      if (!choices?.length) {
+        await i.reply({ content: `⚠️ no live agent on ticket ${ticket} to switch`, ephemeral: true }).catch(() => {})
+        return
+      }
+      await i.reply({
+        content: `Switch \`curia-${ticket}\` to which model? The conversation and the worktree stand either way.`,
+        components: DiscordBridge.modelMenu(ticket, choices),
+        ephemeral: true,
+      }).catch(() => {})
+      return
+    }
+    if (i.isStringSelectMenu?.() && i.customId.startsWith('model|')) {
+      const [, ticket] = i.customId.split('|')
+      const model = i.values?.[0]
+      await i.update({ content: `⏳ switching \`curia-${ticket}\` to \`${model}\`…`, components: [] }).catch(() => {})
+      const reply = await this.handlers.switchModel?.(ticket, model, i.user.id)
+        ?? '❌ this daemon has no model switch path'
+      await i.editReply({ content: reply, components: [] }).catch(() => {})
       return
     }
 

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -81,6 +81,9 @@ import {
   probeTtyd, assertServe, serveOff, CHAT_HANDLE_RE, isChatHandle, nextChatHandle,
 } from './attach.mjs'
 import { failureProse, FailureLines } from './messaging.mjs'
+
+// The reset instant of a hold, as the status line's bars say it (#717).
+const fmtReset = (at) => new Date(at).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
 import {
   CLEAR_MAP_FOG, KEEP_MAP_OPEN, MAP_FOG_VERB,
   clearMapFog, mapFog, mapFogQuestion,
@@ -479,6 +482,9 @@ export class Dispatcher {
     // behind a second timer. NULL is legal: the suite builds dispatchers that
     // have no business spawning a command line interface.
     this.aistack = aistack ?? null
+    // How long a claude pane may take to answer `/model` (#717): the CLI's
+    // validation probe is one short API call.
+    this.switchReadbackMs = 15_000
     this.deps = { ...DEFAULT_DEPS, ...deps }
     this.root = config.dispatch.workspace_root
     this.agents = new Map() // session -> agent record (disposable cache)
@@ -6502,9 +6508,54 @@ export class Dispatcher {
 
   // ---- resume --------------------------------------------------------------------
 
-  // Switch one live ticket to a configured routing model (#717). The pane is
-  // replaced, but its session name, private clone, config root, and harness
-  // resume command keep the running conversation attached to the same ticket.
+  // The models the status line offers for a live ticket (#717): every active
+  // routing label, with the facts the operator picks on. `running` marks the
+  // one the agent is on, `hold` names a cooling the switch would refuse, and
+  // `harness` lets the surface say when a pick would cross harnesses. Null
+  // when the ticket has no live agent, so the surface draws no menu.
+  modelChoices(n) {
+    const agent = this.agents.get(`curia-${String(n)}`)
+    if (!agent) return null
+    this.judgeReadings()
+    return Object.entries(this.routing.models ?? {})
+      .filter(([label]) => isActive(this.routing, label))
+      .map(([label, spec]) => ({
+        label,
+        id: spawnModelId(this.routing, label),
+        harness: spec.harness,
+        running: label === agent.model,
+        hold: this.#holdOn(label, spec.provider),
+      }))
+  }
+
+  // The hold a switch into `model` would walk into, or null. Named the way
+  // CONTEXT.md names the three kinds, with the reset instant when one exists:
+  // a credential hold ends when a person acts, so it states none.
+  #holdOn(model, provider) {
+    if (!this.cooling.isCool(model, provider)) return null
+    const held = this.cooling.heldFor(provider)
+    if (held) return { kind: 'credential', name: `${provider} credential`, reset_at: null, why: held.why ?? null }
+    const predicted = this.cooling.predictionFor(provider)
+    if (predicted) return { kind: 'predicted', name: `${provider} predicted`, reset_at: predicted.at ?? null }
+    const at = this.cooling.models.get(model)?.at ?? this.cooling.providers.get(provider)?.at ?? null
+    return { kind: 'cooling', name: `${model}/${provider} cooling`, reset_at: at }
+  }
+
+  // Switch one live ticket to a configured routing model (#717). Each harness
+  // takes the path prototypes/model-switch/findings.md proved on a real run:
+  //
+  // - claude takes `/model <id>` in its own composer. The CLI validates the
+  //   target live, asks one confirm, and keeps the process, the transcript and
+  //   the queued composer text (cut with Ctrl+U first, pasted back with Ctrl+Y).
+  // - codex offers only its built-in catalog in the `/model` picker, and the
+  //   picker is driven by arrow position, so its proven path for a routing
+  //   model is the resume: kill the pane and `resume -m <id>`, which beats the
+  //   session record. The session name, the private clone, the config root and
+  //   the resume command keep the conversation attached to the same ticket.
+  //
+  // Both refuse a cooled or cross-harness target BEFORE the pane is touched:
+  // codex accepts any model at the switch and burns the next turn on the API
+  // error, so the daemon's own hold table is the only check that costs nothing.
   async switchModel(n, { model, by } = {}) {
     const ticket = String(n)
     const session = `curia-${ticket}`
@@ -6518,18 +6569,16 @@ export class Dispatcher {
       return `❌ cannot switch \`${session}\` to \`${model}\`. That model is \`active: false\` in routing.yaml.`
     }
     this.judgeReadings()
-    if (this.cooling.isCool(model, target.provider)) {
-      const held = this.cooling.heldFor(target.provider)
-      const predicted = this.cooling.predictionFor(target.provider)
-      const hold = held
-        ? `${target.provider} credential`
-        : predicted
-          ? `${target.provider} predicted`
-          : `${model}/${target.provider} cooling`
-      return `❌ cannot switch \`${session}\` to \`${model}\`. The \`${hold}\` hold is active.`
+    const hold = this.#holdOn(model, target.provider)
+    if (hold) {
+      const until = hold.reset_at ? ` until ${fmtReset(hold.reset_at)}` : ''
+      return `❌ \`${model}\` is cooling - the \`${hold.name}\` hold stands${until}. The switch is refused and \`${session}\` stays on **${spawnModelId(this.routing, agent.model)}**.`
     }
     if (target.harness !== agent.harness) {
       return `❌ cannot switch \`${session}\` to \`${model}\`. Its saved conversation belongs to the ${agent.harness} harness.`
+    }
+    if (model === agent.model) {
+      return `ℹ️ \`${session}\` already runs on **${spawnModelId(this.routing, model)}**.`
     }
 
     try {
@@ -6537,6 +6586,9 @@ export class Dispatcher {
     } catch (e) {
       return `❌ could not clear pending composer text in \`${session}\`: ${failureProse(e.message)}`
     }
+
+    if (agent.harness === 'claude') return this.#switchInPane(agent, model, by)
+
     try {
       await this.deps.killSession(session)
     } catch (e) {
@@ -6557,10 +6609,97 @@ export class Dispatcher {
       const released = await this.#releaseClaim(agent, `operator model switch failed: ${e.message}`)
       return `❌ could not switch \`${session}\` to \`${model}\`: ${failureProse(e.message)}. ${released ? 'The claim is released.' : 'The issue is still assigned.'}`
     }
+    return this.#switchedLine(agent, model, { resumed: true })
+  }
 
+  // The claude in-pane switch. The composer is already cut. The pane answers
+  // in one of three shapes the prototype captured: "Set model to" (done),
+  // "Switch model?" (one confirm, Enter), or an API error line (the CLI's own
+  // live validation refused the target; the old model stands). A pane that
+  // says none of them inside the budget is reported as unconfirmed and the
+  // record is left alone, because a record that names a model the pane never
+  // took is the lie the status line exists to avoid.
+  async #switchInPane(agent, model, by) {
+    const session = agent.session
+    const id = spawnModelId(this.routing, model)
+    const from = agent.model
+    let sent
+    try {
+      sent = await this.deps.sendText(session, `/model ${id}`, { readbackMs: 0 })
+    } catch (e) {
+      return `❌ could not type the switch into \`${session}\`: ${failureProse(e.message)}`
+    }
+    if (sent?.status === 'not-sent') {
+      return `⏳ \`${session}\` is mid-turn, so the switch was not typed. Pick again when the turn ends.`
+    }
+    const verdict = await this.#switchVerdict(session, from)
+    // Whatever the pane said, the cut text goes back: the operator's queued
+    // words are not the switch's to spend.
+    await this.deps.sendKey(session, 'C-y').catch(() => {})
+    if (verdict.status === 'refused') {
+      this.reduction.journal('model_switch_refused', {
+        repo: agent.repo, ticket: agent.ticket, agent: session, model, from, by: by ?? 'unknown', why: verdict.why,
+      })
+      return `❌ \`${session}\` refused **${id}** at the switch: ${verdict.why}. It stays on **${spawnModelId(this.routing, from)}**.`
+    }
+    if (verdict.status !== 'switched') {
+      return `⚠️ \`${session}\` did not confirm the switch to **${id}** in time. It is recorded as still on **${spawnModelId(this.routing, from)}**; the terminal shows what the pane took.`
+    }
+    agent.model = model
+    agent.requestedModel = model
+    agent.provider = this.routing.models[model].provider
+    // The effort belongs to the ticket type and the switch keeps it. An agent
+    // adopted after a restart may carry none in memory, so the journal's last
+    // spawn line answers first, then the type route, as a respawn would.
+    agent.reasoningEffort = agent.reasoningEffort
+      ?? this.reduction.questions.epochSpawnLine?.(session)?.reasoning_effort
+      ?? reasoningEffortFor(this.routing, agent.labels ?? [], model)
+    // The whole spawn line, restated with the new model (#219's rule): the
+    // last line about a session has to describe it whole, because a restart
+    // and a stall respawn read only that line.
+    const last = this.reduction.questions.epochSpawnLine?.(session) ?? {}
+    this.reduction.journal('agent_model_switched', {
+      ...last,
+      repo: agent.repo, ticket: agent.ticket, agent: session,
+      model, switched_from: from, requested_model: model, harness: agent.harness,
+      reasoning_effort: agent.reasoningEffort ?? null, by: by ?? 'unknown', operator_model_switch: true, live: true,
+    })
+    return this.#switchedLine(agent, model, { resumed: false })
+  }
+
+  // Read the pane until it states the switch's outcome. The confirm is
+  // answered here, once: the CLI asks it only after its validation passed.
+  async #switchVerdict(session, from) {
+    const deadline = Date.now() + this.switchReadbackMs
+    let confirmed = false
+    let pane = ''
+    while (true) {
+      try {
+        pane = await this.deps.capturePane(session)
+      } catch {
+        pane = ''
+      }
+      const tail = String(pane ?? '').split('\n').slice(-25).join('\n')
+      if (/Set model to /.test(tail)) return { status: 'switched' }
+      const err = tail.match(/(API error:[^\n]*(?:\n[^\n]*){0,3}|Unable to validate model[^\n]*)/)
+      if (err && !/Switch model\?/.test(tail)) {
+        return { status: 'refused', why: err[1].replace(/\s+/g, ' ').trim().slice(0, 200) }
+      }
+      if (!confirmed && /Switch model\?/.test(tail)) {
+        confirmed = true
+        await this.deps.sendKey(session, 'Enter')
+      }
+      if (Date.now() >= deadline) return { status: 'unconfirmed', pane: tail }
+      await sleepFor(Math.min(250, Math.max(1, deadline - Date.now())))
+    }
+  }
+
+  #switchedLine(agent, model, { resumed }) {
     const name = spawnModelId(this.routing, model)
+    const harness = this.routing.models[model].harness
     const effort = agent.reasoningEffort ? `**${agent.reasoningEffort}** effort` : 'the model default effort'
-    return `⚙️ \`${session}\` switched to **${name}** on the **${target.harness}** harness with ${effort}. Its conversation and worktree continue.`
+    const how = resumed ? 'The pane resumed its conversation on the new model.' : 'The conversation stayed in its pane.'
+    return `🔁 \`${agent.session}\` runs on **${name}** now, on the **${harness}** harness with ${effort}. ${how} The worktree and the queued note stand.`
   }
 
   // The resume contract (#81): a fresh agent on the ticket, inheriting the

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1119,6 +1119,14 @@ const gate = {
   // #252, ADR-0013: the second delivery mode. The bridge presses this from the
   // button under a receipt; the dispatcher owns the grace and the keystrokes.
   interruptNote: (id, by) => dispatcher.interruptNote(id, { by }),
+  // #717: the model button on the status line. The dispatcher composes the
+  // choices and refuses the switch; the bridge only draws and relays.
+  modelChoices: async (ticket) => {
+    const agent = dispatcher.agents.get(`curia-${ticket}`)
+    const choices = dispatcher.modelChoices(ticket)
+    return choices?.map((c) => ({ ...c, crossHarness: Boolean(agent) && c.harness !== agent.harness })) ?? null
+  },
+  switchModel: (ticket, model, by) => dispatcher.switchModel(ticket, { model, by }),
 }
 
 // ---- dispatch loop (#33) ----------------------------------------------------

--- a/daemon/src/questions.mjs
+++ b/daemon/src/questions.mjs
@@ -132,7 +132,11 @@ select repo from events
   // 8 — #epochSpawn: which model and harness is this session actually on?
   // Keyed by session, because a re-dispatch down the fallback chain writes a
   // second `agent_spawned` for the same session and the last one is running.
-  epochSpawn: lastBody('agent = :a', ['agent_spawned']),
+  //
+  // An in-pane model switch (#717) restates the whole spawn line with the new
+  // model, so it takes part here: a restart or a stall respawn after the
+  // switch must not put the agent back on the model it left.
+  epochSpawn: lastBody('agent = :a', ['agent_spawned', 'agent_model_switched']),
 
   // 9 — #epochAdoptedMap: which map did this session report? Reset at the
   // session's last spawn, so a resumed handle never inherits the map of the
@@ -289,6 +293,14 @@ export class Questions {
     const ev = this.#event('epochCharting', { t: String(ticket) })
     if (!ev) return { charting: false, instruction: null, newMap: false }
     return { charting: ev.kind === 'charting', instruction: ev.instruction ?? null, newMap: Boolean(ev.newMap) }
+  }
+
+  // The raw last spawn line of a session, for a writer that restates it whole.
+  epochSpawnLine(agent) {
+    const ev = this.#event('epochSpawn', { a: agent })
+    if (!ev) return null
+    const { id, ts, type, ...body } = ev
+    return body
   }
 
   epochSpawn(agent) {

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -299,6 +299,10 @@ export class Reduction {
         updated_at: ev.ts ?? previous.updated_at ?? null,
       })
     }
+    if (ev.type === 'agent_model_switched' && ev.agent) {
+      const previous = this.agentConversations.get(ev.agent)
+      if (previous) this.agentConversations.set(ev.agent, { ...previous, model: ev.model ?? previous.model, updated_at: ev.ts ?? previous.updated_at })
+    }
     if (outcome || ev.type === 'agent_abnormal_exit') {
       const session = ev.agent ?? (ev.ticket == null ? null : `curia-${ev.ticket}`)
       if (session) {

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -259,6 +259,14 @@ export class StatusLine {
         }
         return this.#set(ev.agent, ev.ticket, 'dispatched', { model: ev.model, stage: 'composer' })
       }
+      // #717: an in-pane switch keeps the process and the state; only the
+      // model on the line changes. The meters still name what the transcript
+      // states, so the name flips when the next turn states it, never before.
+      case 'agent_model_switched': {
+        const w = this.agents.get(ev.agent)
+        if (!w) return
+        return this.#set(ev.agent, w.ticket, w.state, { ...w.detail, model: ev.model }, { force: true })
+      }
       case 'dispatch_status':
         return this.#set(ev.agent, ev.ticket, 'dispatched', { model: ev.model })
       case 'agent_ready':

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -5382,45 +5382,146 @@ describe('live model switching (#717)', () => {
     },
   }
 
-  test('a live ticket clears its composer and resumes on the target model with routed effort', async () => {
+  const CLAUDE_SWITCHED = 'claude\n❯ /model opus\n  ⎿  Set model to opus and saved as your default for new sessions\n❯ \n'
+  const CLAUDE_CONFIRM = 'claude\n❯ /model opus\n  Switch model?\n  ❯ 1. Yes, switch to opus\n    2. No, go back\n'
+  const CLAUDE_REFUSED = 'claude\n❯ /model opus\n  ⎿  API error: 403\n     {"type":"error","error":{"type":"permission_error","message":"You do not have access to the model opus."}}\n❯ \n'
+
+  const claudeDispatcher = (panes, steps, extra = {}) => makeDispatcher({
+    fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:task' }] }),
+    sendKey: async (session, key) => { steps.push({ act: 'key', session, key }) },
+    sendText: async (session, text) => { steps.push({ act: 'text', session, text }); return { status: 'unconfirmed', pane: '' } },
+    killSession: async (session) => { steps.push({ act: 'kill', session }) },
+    newSession: async (opts) => { steps.push({ act: 'spawn', ...opts }) },
+    capturePane: async () => (panes.length > 1 ? panes.shift() : panes[0]) ?? '',
+    ...extra,
+  }, { routing: SWITCH_ROUTING })
+
+  test('a claude ticket switches in its own pane: cut, /model, paste back, and the record follows', async () => {
     const steps = []
-    const d = makeDispatcher({
-      fetchIssue: async () => ({
-        ...OPEN_ISSUE,
-        labels: [{ name: 'wayfinder:task' }],
-      }),
-      sendKey: async (session, key) => { steps.push({ act: 'key', session, key }) },
-      killSession: async (session) => { steps.push({ act: 'kill', session }) },
-      newSession: async (opts) => { steps.push({ act: 'spawn', ...opts }) },
-    }, { routing: SWITCH_ROUTING })
+    const d = claudeDispatcher([CLAUDE_SWITCHED], steps)
+    d.switchReadbackMs = 500
     await d.start('42', { repo: 'o/r', by: 'operator-1' })
     steps.length = 0
 
     const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
+
+    assert.deepEqual(steps, [
+      { act: 'key', session: 'curia-42', key: 'C-u' },
+      { act: 'text', session: 'curia-42', text: '/model opus' },
+      { act: 'key', session: 'curia-42', key: 'C-y' },
+    ], 'no kill and no respawn on the claude lane')
+    assert.match(reply, /runs on \*\*opus\*\* now/)
+    assert.match(reply, /xhigh\*\* effort/)
+    assert.match(reply, /conversation stayed in its pane/)
+    const w = d.agents.get('curia-42')
+    assert.equal(w.model, 'opus')
+    assert.equal(w.requestedModel, 'opus')
+    assert.equal(w.reasoningEffort, 'xhigh', 'the type effort survives the switch')
+    const switched = events.find((event) => event.type === 'agent_model_switched')
+    assert.equal(switched.model, 'opus')
+    assert.equal(switched.switched_from, 'sonnet')
+    assert.equal(switched.harness, 'claude')
+    assert.equal(switched.reasoning_effort, 'xhigh')
+    assert.equal(switched.kind, 'ticket', 'the whole spawn line is restated')
+    assert.equal(d.reduction.questions.epochSpawn('curia-42').model, 'opus', 'a restart reads the switched model')
+  })
+
+  test('the claude confirm is answered once, and only after the pane asks', async () => {
+    const steps = []
+    const d = claudeDispatcher([CLAUDE_CONFIRM, CLAUDE_CONFIRM, CLAUDE_SWITCHED], steps)
+    d.switchReadbackMs = 2_000
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+    steps.length = 0
+
+    const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
+
+    assert.match(reply, /runs on \*\*opus\*\* now/)
+    assert.deepEqual(steps.map((s) => s.key ?? s.text), ['C-u', '/model opus', 'Enter', 'C-y'])
+  })
+
+  test('a model the claude CLI refuses at the switch leaves the record on the old model', async () => {
+    const steps = []
+    const d = claudeDispatcher([CLAUDE_REFUSED], steps)
+    d.switchReadbackMs = 500
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+    steps.length = 0
+
+    const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
+
+    assert.match(reply, /refused \*\*opus\*\* at the switch/)
+    assert.match(reply, /API error: 403/)
+    assert.match(reply, /stays on \*\*sonnet\*\*/)
+    assert.equal(d.agents.get('curia-42').model, 'sonnet')
+    assert.equal(steps.at(-1).key, 'C-y', 'the cut composer text goes back either way')
+    assert.ok(events.find((event) => event.type === 'model_switch_refused'))
+    assert.ok(!events.find((event) => event.type === 'agent_model_switched'))
+  })
+
+  test('a pane that never answers leaves the record alone and says so', async () => {
+    const steps = []
+    const d = claudeDispatcher(['claude\n❯ \n'], steps)
+    d.switchReadbackMs = 300
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+
+    const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
+
+    assert.match(reply, /did not confirm the switch/)
+    assert.equal(d.agents.get('curia-42').model, 'sonnet')
+  })
+
+  test('a mid-turn claude pane is not typed into', async () => {
+    const steps = []
+    const d = claudeDispatcher([''], steps, {
+      sendText: async () => ({ status: 'not-sent', pane: '✻ Baking' }),
+    })
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+
+    const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
+
+    assert.match(reply, /mid-turn/)
+    assert.equal(d.agents.get('curia-42').model, 'sonnet')
+  })
+
+  test('a codex ticket clears its composer and resumes on the target model with routed effort', async () => {
+    const steps = []
+    const CODEX_ROUTING = {
+      ...SWITCH_ROUTING,
+      defaults: { untyped: { model: 'gpt', effort: 'high' }, task: { model: 'gpt', effort: 'high' } },
+      models: {
+        ...SWITCH_ROUTING.models,
+        gpt2: { provider: 'openai', harness: 'codex', id: 'gpt-5.5', reasoning_effort: 'low' },
+      },
+    }
+    const d = makeDispatcher({
+      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:task' }] }),
+      sendKey: async (session, key) => { steps.push({ act: 'key', session, key }) },
+      sendText: async (session, text) => { steps.push({ act: 'text', session, text }) },
+      killSession: async (session) => { steps.push({ act: 'kill', session }) },
+      newSession: async (opts) => { steps.push({ act: 'spawn', ...opts }) },
+    }, { routing: CODEX_ROUTING })
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+    steps.length = 0
+
+    const reply = await d.switchModel('42', { model: 'gpt2', by: 'operator-1' })
 
     assert.deepEqual(steps.slice(0, 2), [
       { act: 'key', session: 'curia-42', key: 'C-u' },
       { act: 'kill', session: 'curia-42' },
     ])
     assert.equal(steps[2].act, 'spawn')
-    assert.match(steps[2].shellCmd, /claude --model opus --continue/)
-    assert.match(reply, /opus/)
-    assert.match(reply, /xhigh.*effort/)
-    assert.equal(d.agents.get('curia-42').harness, 'claude')
+    assert.match(steps[2].shellCmd, /codex resume --last --model gpt-5\.5/)
+    assert.ok(!steps.find((s) => s.act === 'text'), 'the codex picker is never typed into')
+    assert.match(reply, /runs on \*\*gpt-5\.5\*\* now/)
+    assert.match(reply, /high\*\* effort/)
+    assert.match(reply, /resumed its conversation/)
     const switched = events.find((event) => event.operator_model_switch)
-    assert.equal(switched.model, 'opus')
-    assert.equal(switched.harness, 'claude')
-    assert.equal(switched.reasoning_effort, 'xhigh')
-    assert.equal(switched.switched_from, 'sonnet')
+    assert.equal(switched.model, 'gpt2')
+    assert.equal(switched.switched_from, 'gpt')
   })
 
   test('a target on another harness is refused before the live pane changes', async () => {
     const steps = []
-    const d = makeDispatcher({
-      fetchIssue: async () => ({ ...OPEN_ISSUE, labels: [{ name: 'wayfinder:task' }] }),
-      sendKey: async (...args) => { steps.push(['key', ...args]) },
-      killSession: async (...args) => { steps.push(['kill', ...args]) },
-    }, { routing: SWITCH_ROUTING })
+    const d = claudeDispatcher([''], steps)
     await d.start('42', { repo: 'o/r', by: 'operator-1' })
     steps.length = 0
 
@@ -5431,31 +5532,55 @@ describe('live model switching (#717)', () => {
     assert.equal(d.agents.get('curia-42').model, 'sonnet')
   })
 
-  test('a cooled target is refused by model and hold name before the pane changes', async () => {
+  test('a cooled target is refused by model, hold name and reset before the pane changes', async () => {
     const steps = []
-    const d = makeDispatcher({
-      fetchIssue: async () => ({
-        ...OPEN_ISSUE,
-        labels: [{ name: 'wayfinder:task' }],
-      }),
-      sendKey: async (session, key) => { steps.push({ act: 'key', session, key }) },
-      killSession: async (session) => { steps.push({ act: 'kill', session }) },
-      newSession: async (opts) => { steps.push({ act: 'spawn', ...opts }) },
-    }, { routing: SWITCH_ROUTING })
+    const d = claudeDispatcher([''], steps)
     await d.start('42', { repo: 'o/r', by: 'operator-1' })
     steps.length = 0
-    d.cooling.coolModel('gpt', new Date(Date.now() + 60_000))
+    const reset = new Date(Date.now() + 60 * 60_000)
+    d.cooling.coolModel('opus', reset)
 
-    const reply = await d.switchModel('42', { model: 'gpt', by: 'operator-1' })
+    const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
 
-    assert.match(reply, /gpt/)
-    assert.match(reply, /hold/)
+    assert.match(reply, /`opus` is cooling/)
+    assert.match(reply, /`opus\/anthropic cooling` hold stands until \d\d:\d\d/)
+    assert.match(reply, /stays on \*\*sonnet\*\*/)
     assert.deepEqual(steps, [])
     assert.equal(d.agents.get('curia-42').model, 'sonnet')
   })
 
+  test('a credential hold is named with no invented reset', async () => {
+    const steps = []
+    const d = claudeDispatcher([''], steps)
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+    d.cooling.holdProvider('anthropic', 'the anthropic credential is dead')
+
+    const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
+
+    assert.match(reply, /`anthropic credential` hold stands\./)
+    assert.doesNotMatch(reply, /until/)
+  })
+
+  test('the choices name every active label with its id, the running one and its hold', async () => {
+    const d = claudeDispatcher([''], [])
+    assert.equal(d.modelChoices('42'), null, 'no live agent, no menu')
+    await d.start('42', { repo: 'o/r', by: 'operator-1' })
+    d.cooling.coolModel('gpt', new Date(Date.now() + 60_000))
+
+    const choices = d.modelChoices('42')
+
+    assert.deepEqual(choices.map((c) => c.label), ['sonnet', 'opus', 'gpt'])
+    assert.equal(choices[0].running, true)
+    assert.equal(choices[1].running, false)
+    assert.equal(choices[2].id, 'gpt-5.6-sol')
+    assert.equal(choices[2].harness, 'codex')
+    assert.equal(choices[2].hold.name, 'gpt/openai cooling')
+    assert.ok(choices[2].hold.reset_at instanceof Date)
+    assert.equal(choices[1].hold, null)
+  })
+
   test('a restart-adopted ticket keeps its type effort when it switches', async () => {
-    const spawns = []
+    const steps = []
     const d = makeDispatcher({
       listSessions: async () => ['curia-42'],
       fetchIssue: async () => ({
@@ -5465,8 +5590,10 @@ describe('live model switching (#717)', () => {
       }),
       containerPorts: async () => [9000, 9001, 9002],
       sendKey: async () => {},
+      sendText: async (session, text) => { steps.push(text); return { status: 'unconfirmed' } },
+      capturePane: async () => CLAUDE_SWITCHED,
       killSession: async () => {},
-      newSession: async (opts) => { spawns.push(opts) },
+      newSession: async () => {},
     }, { routing: SWITCH_ROUTING })
     d.reduction.journal('agent_spawned', {
       repo: 'o/r', ticket: '42', agent: 'curia-42',
@@ -5478,9 +5605,10 @@ describe('live model switching (#717)', () => {
     await d.reconcile({ boot: false })
     const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
 
-    assert.equal(spawns.length, 1)
-    assert.match(reply, /xhigh.*effort/)
+    assert.deepEqual(steps, ['/model opus'])
+    assert.match(reply, /xhigh\*\* effort/)
     assert.equal(d.agents.get('curia-42').reasoningEffort, 'xhigh')
+    assert.equal(d.agents.get('curia-42').model, 'opus')
   })
 })
 

--- a/daemon/test/modelswitch.test.mjs
+++ b/daemon/test/modelswitch.test.mjs
@@ -1,0 +1,143 @@
+// The model switch from the Discord status line (#717, on the #553 shape).
+//
+// The status line carries one more button beside its links while the agent
+// lives: `model`. A press opens an EPHEMERAL select of routing labels, with
+// the harness id, the running mark and any hold as small print. A pick runs
+// the dispatcher's switch and rewrites that ephemeral message with the
+// verdict. The thread stays quiet: the status line redraws off the journal.
+
+import { test, describe, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { DiscordBridge } from '../src/bridge.mjs'
+import { Reduction } from '../src/reduction.mjs'
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'curia-modelswitch-test-'))
+
+const rowsOf = (components) => components.map((row) => row.toJSON().components)
+const menusOf = (components) => rowsOf(components).flat().filter((c) => c.type === 3)
+const buttonsOf = (components) => rowsOf(components).flat().filter((c) => c.type === 2)
+
+const CHOICES = [
+  { label: 'fable', id: 'claude-fable-5', harness: 'claude', running: true, crossHarness: false, hold: { kind: 'cooling', name: 'fable/anthropic cooling', reset_at: new Date('2026-08-31T09:00:00Z') } },
+  { label: 'opus', id: 'claude-opus-5', harness: 'claude', running: false, crossHarness: false, hold: null },
+  { label: 'gpt', id: 'gpt-5.6-sol', harness: 'codex', running: false, crossHarness: true, hold: null },
+]
+
+describe('the model button on the status line (#717)', () => {
+  let bridge, sent, thread, calls
+
+  beforeEach(() => {
+    sent = []
+    calls = []
+    thread = {
+      id: 't-544',
+      send: async (payload) => { sent.push(payload); return { id: 'm-1' } },
+      messages: { fetch: async () => ({ edit: async (payload) => { sent.push(payload) } }) },
+    }
+    bridge = new DiscordBridge({
+      token: 'x', allowedUsers: ['op'], dataDir: tmp(), log: () => {},
+      handlers: {
+        statusLinks: async () => [{ label: 'chat', url: 'https://chat.example/544' }],
+        modelChoices: async (ticket) => { calls.push(['choices', ticket]); return CHOICES },
+        switchModel: async (ticket, model, by) => { calls.push(['switch', ticket, model, by]); return `🔁 \`curia-${ticket}\` runs on **${model}** now` },
+      },
+    })
+    bridge.client = { channels: { fetch: async () => thread } }
+    bridge.ensureThread = async () => thread
+  })
+
+  test('a live status line carries the model button beside its links, and the receipt drops it', async () => {
+    await bridge.postStatus('544', 'working')
+    const live = buttonsOf(sent[0].components)
+    assert.deepEqual(live.map((b) => b.label), ['chat', 'model'])
+    assert.equal(live[1].custom_id, 'model|544|open')
+    assert.equal(live[1].style, 2, 'a secondary button, not a link')
+
+    await bridge.editStatus({ threadId: 't-544', messageId: 'm-1' }, 'resolved', { ticket: '544', settled: true })
+    assert.deepEqual(buttonsOf(sent[1].components).map((b) => b.label), ['chat'], 'a dead button is a trap')
+  })
+
+  test('a press opens an ephemeral pick of routing labels with id, running mark and hold', async () => {
+    let replied
+    await bridge.handleInteraction({
+      user: { id: 'op' }, customId: 'model|544|open',
+      isButton: () => true, isStringSelectMenu: () => false, isChatInputCommand: () => false, isRepliable: () => true,
+      reply: async (payload) => { replied = payload },
+    })
+    assert.deepEqual(calls, [['choices', '544']])
+    assert.equal(replied.ephemeral, true, 'the thread carries no menu')
+    assert.match(replied.content, /Switch `curia-544` to which model\?/)
+    const [menu] = menusOf(replied.components)
+    assert.equal(menu.custom_id, 'model|544|sel')
+    assert.deepEqual(menu.options.map((o) => o.value), ['fable', 'opus', 'gpt'])
+    assert.equal(menu.options[0].label, 'fable - running now')
+    assert.match(menu.options[0].description, /^claude-fable-5 · cooling until \d\d:\d\d \(fable\/anthropic cooling\)$/)
+    assert.equal(menu.options[1].description, 'claude-opus-5')
+    assert.equal(menu.options[2].description, 'gpt-5.6-sol · on the codex harness')
+  })
+
+  test('a press on a ticket with no live agent is told so, ephemerally', async () => {
+    bridge.handlers.modelChoices = async () => null
+    let replied
+    await bridge.handleInteraction({
+      user: { id: 'op' }, customId: 'model|544|open',
+      isButton: () => true, isStringSelectMenu: () => false, isChatInputCommand: () => false, isRepliable: () => true,
+      reply: async (payload) => { replied = payload },
+    })
+    assert.equal(replied.ephemeral, true)
+    assert.match(replied.content, /no live agent on ticket 544/)
+  })
+
+  test('a pick runs the switch and rewrites the ephemeral message with the verdict', async () => {
+    const updates = []
+    await bridge.handleInteraction({
+      user: { id: 'op' }, customId: 'model|544|sel', values: ['opus'],
+      isButton: () => false, isStringSelectMenu: () => true, isChatInputCommand: () => false, isRepliable: () => true,
+      update: async (payload) => { updates.push(payload) },
+      editReply: async (payload) => { updates.push(payload) },
+    })
+    assert.deepEqual(calls, [['switch', '544', 'opus', 'op']])
+    assert.match(updates[0].content, /switching `curia-544` to `opus`/)
+    assert.deepEqual(updates[0].components, [])
+    assert.match(updates[1].content, /runs on \*\*opus\*\* now/)
+    assert.equal(sent.length, 0, 'nothing lands in the thread for the press')
+  })
+
+  test('a refusal reaches the presser the same way', async () => {
+    bridge.handlers.switchModel = async () => '❌ `fable` is cooling - the `fable/anthropic cooling` hold stands until 09:00.'
+    const updates = []
+    await bridge.handleInteraction({
+      user: { id: 'op' }, customId: 'model|544|sel', values: ['fable'],
+      isButton: () => false, isStringSelectMenu: () => true, isChatInputCommand: () => false, isRepliable: () => true,
+      update: async (payload) => { updates.push(payload) },
+      editReply: async (payload) => { updates.push(payload) },
+    })
+    assert.match(updates[1].content, /hold stands until 09:00/)
+  })
+
+  test('a stranger cannot press it', async () => {
+    let replied
+    await bridge.handleInteraction({
+      user: { id: 'nobody' }, customId: 'model|544|open',
+      isButton: () => true, isStringSelectMenu: () => false, isChatInputCommand: () => false, isRepliable: () => true,
+      reply: async (payload) => { replied = payload },
+    })
+    assert.equal(replied.content, 'not authorized')
+    assert.deepEqual(calls, [])
+  })
+})
+
+describe('the conversation record follows an in-pane switch (#717)', () => {
+  test('a restated spawn line moves the retained conversation to the new model', () => {
+    const r = new Reduction(tmp())
+    r.journal('agent_spawned', { repo: 'o/r', ticket: '544', agent: 'curia-544', model: 'fable', harness: 'claude', kind: 'ticket' })
+    r.journal('agent_model_switched', { repo: 'o/r', ticket: '544', agent: 'curia-544', model: 'opus', switched_from: 'fable', harness: 'claude', kind: 'ticket' })
+    const [c] = r.retainedAgentConversations()
+    assert.equal(c.model, 'opus')
+    assert.equal(c.state, 'active')
+    assert.equal(r.questions.epochSpawn('curia-544').model, 'opus', 'a restart adopts the switched model')
+  })
+})

--- a/daemon/test/statusline.test.mjs
+++ b/daemon/test/statusline.test.mjs
@@ -765,4 +765,26 @@ describe('StatusLine', () => {
       fs.rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  test('an in-pane model switch redraws the line in place with the new model (#717)', async () => {
+    line.onEvent({ type: 'agent_ready', agent: 'curia-544', ticket: '544', model: 'fable', ts: 'T' })
+    await drain()
+    assert.match(posts[0].text, /\*\*fable\*\*/)
+
+    line.onEvent({ type: 'agent_model_switched', agent: 'curia-544', ticket: '544', model: 'opus', switched_from: 'fable' })
+    await drain()
+
+    assert.equal(posts.length, 1, 'the state did not change, so the line stays where it is')
+    assert.equal(edits.length, 1)
+    assert.match(edits[0].text, /\*\*opus\*\*/)
+    assert.doesNotMatch(edits[0].text, /fable/)
+    assert.equal(line.stateOf('curia-544').state, 'working')
+  })
+
+  test('a switch event for a session this line never saw draws nothing', async () => {
+    line.onEvent({ type: 'agent_model_switched', agent: 'curia-9', ticket: '9', model: 'opus' })
+    await drain()
+    assert.equal(posts.length, 0)
+  })
+
 })


### PR DESCRIPTION
Closes #717

## What changed

The Discord status line carries a **model** button beside its links while the agent lives. A press opens an ephemeral select of routing labels. Each option shows `models.<label>.id`, marks the running model, and names any hold. A pick runs the switch and rewrites the ephemeral message with the verdict. The thread stays quiet, and the status line redraws off the journal. The receipt drops the button.

Each harness takes the path the [#561 prototype](https://github.com/alp82/curia/issues/561) proved on a real run:

- **claude** switches in its own pane. The daemon cuts the composer with Ctrl+U, types `/model <id>`, answers the one confirm when the pane asks, and pastes the cut text back with Ctrl+Y. The process, the transcript, and the queued note stay. A model the CLI refuses at the switch leaves the record on the old model and names the API error. A pane that never answers is reported as unconfirmed and the record is left alone.
- **codex** keeps the kill and `resume -m <id>` path, because its `/model` picker lists only the built-in catalog and is driven by arrow position.

Both lanes refuse a cooled or cross-harness target before the pane is touched. The refusal names the hold kind and its reset, or no reset for a credential hold.

An in-pane switch journals `agent_model_switched` as a whole spawn line. `epochSpawn` reads it, so a restart and a stall respawn keep the model the agent is on. The retained conversation record follows it.

## Tests

`npm test` in `daemon/`: 3720 tests, 3720 pass, 0 fail, 0 cancelled.

New coverage: the claude in-pane sequence and its confirm, the CLI refusal, the unconfirmed pane, the mid-turn pane, the codex resume path, the cooled and credential-hold refusals, the choices reading, the restart-adopted agent, the status-line button and its ephemeral menu, the pick and the refusal on that path, the status-line redraw, and the conversation record.

## Not measured

Nothing here ran against a live pane. The keystroke sequence and the pane phrases come from the prototype's captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
