### PR TITLE
Finish the GitHub App section's installation reading (alp82/curia#762)

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3242,28 +3242,57 @@ function gistConnections(p) {
   const app = p?.overview?.github_app;
   if (!app) return `<span class="dim-note">state unavailable</span>`;
   if (!app.configured) return `<span style="color:var(--warn)">setup needed</span>`;
-  const missing = (app.owners ?? []).filter((owner) => !owner.installed).length;
+  if (app.installations?.state !== "read") return `<span class="dim-note">installations unread</span>`;
+  const missing = (app.owners ?? []).filter((owner) => owner.installed === false).length;
   return missing
     ? `<span style="color:var(--warn)">${esc(missing)} owner${missing === 1 ? "" : "s"} missing access</span>`
     : `<span style="color:var(--ok)">installed</span>`;
 }
 
+/* The owner row's third state (#762). `installed` is null when the reading
+   has not landed or failed, and that must never read as "missing access":
+   an operator sent to install on an owner that already has the app would
+   be repairing a fact about GitHub's reachability. */
+function ownerState(owner, reading) {
+  if (owner.installed === true) return "installed";
+  if (owner.installed === false) return "missing access";
+  return reading?.state === "failed" ? "unknown (read failed)" : "unknown (not read yet)";
+}
+
 function setConnections(p) {
   const app = p?.overview?.github_app;
   if (!app) return `<p class="unread">Curia hasn't reported the GitHub App state.</p>`;
+  const facts = app.app;
   const state = app.configured
-    ? `<p class="qhint"><b>GitHub App configured.</b> Curia adopts new credentials without exposing the private key to Atlas.</p>`
+    ? `<div class="rows">
+    <div class="row"><span class="key grow">App id</span><span>${esc(facts?.id ?? "")}</span></div>
+    <div class="row"><span class="key grow">Slug</span><span>${facts?.slug ? esc(facts.slug) : `<span class="dim-note">not read yet</span>`}</span></div>
+    <div class="row"><span class="key grow">Bot login</span><span>${facts?.bot_login ? esc(facts.bot_login) : `<span class="dim-note">not read yet</span>`}</span></div>
+    <div class="row"><span class="key grow">Key file</span><span>${esc(facts?.key_file ?? "")}</span></div>
+    ${facts?.settings_url ? `<div class="row"><span class="key grow">Settings</span><span><a href="${esc(facts.settings_url)}" target="_blank" rel="noopener">App settings page on GitHub</a></span></div>` : ""}
+    </div>
+    <p class="qhint">Curia adopts new credentials without exposing the private key to Atlas.</p>`
     : app.status === "pending"
       ? `<p class="unread">GitHub App setup is pending until ${esc(ago(app.expires_at))}.</p>`
       : `<p class="unread">No GitHub App is configured. Create one from Atlas.</p>`;
   const create = app.configured ? "" : `<p><input id="github-app-name" value="curia-box" aria-label="GitHub App name">
     <button class="btn primary" ${anyBusy() ? "disabled" : ""} onclick="doGitHubAppSetup()">Create GitHub App</button></p>
     ${said("github-app")}`;
+  const manual = app.manual_url
+    ? `<p class="qhint"><a href="${esc(app.manual_url)}" target="_blank" rel="noopener">Set up a GitHub App by hand on GitHub</a></p>` : "";
+  const reading = app.installations ?? null;
+  const readLine = !app.configured ? "" : reading?.state === "read"
+    ? `<p class="qhint">Installations read ${esc(ago(reading.at))}.</p>`
+    : reading?.state === "failed"
+      ? `<p class="unread">The installation read failed ${esc(ago(reading.at))}: ${esc(reading.error ?? "")}</p>`
+      : `<p class="unread">Installations have not been read yet.</p>`;
+  const refresh = !app.configured ? "" : `<p><button class="btn" ${anyBusy() ? "disabled" : ""} onclick="doGitHubAppRefresh()">Re-read installations</button></p>
+    ${said("github-app-refresh")}`;
   const owners = (app.owners ?? []).map((owner) => `<div class="row">
     <span class="key grow">${esc(owner.owner)}</span>
-    <span>${owner.installed ? "installed" : "missing access"}</span>
-    <span>${owner.installed ? "" : `<a href="${esc(owner.install_url)}">Manage installation</a>`}</span></div>`).join("");
-  return `${state}${create}<div class="rows">${owners}</div>`;
+    <span>${esc(ownerState(owner, reading))}</span>
+    <span><a href="${esc(owner.install_url)}" target="_blank" rel="noopener">${owner.installed === true ? "Manage installation" : "Install on this owner"}</a></span></div>`).join("");
+  return `${state}${create}${manual}${readLine}<div class="rows">${owners}</div>${refresh}`;
 }
 
 /* Maintenance (#362). Last, because it is the section an operator
@@ -3965,6 +3994,11 @@ function chatScrolled(el) {
 function chatAfterRender() {
   const el = document.getElementById("chat-log");
   if (el && chat.stick) el.scrollTop = el.scrollHeight;
+}
+
+async function doGitHubAppRefresh() {
+  if (anyBusy()) return;
+  await verb("github-app-refresh", "/api/github-app/refresh", {});
 }
 
 async function doGitHubAppSetup() {

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -920,6 +920,11 @@ export class DashboardSurface {
           })
         })
       }
+      // The re-read of the app's installations (#762). No field crosses: the
+      // press is the whole message.
+      if (url.pathname === '/api/github-app/refresh') {
+        return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/github-app/installations', body: {} }))
+      }
       // ---- the operator verbs (#266) ---------------------------------------
       //
       // Every one of them is a call this file COMPOSES. The browser hands over

--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -428,7 +428,30 @@ export async function listInstallations({ jwt, fetchImpl = globalThis.fetch } = 
     if (e.status === 401) throw new Error(`GitHub refused curia's app JWT (401) — ${APP_ID_KEY} and the key file must belong to the same app, and the box clock must be right`)
     throw e
   }
