### PR TITLE
Draw level two on Maps and retire the unreachable frontier screen (alp82/curia#768)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,7 +66,7 @@ The operator's sentence on a map dispatch, in their own words. It rides the `map
 The takeable tickets of a watched repo, in map order.
 
 **Two-level frontier**:
-The frontier plus the tickets each of its members directly unblocks. One level, never a chain. It is what the dashboard draws as a tree, and it comes from the blocking edges the agent-only count already reads.
+The frontier plus the tickets each of its members directly unblocks. One level, never a chain. On the wire it comes from the blocking edges the agent-only count already reads. Atlas Maps draws the same level from the map snapshot, whose takeable facts name the blocked children of their own map that they unblock, walked from the blocker edges the snapshot already holds.
 
 **Frontier snapshot**:
 The two-level frontier as reconcile last computed it, under the instant it did. Reconcile computes it, because that pass already holds the GitHub credentials and the dashboard holds none. The stamp is what makes a served frontier honest: the page states the age of the reading.

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -471,42 +471,12 @@
   .since-marker { color: var(--warn); font: 700 10px ui-monospace, Menlo, monospace; letter-spacing: .08em; text-transform: uppercase; border-top: 1px solid var(--warn); padding-top: 5px; margin: 10px 0; }
   .legacy-feed { margin-top: 24px; color: var(--ink-faint); }
 
-  /* ---------- frontier ---------- */
-  .seg { display: inline-flex; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; background: var(--bg-raise); }
-  .seg button { border: 0; background: none; color: var(--ink-dim); padding: 5px 12px; font-size: 12.5px; }
-  .seg button.on { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
-  .frx-filter { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
-  .frx-filter .fchip { border: 1px solid var(--line); border-radius: 999px; background: var(--bg-raise); color: var(--ink-dim); padding: 3px 12px; font-size: 12.5px; }
-  .frx-filter .fchip.on { border-color: var(--accent); color: var(--accent); background: var(--chip-ok-bg); font-weight: 600; }
-  .frx-filter select { padding: 3px 8px; }
-  .frx-filter .sep { color: var(--ink-faint); }
+  /* ---------- the start control and level two ---------- */
   select {
     background: var(--bg-inset); color: var(--ink); border: 1px solid var(--line);
     border-radius: 6px; padding: 4px 8px; font: 12.5px ui-monospace, Menlo, monospace; max-width: 100%;
   }
-  .frx-sect { margin: 4px 0 18px; }
-  .frx-sect > .eyebrow { display: block; margin-bottom: 8px; }
-  .frx-big { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
-  .frx-card {
-    border: 1px solid var(--line); border-top: 3px solid var(--accent); border-radius: 10px;
-    background: var(--bg-raise); padding: 12px 14px; box-shadow: var(--shadow);
-    display: flex; flex-direction: column; gap: 6px;
-  }
-  .frx-card .head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
-  .frx-card .t { font-family: ui-monospace, Menlo, monospace; font-weight: 700; color: var(--accent); }
-  .frx-card .typ { font-size: 11px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
-  .frx-card .title { font-size: 13.5px; font-weight: 600; }
-  .frx-card .foot { display: flex; justify-content: space-between; gap: 8px; font-size: 11.5px; color: var(--ink-dim); font-family: ui-monospace, Menlo, monospace; flex-wrap: wrap; }
-  .frx-dim { display: grid; gap: 8px; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); }
-  .frx-dimcard { border: 1px solid var(--line); border-radius: 8px; background: var(--bg-inset); padding: 8px 11px; font-size: 12.5px; color: var(--ink-dim); }
-  .frx-dimcard .t { font-family: ui-monospace, Menlo, monospace; margin-right: 5px; }
-  .frx-dimcard .from { display: block; margin-top: 4px; font-size: 11px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
-  .fr-repo { margin-bottom: 14px; }
-  .fr-repo > .eyebrow { margin-bottom: 6px; display: block; }
-  .fr-group { margin-bottom: 10px; }
-  .fr-node { border: 1px solid var(--line); border-left: 3px solid var(--accent); background: var(--bg-raise); border-radius: 7px; padding: 7px 10px; font-size: 13px; }
-  .fr-node .t { font-family: ui-monospace, Menlo, monospace; color: var(--ink-dim); margin-right: 6px; }
-  .fr-node .typ { float: right; font-size: 11px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; margin-left: 8px; }
+  /* Level two of a takeable row on Maps (#768): what the ticket directly unblocks. */
   .fr-kids { margin: 0 0 10px 14px; padding-left: 14px; border-left: 1px dashed var(--line); }
   .fr-kid { position: relative; margin-top: 6px; font-size: 12.5px; color: var(--ink-dim); }
   .fr-kid::before { content: "└─"; position: absolute; left: -16px; color: var(--ink-faint); font-family: ui-monospace, Menlo, monospace; }
@@ -787,7 +757,6 @@ const REVIEW_KIND = "review-gate";
 /* The page's whole mutable state. `var` on purpose — the test reaches it. */
 var UI = {
   screen: "home",
-  fr: { view: "cards", repo: "all", type: "all" },
   /* The maps page's own state (#700): which project the list is filtered to,
      which map and group the detail half shows, and whether the phone is on
      that detail instead of the list. `open` is the route's, never a width's. */
@@ -2434,8 +2403,16 @@ function mapDetailRows(o, map, group) {
       const start = map.deferred
         ? `<div class="act-row"><span class="dim-note">this map is paused (<span class="mono">wayfinder:deferred</span>), and a pause is only ever ended by hand</span></div>`
         : startRow(o, map.repo, item);
+      /* LEVEL TWO (#768). The snapshot names what each takeable ticket
+         directly unblocks, one level down and never a closure, so the
+         operator reads which press opens the most of this way. A ticket that
+         opens nothing says so, because a missing line reads as an unread one. */
+      const kids = item.unblocks?.length
+        ? `<div class="fr-kids">${item.unblocks.map((kid) => `<div class="fr-kid"><a href="https://github.com/${esc(map.repo)}/issues/${esc(kid.number)}"><span class="t">#${esc(kid.number)}</span></a>${esc(kid.title)}</div>`).join("")}</div>`
+        : "";
       return `<div class="map-detail-row">${issue}
-      <span class="sub">${esc(mapType(item))} · routed to ${esc(item.model ?? "unknown")}</span>${start}</div>`;
+      <span class="sub">${esc(mapType(item))} · routed to ${esc(item.model ?? "unknown")} · ${
+        item.unblocks?.length ? `unblocks ${esc(item.unblocks.length)}` : "unblocks nothing yet"}</span>${kids}${start}</div>`;
     }
     if (group === "blocked") {
       /* EVERY blocker, never a count of them: the operator's next question is
@@ -2544,7 +2521,7 @@ function mapRepo(repo) {
   render();
 }
 
-/* ---- frontier -------------------------------------------------------------- */
+/* ---- the start control --------------------------------------------------- */
 
 /* The ticket type is the `wayfinder:` label and nothing else — a ticket with no
    such label has no type, and saying so beats guessing one from another label. */
@@ -2557,20 +2534,6 @@ function typeOf(item) {
   return l ? String(l).slice("wayfinder:".length) : "untyped";
 }
 const shortRepo = (r) => String(r).split("/").pop();
-
-/* The filter runs over the snapshot, never over the wire: the frontier is
-   reconcile's reading and the page must not re-ask for a narrower one. */
-function frFiltered(snap) {
-  const f = UI.fr;
-  return (snap?.repos ?? [])
-    .filter((r) => f.repo === "all" || r.repo === f.repo)
-    .map((r) => (r.error ? r : { ...r, items: (r.items ?? []).filter((i) => f.type === "all" || typeOf(i) === f.type) }));
-}
-function frTypes(snap) {
-  const all = new Set();
-  for (const r of snap?.repos ?? []) for (const i of r.items ?? []) all.add(typeOf(i));
-  return [...all].sort();
-}
 
 /* Start (#266). The dispatch order — claim, prepare, spawn — is `start`'s own,
    and the reply that comes back is curia's sentence about what it did.
@@ -2602,74 +2565,6 @@ function startRow(o, repo, n) {
     ${said(key)}`;
 }
 
-function frCards(repos, o) {
-  const bigs = repos.filter((r) => !r.error).flatMap((r) => (r.items ?? []).map((i) => ({ ...i, repo: r.repo })));
-  const kids = repos.filter((r) => !r.error).flatMap((r) => (r.items ?? []).flatMap((i) => (i.unblocks ?? []).map((k) => ({ ...k, repo: r.repo, from: i.number }))));
-  return `${repos.filter((r) => r.error).map(frError).join("")}
-    <div class="frx-sect"><span class="eyebrow">takeable now (${bigs.length})</span>
-      ${bigs.length ? `<div class="frx-big">${bigs.map((n) => `<div class="frx-card">
-        <div class="head"><span class="t">#${esc(n.number)}</span><span class="typ">${esc(typeOf(n))}</span></div>
-        <div class="title">${esc(n.title)}</div>
-        <div class="foot"><span>${esc(n.repo)}</span><span>${n.unblocks?.length ? `unblocks ${n.unblocks.length}` : "unblocks nothing yet"}</span></div>
-        ${n.mapTitle ? `<div class="dim-note">${esc(n.mapTitle)}</div>` : ""}
-        ${startRow(o, n.repo, n)}
-      </div>`).join("")}</div>` : `<div class="empty">Nothing is takeable under this filter.</div>`}
-    </div>
-    <div class="frx-sect"><span class="eyebrow">unblocked next (${kids.length})</span>
-      ${kids.length ? `<div class="frx-dim">${kids.map((k) => `<div class="frx-dimcard"><span class="t">#${esc(k.number)}</span>${esc(k.title)}
-        <span class="from">↖ #${esc(k.from)} · ${esc(k.repo)}</span></div>`).join("")}</div>`
-        : `<div class="empty">These tickets unblock nothing that is not already takeable.</div>`}
-    </div>`;
-}
-function frTree(repos, o) {
-  return repos.map((r) => {
-    if (r.error) return frError(r);
-    if (!r.items?.length) return `<div class="fr-repo"><span class="eyebrow mono">${esc(r.repo)}</span>
-      <div class="empty">Nothing is takeable under this filter.</div></div>`;
-    return `<div class="fr-repo"><span class="eyebrow mono">${esc(r.repo)}</span>
-      ${r.items.map((n) => `<div class="fr-group">
-        <div class="fr-node"><span class="typ">${esc(typeOf(n))}</span><span class="t">#${esc(n.number)}</span>${esc(n.title)}
-          ${startRow(o, r.repo, n)}</div>
-        ${n.unblocks?.length ? `<div class="fr-kids">${n.unblocks.map((k) => `<div class="fr-kid"><span class="t">#${esc(k.number)}</span>${esc(k.title)}</div>`).join("")}</div>` : ""}
-      </div>`).join("")}</div>`;
-  }).join("");
-}
-function frError(r) {
-  return `<div class="unread"><span class="mono">${esc(r.repo)}</span> could not be read — ${esc(r.error)}. This is not an empty frontier: there may be takeable tickets there.</div>`;
-}
-
-const FR_VIEWS = { cards: ["Cards", frCards], tree: ["Tree", frTree] };
-
-function screenFrontier(p) {
-  const o = p?.overview;
-  if (!o) return noSnapshot(p, "Maps");
-  const snap = o.frontier;
-  const right = `<span class="seg">${Object.entries(FR_VIEWS).map(([k, v]) =>
-    `<button class="${UI.fr.view === k ? "on" : ""}" onclick="frSet('view','${k}')">${esc(v[0])}</button>`).join("")}</span>`;
-  if (!snap || !snap.computed_at) {
-    return `${head(p, "Maps · two levels", right)}
-      <div class="later">No frontier has been computed yet. Reconcile computes it on the credentials that pass already holds, and stamps the instant it did.</div>`;
-  }
-  const types = frTypes(snap);
-  const filter = `<div class="frx-filter">
-    <button class="fchip ${UI.fr.repo === "all" ? "on" : ""}" onclick="frSet('repo','all')">all projects</button>
-    ${(snap.repos ?? []).map((r) => `<button class="fchip ${UI.fr.repo === r.repo ? "on" : ""}" onclick="frSet('repo','${esc(r.repo)}')">${esc(shortRepo(r.repo))}</button>`).join("")}
-    <span class="sep">·</span>
-    <select onchange="frSet('type',this.value)">
-      <option value="all"${UI.fr.type === "all" ? " selected" : ""}>all types</option>
-      ${types.map((t) => `<option${UI.fr.type === t ? " selected" : ""}>${esc(t)}</option>`).join("")}
-    </select>
-    <span class="dim-note">computed ${esc(ago(snap.computed_at))}</span>
-  </div>`;
-  return `${head(p, "Maps · two levels", right)}${filter}${FR_VIEWS[UI.fr.view][1](frFiltered(snap), o)}`;
-}
-function frSet(key, value) {
-  UI.fr[key] = value;
-  /* A repo that leaves the filter takes its types with it — an unreachable
-     type filter would show an empty page and name no reason. */
-  if (key === "repo") UI.fr.type = "all";
-  render();
-}
 
 /* ---- feed ------------------------------------------------------------------ */
 

--- a/daemon/src/mapsnapshot.mjs
+++ b/daemon/src/mapsnapshot.mjs
@@ -101,10 +101,18 @@ export async function readMapSnapshot({ watch, routing, github, journal }) {
           assignees: child.assignees.map((assignee) => assignee.login),
           agent: agentFact(facts.get(String(child.number))?.agent, routing),
         }))
+      // LEVEL TWO RIDES THE SAME READ (#768). A blocked child already names
+      // its open blockers, so what each takeable child DIRECTLY unblocks is
+      // those edges walked the other way round, at no extra call. One level,
+      // never a transitive closure, and only within this map: the operator's
+      // question is which takeable ticket opens the most of THIS way.
       const takeable = categories.takeable
         .map((child) => ({
           ...ticketFact(child),
           model: spawnModelId(routing, resolveModel(routing, labelsOf(child), null)),
+          unblocks: blocked
+            .filter((item) => item.blockers.some((blocker) => blocker.number === child.number))
+            .map((item) => ({ number: item.number, title: item.title })),
         }))
       const fog = fogFacts(map.body)
       maps.push({

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1,4 +1,4 @@
-// The four read screens (#264) — home, agents, frontier, feed.
+// The read screens (#264) — home, maps, agents, feed.
 //
 // The page has no build step: the file the sidecar serves IS the reviewed
 // source. So its test loads that same file, lifts its one script into a vm, and
@@ -210,8 +210,12 @@ const OVERVIEW = () => ({
         assignees: ['alp82'], agent: { session: 'curia-255', model: 'gpt-5.6-sol' },
       }],
       takeable: [
-        { number: 265, title: 'The settings write', type: 'task', model: 'claude-opus-5' },
-        { number: 266, title: 'The verbs reach the browser', type: 'grilling', model: 'gpt-5.6-sol' },
+        { number: 265, title: 'The settings write', type: 'task', model: 'claude-opus-5', unblocks: [
+          { number: 267, title: 'The chat embeds the timeline attach' },
+        ] },
+        { number: 266, title: 'The verbs reach the browser', type: 'grilling', model: 'gpt-5.6-sol', unblocks: [
+          { number: 267, title: 'The chat embeds the timeline attach' },
+        ] },
       ],
       blocked: [{
         number: 267, title: 'The chat embeds the timeline attach', type: 'task',
@@ -321,7 +325,7 @@ describe('the Atlas frame (#686)', () => {
     const held = payload()
     const screens = [
       page.screenHome,
-      page.screenFrontier,
+      page.screenMaps,
       page.screenAgents,
       page.screenFeed,
       page.screenChat,
@@ -977,69 +981,37 @@ describe('the read screens (#264)', () => {
     })
   })
 
-  describe('frontier — two levels', () => {
-    test('cards draw the takeable set and what it unblocks', () => {
-      page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
-      const t = text(page.screenFrontier(payload()))
-      assert.match(t, /takeable now \(2\)/)
-      assert.match(t, /#265 task The settings write/)
-      assert.match(t, /unblocks 1/)
-      assert.match(t, /#266 grilling The verbs reach the browser/)
-      assert.match(t, /unblocks nothing yet/)
-      assert.match(t, /unblocked next \(1\)/)
-      assert.match(t, /#267 The chat embeds the timeline attach ↖ #265/)
+  describe('maps — level two (#768)', () => {
+    const takeable = (p = payload()) => {
+      page.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244, group: 'takeable' }, open: false }
+      return page.screenMaps(p)
+    }
+
+    test('a takeable row names what it directly unblocks, from the map snapshot', () => {
+      const t = text(takeable())
+      assert.match(t, /#265 The settings write/)
+      assert.match(t, /task · routed to claude-opus-5 · unblocks 1/)
+      assert.match(t, /#267 The chat embeds the timeline attach/)
       assert.match(t, /computed \d+m ago/, 'the page states the age of the reading')
     })
 
-    test('a repo whose read failed is not an empty frontier', () => {
-      const t = text(page.screenFrontier(payload()))
-      assert.match(t, /alp82\/aistack could not be read — gh api failed: HTTP 502/)
-      assert.match(t, /there may be takeable tickets there/)
-    })
-
-    test('the tree says the same two levels', () => {
-      page.UI.fr = { view: 'tree', repo: 'all', type: 'all' }
-      const t = text(page.screenFrontier(payload()))
-      assert.match(t, /alp82\/curia/)
-      assert.match(t, /task #265 The settings write/)
-      assert.match(t, /#267 The chat embeds the timeline attach/)
-      page.UI.fr.view = 'cards'
-    })
-
-    test('the project filter narrows to one repo, and the type filter to one type', () => {
-      page.UI.fr = { view: 'cards', repo: 'alp82/curia', type: 'all' }
-      let t = text(page.screenFrontier(payload()))
-      assert.doesNotMatch(t, /aistack could not be read/, 'a repo out of the filter is out of the page')
-      page.UI.fr.type = 'grilling'
-      t = text(page.screenFrontier(payload()))
-      assert.match(t, /takeable now \(1\)/)
-      assert.match(t, /#266/)
-      assert.doesNotMatch(t, /#265 /)
-      // A filter that matches nothing says so rather than drawing a blank page.
-      page.UI.fr.type = 'research'
-      assert.match(text(page.screenFrontier(payload())), /Nothing is takeable under this filter/)
-      page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
-    })
-
-    test('picking a project resets the type — an unreachable filter draws an empty page and names no reason', () => {
-      page.UI.fr = { view: 'cards', repo: 'all', type: 'grilling' }
-      page.document.getElementById = () => ({ innerHTML: '' })
-      page.frSet('repo', 'alp82/curia')
-      assert.deepEqual(page.UI.fr, { view: 'cards', repo: 'alp82/curia', type: 'all' })
-      page.document.getElementById = () => null
-      page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
-    })
-
-    test('a frontier nobody has computed is not an empty frontier', () => {
-      const t = text(page.screenFrontier(payload({ frontier: { computed_at: null, repos: [] } })))
-      assert.match(t, /No frontier has been computed yet/)
-      assert.match(t, /Reconcile computes it/)
-    })
-
-    test('a ticket with no wayfinder label has no type, and none is guessed for it', () => {
+    test('the kids are the snapshot\'s, not the frontier wire\'s', () => {
       const p = payload()
-      p.overview.frontier.repos[0].items[0].labels = ['bug']
-      assert.match(text(page.screenFrontier(p)), /#265 untyped/)
+      p.overview.frontier = { computed_at: null, repos: [] }
+      p.overview.maps.maps[0].takeable[1].unblocks = []
+      const html = takeable(p)
+      assert.match(text(html), /#267 The chat embeds the timeline attach/)
+      assert.match(html, /href="https:\/\/github\.com\/alp82\/curia\/issues\/267"/, 'a kid is a link to its ticket')
+      assert.match(text(html), /grilling · routed to gpt-5\.6-sol · unblocks nothing yet/)
+    })
+
+    test('one Maps screen: the second one, its views, and its state are gone from the page', () => {
+      assert.equal(page.screenFrontier, undefined)
+      assert.equal(page.UI.fr, undefined)
+      const script = pageScript()
+      for (const name of ['screenFrontier', 'FR_VIEWS', 'frCards', 'frTree', 'frSet', 'UI.fr']) {
+        assert.doesNotMatch(script, new RegExp(name.replace('.', '\\.')), `${name} is no longer in the page`)
+      }
     })
   })
 
@@ -2146,53 +2118,44 @@ describe('the operator verbs (#266)', () => {
   before(() => { page = loadPage() })
   beforeEach(() => {
     page.UI.act = { busy: null, said: null, note: null, mode: 'queue', tele: null }
-    page.UI.fr = { view: 'cards', repo: 'all', type: 'all' }
   })
 
   // ---- start ---------------------------------------------------------------
 
-  describe('start, on the frontier', () => {
+  describe('start, on the Maps frontier', () => {
+    const takeable = (p = payload()) => {
+      page.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244, group: 'takeable' }, open: false }
+      return page.screenMaps(p)
+    }
+
     test('the button carries the routed model, so the account is named before it is spent', () => {
-      const t = text(page.screenFrontier(payload()))
+      const t = text(takeable())
       assert.match(t, /Start → claude-opus-5 \(task default\)/)
       assert.match(t, /Start → gpt-5\.6-sol \(grilling default\)/)
     })
 
     test('it names the repo and the number, and the sidecar composes the rest', () => {
-      const html = page.screenFrontier(payload())
-      assert.match(html, /startTicket\('alp82\/curia','265'\)/)
+      assert.match(takeable(), /startTicket\('alp82\/curia','265'\)/)
     })
 
     test('a ticket an agent already holds shows the agent instead of a button that only refuses', () => {
       const p = payload()
       p.overview.agents[0].ticket = '265'
-      const t = text(page.screenFrontier(p))
-      assert.match(t, /⧗ dispatched — curia-263/)
-      assert.equal(/startTicket\('alp82\/curia','265'\)/.test(page.screenFrontier(p)), false)
+      const html = takeable(p)
+      assert.match(text(html), /⧗ dispatched — curia-263/)
+      assert.equal(/startTicket\('alp82\/curia','265'\)/.test(html), false)
     })
 
     test('an unreadable fleet is not an idle one: the button stands and says curia cannot tell', () => {
-      const p = payload({ agents: null, fleet_error: 'tmux is wedged' })
-      const t = text(page.screenFrontier(p))
+      const t = text(takeable(payload({ agents: null, fleet_error: 'tmux is wedged' })))
       assert.match(t, /Start/)
       assert.match(t, /cannot say whether this one is already running/)
     })
 
     test('an item carrying no routed model says so, rather than naming a model nobody chose', () => {
       const p = payload()
-      delete p.overview.frontier.repos[0].items[0].model
-      assert.match(text(page.screenFrontier(p)), /the routed model is not on this reading/)
-    })
-
-    test('the tree view starts a ticket too — the view is a way of reading, not a way of acting', () => {
-      page.UI.fr.view = 'tree'
-      assert.match(page.screenFrontier(payload()), /startTicket\('alp82\/curia','266'\)/)
-    })
-
-    test('a repo whose frontier could not be read offers no button there', () => {
-      const t = text(page.screenFrontier(payload()))
-      assert.match(t, /alp82\/aistack could not be read/)
-      assert.match(t, /there may be takeable tickets there/)
+      delete p.overview.maps.maps[0].takeable[0].model
+      assert.match(text(takeable(p)), /the routed model is not on this reading/)
     })
   })
 
@@ -2487,7 +2450,8 @@ describe('the operator verbs (#266)', () => {
   describe('the outcome of a press', () => {
     test('a command reply is curia\'s own sentence, rendered where the press was', () => {
       page.UI.act.said = { key: 'start:alp82/curia#265', text: '⚙️ `curia-265` spawned on **claude-opus-5**', ok: true }
-      const html = page.screenFrontier(payload())
+      page.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244, group: 'takeable' }, open: false }
+      const html = page.screenMaps(payload())
       assert.match(html, /<code>curia-265<\/code>/, 'the markdown curia speaks everywhere else reads here too')
       assert.match(html, /<b>claude-opus-5<\/b>/)
     })
@@ -2532,7 +2496,8 @@ describe('the operator verbs (#266)', () => {
 
     test('one act at a time: while a press is in flight every other control is disabled', () => {
       page.UI.act.busy = 'esc:esc-7'
-      assert.match(page.screenFrontier(payload()), /button class="btn sm primary" disabled/)
+      page.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244, group: 'takeable' }, open: false }
+      assert.match(page.screenMaps(payload()), /button class="btn sm primary" disabled/)
     })
   })
 

--- a/daemon/test/mapsnapshot.test.mjs
+++ b/daemon/test/mapsnapshot.test.mjs
@@ -114,8 +114,40 @@ test('an unassigned unblocked ticket returns its routed model as takeable', asyn
   })
 
   assert.deepEqual(map.takeable, [
-    { number: 11, title: 'the takeable ticket', type: 'task', model: 'gpt-5.6-sol' },
-    { number: 12, title: 'the pinned ticket', type: 'task', model: 'claude-sonnet-5' },
+    { number: 11, title: 'the takeable ticket', type: 'task', model: 'gpt-5.6-sol', unblocks: [] },
+    { number: 12, title: 'the pinned ticket', type: 'task', model: 'claude-sonnet-5', unblocks: [] },
+  ])
+})
+
+test('a takeable ticket names each blocked child it directly unblocks, from the edges already read', async () => {
+  const github = {
+    repoMaps: async () => [issue(10, 'the map')],
+    mapFrontier: async () => [
+      issue(11, 'the key', { labels: ['wayfinder:task'] }),
+      issue(12, 'the other key', { labels: ['wayfinder:task'] }),
+      issue(14, 'waits on the key', { blockedBy: 1 }),
+      issue(15, 'waits on both keys', { blockedBy: 2 }),
+      issue(16, 'waits on a closed one and the key', { blockedBy: 2 }),
+    ],
+    blockedByOf: async (repo, number) => ({
+      14: [issue(11, 'the key')],
+      15: [issue(11, 'the key'), issue(12, 'the other key')],
+      16: [issue(9, 'walked already', { state: 'closed' }), issue(11, 'the key')],
+    })[number],
+  }
+  const journal = { mapSnapshotFacts: async () => new Map() }
+
+  const { maps: [map] } = await readMapSnapshot({
+    watch: [{ repo: 'o/r', mode: 'map' }], routing, github, journal,
+  })
+
+  assert.deepEqual(map.takeable.map((item) => [item.number, item.unblocks]), [
+    [11, [
+      { number: 14, title: 'waits on the key' },
+      { number: 15, title: 'waits on both keys' },
+      { number: 16, title: 'waits on a closed one and the key' },
+    ]],
+    [12, [{ number: 15, title: 'waits on both keys' }]],
   ])
 })
 


### PR DESCRIPTION
Closes #768

## What changed

`daemon/assets/dashboard.html` carried two Maps screens. `screenFrontier` with its Cards and Tree views was reachable from no route. It held one reading Maps did not: what each takeable ticket directly unblocks. This PR takes the first way out the ticket named.

- `readMapSnapshot` gives each takeable fact an `unblocks` list: the blocked children of the same map whose open blockers include it. The snapshot already reads those blocker edges, so this costs no extra call. It's one level, never a closure, and it stays within the map.
- The Maps takeable detail draws the kids under each row, each a link to its ticket, and the sub line says `unblocks N` or `unblocks nothing yet`.
- `screenFrontier`, `FR_VIEWS`, `frCards`, `frTree`, `frSet`, `UI.fr`, and the `.frx-*` and `.seg` CSS are gone. `startRow`, `agentOn`, `typeOf`, and `shortRepo` stay because Maps uses them.
- The start and outcome tests that drove `screenFrontier` now drive `screenMaps` with the takeable group selected. A test pins that the page source no longer names the retired screen.

## What I didn't do

The frontier wire (`overview.frontier`) still carries its own `unblocks` per item for the dispatcher and Home's unblock bonus. That reading can cross maps; the snapshot's stays within one map. Nothing on Atlas read the cross-map edge, so I left the wire alone.

## Tests

`npm test` in `daemon/`: 3721 tests, 3721 pass, 0 fail, 0 cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD
