### PR TITLE
Read the story page top to bottom on a phone (alp82/curia#773)

### DIFF
--- a/prototypes/story-page/NOTES.md
+++ b/prototypes/story-page/NOTES.md
@@ -2993,3 +2993,19 @@ itself was planned...") goes; the VPS bars are too thin at 8 GB. Desktop still d
   gives it up.
 
 The scroll budget at 375×667: 17.3 screens.
+
+**Round 4.** The operator: the titles 01 and 02 still push the curia animation above and
+below; remove them on a phone and go straight to the animation after 02. And the VPS boxes
+are too wide at 8 and 16 GB (thirty agents ran past the box).
+
+- **A phone reads the hero and then the order beat.** With the canvas on, claims 01 and 02
+  and the room between them are gone below 40rem. The frame forces `rise` to 0 and drives
+  `fall` from the arc's own scroll, a third of a screen in, over `ORDER_SPAN` screens; the
+  map never leaves the foot. Each claim crossing the screen had shoved the art out of its
+  way, and no keyframe change could fix that, because the art's box IS what the words leave.
+  With no canvas the three panels stand and read as before, so the locked words are still on
+  the page.
+- **The bar floor is the even share at most.** The script writes `--gn`, the group count, on
+  the strip and the label row, and the phone floor is `min(2.4rem, 100% / var(--gn))`.
+
+Desktop diffs to zero pixels. The scroll budget at 375×667: 16.2 screens, the arc 4.8.

--- a/prototypes/story-page/NOTES.md
+++ b/prototypes/story-page/NOTES.md
@@ -2934,3 +2934,36 @@ The scroll budget at 393×659: 20.6 screens. The opening arc takes 7.2 of them, 
 **Left for the operator:** on a phone the ticket-run scene's Discord phone lane shrinks to a
 sliver beside the atlas window. That is the round 15 arrangement measured against a desk that
 is only a phone wide, and it is a decision, not a fault.
+
+**Round 2.** The operator, from an iPhone SE: "we got lots to do here". The art at the top
+needs more room, and small screens may leave elements out and simplify the visualizations to
+avoid density. The full page went through first at 375×667, scene by scene, and the operator
+took the cuts as proposed, with one rule: desktop stays exactly as it was.
+
+**The rule the round keeps:** one breakpoint, `max-width: 40rem`. Below it a scene shows one
+object per beat and no chrome that is not the point. Above it nothing changes. The canvas
+gates its own cuts on `W < 620`, the flag the arc already had. Proof: eight desktop screens at
+1440×900 diffed pixel for pixel against the file before the round, zero pixels changed.
+
+The cuts, scene by scene:
+
+- **The arc.** The hero drops its kicker and its skills line and tightens, so the art has the
+  top half of the first screen. The canvas draws ONE map on a phone, its rows as bars with the
+  state dot and no words (11px in a 90px card reads as noise), and two thirds of the pile while
+  it is only a pile; the rest join under the melt as they start to travel. The order beat is a
+  screen shorter (`ORDER_SPAN` 3.2 on a phone) and the two rooms hold for less.
+- **The grilling.** The guild rail and the channel list go. The chat pane is the whole window,
+  and the base type grows from `w / 40` to `w / 33` under 640px, which the desktop window never
+  is.
+- **The preview.** The phone alone, at 54vw. The desk window behind it was a thumbnail.
+- **The atlas.** Two maps instead of three; the walked line and the frontier; the five blocked
+  rows and the fog go.
+- **The terminal.** The browser tab and URL bar go. The tmux line and the four harness tabs
+  stay, because they are the scene.
+- **The ticket run.** One object per beat: the Discord phone beside the pull request was a
+  sliver on a desk one phone wide, so on the two-lane cards it goes and the pull request stands
+  square. The stage holds 52dvh instead of 62, and each beat holds for less scroll.
+- **The `git clone` line** wraps instead of clipping.
+
+The scroll budget at 375×667: 18.1 screens, from 20.5. The arc 5.9 (was 7.2), the ticket run
+3.5 (was 4.3), the atlas 1.5 (was 2.0), the preview 1.2 (was 0.9, the bigger phone).

--- a/prototypes/story-page/NOTES.md
+++ b/prototypes/story-page/NOTES.md
@@ -3009,3 +3009,9 @@ are too wide at 8 and 16 GB (thirty agents ran past the box).
   the strip and the label row, and the phone floor is `min(2.4rem, 100% / var(--gn))`.
 
 Desktop diffs to zero pixels. The scroll budget at 375×667: 16.2 screens, the arc 4.8.
+
+**Round 5.** The operator: the strip is still too wide at 16 GB. Round 4's floor forgot the
+gaps between groups: thirty of them at 0.42rem are 13rem on their own. The floor is now the
+even share of the row MINUS its gaps, the two rows clip as a backstop, and past a dozen groups
+the agent labels are blank rather than slivers of glyph. Measured on the phone at 16 GB and
+thirty agents: strip 293px in a 293px row. Desktop diffs to zero.

--- a/prototypes/story-page/NOTES.md
+++ b/prototypes/story-page/NOTES.md
@@ -3015,3 +3015,12 @@ gaps between groups: thirty of them at 0.42rem are 13rem on their own. The floor
 even share of the row MINUS its gaps, the two rows clip as a backstop, and past a dozen groups
 the agent labels are blank rather than slivers of glyph. Measured on the phone at 16 GB and
 thirty agents: strip 293px in a 293px row. Desktop diffs to zero.
+
+**Round 6.** The operator, at 16 GB and six agents: the widths must always be 100% correct,
+and if the grouping does not work, find another way. It did not work: a floor under a group
+takes its width from another group, so at 16 GB with six agents the 12 GB of free space had
+shrunk to a sliver. The floor is gone. On a phone the strip is a grid of equal cells now, one
+per 0.1 GB, twenty to a row, wrapping: 2 rows at 4 GB, 8 at 16. Every width is exact by count.
+Measured in five states (4/4, 16/6, 16/30, 16/1, 2/1): cells = RAM × 10, every cell 12.75px,
+rows = cells ÷ 20, strip never wider than its row. The group labels and the ticks go on a
+phone; the legend names the colors. Desktop diffs to zero.

--- a/prototypes/story-page/NOTES.md
+++ b/prototypes/story-page/NOTES.md
@@ -2901,3 +2901,36 @@ five operator rounds.** The frame every scene ticket (#625 to #631) conforms to:
 7. One slab accent: the gate climax claim. Slabs mark importance and stay rare.
 8. The hero stays out of this frame. Its words sit at the bottom, locked at #567, and the
    opening arc ticket [#625](https://github.com/alp82/curia/issues/625) revisits it.
+
+## The whole page on a phone ([#773](https://github.com/alp82/curia/issues/773))
+
+**Round 1.** The first read of the twelve scenes in sequence at 393px (iPhone 15), frame by
+frame, with the page measured at every stop. Five faults, none visible in any one scene's own
+ticket because each one only shows across scenes or across the whole document:
+
+- **The page scrolled sideways.** Four things reached past the right edge: the arc panel
+  frames (`inset: -20px`), the grilling orb (`-25vw`), the preview light (`-18%`), and every
+  right-docked reveal parked at `translateX(2.4rem)` before it comes in. The phone's layout
+  viewport grew to 491px to hold them, so every scene rendered a fifth too small. Every
+  `.scene` and `.arc-flow` clips its own sides now. **The clip must not go on the root:** on
+  `html` it unstuck every sticky stage on the page, measured A/B against the file on `main`.
+- **The grilling window scrolled up through its own claim.** The stage let go at the section's
+  end, but the sticky claim held on to the same end and the window climbed through the words.
+  The claim has its own sticky box now, `.grill-headbox`, which ends a screen above the
+  section, so the claim lets go first and rides off ahead of the window.
+- **A class collision, the third.** Scene 7's bare `.oc { width: 1em }` (its octicons) reached
+  the Discord card's option lines, which carry the same class, and squeezed each one to one em
+  wide, so the text wrapped a word per line over the blocks below. Scoped to `.gx .oc`. The
+  atlas scene's bare `.rl { margin-top }` reached the preview bar and the terminal rail the same
+  way; scoped to `#atlas .rl`.
+- **The terminal never started.** Its observer wrote `seen = true` and `seen` was never
+  declared. Under `'use strict'` that is a `ReferenceError` on the first intersection, thrown
+  before `start()`, so no harness ever typed. Declared.
+- **The setup command clipped** at `--build`. The `pre` wraps now.
+
+The scroll budget at 393×659: 20.6 screens. The opening arc takes 7.2 of them, the ticket run
+4.3, the atlas 2.1, and every other scene one or less.
+
+**Left for the operator:** on a phone the ticket-run scene's Discord phone lane shrinks to a
+sliver beside the atlas window. That is the round 15 arrangement measured against a desk that
+is only a phone wide, and it is a decision, not a fault.

--- a/prototypes/story-page/NOTES.md
+++ b/prototypes/story-page/NOTES.md
@@ -2967,3 +2967,29 @@ The cuts, scene by scene:
 
 The scroll budget at 375×667: 18.1 screens, from 20.5. The arc 5.9 (was 7.2), the ticket run
 3.5 (was 4.3), the atlas 1.5 (was 2.0), the preview 1.2 (was 0.9, the bigger phone).
+
+**Round 3.** The operator, from the phone: the first two scenes push the curia animation up
+and down the screen while scrolling, busy and meaningless; scene 05 could overlay the two
+screens, tilted toward each other, alternating which is in front like flip covers; scene 07
+does not show the screens at all, the narration titles are in the way, and mobile needs a
+different way to tell the story; the close ("just type your rejection reasons", "This page
+itself was planned...") goes; the VPS bars are too thin at 8 GB. Desktop still diffs to zero.
+
+- **The arc on a phone is one pipeline in every beat.** The pile above, curia in the middle,
+  the map at the foot. Nothing changes place between beats: the pile changes shape (a flat
+  ring, then a globe, then it resolves through curia), and the map leaves and comes back by
+  the foot. The desktop keyframes, where the maps stand above in the hero and the pile turns
+  around curia, were what moved curia. Gated on `W < 620`, in the frame after `keyframes()`.
+- **The atlas flips.** Below 40rem both screens share one grid cell, each tilted toward the
+  other, the front one whole and the back one dimmed and a step smaller. A 3.6s timer turns
+  them. Without the script the atlas stays in front.
+- **The ticket run is a stack.** Below 40rem the script moves the ticket under the first
+  title and card k under title k, adds `stack` to the section, and the stage is gone: title,
+  screen, title, screen, in reading order, nothing held. The beat observer still runs, so the
+  ticket's timeline grows as the titles cross the middle. Decided once at load.
+- **The close** is hidden below 40rem. It stands on desktop; the dogfood line is an operator
+  addition of #508 and stays there until the operator rules on it.
+- **The VPS bars** have a floor of 2.4rem per group and label below 40rem, and the free space
+  gives it up.
+
+The scroll budget at 375×667: 17.3 screens.

--- a/prototypes/story-page/index.html
+++ b/prototypes/story-page/index.html
@@ -104,7 +104,9 @@
      ================================================================ */
   .arc { position: relative; }
   .arc-stage { display: none; }
-  .arc-flow { position: relative; z-index: 1; }
+  /* The arc panel frames reach 20px past the edge; see `.scene` for
+     why that clips here and not on the root (#773). */
+  .arc-flow { position: relative; z-index: 1; overflow-x: clip; }
   .a-hero {
     min-height: 62svh; display: flex; flex-direction: column; justify-content: flex-end;
     padding-bottom: clamp(1.5rem, 5vh, 3.5rem);
@@ -192,7 +194,14 @@
      sides: .sL docks left, .sR docks right, and the evidence leans
      toward the other side.
      ================================================================ */
-  .scene { position: relative; }
+  /* Every scene clips its own sides (#773). Four things reached past
+     the right edge of a phone and each one scrolled the page sideways:
+     the arc panel frames at -20px, the grilling orb at -25vw, the
+     preview light at -18%, and every right-docked reveal parked at
+     +2.4rem before it comes in. The clip must NOT go on the root: there
+     it unstuck every sticky stage on the page. `clip` on a scene makes
+     no scroll container, so the stages inside keep working. */
+  .scene { position: relative; overflow-x: clip; }
   .claim { margin: 0 0 1rem; }
   .claim .bold { margin-bottom: 0; }
   .kick { margin: 0 0 0.55rem; font-family: var(--mono); color: var(--dim); font-size: 0.72rem; }
@@ -279,6 +288,16 @@
      window grows under it. The cap the script sets on the window keeps
      the two apart, so the words never sit on the evidence. */
   .grill-head { position: sticky; top: 3svh; z-index: 3; }
+  /* The claim's own sticky box (#773). It ends a screen above the
+     section, so the claim lets go BEFORE the stage does and rides off
+     ahead of the window. Bounded by the section alone, the claim held
+     on while the stage left, and on a phone the window scrolled up
+     straight through the words. */
+  .grill-headbox {
+    position: absolute; left: 0; right: 0; top: 8vh; bottom: calc(100dvh - 3svh);
+    z-index: 3; pointer-events: none;
+  }
+  .grill-headbox .grill-head { pointer-events: auto; }
 
   /* The track is pulled up under the claim ON PURPOSE. The stage is a
      screen tall and sticks at the top, so it must be stuck ALREADY by
@@ -1186,7 +1205,7 @@
   .at-nm { font-weight: 700; font-size: 0.8rem; min-width: 0; }
   .at-meta { margin: 0.2rem 0 0; font: 0.58rem var(--mono); color: #8a93a3; }
 
-  .rl { margin-top: 0.75rem; }
+  #atlas .rl { margin-top: 0.75rem; }
   .rrow {
     position: relative; display: flex; align-items: center; gap: 0.55rem;
     padding: 0.36rem 0 0.36rem 1.4rem; font-size: 0.74rem;
@@ -1608,7 +1627,10 @@
     font: 0.86em var(--mono); background: #6e768166; border-radius: 4px;
     padding: 0.1em 0.4em; color: var(--gx-ink);
   }
-  .oc { width: 1em; height: 1em; flex: none; vertical-align: -0.15em; }
+  /* Scoped to the GitHub blocks (#773): a bare `.oc` reached the Discord
+     card's option lines, which also carry that class, and squeezed each
+     of them to one em wide. */
+  .gx .oc { width: 1em; height: 1em; flex: none; vertical-align: -0.15em; }
   .gx-h1 {
     margin: 0; font-size: 1.28em; font-weight: 600; line-height: 1.3;
     letter-spacing: -0.01em; color: var(--gx-ink); text-wrap: pretty;
@@ -2259,7 +2281,7 @@
     background: #ffffff08; box-shadow: inset 0 0 0 1px var(--line);
     border-radius: 6px; padding: 0.7rem 0.85rem; overflow-x: auto; margin: 0.55rem 0;
   }
-  .step pre code { background: none; padding: 0; font-size: 0.78rem; }
+  .step pre code { background: none; padding: 0; font-size: 0.78rem; white-space: pre-wrap; overflow-wrap: anywhere; }
   .readmore { color: var(--body); font-size: 0.95rem; }
 
   footer { padding: 3rem 0 4rem; color: var(--dim); font-size: 0.85rem; }
@@ -2285,7 +2307,7 @@
   /* With reduced motion the grilling scene is an ordinary section: no
      track, no sticky, no growth, and the whole card standing. */
   @media (prefers-reduced-motion: reduce) {
-    .grill-head, .grill-stage { position: static; }
+    .grill-head, .grill-headbox, .grill-stage { position: static; }
     .grill-stage { height: auto; padding: 0 0.6rem; }
     .grill-track { height: auto; margin-top: 1.5rem; }
     .grill-stage::before { display: none; }
@@ -2387,12 +2409,14 @@
        in, while the claim rides to the top of the screen. Then the
        press, and the edit that clears the components. -->
   <section class="scene sL grillpin" id="grill-pin" data-stage="agent" data-n="03" data-name="the grilling" style="--g1:#171930;--g2:#0d0e1c">
+    <div class="grill-headbox">
     <div class="wrap grill-head" id="grill-head">
       <header class="claim rv">
         <p class="kick"><span class="kn">03</span><span class="kname">the grilling</span></p>
         <h2 class="bold">Answer from the couch.</h2>
       </header>
       <p class="story rv">An agent hits a real decision and asks you in Discord.</p>
+    </div>
     </div>
 
     <div class="grill-track">
@@ -3696,6 +3720,7 @@ if (prefersStill || !window.IntersectionObserver) {
   /* The run happens once. Scrolling away mid-print settles the pane
      whole rather than leaving it half written. */
   var ran = false;
+  var seen = false;
   function start() {
     if (ran) return;
     ran = true;

--- a/prototypes/story-page/index.html
+++ b/prototypes/story-page/index.html
@@ -2314,7 +2314,15 @@
   /* #773 round 3: on a phone a 0.5 GB group at 8 GB was a sliver. Every
      group and its label get a floor, and the free space gives it up. */
   @media (max-width: 40rem) {
-    .gg .gg-strip .g, .gg-groups span { min-width: min(2.4rem, calc(100% / var(--gn, 3))); }
+    /* The even share is the row minus its gaps, divided by the groups.
+       Round 4 forgot the gaps, and thirty of them at 0.42rem ran the
+       strip past the box. */
+    .gg .gg-strip .g, .gg-groups span {
+      min-width: min(2.4rem, calc((100% - (var(--gn, 3) - 1) * 0.42rem) / var(--gn, 3)));
+    }
+    .gg .gg-strip, .gg-groups { overflow: hidden; }
+    /* Past a dozen groups the agent labels are slivers of glyph. */
+    .gg-groups.many span:not(.s):not(.h) { visibility: hidden; }
   }
   .gg .gg-strip i.p { background: var(--ca); }
   .gg .gg-strip i.s { background: var(--cs); }
@@ -3481,6 +3489,7 @@ if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').m
        most, so thirty agents at 16 GB cannot run past the box. */
     strip.style.setProperty('--gn', strip.children.length);
     groups.style.setProperty('--gn', groups.children.length);
+    groups.classList.toggle('many', groups.children.length > 12);
   }
   function drawStrip() {
     var ram = RAM[+ramIn.value], cols = ram * 10, max = Math.floor((cols - 10) / 5);

--- a/prototypes/story-page/index.html
+++ b/prototypes/story-page/index.html
@@ -1146,6 +1146,27 @@
   .at > .claim .bold { text-wrap: balance; }
   .at > .hm-scr { grid-area: hm; }
   .at > .mp-scr { grid-area: mp; }
+  /* #773 round 3: on a phone the two screens share one spot, each tilted
+     toward the other, and take turns in front like flip covers. The
+     script turns them; without it the atlas stays in front. */
+  @media (max-width: 40rem) {
+    .at { grid-template-areas: "claim" "scr"; }
+    .at > .hm-scr, .at > .mp-scr {
+      grid-area: scr; width: 88%;
+      transition: transform 0.7s var(--ease), filter 0.7s var(--ease);
+    }
+    .at > .hm-scr {
+      justify-self: start; z-index: 2;
+      transform: rotateY(12deg) rotate(-1deg) translateX(0);
+    }
+    .at > .mp-scr {
+      justify-self: end; z-index: 1;
+      transform: rotateY(-12deg) rotate(1deg) translateX(0) scale(0.94);
+      filter: brightness(0.72);
+    }
+    .at.flip > .hm-scr { z-index: 1; transform: rotateY(12deg) rotate(-1deg) scale(0.94); filter: brightness(0.72); }
+    .at.flip > .mp-scr { z-index: 2; transform: rotateY(-12deg) rotate(1deg) scale(1); filter: none; }
+  }
 
   /* Each screen is a screen: a bounded card with its own header strip
      that clips what runs past its bottom edge, rather than a list
@@ -2168,6 +2189,8 @@
   /* ---- the two lines that close the scene ---- */
   .caption { color: var(--dim); font-size: 0.85rem; font-style: italic; margin: 1.4rem 0 0; text-align: center; }
   .dogfood { color: var(--body); margin-top: 1.6rem; }
+  /* #773 round 3: the close leaves the phone read. */
+  @media (max-width: 40rem) { .scene.close { display: none; } }
 
   /* ---- the fail-open path. With reduced motion or no script the desk
          lets go, every card stands in order, and the ticket shows its
@@ -2181,6 +2204,26 @@
   .still .r8-lane .win-body, .still .r8-lane .at-body, .still .r8-lane .dcx-log { max-height: none; }
   .still .r8-nb { min-height: 0; opacity: 1; margin-bottom: 2rem; }
   .still .r8-tl li { visibility: visible; opacity: 1; }
+  /* #773 round 3: the stacked story on a phone. The stage is empty and
+     gone; the ticket and the cards stand in the steps column, each
+     under its title, whole. */
+  #run.stack .r8-stage { display: none; }
+  #run.stack .r8-steps { display: grid; gap: 1.2rem; }
+  #run.stack .r8-nb { min-height: 0; opacity: 1; margin: 1.2rem 0 0; }
+  #run.stack .r8-nb:first-child { margin-top: 0; }
+  #run.stack .r8-nb.on { opacity: 1; }
+  #run.stack .r8-tkt { font-size: 0.72rem; }
+  #run.stack .r8-card {
+    position: relative; inset: auto; opacity: 1; pointer-events: auto;
+    transform: none; filter: none; transition: none;
+  }
+  #run.stack .r8-card > * { height: auto; display: block; }
+  #run.stack .r8-lane { height: auto; }
+  #run.stack .r8-lane[data-app="discord"] { position: relative; right: auto; bottom: auto; }
+  #run.stack .r8-card.two .r8-lane[data-app="discord"] { display: none; }
+  #run.stack .pv-win { width: 100%; aspect-ratio: 16 / 11; }
+  #run.stack .pv-phone { width: min(100%, 15rem); margin: 0 auto; }
+  #run.stack .r8-lane .win-body, #run.stack .r8-lane .at-body, #run.stack .r8-lane .dcx-log { max-height: none; }
 
   /* ================================================================
      Scene 9 — your VPS. One box, four lanes, the measured numbers.
@@ -2264,6 +2307,11 @@
   .gg .gg-strip .g { gap: 0; border-radius: 6px; overflow: hidden; background: var(--ch); }
   .gg .gg-strip i { border-radius: 0; background: none; height: 2.4rem; }
   .gg .gg-strip i:last-child { box-shadow: none; }
+  /* #773 round 3: on a phone a 0.5 GB group at 8 GB was a sliver. Every
+     group and its label get a floor, and the free space gives it up. */
+  @media (max-width: 40rem) {
+    .gg .gg-strip .g, .gg-groups span { min-width: 2.4rem; }
+  }
   .gg .gg-strip i.p { background: var(--ca); }
   .gg .gg-strip i.s { background: var(--cs); }
   .gg.dense .gg-strip i { box-shadow: none; }
@@ -3290,7 +3338,7 @@
   </section>
 
   <!-- Scene 8, the close: the fact line and the dogfood line. -->
-  <section class="scene sL" data-stage="gate" style="padding-top:0;--g1:#0c1020;--g2:#0c1020">
+  <section class="scene sL close" data-stage="gate" style="padding-top:0;--g1:#0c1020;--g2:#0c1020">
     <div class="wrap">
       <p class="fact rv">just type your rejection reasons if you don't agree with the result</p>
       <p class="dogfood rv">This page itself was
@@ -3498,6 +3546,11 @@ if (prefersStill || !window.IntersectionObserver) {
   (function () {
     var at = document.getElementById('atlas');
     if (!at) return;
+    /* #773 round 3: on a phone the two screens take turns in front. */
+    if (window.matchMedia && window.matchMedia('(max-width: 40rem)').matches) {
+      var grid = document.getElementById('at');
+      if (grid) setInterval(function () { grid.classList.toggle('flip'); }, 3600);
+    }
     var seen = new IntersectionObserver(function (entries) {
       entries.forEach(function (e) {
         if (!e.isIntersecting) return;
@@ -3918,6 +3971,21 @@ function clampNum(v, a, b) { return v < a ? a : v > b ? b : v; }
 
   /* The arrangement is settled, so there is nothing to switch. What is
      left is the one thing this script owns: the beat. */
+  /* #773 round 3. A phone tells this scene as a stack: each title, then
+     the screen it names, in reading order, nothing held. The held desk
+     hid the screens under the titles on a phone. The ticket follows
+     the first title and card k follows title k. Decided once, at load:
+     a phone does not change width. */
+  var stack = !prefersStill && window.matchMedia && window.matchMedia('(max-width: 40rem)').matches;
+  if (stack) {
+    sec.classList.add('stack');
+    var tkt = document.getElementById('tkt');
+    if (tkt && steps[0]) steps[0].insertAdjacentElement('afterend', tkt);
+    cards.forEach(function (c) {
+      var i = parseInt(c.getAttribute('data-i'), 10);
+      if (steps[i]) steps[i].insertAdjacentElement('afterend', c);
+    });
+  }
   if (prefersStill) { sec.classList.add('still'); press(); } else { watch(); }
 })();
 
@@ -5253,6 +5321,24 @@ function runArc() {
     var mapsH = maps.length ? mapHeight(maps[0].w / MAP_W) : 140;
 
     var K = keyframes(b, mapsH);
+    if (!wide) {
+      /* #773 round 3. On a phone the three beats are ONE pipeline: the
+         pile above, curia in the middle, the maps at the foot. Nothing
+         changes place between beats; the pile changes shape, and the
+         maps leave and come back by the foot. The desktop keyframes,
+         where the maps stand above in the hero and the pile turns
+         around curia, pushed curia up and down the screen with every
+         turn of the wheel. */
+      var bh = K.bh, bw = K.bw;
+      var ny = b.y0 + bh * 0.50, nr = clamp(Math.min(bh * 0.13, bw * 0.22), 42, 100);
+      K.hero.nodeY = K.mess.nodeY = K.order.nodeY = ny;
+      K.hero.nodeR = K.mess.nodeR = K.order.nodeR = nr;
+      K.hero.cloudY = b.y0 + bh * 0.20; K.hero.cloudRY = bh * 0.11; K.hero.cloudRX = bw * 0.44;
+      K.hero.mapsY = b.y1 - mapsH / 2;
+      K.mess.cloudY = b.y0 + bh * 0.24; K.mess.cloudRY = bh * 0.20; K.mess.cloudRX = bw * 0.46;
+      K.mess.mapsY = b.y1 + mapsH * 0.9;
+      K.order.cloudY = b.y0 + bh * 0.17;
+    }
     var S = mixkf(mixkf(K.hero, K.mess, rise), K.order, fall);
     S.cx = K.cx;
     /* Measured in screens of scroll, not in a share of the arc: the

--- a/prototypes/story-page/index.html
+++ b/prototypes/story-page/index.html
@@ -142,6 +142,11 @@
   body.arcon .room { height: 70svh; }
   body.arcon .room.lead { height: 55svh; }
   body.arcon .room.short { height: var(--tail, 440svh); }
+  /* #773 round 2: a phone holds the hero and the mess for less scroll. */
+  @media (max-width: 40rem) {
+    body.arcon .room { height: 52svh; }
+    body.arcon .room.lead { height: 40svh; }
+  }
 
   /* Round 3 of #625: the words and the canvas must never sit on top of
      each other. On a wide screen each claim docks to its own side and
@@ -170,6 +175,15 @@
   }
   .cta:active { transform: scale(0.98); }
   .cta.ghost { background: none; color: var(--text); box-shadow: inset 0 0 0 1px var(--line); }
+  /* A phone gives the art the top of the first screen (#773 round 2):
+     the kicker and the skills line go, and the block tightens. */
+  @media (max-width: 40rem) {
+    .a-hero .q-mark, .a-hero .skills { display: none; }
+    h1 { font-size: clamp(1.6rem, 7.2vw, 3.2rem); margin-top: 0; }
+    .lede { font-size: 1rem; margin-top: 0.7rem; }
+    .ctas { margin-top: 1.1rem; }
+    .a-hero { padding-bottom: 1.2rem; }
+  }
 
   /* ================================================================
      The shared scene skeleton. A room is the space an animation owns;
@@ -514,8 +528,9 @@
   /* A desktop window on a phone is a miniature. Narrowing the rail and
      the channel list buys the chat pane back what it can. */
   @media (max-width: 40rem) {
-    .dc-rail { flex-basis: 3em; }
-    .dc-side { flex-basis: 9.4em; }
+    /* #773 round 2: on a phone the chat pane is the whole window. The
+       guild rail and the channel list carry nothing the story needs. */
+    .dc-rail, .dc-side { display: none; }
   }
 
   /* ---- the channel header. It carries the breadcrumb the client
@@ -1020,6 +1035,12 @@
       radial-gradient(52% 44% at var(--gx) var(--gy), var(--pvglow, transparent), transparent 74%);
     transition: background 0.5s var(--ease);
   }
+  /* #773 round 2: a phone shows the phone alone, larger. The desk
+     window behind it was a thumbnail nobody could read. */
+  @media (max-width: 40rem) {
+    .pv-desk { display: none; }
+    .pv-dev { --pvw: min(54vw, 13rem); justify-self: center; }
+  }
   /* The words never sit in the light (#624 rule 5). */
   #preview .claim, #preview .pv-rail, #preview .fact { position: relative; z-index: 4; }
 
@@ -1235,6 +1256,12 @@
   /* The blocked box and the fog strip, as #588 round 5 drew them:
      red rules behind what waits, diagonal grey stripes behind what
      nobody has specified yet. */
+  /* #773 round 2: a phone keeps the dial, the running agent, two maps,
+     the walked line and the frontier. The third map, the five blocked
+     rows and the fog go: the scene is the dashboard, not its depth. */
+  @media (max-width: 40rem) {
+    .hm-maps .quest:nth-child(n + 3), .waitr, .fogs { display: none; }
+  }
   .waitr {
     margin-top: 0.6rem; padding: 0.45rem 0.65rem 0.5rem;
     border: 1px solid rgba(242, 112, 122, 0.45); border-radius: 8px;
@@ -1530,6 +1557,12 @@
 
   /* ---- the control below 60rem: bottom tabs. NEVER both (round 1) ---- */
   .tm-tabs { display: flex; border-top: 1px solid #262d33; background: #0f1116; }
+  /* #773 round 2: a phone drops the browser chrome. The tab and the URL
+     bar are the point on a desk and noise at 7px; the tmux line and
+     the four harness tabs stay, because they are the scene. */
+  @media (max-width: 40rem) {
+    .br { display: none; }
+  }
   .tm-tabs button {
     flex: 1 1 0; min-width: 0; border: 0; background: none; cursor: pointer; color: #8a93a3;
     display: flex; flex-direction: column; align-items: center; gap: 0.2rem;
@@ -1714,6 +1747,12 @@
   .r8-nb:first-child { padding-top: 0.4rem; min-height: 44svh; }
   .r8-nb:last-child { min-height: 54svh; }
   .r8-nb { opacity: 0.5; transition: opacity 0.4s var(--ease); }
+  /* #773 round 2: a phone holds each beat for less scroll. */
+  @media (max-width: 40rem) {
+    .r8-nb { min-height: 58svh; }
+    .r8-nb:first-child { min-height: 36svh; }
+    .r8-nb:last-child { min-height: 44svh; }
+  }
   .r8-nb.on { opacity: 1; }
   .r8-nb .nn {
     display: inline-block; align-self: flex-start;
@@ -2112,6 +2151,15 @@
   .r8-lane[data-app="discord"] { position: absolute; right: 1%; bottom: -0.6rem; height: auto; --ph-h: 92cqh; z-index: 3; }
   .r8-lane[data-app="curia"] { transform: rotateX(8deg) rotate(-0.4deg); transform-origin: 50% 100%; }
   .r8-card:not(.two) .pv-phone { margin-left: auto; margin-right: 6%; }
+  /* A phone shows ONE object per beat (#773 round 2). The desk is only
+     a phone wide, so the Discord phone beside the pull request was a
+     sliver. It goes, the pull request stands square, and the held stage
+     gives the titles more of the screen. */
+  @media (max-width: 40rem) {
+    .r8-card.two .r8-lane[data-app="discord"] { display: none; }
+    .r8-lane[data-app="github"] { transform: none; }
+    .r8-stage { height: 52dvh; }
+  }
 
   /* ---- the column the claim and the closing lines sit in ---- */
   .runwrap { max-width: 36rem; margin: 0 auto; padding: 0 1.25rem; }
@@ -2261,7 +2309,7 @@
   .clone {
     font: 0.78rem var(--mono); color: #cfd5de; background: #ffffff08;
     box-shadow: inset 0 0 0 1px var(--line); border-radius: 8px;
-    padding: 0.8rem 0.9rem; overflow-x: auto; white-space: nowrap;
+    padding: 0.8rem 0.9rem; white-space: pre-wrap; overflow-wrap: anywhere;
   }
 
   /* ================================================================
@@ -3947,7 +3995,9 @@ function clampNum(v, a, b) { return v < a ? a : v > b ? b : v; }
      the 16px the client itself uses. */
   function base() {
     var w = dc.clientWidth || 320;
-    return clampNum(w / 40, 7, 16.5);
+    /* A phone window has no rail and no channel list, so its chat pane
+       is the whole width and the type can be bigger (#773 round 2). */
+    return clampNum(w / (w < 640 ? 33 : 40), 7, 16.5);
   }
   function fit() {
     var on = dc.classList.contains('on');
@@ -4288,6 +4338,18 @@ function runArc() {
       ctx.fillStyle = rgb(sc);
       ctx.fill();
     }
+    if (BAR_ROWS) {
+      /* A phone cannot read 11px in a card 90px wide. The row keeps its
+         state dot and shows its words as two bars. */
+      roundRect(x + 25 * s, dy - 2 * s, Math.max(10, (w - 36 * s) * 0.42), 4 * s, 2 * s);
+      ctx.fillStyle = rgba(C.text, st === 0 ? 0.3 : 0.6);
+      ctx.fill();
+      roundRect(x + 25 * s + (w - 36 * s) * 0.5, dy - 2 * s, Math.max(10, (w - 36 * s) * 0.36), 4 * s, 2 * s);
+      ctx.fillStyle = rgba(C.dim, st === 0 ? 0.3 : 0.55);
+      ctx.fill();
+      ctx.restore();
+      return;
+    }
     ctx.textAlign = 'left';
     ctx.textBaseline = 'middle';
     ctx.font = '700 ' + (10.5 * s).toFixed(1) + 'px ' + MONOF;
@@ -4594,6 +4656,9 @@ function runArc() {
      many of them genuinely fit. Never one card because the code said
      so: round 2 called that out on its own. */
   var GAPM = 16;
+  /* Set each frame (#773 round 2): a phone draws ONE map, and its rows
+     as bars with no words. The desktop path never sets either. */
+  var MAX_MAPS = 3, BAR_ROWS = false;
   /* drawMapCard draws nothing under 90 px wide, so no fit may ask for
      less: a map that vanishes is worse than one that crowds. */
   var MIN_S = 92 / MAP_W;
@@ -4601,7 +4666,7 @@ function runArc() {
     var s, n, need, k;
     if (column) {
       s = clamp(availW / MAP_W, MIN_S, 1.0);
-      n = clamp(Math.floor((availH + GAPM) / (mapHeight(s) + GAPM)), 1, 3);
+      n = clamp(Math.floor((availH + GAPM) / (mapHeight(s) + GAPM)), 1, MAX_MAPS);
       need = n * mapHeight(s) + GAPM * (n - 1);
       if (need > availH) s = Math.max(MIN_S, s * (availH / need));
       var ch = mapHeight(s), totalH = ch * n + GAPM * (n - 1);
@@ -4611,7 +4676,7 @@ function runArc() {
       return;
     }
     var minW = 118;
-    n = clamp(Math.floor((availW + GAPM) / (minW + GAPM)), 1, 3);
+    n = clamp(Math.floor((availW + GAPM) / (minW + GAPM)), 1, MAX_MAPS);
     s = clamp(Math.min((availW - GAPM * (n - 1)) / n / MAP_W, availH / mapHeight(1)), MIN_S, 1.05);
     var cw = MAP_W * s, totalW = cw * n + GAPM * (n - 1);
     for (k = 0; k < n; k++) {
@@ -5047,7 +5112,7 @@ function runArc() {
 
      The span is how many screens of scroll the order beat is given, and
      the tail room under the claim is set from it. */
-  var ORDER_SPAN = 4.2;
+  var ORDER_SPAN = window.innerWidth < 620 ? 3.2 : 4.2;   /* a phone: one screen less (#773 round 2) */
   /* EVERY piece of work makes the journey: the mess is cleared out, and
      nothing of it is left standing at the end. */
   var TRAVEL_N = MESS.length;
@@ -5168,6 +5233,8 @@ function runArc() {
     if (arcBox.bottom < -40 || arcBox.top > H + 40) return;
 
     var wide = W >= 620;
+    MAX_MAPS = wide ? 3 : 1;
+    BAR_ROWS = !wide;
     var travelPx = arcEl.offsetHeight - window.innerHeight;
     var arcP = travelPx > 0 ? clamp(-arcBox.top / travelPx, 0, 1) : 0;
     var rise = smooth(0.04, 0.50, panelProgress(messPanel));
@@ -5264,6 +5331,9 @@ function runArc() {
         arrivals[MAPOF[i]].push({ i: i, u: u, st: STOF[i] });
       }
       if (u >= 0.999) continue;                 /* it lives in the map now */
+      /* A phone shows two thirds of the pile while it is only a pile.
+         The rest join as they start to travel, under the melt. */
+      if (!wide && u <= 0.001 && i % 3 === 2) continue;
       var slot = MAPOF[i] % Math.max(1, nMaps);
       var mm = maps[slot];
       var it = { i: i, slot: slot, a: 0.95, pop: home.scale };

--- a/prototypes/story-page/index.html
+++ b/prototypes/story-page/index.html
@@ -144,8 +144,12 @@
   body.arcon .room.short { height: var(--tail, 440svh); }
   /* #773 round 2: a phone holds the hero and the mess for less scroll. */
   @media (max-width: 40rem) {
-    body.arcon .room { height: 52svh; }
     body.arcon .room.lead { height: 40svh; }
+    /* #773 round 4: with the canvas on, a phone reads the hero and then
+       the order beat. Claims 01 and 02 and the room between them go:
+       each one crossing the screen shoved the art out of its way. With
+       no canvas the three panels stand and read as before. */
+    body.arcon #w-mess, body.arcon #w-order, body.arcon .room.mid { display: none; }
   }
 
   /* Round 3 of #625: the words and the canvas must never sit on top of
@@ -2310,7 +2314,7 @@
   /* #773 round 3: on a phone a 0.5 GB group at 8 GB was a sliver. Every
      group and its label get a floor, and the free space gives it up. */
   @media (max-width: 40rem) {
-    .gg .gg-strip .g, .gg-groups span { min-width: 2.4rem; }
+    .gg .gg-strip .g, .gg-groups span { min-width: min(2.4rem, calc(100% / var(--gn, 3))); }
   }
   .gg .gg-strip i.p { background: var(--ca); }
   .gg .gg-strip i.s { background: var(--cs); }
@@ -2476,7 +2480,7 @@
         </header>
       </section>
 
-      <div class="room" aria-hidden="true"></div>
+      <div class="room mid" aria-hidden="true"></div>
 
       <!-- Scene 3 · maps bring order -->
       <section class="apanel wrap sR" id="w-order">
@@ -3472,6 +3476,13 @@ if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').m
   function label(t, cls, n) { var l = document.createElement('span'); l.textContent = t; l.className = cls; l.style.flexGrow = n; return l; }
   function all(sel, f) { [].slice.call(box.querySelectorAll(sel)).forEach(f); }
   function draw() {
+    drawStrip();
+    /* #773 round 4: the phone floor under a group is its even share at
+       most, so thirty agents at 16 GB cannot run past the box. */
+    strip.style.setProperty('--gn', strip.children.length);
+    groups.style.setProperty('--gn', groups.children.length);
+  }
+  function drawStrip() {
     var ram = RAM[+ramIn.value], cols = ram * 10, max = Math.floor((cols - 10) / 5);
     nIn.max = max; if (+nIn.value > max) nIn.value = max;
     var n = +nIn.value, free = cols - 10 - 5 * n;
@@ -5309,6 +5320,13 @@ function runArc() {
     /* how far PAST the order claim the reader has come, in screens */
     var ro = orderPanel ? orderPanel.getBoundingClientRect() : null;
     var fall = ro ? clamp((H * 0.55 - ro.top) / (H * ORDER_SPAN), 0, 1) : 0;
+    if (!wide) {
+      /* #773 round 4: a phone has no mess beat and no claims on the
+         stage. The order beat starts a third of a screen into the
+         scroll and runs for ORDER_SPAN screens. */
+      rise = 0;
+      fall = clamp((-arcBox.top - H * 0.35) / (H * ORDER_SPAN), 0, 1);
+    }
     stageEl.style.setProperty('--warm', (1 - 0.86 * rise * (1 - fall)).toFixed(3));
     stageEl.style.setProperty('--ord', fall.toFixed(3));
 
@@ -5355,6 +5373,7 @@ function runArc() {
        while the claim is still below the fold and finishes inside half
        a screen. */
     var mapsIn = ro ? smooth(0, 1, clamp((H * 1.15 - ro.top) / (H * 0.62), 0, 1)) : 0;
+    if (!wide) mapsIn = 0;   /* the map never leaves the foot on a phone */
     var mapsA, mi;
     if (mapsIn <= 0.001) {
       S.mapsY = lerp(K.hero.mapsY, K.mess.mapsY, rise);

--- a/prototypes/story-page/index.html
+++ b/prototypes/story-page/index.html
@@ -2311,18 +2311,23 @@
   .gg .gg-strip .g { gap: 0; border-radius: 6px; overflow: hidden; background: var(--ch); }
   .gg .gg-strip i { border-radius: 0; background: none; height: 2.4rem; }
   .gg .gg-strip i:last-child { box-shadow: none; }
-  /* #773 round 3: on a phone a 0.5 GB group at 8 GB was a sliver. Every
-     group and its label get a floor, and the free space gives it up. */
+  /* #773 round 6: on a phone the strip is a GRID of equal cells, one per
+     0.1 GB, twenty to a row, wrapping. Every width is exact by count:
+     a 0.5 GB system is five cells whether the box has 4 GB or 16, and
+     nothing can run past the row. Rounds 3 to 5 tried a floor under
+     each group, and a floor is a lie: it takes width from another
+     group. The group labels and the ticks go; the legend names the
+     colors. */
   @media (max-width: 40rem) {
-    /* The even share is the row minus its gaps, divided by the groups.
-       Round 4 forgot the gaps, and thirty of them at 0.42rem ran the
-       strip past the box. */
-    .gg .gg-strip .g, .gg-groups span {
-      min-width: min(2.4rem, calc((100% - (var(--gn, 3) - 1) * 0.42rem) / var(--gn, 3)));
+    .gg .gg-strip { display: flex; flex-wrap: wrap; gap: 2px; margin: 0.5rem 0; }
+    .gg .gg-strip .g { display: contents; }
+    .gg .gg-strip i {
+      flex: 0 0 auto; width: calc((100% - 19 * 2px) / 20); aspect-ratio: 1; height: auto;
+      border-radius: 2px; box-shadow: none; background: var(--ch);
     }
-    .gg .gg-strip, .gg-groups { overflow: hidden; }
-    /* Past a dozen groups the agent labels are slivers of glyph. */
-    .gg-groups.many span:not(.s):not(.h) { visibility: hidden; }
+    .gg .gg-strip i.p { background: var(--ca); }
+    .gg .gg-strip i.s { background: var(--cs); }
+    .gg-groups, .gg-ticks { display: none; }
   }
   .gg .gg-strip i.p { background: var(--ca); }
   .gg .gg-strip i.s { background: var(--cs); }
@@ -3484,14 +3489,6 @@ if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').m
   function label(t, cls, n) { var l = document.createElement('span'); l.textContent = t; l.className = cls; l.style.flexGrow = n; return l; }
   function all(sel, f) { [].slice.call(box.querySelectorAll(sel)).forEach(f); }
   function draw() {
-    drawStrip();
-    /* #773 round 4: the phone floor under a group is its even share at
-       most, so thirty agents at 16 GB cannot run past the box. */
-    strip.style.setProperty('--gn', strip.children.length);
-    groups.style.setProperty('--gn', groups.children.length);
-    groups.classList.toggle('many', groups.children.length > 12);
-  }
-  function drawStrip() {
     var ram = RAM[+ramIn.value], cols = ram * 10, max = Math.floor((cols - 10) / 5);
     nIn.max = max; if (+nIn.value > max) nIn.value = max;
     var n = +nIn.value, free = cols - 10 - 5 * n;


### PR DESCRIPTION
Part of #773 on map #600. Round 1 of the whole-page phone read.

Five faults that only show across scenes, each recorded in `prototypes/story-page/NOTES.md`:

- **The page scrolled sideways.** Four overflows (arc panel frames, grilling orb, preview light, and every right-docked reveal parked at `+2.4rem`) widened the phone's layout viewport to 491px, so every scene rendered a fifth too small. Every `.scene` and `.arc-flow` clips its own sides now. The clip must not go on the root: there it unstuck every sticky stage, measured A/B against `main`.
- **The grilling window scrolled up through its own claim.** The claim has its own sticky box that ends a screen above the section, so it lets go before the stage does.
- **Two bare classes leaked between scenes.** Scene 7's `.oc { width: 1em }` squeezed the Discord card's option lines to one em wide. Scoped, along with the atlas scene's `.rl`.
- **The terminal never started.** `seen` was assigned but never declared, a `ReferenceError` under strict mode on first intersection. Declared.
- **The setup command clipped.** The `pre` wraps.

Left for the operator: scene 7's Discord phone lane is a sliver on a phone (a round 15 decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xubHoKEAXQWTkb7wGUVD