-  return (payload ?? []).map((i) => ({ id: i.id, owner: i.account?.login ?? null }))
+  // `account_id` rides along (#762): the app's own install page takes it as
+  // `target_id`, which is what makes a per-owner install link possible.
+  return (payload ?? []).map((i) => ({ id: i.id, owner: i.account?.login ?? null, account_id: i.account?.id ?? null }))
+}
+
+// The app's own settings-page facts, from `/app` on the app JWT (#762). One
+// shape for the Settings section and for the bot login.
+export function appFactsFrom(app) {
+  const slug = String(app?.slug ?? '').trim() || null
+  return {
+    id: app?.id ?? null,
+    slug,
+    name: app?.name ?? null,
+    owner: app?.owner?.login ?? null,
+    settings_url: app?.html_url ? `${app.html_url}` : (slug ? `https://github.com/apps/${slug}` : null),
+  }
+}
+
+// Where an owner installs, or manages, THIS app. With no slug there is no
+// app-specific page, so the generic installations list is the fallback.
+export function installUrlFor({ slug = null, accountId = null } = {}) {
+  if (!slug) return 'https://github.com/settings/installations'
+  const base = `https://github.com/apps/${encodeURIComponent(slug)}/installations`
+  return accountId ? `${base}/new/permissions?target_id=${encodeURIComponent(accountId)}` : `${base}/new`
 }
 
 // How many pages of repositories one installation may state. An installation
