### PR TITLE
Remove temporary live check mount

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -321,7 +321,6 @@ services:
       # Read-only because nothing in here has a reason to write a credential, and
       # the shell in here is the reason to say so.
       - ${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/credentials:${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/credentials:ro
-      - ${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/live-check-723:${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/live-check-723:ro
       # The config dir, at the SAME PATH on both sides, because the Chat screen
       # reads the overseer's transcript off it (ADR-0015).
       - ${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/cfg/curia-overseer:${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/cfg/curia-overseer

--- a/deploy/self-deploy.sh
+++ b/deploy/self-deploy.sh
@@ -48,7 +48,7 @@ recreate() {
   # `home/` is curia's own HOME since #473, and it is made here for the same
   # reason. What it does NOT do is fill it: the credentials are the operator's
   # to seed once, and docs/deploy.md says how.
-  [ -n "$WORK" ] && mkdir -p "$WORK/cfg/curia-overseer" "$WORK/overseer/repos" "$WORK/credentials" "$WORK/home" "$WORK/live-check-723"
+  [ -n "$WORK" ] && mkdir -p "$WORK/cfg/curia-overseer" "$WORK/overseer/repos" "$WORK/credentials" "$WORK/home"
   docker compose -f "$REPO/deploy/compose.yaml" up -d --build --force-recreate --no-deps daemon dashboard overseer
 }
 


### PR DESCRIPTION
Cleans up the throwaway bind mount after the successful live deployment check in #723.

Tests: `node --test test/deploy.test.mjs test/composepaths.test.mjs` in `daemon/` (47 passed; 0 failed; 0 cancelled)