### PR TITLE
The status line states the dispatched effort (alp82/curia#763)

### DIFF
--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -512,14 +512,17 @@ const harnessFor = (session) => dispatcher?.agents.get(session)?.harness ?? dete
 // dashboard's provider strip (#262), and one agent must not be measured two
 // ways on two surfaces.
 //
-// The routing label takes the same route (#187). The status line only learns
-// it from a spawn event, so a line first drawn after a restart carries none —
-// and the effort meter reads off the label's routing row. The dispatcher's
-// record answers instead, which reconcile now rebuilds from the journal.
+// The model and the effort take the same route (#187, #763). The status line
+// only learns them from a spawn event, so a line first drawn after a restart
+// carries none. The dispatcher's record answers instead, which reconcile
+// rebuilds from the journal. The effort is the depth the agent was dispatched
+// at, which a type route can set away from the model default; the model
+// default only speaks when no record exists.
 const metersFor = (session, model) => agentMeters({
   harness: harnessFor(session),
   cfgDir: cfgDirFor(session),
   model: model ?? dispatcher?.agents.get(session)?.model ?? null,
+  effort: dispatcher?.agents.get(session)?.reasoningEffort ?? null,
   routing: routingConfig,
   account: accountUsage,
   models: modelWindows,
@@ -2824,7 +2827,7 @@ async function overview() {
 // The browser conversations, on the wire (#333). Everything about the shape
 // lives in usage.mjs beside `ctxOnWire`; what stays here is the wiring — the
 // reduction this daemon holds and the overseer container's config dir and model.
-function ticketConversationOnWire({ session, repo, ticket, title = null, model = null, state, reviewer = false, cfgDir = null, harness = null, live = true }) {
+function ticketConversationOnWire({ session, repo, ticket, title = null, model = null, reasoningEffort = null, state, reviewer = false, cfgDir = null, harness = null, live = true }) {
   const root = cfgDir ?? cfgDirFor(curiaConfig.dispatch.workspace_root, session)
   const detected = harness ?? detectHarness(root)
   const transcript = detected ? findTranscript(detected, root) : null
@@ -2848,6 +2851,7 @@ function ticketConversationOnWire({ session, repo, ticket, title = null, model =
       harness: detected,
       cfgDir: root,
       model,
+      effort: reasoningEffort,
       routing: routingConfig,
       account: accountUsage,
       models: modelWindows,

--- a/daemon/src/questions.mjs
+++ b/daemon/src/questions.mjs
@@ -316,6 +316,10 @@ export class Questions {
       model: ev.model ?? null,
       requested_model: ev.requested_model ?? null,
       harness: ev.harness ?? null,
+      // #763: the depth the agent was dispatched at. Without it a restart
+      // rebuilt the record with no effort, and the status line fell back to
+      // the model default a type route may have overridden.
+      reasoning_effort: ev.reasoning_effort ?? null,
       prompt_carries_limit_text: ev.prompt_carries_limit_text ?? null,
       // ADR-0023: the skill a ticketless run carries. Read by the gate guard
       // and the ending after a restart, when no agent record holds it.

--- a/daemon/src/usage.mjs
+++ b/daemon/src/usage.mjs
@@ -5,7 +5,8 @@
 //
 // THREE SOURCES, and the split is the whole design:
 //
-//   model + effort  the routing pick and `models.<name>.reasoning_effort`.
+//   model + effort  the routing pick and the depth the agent was dispatched at
+//                   (the model's `reasoning_effort` when no dispatch record exists).
 //                   The daemon already knows both at dispatch; nothing is read.
 //                   A DISPATCH is not a process, though — #187 measured what a
 //                   restart cost, because the label reached this function only
@@ -1096,10 +1097,13 @@ export function modelName(model, spec, stated = null) {
 // conversation's percent is the defect this argument exists to end, not a
 // fallback. ADR-0016 makes this meter the one signal that a conversation is
 // getting long, so a number about another conversation cannot carry the job.
-export function agentMeters({ harness, cfgDir, model, routing, account, models, transcript, now = Date.now() }) {
+// EFFORT is the depth the agent was dispatched at (#763): the dispatcher's
+// record, which a type route can set away from the model default. Only when
+// no record exists (a re-adopted or lab session) does the model default speak.
+export function agentMeters({ harness, cfgDir, model, effort = null, routing, account, models, transcript, now = Date.now() }) {
   const spec = routing?.models?.[model] ?? null
   const out = {
-    model: modelName(model, spec), effort: spec?.reasoning_effort ?? null, ctxPct: null, ctxOver: false, ctxTokens: null, windows: null,
+    model: modelName(model, spec), effort: effort ?? spec?.reasoning_effort ?? null, ctxPct: null, ctxOver: false, ctxTokens: null, windows: null,
   }
   if (!harness || !cfgDir) return out
 

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -17,6 +17,7 @@ import path from 'node:path'
 import { Dispatcher, discordTime, paneTail, paneConfirmsStall, paneAcceptedNudge, textCarriesLimitPhrase, parseTicketRef, newExitMarker, parseExitMarker, paneExcerpt } from '../src/dispatch.mjs'
 import { Reduction } from '../src/reduction.mjs'
 import { parseUsageLimit } from '../src/routing.mjs'
+import { agentMeters } from '../src/usage.mjs'
 import { TEST_PINS, containerDeps, fakePrivateClone, seedConfigDirStub, withTestCredential } from './fixtures/sandbox.mjs'
 import { ENV_FILE, GUEST_CFG } from '../src/sandbox.mjs'
 import { GH_DIR, readGhCredentials, writeGhCredentials } from '../src/agentgh.mjs'
@@ -5694,6 +5695,40 @@ describe('live model switching (#717)', () => {
     assert.match(reply, /xhigh\*\* effort/)
     assert.equal(d.agents.get('curia-42').reasoningEffort, 'xhigh')
     assert.equal(d.agents.get('curia-42').model, 'opus')
+  })
+
+  // #763: the status line's meter is built the way `metersFor` builds it in
+  // index.mjs, from the dispatcher's record. A task route dispatches gpt at
+  // xhigh while the model's own default is low, and the meter must say xhigh.
+  test('the status line meter states the depth the type route dispatched, not the model default', async () => {
+    const d = makeDispatcher({
+      listSessions: async () => ['curia-42'],
+      fetchIssue: async () => ({
+        ...OPEN_ISSUE,
+        assignees: [{ login: 'me' }],
+        labels: [{ name: 'wayfinder:task' }],
+      }),
+      containerPorts: async () => [9000, 9001, 9002],
+    }, { routing: SWITCH_ROUTING })
+    d.reduction.journal('agent_spawned', {
+      repo: 'o/r', ticket: '42', agent: 'curia-42',
+      model: 'gpt', requested_model: 'gpt', harness: 'codex',
+      reasoning_effort: 'xhigh', kind: 'ticket',
+    })
+    fakePrivateClone(d.root, 'o/r', '42')
+    await d.reconcile({ boot: false })
+
+    const agent = d.agents.get('curia-42')
+    assert.equal(agent.reasoningEffort, 'xhigh')
+    const meters = (session, model) => agentMeters({
+      harness: agent.harness, cfgDir: null,
+      model: model ?? d.agents.get(session)?.model ?? null,
+      effort: d.agents.get(session)?.reasoningEffort ?? null,
+      routing: SWITCH_ROUTING, account: null,
+    })
+    assert.equal(meters('curia-42', 'gpt').effort, 'xhigh')
+    // No record: the model default is all there is to say.
+    assert.equal(meters('curia-nobody', 'gpt').effort, 'low')
   })
 })
 

--- a/daemon/test/questions.test.mjs
+++ b/daemon/test/questions.test.mjs
@@ -255,11 +255,11 @@ describe('the last event of a type for a key', () => {
       spawn('42', 'curia-42', { model: 'opus', harness: 'claude' }),
       spawn('42', 'curia-42', {
         model: 'codex-high', requested_model: 'opus', harness: 'codex',
-        prompt_carries_limit_text: true,
+        reasoning_effort: 'xhigh', prompt_carries_limit_text: true,
       }),
     ])
     assert.deepEqual(q.epochSpawn('curia-42'), {
-      model: 'codex-high', requested_model: 'opus', harness: 'codex',
+      model: 'codex-high', requested_model: 'opus', harness: 'codex', reasoning_effort: 'xhigh',
       prompt_carries_limit_text: true, skill: null, skill_target: null,
     })
   })
@@ -269,7 +269,7 @@ describe('the last event of a type for a key', () => {
     // and the program under it was its backend.
     const q = ask([{ type: 'worker_spawned', ticket: '170', worker: 'curia-170', model: 'opus', backend: 'claude' }])
     assert.deepEqual(q.epochSpawn('curia-170'), {
-      model: 'opus', requested_model: null, harness: 'claude',
+      model: 'opus', requested_model: null, harness: 'claude', reasoning_effort: null,
       prompt_carries_limit_text: null, skill: null, skill_target: null,
     })
     assert.deepEqual([...q.epochs()], [['170', { repo: null }]])

--- a/daemon/test/usage.test.mjs
+++ b/daemon/test/usage.test.mjs
@@ -855,6 +855,19 @@ describe('agentMeters', () => {
     assert.deepEqual(m, { model: 'gpt-5.6-sol', effort: 'high', ctxPct: null, ctxOver: false, ctxTokens: null, windows: null })
   })
 
+  // #763: a type route can dispatch a model away from its configured default,
+  // and the meter must state THAT depth. The model default is only the answer
+  // when no dispatch record exists to say otherwise.
+  test('the dispatched effort beats the model default', () => {
+    const m = agentMeters({ harness: 'codex', cfgDir: cfgDir(), model: 'gpt', effort: 'xhigh', routing, account: null, now: NOW })
+    assert.equal(m.effort, 'xhigh')
+  })
+
+  test('the model default shows when no dispatch record names an effort', () => {
+    const m = agentMeters({ harness: 'codex', cfgDir: cfgDir(), model: 'gpt', effort: null, routing, account: null, now: NOW })
+    assert.equal(m.effort, 'high')
+  })
+
   // #332, building ADR-0016: the meter is the ONE signal that a conversation is
   // getting long, so it has to read the conversation it was asked about. Every
   // overseer conversation writes into one config dir, where newest-by-mtime is


### PR DESCRIPTION
## What changed

The status line's effort meter read the model's configured default, not the depth the agent was dispatched at. A ticket type whose route overrides its model's default rendered the wrong depth.

- `agentMeters` in `daemon/src/usage.mjs` takes an `effort` argument and prefers it over `models.<name>.reasoning_effort`.
- `metersFor` in `daemon/src/index.mjs` passes the dispatcher record's `reasoningEffort`. The comment that said the meter reads off the routing row is corrected.
- The dashboard sidecar's ticket conversation row passes the same effort, so both surfaces measure one agent one way.
- `epochSpawn` in `daemon/src/questions.mjs` now projects `reasoning_effort`. Without it, reconcile rebuilt a re-adopted agent's record with no effort, and the meter fell back to the model default after every restart.

## Tests

- `agentMeters` prefers the dispatched effort, and shows the model default when none is passed.
- A dispatcher test journals a task-route spawn of `gpt` at `xhigh` (model default `low`), reconciles, and builds the meter the way `metersFor` does. The meter says `xhigh`; a session with no record says `low`.
- `questions.test.mjs` expectations carry the new field.

`npm test` in `daemon/`: 3744 pass, 0 fail, 0 cancelled.

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
