### PR TITLE
Dispatch prose skill asks behind a durable wave gate (alp82/curia#719)

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -4319,6 +4319,26 @@ export class Dispatcher {
       // the moment it matters. A charting agent closes research tickets, never
       // the map — and it closes them after the merge, never before, because a
       // ticket closed on unmerged findings is exactly the map that lies.
+      // ADR-0023: a skill run's product is tracker writes, and there is no pull
+      // request to merge. The approval is what publishes, so the record of WHAT
+      // was approved is written here, before the agent touches the tracker,
+      // and the agent is told to publish exactly that list and nothing else.
+      if (skillName) {
+        if (w) w.trackerWritesApproved = trackerWrites.length
+        this.reduction.journal('tracker_writes_approved', {
+          repo, ticket, agent: agentName, skill: skillName, count: trackerWrites.length, items: trackerWrites,
+        })
+        return {
+          ok: true,
+          approved: true,
+          text: said([
+            `APPROVED by the human. Publish exactly the ${trackerWrites.length} tracker writes the gate showed, wave by wave,`,
+            'with their labels and their native blocked-by edges. Add nothing that was not on the card.',
+            'Then resolve this record issue, and call report_result with every issue number you created in',
+            '`published`, so the receipt can name them.',
+          ].join('\n')),
+        }
+      }
       return {
         ok: true,
         approved: true,
@@ -4329,6 +4349,25 @@ export class Dispatcher {
             'Nothing closes before the merge, and the map itself never closes.',
           ].join('\n')
           : `APPROVED by the human. Now, in order: merge the pull request (\`gh pr merge <url> --repo ${repo} --squash --delete-branch\`), then resolve the ticket, then report_result.`),
+      }
+    }
+    // ADR-0023: a rejected skill run publishes nothing. The journal says so,
+    // and the agent is sent back to the proposal rather than to a pull request.
+    if (skillName) {
+      this.reduction.journal('tracker_writes_withheld', {
+        repo, ticket, agent: agentName, skill: skillName, count: trackerWrites.length,
+      })
+      return {
+        ok: true,
+        approved: false,
+        text: said([
+          'NOT approved. The human said:',
+          feedback || '(nothing beyond the rejection itself — ask them what to change with ask_human)',
+          '',
+          'Publish nothing: no issue, no label, no edge. Nothing from the card exists on the tracker, and',
+          'it stays that way. Revise the proposal from their words, then call request_review again with',
+          'the full `tracker_writes` list.',
+        ].join('\n')),
       }
     }
     return {
@@ -5242,7 +5281,13 @@ export class Dispatcher {
       this.reduction.journal('resolved_unreviewed', { repo, ticket, agent: agentName })
       out.warnings.push('NO approved review gate for this dispatch — this ticket was resolved without anyone approving it')
     }
-    const text = summariseOutcome(out)
+    // ADR-0023: the receipt of a skill run names the tracker writes instead of
+    // a merge, and the real issue numbers appear here for the first time. The
+    // numbers come from the agent's `published` field, checked against the
+    // count the gate approved, so a run that published more or less than the
+    // card, or was never approved at all, says so in small print.
+    const skillName = w?.skillName ?? this.#epochSpawn(agentName)?.skill ?? null
+    const text = skillName ? this.#skillOutcome(out, result, repo, w, agentName) : summariseOutcome(out)
     // `summary` is what the ending receipt says about the tracker (#253). It
     // rides the journal rather than the agent record because report_result and
     // the Stop hook are two calls, and a restart between them must not silence
@@ -5585,6 +5630,30 @@ export class Dispatcher {
   //
   // The 🏁 line is gone with no replacement: it said "done" about the same
   // event this sentence opens with (statusline.mjs, #retire).
+  // What a skill run's ending says about the tracker (ADR-0023). Replaces the
+  // landing sentence, because a skill run has no code to land: its product is
+  // the published issues, and the approved count is the measure of them.
+  #skillOutcome(out, result, repo, w, agentName) {
+    const published = Array.isArray(result?.published)
+      ? [...new Set(result.published.map((n) => String(n).trim()).filter((n) => /^\d+$/.test(n)))]
+      : []
+    const approved = w?.trackerWritesApproved ?? this.reduction.questions.trackerWritesApproved(agentName)
+    const bits = []
+    bits.push(out.close === 'repaired' ? 'record closed by curia' : out.close === 'present' ? 'record closed' : 'record close state unknown')
+    if (out.comment === 'repaired') bits.push('resolution comment recorded by curia')
+    else if (out.comment === 'unknown') bits.push('resolution comment unverified')
+    bits.push(published.length
+      ? `published ${published.length} tracker write${published.length === 1 ? '' : 's'}: ${published.map((n) => `${repo}#${n}`).join(', ')}`
+      : 'no tracker write published')
+    const warnings = [...out.warnings]
+    if (approved == null && published.length) warnings.push('the tracker writes were published with NO approved gate')
+    else if (approved != null && approved !== published.length) {
+      warnings.push(`the gate approved ${approved} tracker write${approved === 1 ? '' : 's'} and the report names ${published.length}`)
+    }
+    const warn = warnings.length ? ` · ⚠️ ${warnings.join(' · ⚠️ ')}` : ''
+    return bits.join(' · ') + warn
+  }
+
   #endingReceipt(agentName, lease) {
     const clause = this.#endingClause(agentName)
     const head = clause ?? '✅ resolved - result recorded'

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -2289,6 +2289,9 @@ function buildMcpServer(agent, ticket) {
       headline: z.string().optional().describe('What the work came to, in one line, at most 150 characters. No markdown and no link.'),
       detail: z.string().optional().describe('Short FACTS, rendered as a spoiler. One line, 500 characters.'),
       ...VISUAL_SHAPE,
+      // ADR-0023: a skill run's product is tracker writes, and the receipt
+      // names them by their real numbers. Only a skill run fills this.
+      published: z.array(z.number().int().positive()).optional().describe('Skill runs only: the issue numbers you created after the approved gate, in the order you created them.'),
       // ADR-0019 rule 3: a free record. No surface renders it and no lint reads
       // it, so it stays the one field an agent may shape for itself.
       details: z.record(z.string(), z.any()).optional(),

--- a/daemon/src/overseerprompt.mjs
+++ b/daemon/src/overseerprompt.mjs
@@ -42,7 +42,7 @@ const BASE_PROMPT = `You are the curia overseer. Curia is a personal orchestrati
 You speak with one operator, in one Discord thread, in short Discord markdown. You act only through the curia tools. The daemon executes every effect.
 
 What you do:
-- Translate the operator's prose into the verbs: tickets, next, status, start, map_update, map_new, cancel, resume, attach.
+- Translate the operator's prose into the verbs: tickets, next, status, start, map_update, map_new, cancel, resume, attach, skill.
 - Answer reasoning questions from tool output ("what should I start next?" — call tickets, then recommend one, with a one-line reason).
 - Report tool replies faithfully. Do not invent agents, tickets, or states.
 
@@ -59,6 +59,7 @@ Vocabulary the operator uses:
 - Use \`map_update\` when the operator asks to CHANGE a map that already exists ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the \`instruction\` field, in their own words. Do not rewrite it and do not summarize it.
 - Use \`start\` when the operator asks to work the map ("continue with <map>", "start the landing page map"). Either the map's own number or the ticket number listed under its header does this.
 - Use \`map_new\` when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". The tool takes no number, so do not ask the operator for one. Put their words in \`instruction\`, unchanged: it is the whole brief the charting agent settles the destination from. Add \`repo\` only when more than one repo is watched.
+- A skill asked for in prose ("cut the build tickets for the payments map", "write the spec for X", "research Y") has two routes, split by the ticket. When an open ticket already carries that skill (a handoff task under the map, a research ticket), \`start\` that ticket: it is a normal ticket run, and it needs no confirmation. When no ticket carries it, call \`skill\` with the skill name and the target issue: curia creates the durable record issue and runs the skill under the review gate, so nothing reaches the tracker before the operator approves the card. Never ask the operator to confirm a skill dispatch, and never add a ticket to a map only to start it.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run \`tickets\` or \`status\` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/src/questions.mjs
+++ b/daemon/src/questions.mjs
@@ -138,6 +138,13 @@ select repo from events
   // switch must not put the agent back on the model it left.
   epochSpawn: lastBody('agent = :a', ['agent_spawned', 'agent_model_switched']),
 
+  // 8b — #skillOutcome: how many tracker writes did the gate approve for this
+  // session? Reset at the last spawn, like the ending clause: an approval on
+  // an earlier dispatch of the same record must not license a later one's
+  // publication. ADR-0023.
+  trackerWritesApproved: lastBody('agent = :a', ['tracker_writes_approved'],
+    `\n   and id > ${LAST_SPAWN}`),
+
   // 9 — #epochAdoptedMap: which map did this session report? Reset at the
   // session's last spawn, so a resumed handle never inherits the map of the
   // dispatch before it.
@@ -310,7 +317,16 @@ export class Questions {
       requested_model: ev.requested_model ?? null,
       harness: ev.harness ?? null,
       prompt_carries_limit_text: ev.prompt_carries_limit_text ?? null,
+      // ADR-0023: the skill a ticketless run carries. Read by the gate guard
+      // and the ending after a restart, when no agent record holds it.
+      skill: ev.skill ?? null,
+      skill_target: ev.skill_target ?? null,
     } : null
+  }
+
+  trackerWritesApproved(agent) {
+    const ev = this.#event('trackerWritesApproved', { a: agent })
+    return ev?.count == null ? null : Number(ev.count)
   }
 
   adoptedMap(agent) {

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -1913,6 +1913,9 @@ export function writePrompt(cfgDir, issue, {
     '- The product is tracker writes. Before publication, pass every proposed title, label, and native',
     '  dependency edge in `tracker_writes` to `request_review`. Grouping into dispatch waves is done by curia.',
     '- Nothing in `tracker_writes` exists on GitHub before approval. Publish only what the operator approved.',
+    '- A rejected gate publishes nothing. Revise the proposal and pass it through `request_review` again.',
+    '- After approval, publish the list wave by wave, then call `report_result` with every issue number you',
+    '  created in `published`. The receipt names those numbers, and nothing before the receipt does.',
   ]
 
   const params = skill ? skillParams : newMap ? newMapParams : charting ? chartingParams : [

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -426,6 +426,91 @@ describe('ticketless skill dispatch (#684)', () => {
     assert.deepEqual(gateBinding, { agent: 'curia-91', ticket: '91' })
   })
 
+  // ADR-0023, the gate on a run no ticket claims. The record issue is the one
+  // write curia makes itself; every proposed write waits on the press.
+  const skillRun = async (answer) => {
+    const writes = []
+    const d = makeDispatcher({
+      fetchIssue: async (_repo, number) => ({ ...OPEN_ISSUE, number: Number(number), title: 'x' }),
+      createIssue: async (repo, proposal) => {
+        writes.push({ repo, proposal })
+        return {
+          number: 91, title: proposal.title, body: proposal.body,
+          state: 'open', assignees: [], labels: [], html_url: 'https://github.com/o/r/issues/91',
+        }
+      },
+      closeIssue: async () => {},
+    }, {
+      skills: { root: '/skills', install: ['to-tickets'] },
+      askReview: async () => ({ text: answer, status: 'answered' }),
+    })
+    await d.skill('to-tickets', 'o/r#42', { by: 'operator-1' })
+    const proposal = [
+      { id: 'schema', title: 'The retry table', labels: ['ready-for-agent'] },
+      { id: 'worker', title: 'The worker drains the queue', labels: ['ready-for-agent'], after: ['schema'] },
+    ]
+    return { d, writes, proposal }
+  }
+
+  test('a rejected gate withholds every tracker write and sends the agent back to the proposal', async () => {
+    const { d, writes, proposal } = await skillRun('reject: split the worker ticket')
+
+    const r = await d.requestReview('curia-91', { summary: 's', charting: 'c', trackerWrites: proposal })
+
+    assert.equal(r.approved, false)
+    assert.match(r.text, /Publish nothing/)
+    assert.match(r.text, /split the worker ticket/)
+    assert.doesNotMatch(r.text, /merge|open_pull_request/)
+    assert.equal(writes.length, 1, 'the record issue is the only write, before and after the rejection')
+    const withheld = events.find((e) => e.type === 'tracker_writes_withheld')
+    assert.equal(withheld.count, 2)
+    assert.equal(withheld.skill, 'to-tickets')
+    assert.ok(!events.some((e) => e.type === 'tracker_writes_approved'))
+  })
+
+  test('an approved gate records what was approved, and the receipt names the real numbers', async () => {
+    const { d, proposal } = await skillRun('approve')
+
+    const r = await d.requestReview('curia-91', { summary: 's', charting: 'c', trackerWrites: proposal })
+
+    assert.equal(r.approved, true)
+    assert.match(r.text, /Publish exactly the 2 tracker writes/)
+    assert.match(r.text, /`published`/)
+    assert.doesNotMatch(r.text, /merge/)
+    const approved = events.find((e) => e.type === 'tracker_writes_approved')
+    assert.equal(approved.count, 2)
+    assert.deepEqual(approved.items.map((i) => i.id), ['schema', 'worker'])
+    // The journal answers the count after a restart, when no record holds it.
+    assert.equal(d.reduction.questions.trackerWritesApproved('curia-91'), 2)
+    assert.equal(d.reduction.questions.epochSpawn('curia-91').skill, 'to-tickets')
+
+    await d.onResult('curia-91', { ticket: '91', status: 'resolved', summary: 'published', published: [101, 102] })
+
+    const resolved = events.find((e) => e.type === 'ticket_resolved' && e.ticket === '91')
+    assert.match(resolved.summary, /published 2 tracker writes: o\/r#101, o\/r#102/)
+    assert.doesNotMatch(resolved.summary, /no code to land|merged/)
+    assert.doesNotMatch(resolved.summary, /⚠️ the gate approved/)
+  })
+
+  test('a report that names fewer numbers than the gate approved says so on the receipt', async () => {
+    const { d, proposal } = await skillRun('approve')
+    await d.requestReview('curia-91', { summary: 's', charting: 'c', trackerWrites: proposal })
+
+    await d.onResult('curia-91', { ticket: '91', status: 'resolved', summary: 'published', published: [101] })
+
+    const resolved = events.find((e) => e.type === 'ticket_resolved' && e.ticket === '91')
+    assert.match(resolved.summary, /the gate approved 2 tracker writes and the report names 1/)
+  })
+
+  test('numbers published with no approved gate are flagged, never silently accepted', async () => {
+    const { d } = await skillRun('approve')
+
+    await d.onResult('curia-91', { ticket: '91', status: 'resolved', summary: 'published', published: [101] })
+
+    const resolved = events.find((e) => e.type === 'ticket_resolved' && e.ticket === '91')
+    assert.match(resolved.summary, /published with NO approved gate/)
+  })
+
   test('refuses an unconfigured skill before creating a record', async () => {
     let writes = 0
     const d = makeDispatcher({ createIssue: async () => { writes += 1 } }, {

--- a/daemon/test/fixtures/overseer-prompt-no-shell.txt
+++ b/daemon/test/fixtures/overseer-prompt-no-shell.txt
@@ -3,7 +3,7 @@ You are the curia overseer. Curia is a personal orchestration daemon: it watches
 You speak with one operator, in one Discord thread, in short Discord markdown. You act only through the curia tools. The daemon executes every effect.
 
 What you do:
-- Translate the operator's prose into the verbs: tickets, next, status, start, map_update, map_new, cancel, resume, attach.
+- Translate the operator's prose into the verbs: tickets, next, status, start, map_update, map_new, cancel, resume, attach, skill.
 - Answer reasoning questions from tool output ("what should I start next?" — call tickets, then recommend one, with a one-line reason).
 - Report tool replies faithfully. Do not invent agents, tickets, or states.
 
@@ -20,6 +20,7 @@ Vocabulary the operator uses:
 - Use `map_update` when the operator asks to CHANGE a map that already exists ("update the landing page map so that X", "add a ticket for Y", "the map is wrong about Z"). Put their sentence in the `instruction` field, in their own words. Do not rewrite it and do not summarize it.
 - Use `start` when the operator asks to work the map ("continue with <map>", "start the landing page map"). Either the map's own number or the ticket number listed under its header does this.
 - Use `map_new` when the operator asks for a map that does not exist YET: "create a new map for X", "chart a new map", "add a map for the next feature", "we need a map for Y". The tool takes no number, so do not ask the operator for one. Put their words in `instruction`, unchanged: it is the whole brief the charting agent settles the destination from. Add `repo` only when more than one repo is watched.
+- A skill asked for in prose ("cut the build tickets for the payments map", "write the spec for X", "research Y") has two routes, split by the ticket. When an open ticket already carries that skill (a handoff task under the map, a research ticket), `start` that ticket: it is a normal ticket run, and it needs no confirmation. When no ticket carries it, call `skill` with the skill name and the target issue: curia creates the durable record issue and runs the skill under the review gate, so nothing reaches the tracker before the operator approves the card. Never ask the operator to confirm a skill dispatch, and never add a ticket to a map only to start it.
 
 Your memory goes stale:
 - Tool output from an earlier turn may be minutes or hours old, and the daemon, the trackers, and the operator all change state between your turns. Re-run `tickets` or `status` before you refuse, recommend, or report state. Never answer from a previous turn's tool output.

--- a/daemon/test/overseerprompt.test.mjs
+++ b/daemon/test/overseerprompt.test.mjs
@@ -34,7 +34,8 @@ describe('the standing orders, with no shell (#328)', () => {
   // TWO CHANGES HAVE LANDED SINCE, both deliberate. First the writing rules,
   // when #133's voice went from Simplified Technical English to the Google
   // developer documentation style. Then #692 (ADR-0022) added the tool-reply
-  // section and split the map verb in two. The fixture was regenerated for
+  // section and split the map verb in two. Then #719 (ADR-0023) added the
+  // `skill` verb and its two-route rule. The fixture was regenerated for
   // each, and for nothing else.
   test('it is byte for byte the text the in-daemon host always sent', () => {
     assert.equal(`${buildSystemPrompt()}\n`, fs.readFileSync(FIXTURE, 'utf8'))
@@ -51,6 +52,25 @@ describe('the standing orders, with no shell (#328)', () => {
     for (const absent of ['origin/pr/', 'git pull', 'checkouts are at', 'never orders']) {
       assert.ok(!SYSTEM_PROMPT.includes(absent), `the no-shell text should not mention "${absent}"`)
     }
+  })
+})
+
+// ADR-0023: a skill asked for in prose has two routes, split by the ticket,
+// and neither one asks the operator to confirm.
+describe('the skill dispatch from prose (#719, ADR-0023)', () => {
+  test('the verb list names skill, and the tool is offered', () => {
+    assert.match(SYSTEM_PROMPT, /verbs: .*attach, skill\./)
+    assert.ok(ALLOWED_TOOLS.includes('mcp__curia__skill'))
+  })
+
+  test('a ticket that carries the skill is started, and no ticket means the skill verb', () => {
+    assert.match(SYSTEM_PROMPT, /When an open ticket already carries that skill[^\n]*`start` that ticket/)
+    assert.match(SYSTEM_PROMPT, /When no ticket carries it, call `skill`/)
+    assert.match(SYSTEM_PROMPT, /nothing reaches the tracker before the operator approves/)
+  })
+
+  test('no confirm press guards a skill dispatch', () => {
+    assert.match(SYSTEM_PROMPT, /Never ask the operator to confirm a skill dispatch/)
   })
 })
 

--- a/daemon/test/questions.test.mjs
+++ b/daemon/test/questions.test.mjs
@@ -260,7 +260,7 @@ describe('the last event of a type for a key', () => {
     ])
     assert.deepEqual(q.epochSpawn('curia-42'), {
       model: 'codex-high', requested_model: 'opus', harness: 'codex',
-      prompt_carries_limit_text: true,
+      prompt_carries_limit_text: true, skill: null, skill_target: null,
     })
   })
 
@@ -270,7 +270,7 @@ describe('the last event of a type for a key', () => {
     const q = ask([{ type: 'worker_spawned', ticket: '170', worker: 'curia-170', model: 'opus', backend: 'claude' }])
     assert.deepEqual(q.epochSpawn('curia-170'), {
       model: 'opus', requested_model: null, harness: 'claude',
-      prompt_carries_limit_text: null,
+      prompt_carries_limit_text: null, skill: null, skill_target: null,
     })
     assert.deepEqual([...q.epochs()], [['170', { repo: null }]])
   })

--- a/daemon/test/theflip.test.mjs
+++ b/daemon/test/theflip.test.mjs
@@ -204,6 +204,8 @@ describe('an untyped ask_human is refused since the flip (#422, real boot)', () 
       const notify = listed.tools.find((tool) => tool.name === 'notify')
       assert.ok(review.inputSchema.properties.tracker_writes)
       assert.equal(notify.inputSchema.properties.tracker_writes, undefined)
+      const report = listed.tools.find((tool) => tool.name === 'report_result')
+      assert.ok(report.inputSchema.properties.published, 'the receipt reads the real numbers from `published`')
 
       const result = await c.callTool({
         name: 'request_review',


### PR DESCRIPTION
Closes #719

## What changed

Most of #719 landed with #738: the `skill` verb, the durable record issue, the wave renderer on `request_review`, and the prompt. This PR closes what ADR-0023 still left open on that build.

- **Routing.** The overseer's standing orders name `skill` and state the two-route rule: an open ticket that carries the skill is started, with no confirm press, and a ticketless ask calls `skill`. The no-shell fixture was regenerated for it.
- **The gate decides on the daemon side.** An approved skill gate journals `tracker_writes_approved` with the card and tells the agent to publish exactly that list. A rejected one journals `tracker_writes_withheld` and sends the agent back to the proposal, not to a pull request.
- **The receipt names the tracker writes.** `report_result` takes `published`, the real issue numbers. The ending compares them with the approved count, so a run that published with no gate, or more or fewer than the card, says so on the receipt. The count survives a restart through a journal question.
- **A defect on the way.** `epochSpawn` never returned `skill`, so every skill guard reading it after a restart saw a plain ticket run.

## What isn't enforced

The daemon can't stop an agent with `gh` from creating an issue on its own. The guard is the prompt, the gate text, and the receipt's small print, which flags a publication with no approved gate. That is the same posture as the resolve-without-review warning.

## Tests

`npm test` in `daemon/`: 3734 tests, 611 suites, 0 failed, 0 cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
