### PR TITLE
Lead the operator from one answered item to the next (alp82/curia#718)

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -274,6 +274,18 @@
   .need-rank.compact .att-item { padding: 6px 10px; background: transparent; border-left-color: var(--line); color: var(--ink-dim); }
   .need-rank.compact .att-item .diff, .need-rank.compact .att-item .act-row, .need-rank.compact .att-item .opts { display: none; }
   .need-rank.aged .att-item { border-left-color: var(--warn); }
+  /* The handoff sheet (#718): a bottom sheet on the phone, a centered dialog
+     on the desktop. Its rows are landings, not answers, so they are plain. */
+  .handoff-scrim { position: fixed; inset: 0; background: rgba(0,0,0,.45); z-index: 40; }
+  .handoff { position: fixed; left: 0; right: 0; bottom: 0; z-index: 41; background: var(--bg-raise); box-shadow: var(--shadow); border-top: 1px solid var(--line);
+    border-radius: 14px 14px 0 0; padding: 16px 16px calc(16px + env(safe-area-inset-bottom)); display: grid; gap: 10px; }
+  @media (min-width: 900px) { .handoff { left: 50%; right: auto; bottom: auto; top: 50%; transform: translate(-50%, -50%); width: 520px; border-radius: 14px; border: 1px solid var(--line); } }
+  .handoff-head { font-size: 15px; }
+  .handoff-list { display: grid; gap: 6px; }
+  .handoff-item { text-align: left; font: inherit; color: var(--ink); background: transparent; border: 1px solid var(--line); border-left: 3px solid var(--line);
+    border-radius: 8px; padding: 8px 10px; cursor: pointer; display: flex; gap: 10px; align-items: baseline; }
+  .handoff-item.aged { border-left-color: var(--warn); }
+  .handoff-item .rank { font-family: ui-monospace, Menlo, monospace; color: var(--ink-dim); }
   /* A credential that is dying reads as bad, not as a warning: nothing on this
      page fixes it, and an agent meets it as a failed first `gh` call (#380). */
   .att-item.token { border-left-color: var(--bad); background: var(--chip-bad-bg); }
@@ -799,7 +811,11 @@ var UI = {
      the control it came from; `said` is what curia answered, shown at that same
      control. `note` and `tele` name the agent whose box is open, and `mode` is
      the delivery ADR-0013 defaults to. */
-  act: { busy: null, said: null, note: null, mode: "queue", tele: null, diff: null },
+  act: { busy: null, said: null, note: null, mode: "queue", tele: null, diff: null,
+    /* The handoff sheet (#718): the id of the item the operator just answered,
+       or null when no sheet is up. The sheet draws nothing of its own — it
+       reads the same `attentionItems` Home reads, minus this one id. */
+    handoff: null },
 };
 var payload = null;   /* the sidecar's last answer */
 var reachable = true; /* is the SIDECAR itself answering — a different fact from daemon_up */
@@ -973,11 +989,10 @@ function receiptLine(x) {
 function outcome(b) {
   if (typeof b.reply === "string") return b.reply;
   if (b.mode) return noteOutcome(b);
-  if (b.ok) {
-    const next = (b.next_needs ?? []).slice(0, 3);
-    const more = next.length ? `\nNext ${next.length} needs:\n${next.map((need, i) => `${i + 1}. ${need.headline} · ${need.agent} · ticket ${need.ticket}`).join("\n")}` : "";
-    return "Answered. It is with the agent." + more;
-  }
+  /* The daemon's `next_needs` ride the reply for Discord. Atlas does not read
+     them (#718): the handoff sheet ranks the next items as Home ranks them,
+     off the fresh overview, so the two surfaces cannot disagree. */
+  if (b.ok) return "Answered. It is with the agent.";
   return "Done.";
 }
 /* A note says which delivery it got, because the delivery is the half the
@@ -1017,7 +1032,14 @@ async function answerEsc(id, body) {
   } catch (e) {
     return refuse("esc:" + id, e.message);
   }
-  return verb("esc:" + id, "/api/answer", { id, ...answer });
+  const out = await verb("esc:" + id, "/api/answer", { id, ...answer });
+  /* One successful answer opens the handoff sheet (#718). A refusal opens
+     nothing: the receipt under the card is the whole of what happened. */
+  if (out && out.ok !== false) {
+    UI.act.handoff = id;
+    render();
+  }
+  return out;
 }
 function answerIndex(id, index) { return answerEsc(id, { index: Number(index) }); }
 function answerSelect(id, field) {
@@ -1798,16 +1820,19 @@ function attentionItems(o) {
     const unblocks = Array.isArray(row?.unblocks) ? row.unblocks.length : Number(row?.unblocks ?? 0);
     return waitMinutes(row?.opened_at ?? row?.at) + unblocks * 90 + (gate ? 20 : 0);
   };
+  /* Each item also carries an `id`, a one-line `line`, and a `landing` (#718):
+     the handoff sheet names the next items with these and lands the operator
+     on the card itself. It never carries an answer control of its own. */
   const items = [
-    ...credentialPointers(o).map((html) => ({ html, score: 100_000, aged: false })),
-    ...(o?.escalations ?? []).map((row) => ({ html: escCard(row), score: effectiveWait(row), aged: waitMinutes(row.opened_at) >= 240 })),
-    ...(o?.review_gate ?? []).map((row) => ({ html: gateCard(row), score: effectiveWait(row, true), aged: waitMinutes(row.opened_at) >= 240 })),
-    ...(o?.token_warnings ?? []).map((row) => ({ html: tokenCard(row), score: 50_000, aged: false })),
+    ...credentialPointers(o).map((html, i) => ({ id: "cred-" + i, line: "a model credential wants you", landing: "credentials", html, score: 100_000, aged: false })),
+    ...(o?.escalations ?? []).map((row) => ({ id: row.id, line: `${row.agent} · ${row.kind} · ${ticketName(null, row.ticket)}: ${snip(row.prompt, 90)}`, landing: "home", html: escCard(row), score: effectiveWait(row), aged: waitMinutes(row.opened_at) >= 240 })),
+    ...(o?.review_gate ?? []).map((row) => ({ id: row.id, line: `${row.agent} · review gate · ${ticketName(null, row.ticket)}: ${snip(row.prompt, 90)}`, landing: "home", html: gateCard(row), score: effectiveWait(row, true), aged: waitMinutes(row.opened_at) >= 240 })),
+    ...(o?.token_warnings ?? []).map((row) => ({ id: "token-" + row.key, line: `${row.key} cannot reach ${row.repo}`, landing: "home", html: tokenCard(row), score: 50_000, aged: false })),
     /* The tickets the auto loop steps over (#444). On this list where a spent
        window is not, by this list's own test: an operator act is what ends one.
        Nothing lifts it on a clock, and the ticket sits on the frontier
        untouched until somebody fixes the cause and dispatches it. */
-    ...(o?.dispatch_holds ?? []).map((row) => ({ html: dispatchHoldCard(row), score: 50_000, aged: false })),
+    ...(o?.dispatch_holds ?? []).map((row) => ({ id: `hold-${row.repo}-${row.ticket}`, line: `${ticketName(row.repo, row.ticket)} is held from auto-dispatch`, landing: "home", html: dispatchHoldCard(row), score: 50_000, aged: false })),
   ];
   items.sort((a, b) => b.score - a.score);
   return items;
@@ -1818,8 +1843,54 @@ function attentionItems(o) {
 function attentionList(o) {
   const items = attentionItems(o);
   return items.length
-    ? items.map((item, index) => `<div class="need-rank ${index < 3 ? "full" : "compact"}${item.aged ? " aged" : ""}">${item.html}</div>`).join("")
+    ? items.map((item, index) => `<div class="need-rank ${index < 3 ? "full" : "compact"}${item.aged ? " aged" : ""}" id="need-${esc(item.id)}">${item.html}</div>`).join("")
     : `<div class="empty">Nothing wants you.</div>`;
+}
+
+/* ---- the handoff sheet (#718) ----------------------------------------------
+
+   After one answer lands, the sheet says how many items still want the operator
+   and names the next three, IN HOME'S ORDER: it reads `attentionItems`, the one
+   source the ring and the column read, so the sheet and Home cannot rank
+   differently. It re-reads on every render, so the poll after the answer
+   updates it, and the answered id is left out until that poll lands.
+
+   THE SHEET ANSWERS NOTHING. Each item is a landing on its own card, where its
+   own first valid answer is taken. A sheet with answer buttons on it is a batch
+   answer, and a batch answer is what ADR-0025's first-valid-wins refuses. */
+function nextNeeds(o, answered) {
+  return attentionItems(o).filter((item) => item.id !== answered);
+}
+function handoffSheet() {
+  const answered = UI.act.handoff;
+  if (answered == null) return "";
+  const items = nextNeeds(payload?.overview, answered);
+  const n = items.length;
+  const next = items.slice(0, 3);
+  const head = n
+    ? `<strong>Answered.</strong> ${esc(n)} ${n === 1 ? "item still needs" : "items still need"} you.`
+    : `<strong>Answered.</strong> Nothing else wants you.`;
+  const list = next.length
+    ? `<div class="dim-note">Next ${next.length === 1 ? "up" : next.length}, as Home ranks ${next.length === 1 ? "it" : "them"}. Each takes its own answer.</div>
+    <div class="handoff-list">${next.map((item, i) => `<button class="handoff-item${item.aged ? " aged" : ""}" onclick="handoffGo(${i})"><span class="rank">${i + 1}</span>${esc(item.line)}</button>`).join("")}</div>`
+    : "";
+  return `<div class="handoff-scrim" onclick="handoffClose()"></div><div class="handoff" role="dialog" aria-label="What needs you next">
+    <div class="handoff-head">${head}</div>${list}
+    <div class="act-row"><button class="btn sm" onclick="handoffClose()">Close</button></div></div>`;
+}
+function handoffClose() {
+  UI.act.handoff = null;
+  render();
+}
+/* The tap lands on the item's own card. The sheet closes first, so the card is
+   what the operator sees, with its own controls and nothing else's. */
+function handoffGo(i) {
+  const item = nextNeeds(payload?.overview, UI.act.handoff)[i];
+  UI.act.handoff = null;
+  if (!item) return render();
+  goto(item.landing);
+  const card = typeof document.getElementById === "function" ? document.getElementById("need-" + item.id) : null;
+  if (card && typeof card.scrollIntoView === "function") card.scrollIntoView({ block: "start" });
 }
 
 /* ---- the feed -------------------------------------------------------------- */
@@ -4277,6 +4348,7 @@ function render() {
     <main>${SCREENS[UI.screen][1](payload)}</main>
     ${mobileNav(n, stale)}
     ${searchOverlay()}
+    ${handoffSheet()}
   </div>`;
   document.title = (n ? `(${n}) ` : "") + "Atlas · Curia";
   restoreField(field);

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2415,20 +2415,13 @@ describe('the operator verbs (#266)', () => {
       assert.match(page.outcome({ mode: 'interrupt', ok: true, session: 'curia-263', graceMs: 5000 }), /5s of grace/)
     })
 
-    test('an answer keeps the next three needs under the answered card', () => {
+    test('an answer says only that it landed: the next needs are the handoff sheet\'s, not the reply text\'s (#718)', () => {
       const said = page.outcome({
         ok: true,
-        next_needs: [
-          { headline: 'Review the map.', agent: 'curia-8', ticket: '8' },
-          { headline: 'Choose the limit.', agent: 'curia-9', ticket: '9' },
-          { headline: 'Approve the preview.', agent: 'curia-10', ticket: '10' },
-          { headline: 'Hidden fourth.', agent: 'curia-11', ticket: '11' },
-        ],
+        next_needs: [{ headline: 'Review the map.', agent: 'curia-8', ticket: '8' }],
       })
-      assert.match(said, /Next 3 needs/)
-      assert.match(said, /Review the map/)
-      assert.match(said, /Approve the preview/)
-      assert.doesNotMatch(said, /Hidden fourth/)
+      assert.match(said, /Answered/)
+      assert.doesNotMatch(said, /Review the map/, 'the daemon orders next_needs by age, and Atlas ranks as Home does instead')
     })
 
     test('an interrupt curia refused still delivered the words — queued, which is the default anyway', () => {
@@ -2446,6 +2439,112 @@ describe('the operator verbs (#266)', () => {
     test('one act at a time: while a press is in flight every other control is disabled', () => {
       page.UI.act.busy = 'esc:esc-7'
       assert.match(page.screenFrontier(payload()), /button class="btn sm primary" disabled/)
+    })
+  })
+
+  // ---- the handoff sheet (#718) --------------------------------------------
+  //
+  // After one answer, the sheet names the next three items in HOME'S order and
+  // the count that still stands. It reads `attentionItems`, the one source the
+  // ring and the column read, so the two cannot disagree. It answers nothing.
+
+  describe('the handoff sheet leads from one answered item to the next', () => {
+    // Three open items besides esc-7: a gate at 5 minutes, an aged escalation
+    // at 5 hours, and a young one that unblocks two tickets. Home ranks them
+    // aged first, then the unblocker, then the gate, with esc-7 in between.
+    const crowded = () => {
+      const p = payload()
+      p.overview.escalations.push(
+        { id: 'esc-20', agent: 'curia-20', ticket: '20', kind: 'free-text', prompt: 'Five hours old.', options: null, preview_url: null, opened_at: at(5 * 3600), agent_died: false, rendered: true },
+        { id: 'esc-21', agent: 'curia-21', ticket: '21', kind: 'choice', prompt: 'Young, but two tickets wait on it.', options: ['a', 'b'], preview_url: null, opened_at: at(60), agent_died: false, rendered: true, unblocks: [1, 2] },
+        { id: 'esc-22', agent: 'curia-22', ticket: '22', kind: 'free-text', prompt: 'Young and unblocks nothing.', options: null, preview_url: null, opened_at: at(30), agent_died: false, rendered: true },
+      )
+      return p
+    }
+    const answered = (p, id = 'esc-7') => {
+      const local = loadPage({ fetchImpl: async () => ({ ok: true, json: async () => ({ ok: true }) }) })
+      local.payload = p
+      return local.answerEsc(id, 'approve').then(() => local)
+    }
+
+    test('no sheet stands before an answer, and none after a refused one', async () => {
+      const p = crowded()
+      assert.equal(page.handoffSheet(), '')
+      const local = loadPage({ fetchImpl: async () => ({ ok: false, status: 409, json: async () => ({ error: 'already answered', receipt: { by: 'alp', answer: 'x' } }) }) })
+      local.payload = p
+      await local.answerEsc('esc-7', 'approve')
+      assert.equal(local.UI.act.handoff, null)
+      assert.equal(local.handoffSheet(), '')
+    })
+
+    test('one successful answer opens the sheet with the open count and the next three in Home\'s order', async () => {
+      const local = await answered(crowded())
+      assert.equal(local.UI.act.handoff, 'esc-7')
+      const html = local.handoffSheet()
+      const t = text(html)
+      // esc-7 is still on the stale payload; the sheet leaves it out, so the
+      // count is the four others.
+      assert.match(t, /Answered\. 4 items still need you\./)
+      const homeOrder = local.attentionItems(local.payload.overview).map((i) => i.id).filter((id) => id !== 'esc-7')
+      assert.equal(homeOrder.slice(0, 3).join(','), 'esc-20,esc-21,esc-9', 'the fixture ranks as intended')
+      const rows = [...html.matchAll(/<button class="handoff-item[^"]*"[^>]*>.*?<\/button>/g)].map((m) => text(m[0]))
+      assert.equal(rows.length, 3)
+      assert.match(rows[0], /^1 curia-20 · free-text · #20: Five hours old\./)
+      assert.match(rows[1], /^2 curia-21 · choice · #21: Young, but two tickets/)
+      assert.match(rows[2], /^3 curia-261 · review gate · #261: is this done\?/)
+      assert.doesNotMatch(t, /Young and unblocks nothing/, 'the fourth stays off the sheet')
+      assert.doesNotMatch(t, /Two notes race/, 'the answered item is not offered back')
+    })
+
+    test('the sheet carries no answer control: each item is a landing on its own card', async () => {
+      const local = await answered(crowded())
+      const html = local.handoffSheet()
+      assert.doesNotMatch(html, /answerEsc|answerIndex|answerTyped|answerSelect|rejectGate/)
+      assert.doesNotMatch(html, /<input/)
+      assert.match(html, /onclick="handoffGo\(0\)"/)
+      // The card the first row lands on has the anchor the landing scrolls to.
+      assert.match(local.screenHome(local.payload), /id="need-esc-20"/)
+    })
+
+    test('the sheet re-ranks off the fresh poll: an item answered elsewhere leaves, and the count drops', async () => {
+      const local = await answered(crowded())
+      assert.match(text(local.handoffSheet()), /4 items still need you/)
+      const fresh = crowded()
+      fresh.overview.escalations = fresh.overview.escalations.filter((r) => r.id !== 'esc-7' && r.id !== 'esc-20')
+      local.payload = fresh
+      const t = text(local.handoffSheet())
+      assert.match(t, /3 items still need you/)
+      assert.match(t, /1 curia-21 · choice/)
+      assert.doesNotMatch(t, /Five hours old/)
+    })
+
+    test('with nothing left the sheet says so, and offers no list', async () => {
+      const p = payload()
+      p.overview.review_gate = []
+      const local = await answered(p)
+      const t = text(local.handoffSheet())
+      assert.match(t, /Answered\. Nothing else wants you\./)
+      assert.doesNotMatch(local.handoffSheet(), /handoff-item/)
+    })
+
+    test('a landing closes the sheet and moves to the item\'s screen; close closes it', async () => {
+      const local = await answered(crowded())
+      local.handoffGo(2)
+      assert.equal(local.UI.act.handoff, null)
+      assert.equal(local.UI.screen, 'home')
+      const again = await answered(crowded())
+      again.handoffClose()
+      assert.equal(again.UI.act.handoff, null)
+      assert.equal(again.handoffSheet(), '')
+    })
+
+    test('a dead credential ranks first on the sheet as on Home, and lands on Credentials', async () => {
+      const p = crowded()
+      p.overview.credentials = { consumers: [{ consumer: 'claude', provider: 'anthropic', state: 'expired' }], reauth: null }
+      const local = await answered(p)
+      assert.match(text(local.handoffSheet()), /1 a model credential wants you/)
+      local.handoffGo(0)
+      assert.equal(local.UI.screen, 'credentials')
     })
   })
 


### PR DESCRIPTION
Closes #718.

## What changed

- After one successful answer on Atlas, a handoff sheet opens. It says how many items still need you and names the next three. The sheet reads `attentionItems`, the one source the verdict ring and the Needs-you column read, so its ranking is Home's ranking. It re-reads on every render, so the poll after the answer updates it, and the answered item is left out until that poll lands.
- The sheet answers nothing. Each row is a landing on the item's own card (Home, or Credentials for a dead credential), where its own first valid answer is taken. No batch answer exists.
- A refused answer opens no sheet. The receipt under the card stays the whole of what happened.
- The reply text no longer lists the daemon's `next_needs`. Those are ordered by age and would disagree with Home. The Discord bridge keeps reading them.
- Every attention item now carries `id`, `line`, and `landing`, and the Needs-you column anchors each card as `need-<id>`.

## What was measured

The daemon suite: 3727 tests, 0 failed, 0 cancelled. The sheet's open, count, order, exclusion of the answered item, re-rank on a fresh payload, empty state, landings, and absence of answer controls run through the page in a vm against the sidecar's answer route.

Not measured: a real browser scrolling to the card, and the sheet's layout on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
