### PR TITLE
Retire the caller-less maintenance hook (alp82/curia#765)

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -402,7 +402,7 @@ export class Dispatcher {
   // escalation and returns its record; lapseEscalation closes one as lapsed
   // (journal + message edit); confirmNote posts a line next to a record's
   // buttons; overseerNote journals a synthetic line for a thread's session.
-  constructor({ config, routing, reduction, notify, announce, openConfirm, openMapQuestion, lapseEscalation, confirmNote, overseerNote, askReview, cancelEscalation, threads, log = console.log, cooling, readings, dataDir, daemonPort, previews, attachLinks, attachSessionLink, dashboardLink, channelName, minter, credentials, anthropic, anthropicHealth, maintenance, aistack, deps }) {
+  constructor({ config, routing, reduction, notify, announce, openConfirm, openMapQuestion, lapseEscalation, confirmNote, overseerNote, askReview, cancelEscalation, threads, log = console.log, cooling, readings, dataDir, daemonPort, previews, attachLinks, attachSessionLink, dashboardLink, channelName, minter, credentials, anthropic, anthropicHealth, aistack, deps }) {
     this.config = config
     this.routing = routing
     this.reduction = reduction
@@ -565,9 +565,6 @@ export class Dispatcher {
     // account bars are disabled and no agent is running. It reports terminal
     // evidence through `holdCredentialLane`, so this field owns only scheduling.
     this.anthropicHealth = anthropicHealth ?? null
-    // Recurring publishers share the daemon's existing tick. A publisher owns
-    // no second timer, and a failure cannot stop liveness or dispatch work.
-    this.maintenance = maintenance ?? null
     // The re-authentication flow (#642). It takes the RAW tmux calls above, for
     // the reason the refusal states, and its image is filled in by
     // `startReauth` — an image ref is a per-dispatch build, not a constant.
@@ -8242,7 +8239,6 @@ export class Dispatcher {
   }
 
   async #autoTick() {
-    await this.maintenance?.().catch((e) => this.log('maintenance failed:', e.message))
     // #138: the liveness sweep rides the dispatch tick — dead agents stop
     // lying on every surface before anything new is dispatched.
     await this.livenessSweep().catch((e) => this.log('liveness sweep failed:', e.message))

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -155,7 +155,6 @@ function makeDispatcher(deps = {}, {
   // than reach the box's own `~/.codex`.
   credentials = null,
   anthropicHealth = null,
-  maintenance = null,
   // #695: the recurring aistack sync. NULL by default and on purpose - a real
   // one spawns `npx`, and a test that forgot to pass one must run nothing rather
   // than reach the network.
@@ -356,7 +355,6 @@ function makeDispatcher(deps = {}, {
     credentials,
     anthropic,
     anthropicHealth,
-    maintenance,
     aistack,
     deps: { ...base, ...deps },
   })
@@ -2703,18 +2701,6 @@ describe('the limit resume: the window rolls and curia puts the agent back (#346
     clearInterval(d.autoTimer)
 
     assert.ok(!started.includes('42'), 'the armed ticket is the resume\'s, and a start would recreate its worktree')
-  })
-
-  test('the existing tick runs recurring publishers with auto-dispatch off', async () => {
-    let runs = 0
-    const d = makeDispatcher({}, { maintenance: async () => { runs += 1 } })
-    d.config.dispatch.poll_interval_s = 0.05
-
-    d.startAutoLoop()
-    await waitFor(() => runs > 0)
-    d.stopAutoLoop()
-
-    assert.ok(runs > 0)
   })
 
   // #376: #346 closed ONE instance of this and not the class. A ticket whose
@@ -8248,5 +8234,16 @@ describe('the aistack sync rides the dispatch tick (#695)', () => {
 
   test('a dispatcher with no sync holds none', () => {
     assert.equal(makeDispatcher().aistack, null)
+  })
+
+  // #765: the daemon once built two syncs, and the generic `maintenance` hook
+  // that ran the second one disabled the journalled first. One construction,
+  // one hook on the tick, and no second seam for a publisher to ride.
+  test('the daemon constructs one sync, and the dispatcher offers it one seat (#765)', () => {
+    const index = fs.readFileSync(new URL('../src/index.mjs', import.meta.url), 'utf8')
+    assert.equal(index.match(/new AistackSync\(/g).length, 1, 'index.mjs builds the sync once')
+    const d = makeDispatcher({}, { aistack: { pass: async () => null } })
+    assert.equal(d.maintenance, undefined, 'the caller-less maintenance hook is gone')
+    assert.equal(typeof d.aistack.pass, 'function')
   })
 })


### PR DESCRIPTION
## What changed

- `daemon/src/dispatch.mjs`: the generic `maintenance` constructor option and its call at the top of `#autoTick` are gone. #758 removed its only caller when it deleted the unjournalled second sync, and wiring it had been what disabled the journalled one.
- `daemon/test/dispatch.test.mjs`: the harness no longer threads `maintenance`, the orphan test for it is deleted, and a new test pins the ticket's outcome: `index.mjs` constructs `AistackSync` once, and the dispatcher exposes one seat for it (`aistack.pass()` on the tick).

## What was already true on main

The ticket's other two "done when" lines landed with #758: status comes from the reduction (`lastAistackSync`, `standingAistackAlarm`), so it survives a restart, and `GET /overview` answers through `aistackStatus()`. Those paths are pinned in `aistack.test.mjs` and the dashboard tests and are untouched here.

## Tests

`npm test` in `daemon/`: 3726 pass, 0 fail, 0 cancelled.

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