@@ -508,6 +531,15 @@ export class TokenMinter {
 
   #bot = null
 
+  #facts = null
+
+  // The last installation read, as a tri-state record (#762): `unread` until
+  // the first read answers, then `read` with the rows or `failed` with the
+  // error, each stamped with the instant it happened. The overview serves this
+  // record and never calls GitHub itself, so an owner whose read failed is
+  // drawn as unknown rather than as absent.
+  reading = { state: 'unread', at: null, installations: [], error: null }
+
   // `<owner>|<role>` → the promise of a mint that has not answered yet (#390).
   #minting = new Map()
 
@@ -533,8 +565,28 @@ export class TokenMinter {
   // one case that matters is an owner added to the watch list and installed the
   // same minute, and `refreshInstallations` is what a restart-free box calls.
   async installations() {
-    if (!this.#installations) this.#installations = await listInstallations({ jwt: this.jwt(), fetchImpl: this.fetchImpl })
+    if (!this.#installations) {
+      try {
+        this.#installations = await listInstallations({ jwt: this.jwt(), fetchImpl: this.fetchImpl })
+        this.reading = { state: 'read', at: new Date(this.now()).toISOString(), installations: this.#installations, error: null }
+      } catch (e) {
+        this.reading = { state: 'failed', at: new Date(this.now()).toISOString(), installations: [], error: e.message }
+        throw e
+      }
+    }
     return this.#installations
+  }
+
+  // The app's identity, read once from `/app` and kept (#762). `facts` is
+  // the cached answer, null until the first read lands, so the overview can
+  // state what it knows without a network call on the poll path.
+  get facts() {
+    return this.#facts
+  }
+
+  async readFacts() {
+    if (!this.#facts) this.#facts = appFactsFrom(await api('/app', { jwt: this.jwt(), fetchImpl: this.fetchImpl }))
+    return this.#facts
   }
 
   async refreshInstallations() {
@@ -620,8 +672,7 @@ export class TokenMinter {
   // whole of GitHub, so another operator's daemon has another bot entirely.
   async botIdentity(token) {
     if (this.#bot) return this.#bot
-    const app = await api('/app', { jwt: this.jwt(), fetchImpl: this.fetchImpl })
-    const slug = String(app?.slug ?? '').trim()
+    const { slug } = await this.readFacts()
     if (!slug) throw new Error('GitHub described curia\'s app without a slug, so its bot login cannot be built')
     const login = `${slug}[bot]`
     const user = await api(`/users/${encodeURIComponent(login)}`, { jwt: token, fetchImpl: this.fetchImpl })
@@ -638,6 +689,7 @@ export class TokenMinter {
     this.#minting.clear()
     this.#installations = null
     this.#bot = null
+    this.#facts = null
   }
 }
 

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -51,7 +51,7 @@ import { OVERSEER_MCP_PATH } from './overseerturn.mjs'
 import { ConversationRuntime } from './conversationruntime.mjs'
 import { hasSession } from './tmux.mjs'
 import { retiredAgentTokenKeys } from './workspace.mjs'
-import { APP_ID_KEY, APP_KEY_FILE_KEY, GitHubAppSetup, minterFrom } from './githubapp.mjs'
+import { APP_ID_KEY, APP_KEY_FILE_KEY, GitHubAppSetup, installUrlFor, minterFrom } from './githubapp.mjs'
 import { AppSetup, minterForAdopted } from './appsetup.mjs'
 import { CodexCredentialBroker, AnthropicCredentialStore, anthropicStoreFile } from './credentials.mjs'
 import {
@@ -338,6 +338,9 @@ if (!appMinter) {
 // settings screen must get the reading a booted one gets.
 function checkAppInstallations() {
   if (!appMinter) return
+  // The app's own facts ride the same detached pass (#762): slug, id and
+  // settings page, read once and kept for the Settings section.
+  appMinter.readFacts().catch((e) => log(`could not read the GitHub App's own facts (${e.message})`))
   appMinter.refreshInstallations().then((installs) => {
     for (const { id, owner } of installs) log(`GitHub App installed on ${owner} (installation ${id})`)
     const seen = new Set(installs.map((i) => String(i.owner ?? '').toLowerCase()))
@@ -2699,12 +2702,15 @@ async function overview() {
   }
   const health = bridge ? bridge.status() : null
   const open = reduction.openEscalations()
-  let appInstallations = []
-  let appError = null
-  if (appMinter) {
-    try { appInstallations = await appMinter.installations() } catch (e) { appError = e.message }
-  }
-  const installedOwners = new Set(appInstallations.map((row) => String(row.owner ?? '').toLowerCase()))
+  // The installation reading is the KEPT one (#762), never a call made here:
+  // the overview rides the poll, and GitHub is not on the poll path. The
+  // detached pass at boot, reload, adopt and the refresh route are what write
+  // it. `owners[].installed` is a tri-state: true and false are measured, null
+  // is a reading that has not landed or failed, and the page draws null as
+  // unknown rather than as absent.
+  const reading = appMinter?.reading ?? { state: 'unread', at: null, installations: [], error: null }
+  const installedBy = new Map(reading.installations.map((row) => [String(row.owner ?? '').toLowerCase(), row]))
+  const facts = appMinter?.facts ?? null
   return {
     at: new Date().toISOString(),
     daemon: {
@@ -2742,12 +2748,25 @@ async function overview() {
     github_app: {
       ...githubAppSetup.status(),
       configured: Boolean(appMinter),
-      error: appError,
-      owners: [...WATCHED_OWNERS].map((owner) => ({
-        owner,
-        installed: installedOwners.has(owner.toLowerCase()),
-        install_url: 'https://github.com/settings/installations',
-      })),
+      error: reading.error,
+      app: appMinter ? {
+        id: appMinter.appId,
+        slug: facts?.slug ?? null,
+        name: facts?.name ?? null,
+        bot_login: facts?.slug ? `${facts.slug}[bot]` : null,
+        key_file: appMinter.keyFile,
+        settings_url: facts?.settings_url ?? null,
+      } : null,
+      installations: { state: reading.state, at: reading.at, error: reading.error },
+      owners: [...WATCHED_OWNERS].map((owner) => {
+        const row = installedBy.get(owner.toLowerCase()) ?? null
+        return {
+          owner,
+          installed: reading.state === 'read' ? Boolean(row) : null,
+          installation_id: row?.id ?? null,
+          install_url: installUrlFor({ slug: facts?.slug, accountId: row?.account_id }),
+        }
+      }),
       manual_url: 'https://github.com/settings/apps/new',
     },
     // The gate is its own list, not a kind to filter for. It is the one
@@ -3085,6 +3104,21 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
       return json(200, started)
     } catch (e) {
       return json(400, { error: e.message })
+    }
+  }
+
+  // The re-read (#762). An install on github.com is an act between polls, so
+  // the operator presses once and the kept reading is replaced, awaited here
+  // so the answer states what the press measured.
+  if (url.pathname === '/github-app/installations' && req.method === 'POST') {
+    if (!appMinter) return json(400, { error: 'no GitHub App is configured, so there is nothing to read installations for' })
+    appMinter.readFacts().catch((e) => log(`could not read the GitHub App's own facts (${e.message})`))
+    try {
+      const installs = await appMinter.refreshInstallations()
+      reduction.journal('github_app_installations_read', { owners: installs.map((i) => i.owner) })
+      return json(200, { ok: true, reply: `Read ${installs.length} installation${installs.length === 1 ? '' : 's'}: ${installs.map((i) => i.owner).join(', ') || 'none'}`, installations: appMinter.reading })
+    } catch (e) {
+      return json(200, { ok: false, reply: `The installation read failed: ${e.message}`, installations: appMinter.reading })
     }
   }
 

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -812,6 +812,7 @@ describe('the operator verbs (#266)', () => {
       '/feed/read': [200, { ok: true, by: 'alp@example.com', at: '2026-08-26T09:00:00.000Z', previous: null }],
       '/github-app/start': [200, { action: 'https://github.com/settings/apps/new', manifest: { name: 'curia-box' } }],
       '/github-app/complete?code=one-use&state=expected': [200, { ok: true, app: { id: '42', slug: 'curia-box' } }],
+      '/github-app/installations': [200, { ok: true, reply: 'Read 1 installation: alp82', installations: { state: 'read' } }],
     }
     daemon = http.createServer((r, res) => {
       let buf = ''
@@ -917,6 +918,18 @@ describe('the operator verbs (#266)', () => {
     const completed = await req(surface.port, '/api/github-app/complete?code=one-use&state=expected', { headers: served() })
     assert.equal(completed.status, 303)
     assert.equal(completed.text.includes('PRIVATE KEY'), false)
+  })
+
+  // The re-read (#762). The press carries no field the daemon acts on, and the
+  // next page read is a fresh one so the owner rows show what was measured.
+  test('the installation re-read reaches the daemon as a bare press and drops the snapshot', async () => {
+    surface.snapshotAt = Date.now()
+    const out = await press('/api/github-app/refresh', { anything: 'ignored' })
+    assert.equal(out.status, 200)
+    assert.equal(sent('/github-app/installations').method, 'POST')
+    assert.deepEqual(sent('/github-app/installations').body, {})
+    assert.equal(surface.snapshotAt, 0)
+    assert.match(out.text, /Read 1 installation: alp82/)
   })
 
   // GitHub sends the one-use conversion code to the redirect URL, so a caller

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1878,19 +1878,73 @@ describe('the settings screen (#265)', () => {
     p.overview.github_app = {
       configured: false,
       status: 'idle',
+      app: null,
+      installations: { state: 'unread', at: null, error: null },
+      manual_url: 'https://github.com/settings/apps/new',
       owners: [
-        { owner: 'alp82', installed: true, install_url: 'https://github.com/settings/installations' },
-        { owner: 'getalfredo', installed: false, install_url: 'https://github.com/settings/installations' },
+        { owner: 'alp82', installed: null, install_url: 'https://github.com/settings/installations' },
       ],
     }
     page.UI.drill.settings = { open: 'connections', list: false }
     const html = page.screenSettings(p)
     const t = text(html)
     assert.match(t, /No GitHub App is configured\. Create one from Atlas\./)
-    assert.match(t, /alp82 installed/)
-    assert.match(t, /getalfredo missing access Manage installation/)
+    assert.match(html, /href="https:\/\/github\.com\/settings\/apps\/new"/, 'the manual setup link is reachable')
     assert.match(html, /doGitHubAppSetup\(\)/)
+    assert.doesNotMatch(html, /doGitHubAppRefresh\(\)/, 'nothing to re-read before an app exists')
     assert.match(fs.readFileSync(DEFAULT_DASHBOARD_INDEX, 'utf8'), /manifest\.name = "manifest"/)
+  })
+
+  // #762: the configured section states the app, the reading, and three owner
+  // states, and the third is never drawn as the second.
+  test('Connections states the app identity, the reading, and each owner in three states', () => {
+    const p = payload()
+    p.overview.github_app = {
+      configured: true,
+      status: 'complete',
+      app: {
+        id: '4610603', slug: 'curia-sh', name: 'Curia', bot_login: 'curia-sh[bot]',
+        key_file: '/srv/curia/daemon/github-app.pem', settings_url: 'https://github.com/apps/curia-sh',
+      },
+      installations: { state: 'read', at: p.overview.at, error: null },
+      manual_url: 'https://github.com/settings/apps/new',
+      owners: [
+        { owner: 'alp82', installed: true, installation_id: 111, install_url: 'https://github.com/apps/curia-sh/installations/new/permissions?target_id=9' },
+        { owner: 'getalfredo', installed: false, installation_id: null, install_url: 'https://github.com/apps/curia-sh/installations/new' },
+      ],
+    }
+    page.UI.drill.settings = { open: 'connections', list: false }
+    let html = page.screenSettings(p)
+    let t = text(html)
+    assert.match(t, /App id 4610603/)
+    assert.match(t, /Slug curia-sh/)
+    assert.match(t, /Bot login curia-sh\[bot\]/)
+    assert.match(t, /Key file \/srv\/curia\/daemon\/github-app\.pem/)
+    assert.match(html, /href="https:\/\/github\.com\/apps\/curia-sh"/)
+    assert.match(t, /Installations read/)
+    assert.match(t, /alp82 installed Manage installation/)
+    assert.match(t, /getalfredo missing access Install on this owner/)
+    assert.match(html, /href="https:\/\/github\.com\/apps\/curia-sh\/installations\/new"/)
+    assert.match(html, /doGitHubAppRefresh\(\)/)
+    assert.match(text(page.screenSettings(p)), /1 owner missing access/)
+
+    p.overview.github_app.installations = { state: 'failed', at: p.overview.at, error: 'GitHub answered 502' }
+    p.overview.github_app.owners.forEach((owner) => { owner.installed = null })
+    html = page.screenSettings(p)
+    t = text(html)
+    assert.match(t, /The installation read failed .*GitHub answered 502/)
+    assert.match(t, /alp82 unknown \(read failed\)/)
+    assert.doesNotMatch(t, /missing access/, 'a failed read is not an absent owner')
+
+    p.overview.github_app.installations = { state: 'unread', at: null, error: null }
+    p.overview.github_app.app.slug = null
+    p.overview.github_app.app.bot_login = null
+    t = text(page.screenSettings(p))
+    assert.match(t, /Installations have not been read yet/)
+    assert.match(t, /getalfredo unknown \(not read yet\)/)
+    assert.match(t, /Slug not read yet/)
+    page.UI.drill.settings = { open: null, list: true }
+    assert.match(text(page.screenSettings(p)), /installations unread/)
   })
 
   // ---- aistack (#706) ------------------------------------------------------

--- a/daemon/test/githubapp.test.mjs
+++ b/daemon/test/githubapp.test.mjs
@@ -12,7 +12,7 @@ import {
   WRITE_PERMISSIONS, READ_PERMISSIONS,
   appConfigFrom, readPrivateKey, keyFileIsPrivate, appJwt, permissionsFor,
   listInstallations, listInstallationRepos, mintInstallationToken, TokenMinter, minterFrom,
-  MAX_REPO_PAGES,
+  MAX_REPO_PAGES, appFactsFrom, installUrlFor,
 } from '../src/githubapp.mjs'
 
 let dir
@@ -182,8 +182,8 @@ describe('the API calls (#352)', () => {
       { id: 222, account: { login: 'getalfredo' } },
     ] }])
     assert.deepEqual(await listInstallations({ jwt: 'j', fetchImpl }), [
-      { id: 111, owner: 'alp82' },
-      { id: 222, owner: 'getalfredo' },
+      { id: 111, owner: 'alp82', account_id: null },
+      { id: 222, owner: 'getalfredo', account_id: null },
     ])
     const { url, opts } = fetchImpl.calls[0]
     // per_page, because GitHub's default page is 30 and nothing here paginates
@@ -389,6 +389,50 @@ describe('the app\'s own git identity (#389)', () => {
     const fetchImpl = fakeFetch(answers)
     return { m: new TokenMinter({ appId: '7', key: keyPair.privateKey, fetchImpl }), fetchImpl }
   }
+
+  // #762: the reading is a record with three states, and the facts are read
+  // once and shared with the bot identity.
+  test('the installation reading is unread, then read or failed, each with its instant', async () => {
+    const now = () => Date.parse('2026-08-26T10:00:00.000Z')
+    const fetchImpl = fakeFetch([
+      { status: 500, body: { message: 'down' } },
+      { status: 200, body: [{ id: 111, account: { login: 'alp82', id: 9 } }] },
+    ])
+    const m = new TokenMinter({ appId: '7', key: keyPair.privateKey, fetchImpl, now })
+    assert.deepEqual(m.reading, { state: 'unread', at: null, installations: [], error: null })
+    await assert.rejects(m.installations())
+    assert.equal(m.reading.state, 'failed')
+    assert.equal(m.reading.at, '2026-08-26T10:00:00.000Z')
+    assert.match(m.reading.error, /down/)
+    assert.deepEqual(m.reading.installations, [])
+    await m.refreshInstallations()
+    assert.equal(m.reading.state, 'read')
+    assert.deepEqual(m.reading.installations, [{ id: 111, owner: 'alp82', account_id: 9 }])
+    assert.equal(m.reading.error, null)
+  })
+
+  test('the app facts are read once, and the bot identity reads them rather than /app again', async () => {
+    const { m, fetchImpl } = minter([
+      { status: 200, body: { id: 4610603, slug: 'curia-sh', name: 'Curia', html_url: 'https://github.com/apps/curia-sh', owner: { login: 'alp82' } } },
+      bot,
+    ])
+    assert.equal(m.facts, null)
+    assert.deepEqual(await m.readFacts(), {
+      id: 4610603, slug: 'curia-sh', name: 'Curia', owner: 'alp82', settings_url: 'https://github.com/apps/curia-sh',
+    })
+    await m.readFacts()
+    assert.equal((await m.botIdentity('ghs_x')).name, 'curia-sh[bot]')
+    assert.equal(fetchImpl.calls.filter((c) => c.url.endsWith('/app')).length, 1)
+    m.forget()
+    assert.equal(m.facts, null)
+  })
+
+  test('the install link is the app\'s own page once the slug is known', () => {
+    assert.equal(installUrlFor({}), 'https://github.com/settings/installations')
+    assert.equal(installUrlFor({ slug: 'curia-sh' }), 'https://github.com/apps/curia-sh/installations/new')
+    assert.equal(installUrlFor({ slug: 'curia-sh', accountId: 9 }), 'https://github.com/apps/curia-sh/installations/new/permissions?target_id=9')
+    assert.equal(appFactsFrom({ slug: ' ' }).slug, null)
+  })
 
   test('the slug becomes the login, and the bot id becomes the email', async () => {
     const { m, fetchImpl } = minter([app, bot])


### PR DESCRIPTION
Closes #762.

## What changed

- **The re-read.** `POST /github-app/installations` on the daemon replaces the kept reading and journals `github_app_installations_read`. The sidecar relays it as `POST /api/github-app/refresh`, beside the other `/api/github-app/*` routes, and drops its snapshot so the next poll shows what the press measured. The section has a **Re-read installations** button.
- **Tri-state installation.** `TokenMinter.reading` is `unread`, `read`, or `failed`, stamped with the instant. The wire carries `github_app.installations` and `owners[].installed` as `true`, `false`, or `null`. The page draws `null` as "unknown (not read yet)" or "unknown (read failed)", never as "missing access".
- **The real install link.** `listInstallations` now carries `account_id`. `installUrlFor()` builds the app's own page from the slug, with `target_id` for an installed owner, and falls back to the generic list when the slug isn't read yet.
- **App facts.** `github_app.app` carries id, slug, bot login, key file, and the settings page link. The section renders each.
- **The manual setup link** is rendered from `manual_url`.
- **`TokenMinter.readFacts()`** caches `/app`; `botIdentity` reads it instead of calling `/app` a second time. `facts` is the synchronous cached getter.
- **Off the poll path.** `overview()` reads `appMinter.reading` and `appMinter.facts` and calls GitHub no more. The detached `checkAppInstallations()` pass reads facts too.

## Tests

`npm test` in `daemon/`: 3741 pass, 0 fail, 0 cancelled. New assertions cover the minter's reading and facts, the sidecar relay, and the section's three owner states.

## Not measured

The daemon route in `index.mjs` and the live github.com round trip are not covered by a test. #764 (the two setup stacks) is untouched; this change lives on the `#738` stack the Settings screen uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
