### PR TITLE
Make the Needs-you unblock bonus actually fire (alp82/curia#761)

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -274,6 +274,8 @@
   .need-rank.compact .att-item { padding: 6px 10px; background: transparent; border-left-color: var(--line); color: var(--ink-dim); }
   .need-rank.compact .att-item .diff, .need-rank.compact .att-item .act-row, .need-rank.compact .att-item .opts { display: none; }
   .need-rank.aged .att-item { border-left-color: var(--warn); }
+  .need-rank .need-why { font-size: 11.5px; color: var(--ink-dim); padding: 0 0 2px 4px; }
+  .need-rank.aged .need-why { color: var(--warn); }
   /* The handoff sheet (#718): a bottom sheet on the phone, a centered dialog
      on the desktop. Its rows are landings, not answers, so they are plain. */
   .handoff-scrim { position: fixed; inset: 0; background: rgba(0,0,0,.45); z-index: 40; }
@@ -1816,23 +1818,42 @@ function credLink(words) {
    keep their full controls, while later items remain visible as compact rows. */
 function attentionItems(o) {
   const waitMinutes = (opened) => opened ? Math.max(0, Math.floor((Date.now() - Date.parse(opened)) / 60_000)) : 0;
-  const effectiveWait = (row, gate = false) => {
-    const unblocks = Array.isArray(row?.unblocks) ? row.unblocks.length : Number(row?.unblocks ?? 0);
-    return waitMinutes(row?.opened_at ?? row?.at) + unblocks * 90 + (gate ? 20 : 0);
-  };
+  /* THE UNBLOCK TERM READS THE WIRE (#761). No row on `escalations` or
+     `review_gate` ever carried an `unblocks` field: the daemon builds them in
+     `wireEscalation` and the review-gate mapper, and neither writes one. What
+     the daemon does emit is the blocked set of every map, which names its
+     blockers, and the frontier's takeable items, each naming what it unblocks.
+     Both are keyed on the bare ticket number: an escalation carries no repo,
+     so a repo-qualified key would match nothing and score zero for ever, which
+     is the defect this replaces. The bonus is FLAT: one item that unblocks
+     other work is 90 minutes ahead, however many tickets wait behind it. */
+  const unblockers = unblockSet(o);
+  const effectiveWait = (row, gate = false) =>
+    waitMinutes(row?.opened_at ?? row?.at) + (unblockers.has(String(row?.ticket)) ? 90 : 0) + (gate ? 20 : 0);
   /* Each item also carries an `id`, a one-line `line`, and a `landing` (#718):
      the handoff sheet names the next items with these and lands the operator
-     on the card itself. It never carries an answer control of its own. */
+     on the card itself. It never carries an answer control of its own.
+
+     Amber follows the SCORE, not the raw wait (#761): an item that ranks as
+     overdue is marked as overdue, and the mark says the wait in minutes and
+     names the unblock when one is there, so 90 minutes of rank is never
+     unaccountable. */
+  const need = (row, gate = false) => {
+    const score = effectiveWait(row, gate);
+    const waited = waitMinutes(row?.opened_at);
+    const unblocks = unblockers.has(String(row?.ticket));
+    return { score, aged: score >= 240, why: score >= 240 ? `waited ${waited} min · overdue${unblocks ? " · unblocks other work" : ""}` : (unblocks ? "unblocks other work" : "") };
+  };
   const items = [
-    ...credentialPointers(o).map((html, i) => ({ id: "cred-" + i, line: "a model credential wants you", landing: "credentials", html, score: 100_000, aged: false })),
-    ...(o?.escalations ?? []).map((row) => ({ id: row.id, line: `${row.agent} · ${row.kind} · ${ticketName(null, row.ticket)}: ${snip(row.prompt, 90)}`, landing: "home", html: escCard(row), score: effectiveWait(row), aged: waitMinutes(row.opened_at) >= 240 })),
-    ...(o?.review_gate ?? []).map((row) => ({ id: row.id, line: `${row.agent} · review gate · ${ticketName(null, row.ticket)}: ${snip(row.prompt, 90)}`, landing: "home", html: gateCard(row), score: effectiveWait(row, true), aged: waitMinutes(row.opened_at) >= 240 })),
-    ...(o?.token_warnings ?? []).map((row) => ({ id: "token-" + row.key, line: `${row.key} cannot reach ${row.repo}`, landing: "home", html: tokenCard(row), score: 50_000, aged: false })),
+    ...credentialPointers(o).map((html, i) => ({ id: "cred-" + i, line: "a model credential wants you", landing: "credentials", html, score: 100_000, aged: false, why: "" })),
+    ...(o?.escalations ?? []).map((row) => ({ id: row.id, line: `${row.agent} · ${row.kind} · ${ticketName(null, row.ticket)}: ${snip(row.prompt, 90)}`, landing: "home", html: escCard(row), ...need(row) })),
+    ...(o?.review_gate ?? []).map((row) => ({ id: row.id, line: `${row.agent} · review gate · ${ticketName(null, row.ticket)}: ${snip(row.prompt, 90)}`, landing: "home", html: gateCard(row), ...need(row, true) })),
+    ...(o?.token_warnings ?? []).map((row) => ({ id: "token-" + row.key, line: `${row.key} cannot reach ${row.repo}`, landing: "home", html: tokenCard(row), score: 50_000, aged: false, why: "" })),
     /* The tickets the auto loop steps over (#444). On this list where a spent
        window is not, by this list's own test: an operator act is what ends one.
        Nothing lifts it on a clock, and the ticket sits on the frontier
        untouched until somebody fixes the cause and dispatches it. */
-    ...(o?.dispatch_holds ?? []).map((row) => ({ id: `hold-${row.repo}-${row.ticket}`, line: `${ticketName(row.repo, row.ticket)} is held from auto-dispatch`, landing: "home", html: dispatchHoldCard(row), score: 50_000, aged: false })),
+    ...(o?.dispatch_holds ?? []).map((row) => ({ id: `hold-${row.repo}-${row.ticket}`, line: `${ticketName(row.repo, row.ticket)} is held from auto-dispatch`, landing: "home", html: dispatchHoldCard(row), score: 50_000, aged: false, why: "" })),
   ];
   items.sort((a, b) => b.score - a.score);
   return items;
@@ -1840,10 +1861,20 @@ function attentionItems(o) {
 
 /* The column itself. It carries no count of its own any more: the number has one
    home, `needsYou`, and a second one here is how the two drifted. */
+/* The bare ticket numbers whose answer frees other work, from the two places
+   the wire says so: a map's blocked children name their blockers, and a
+   frontier item names what it unblocks. A repo's failed frontier read carries
+   no items and adds nothing. */
+function unblockSet(o) {
+  const set = new Set();
+  for (const m of o?.maps?.maps ?? []) for (const b of m?.blocked ?? []) for (const k of b?.blockers ?? []) if (k?.number != null) set.add(String(k.number));
+  for (const r of o?.frontier?.repos ?? []) for (const i of r?.items ?? []) if (i?.unblocks?.length && i.number != null) set.add(String(i.number));
+  return set;
+}
 function attentionList(o) {
   const items = attentionItems(o);
   return items.length
-    ? items.map((item, index) => `<div class="need-rank ${index < 3 ? "full" : "compact"}${item.aged ? " aged" : ""}" id="need-${esc(item.id)}">${item.html}</div>`).join("")
+    ? items.map((item, index) => `<div class="need-rank ${index < 3 ? "full" : "compact"}${item.aged ? " aged" : ""}" id="need-${esc(item.id)}">${item.why ? `<div class="need-why">${esc(item.why)}</div>` : ""}${item.html}</div>`).join("")
     : `<div class="empty">Nothing wants you.</div>`;
 }
 

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -382,11 +382,14 @@ describe('the read screens (#264)', () => {
     })
 
     test('Home ranks every open need by effective wait, with three full rows and compact rows after them', () => {
+      // No row carries an `unblocks` field: the wire never does (#761). Ticket
+      // 265 ranks ahead because the map's blocked set names it as a blocker and
+      // the frontier says it unblocks 267, both in the shared fixture.
       const p = payload({
         usage: [], token_warnings: [], dispatch_holds: [], credentials: { consumers: [], reauth: null },
         escalations: [
           { id: 'old', agent: 'curia-old', ticket: '1', kind: 'free-text', prompt: 'Oldest wait', opened_at: at(15_000) },
-          { id: 'route', agent: 'curia-route', ticket: '2', kind: 'free-text', prompt: 'Unblocks two', opened_at: at(60), unblocks: 2 },
+          { id: 'route', agent: 'curia-route', ticket: '265', kind: 'free-text', prompt: 'Unblocks two', opened_at: at(60) },
           { id: 'plain', agent: 'curia-plain', ticket: '3', kind: 'free-text', prompt: 'Plain thirty', opened_at: at(1_800) },
           { id: 'small', agent: 'curia-small', ticket: '4', kind: 'free-text', prompt: 'Small wait', opened_at: at(120) },
         ],
@@ -397,6 +400,43 @@ describe('the read screens (#264)', () => {
       assert.ok(html.indexOf('Oldest wait') < html.indexOf('Unblocks two'))
       assert.ok(html.indexOf('Unblocks two') < html.indexOf('Plain thirty'))
       assert.match(html, /need-rank full aged/)
+    })
+
+    test('the unblock bonus is derived from the wire and is flat (#761)', () => {
+      const o = payload({ usage: [], token_warnings: [], dispatch_holds: [], credentials: { consumers: [], reauth: null }, escalations: [] }).overview
+      // 265 and 266 block 267 on the map; 265 unblocks 267 on the frontier too.
+      assert.deepEqual([...page.unblockSet(o)].sort(), ['265', '266'])
+      // A fabricated `unblocks` field on the row itself is ignored.
+      o.escalations = [
+        { id: 'fake', agent: 'a', ticket: '9', kind: 'free-text', prompt: 'fabricated', opened_at: at(60), unblocks: [1, 2, 3] },
+        { id: 'one', agent: 'b', ticket: '265', kind: 'free-text', prompt: 'blocks one on the frontier', opened_at: at(60) },
+        { id: 'two', agent: 'c', ticket: '266', kind: 'free-text', prompt: 'blocks one on the map', opened_at: at(60) },
+      ]
+      const items = page.attentionItems(o)
+      const score = (id) => items.find((i) => i.id === id).score
+      assert.equal(score('fake'), 1)
+      assert.equal(score('one'), 91, 'a flat 90 on top of the minute')
+      assert.equal(score('two'), 91, 'the map blocked set alone is enough, and the count does not multiply')
+      // A frontier repo that failed to read adds nothing and throws nothing.
+      o.frontier = { computed_at: null, repos: [{ repo: 'x', error: 'boom' }] }
+      o.maps = { computed_at: null, maps: null, error: 'boom' }
+      assert.equal(page.unblockSet(o).size, 0)
+    })
+
+    test('amber follows the effective score and states the wait and the reason (#761)', () => {
+      const p = payload({
+        usage: [], token_warnings: [], dispatch_holds: [], credentials: { consumers: [], reauth: null }, review_gate: [],
+        escalations: [
+          // 170 minutes raw is under the 240 line, but with the 90 unblock it ranks overdue.
+          { id: 'byrank', agent: 'curia-a', ticket: '265', kind: 'free-text', prompt: 'Amber by rank', opened_at: at(170 * 60) },
+          { id: 'young', agent: 'curia-b', ticket: '4', kind: 'free-text', prompt: 'Young and plain', opened_at: at(60) },
+        ],
+      })
+      const html = page.screenHome(p)
+      const rows = [...html.matchAll(/<div class="need-rank[^"]*" id="need-([^"]+)">(?:<div class="need-why">([^<]*)<\/div>)?/g)].map((m) => [m[1], m[2] ?? ''])
+      assert.deepEqual(rows, [['byrank', 'waited 170 min · overdue · unblocks other work'], ['young', '']])
+      assert.match(html, /need-rank full aged" id="need-byrank"/)
+      assert.doesNotMatch(html, /aged" id="need-young"/)
     })
 
     test('the tiles, the attention list and the fleet all draw one snapshot', () => {
@@ -2456,8 +2496,14 @@ describe('the operator verbs (#266)', () => {
       const p = payload()
       p.overview.escalations.push(
         { id: 'esc-20', agent: 'curia-20', ticket: '20', kind: 'free-text', prompt: 'Five hours old.', options: null, preview_url: null, opened_at: at(5 * 3600), agent_died: false, rendered: true },
-        { id: 'esc-21', agent: 'curia-21', ticket: '21', kind: 'choice', prompt: 'Young, but two tickets wait on it.', options: ['a', 'b'], preview_url: null, opened_at: at(60), agent_died: false, rendered: true, unblocks: [1, 2] },
+        { id: 'esc-21', agent: 'curia-21', ticket: '21', kind: 'choice', prompt: 'Young, but two tickets wait on it.', options: ['a', 'b'], preview_url: null, opened_at: at(60), agent_died: false, rendered: true },
         { id: 'esc-22', agent: 'curia-22', ticket: '22', kind: 'free-text', prompt: 'Young and unblocks nothing.', options: null, preview_url: null, opened_at: at(30), agent_died: false, rendered: true },
+      )
+      // The unblock is on the wire, not on the row (#761): two map children
+      // are blocked by 21.
+      p.overview.maps.maps[0].blocked.push(
+        { number: 31, title: 'Waits on 21', type: 'task', blockers: [{ number: 21, title: 'Young' }] },
+        { number: 32, title: 'Also waits on 21', type: 'task', blockers: [{ number: 21, title: 'Young' }] },
       )
       return p
     }


### PR DESCRIPTION
## What changed

Home's `effectiveWait` read `row.unblocks` off each escalation and review-gate row. Nothing in `daemon/src` writes that field (the frontier's `items[].unblocks` in `dispatch.mjs` is the only producer, and it's on frontier items, not on needs), so production always scored zero on that term while the test fixture fabricated it.

- `unblockSet(o)` in `daemon/assets/dashboard.html` derives the unblocking tickets from the wire: `overview.maps.maps[].blocked[].blockers[].number` and `frontier.repos[].items[].number` where the item names an `unblocks` list. Keys are bare ticket numbers, because escalations carry no repo.
- The bonus is a flat 90 minutes, not 90 times a count.
- Amber follows the effective score. An amber row carries a `need-why` line that states the wait in minutes, says `overdue`, and says `unblocks other work` when that's why it ranks there. A non-amber unblocker says `unblocks other work` alone.
- The fixtures stop asserting a field the wire never carries. The ranking test and the handoff-sheet test now put the unblock on the map's blocked set, and a new test checks the set against a wire-shaped payload, a fabricated `unblocks` row field is ignored, the bonus is flat, and a failed frontier or map read adds nothing.

## Not done

The optional one-line compact row with a "+N more" line stays out until the tail proves unreadable in use.

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
