### PR TITLE
The review gate takes a composite send (ADR-0026)

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -117,6 +117,18 @@ export const reviewSessionFor = (n) => `curia-review-${n}`
 // The Stop hook names the tool, because the model has to make the call again.
 const TOOL_FOR_KIND = { [REVIEW_KIND]: 'request_review', [RESULT_KIND]: 'report_result', [NOTIFY_KIND]: 'notify' }
 
+// The line every rejection ends on (ADR-0026). A rejection is the human's own
+// words, and the next gate is the agent's reply to them — which had no field
+// before the composite send, so the reply went into the `summary` that is
+// supposed to say what CHANGED, or into an attached markdown file the ADR calls
+// counterproductive. This is where the agent is told where the reply goes,
+// because this is the one moment it is about to write one.
+const REPLY_TO_REJECTION = [
+  'Answer their words in that call\'s `messages`: one prose message that leads with its conclusion in',
+  'bold. `summary` stays what changed. The gate card posts last, under your reply, so a send here',
+  'carries nothing that decides.',
+].join('\n')
+
 // The label a CHARTING dispatch needs (#160): `map curia#<n>` on a map's own
 // issue spawns an agent that updates the map, not one that resolves a ticket
 // under it. Since #221 the VERB decides the kind and this label is the check on
@@ -4083,7 +4095,14 @@ export class Dispatcher {
   // preview from the registry that allocated it, the pull request from GitHub,
   // the ticket from the spawn binding. #40 recorded the alternative as a live
   // limit: an agent can hand ask_human any `preview_url` string it likes.
-  async requestReview(agentName, { summary = '', charting = '', body = '', trackerWrites = null } = {}) {
+  // `postPreludes` is the composite send of ADR-0026 (#622): the messages the
+  // agent composed above its gate, awaited at the one instant the card is
+  // certain to open. It is a callback rather than a payload because the files
+  // and the bridge belong to index.mjs, and because every refusal below must
+  // return with the thread untouched.
+  async requestReview(agentName, {
+    summary = '', charting = '', body = '', trackerWrites = null, postPreludes = null,
+  } = {}) {
     // #164: the reviewer is what a gate ASKS ABOUT, never what opens one. A
     // reviewer at the gate would put its own reading in front of the operator as
     // if it were the work, on a ticket it is not building.
@@ -4207,6 +4226,18 @@ export class Dispatcher {
       this.reduction.journal('preview_missing', {
         repo, ticket, agent: agentName, files: expectation.paths.slice(0, 10),
       })
+    }
+
+    // Past every refusal, so the send goes out only with a card under it. A
+    // prelude that fails to post must not take the gate with it: the operator
+    // can still judge the diff from the card, and an agent blocked here would
+    // be blocked on its own reply rather than on their answer.
+    if (postPreludes) {
+      try {
+        await postPreludes()
+      } catch (e) {
+        this.log(`review gate for ${repo}#${ticket}: the composite send failed to post (${e.message})`)
+      }
     }
 
     const { text } = reviewGateText({
@@ -4364,6 +4395,8 @@ export class Dispatcher {
           'Publish nothing: no issue, no label, no edge. Nothing from the card exists on the tracker, and',
           'it stays that way. Revise the proposal from their words, then call request_review again with',
           'the full `tracker_writes` list.',
+          '',
+          REPLY_TO_REJECTION,
         ].join('\n')),
       }
     }
@@ -4376,6 +4409,8 @@ export class Dispatcher {
         '',
         'Do not merge and do not resolve. Make the changes, commit, call open_pull_request again, then',
         'request_review again.',
+        '',
+        REPLY_TO_REJECTION,
       ].join('\n')),
     }
   }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -92,9 +92,9 @@ import { MAP_FOG_VERB } from './mapfog.mjs'
 import { GlobalSearch } from './search.mjs'
 import { githubSearchSource, journalSearchSource, transcriptSearchSource } from './searchsources.mjs'
 import {
-  compositeSendFaults, compositeSendSchemaFaults, renderCompositeSend,
+  compositeSendFaults, compositeSendSchemaFaults, lintCompositeSend, renderCompositeSend,
 } from './composite.mjs'
-import { sendSchema, sendHasText, decidingIndex, SEND_HINT } from './send.mjs'
+import { sendSchema, sendHasText, sendDecisionFaults, SEND_HINT } from './send.mjs'
 import { trackerWriteWaves } from './trackerwrites.mjs'
 import {
   AccountUsage, AnthropicCredentialHealth, ModelWindows,
@@ -886,14 +886,7 @@ function compositeGate(agentName, tool, messages, maxMessages) {
   const schemaFaults = compositeSendSchemaFaults(messages, { maxMessages })
   const rendered = Array.isArray(messages) ? renderCompositeSend(messages) : []
   const deciding = rendered.at(-1)
-  const decisionFaults = []
-  if (tool === 'ask_human' && !deciding?.deciding) {
-    decisionFaults.push('messages: `ask_human` needs one deciding message last. Use `notify` when no answer blocks the work.')
-  }
-  const decides = Array.isArray(messages) ? decidingIndex(messages) : -1
-  if (tool === 'notify' && decides >= 0) {
-    decisionFaults.push(`messages: \`notify\` decides nothing, and message ${decides + 1} is a ${messages[decides].format}. Use \`ask_human\` when an answer blocks the work.`)
-  }
+  const decisionFaults = sendDecisionFaults(tool, messages)
   const faults = [...compositeSendFaults(messages, { maxMessages }), ...decisionFaults]
   const verdict = lintGate.judge({
     agent: agentName,
@@ -928,6 +921,35 @@ function compositeAskHumanGate(agentName, messages, maxMessages) {
     attachments: deciding.attachments,
     flags,
     note,
+  }
+}
+
+// The send a `request_review` carries (ADR-0026): "`request_review` composes
+// one for the reply after a rejection." A rejection comes back as the human's
+// own words, and the gate the agent opens next is its reply to them — a reply
+// that had no field before this, so it went in the `summary` that is supposed
+// to say what changed, or in an attached markdown file the ADR calls
+// counterproductive.
+//
+// The gate card stays CURIA's. It composes the pull request, the preview, the
+// diff digest and the tracker-write waves from its own records, and none of
+// those are fields an agent could author into a `preview-review` message. So
+// the send carries the preludes only, and the gate posts last under them —
+// which is the ADR-0026 order read on this surface rather than an exception
+// to it.
+//
+// The faults come back in their two CLASSES rather than judged here, because
+// the gate judges them with its own fields in one verdict: a send and a gate
+// arrive on one call, so they spend one attempt of the three.
+function reviewSendFaults(messages, maxMessages) {
+  const rendered = Array.isArray(messages) ? renderCompositeSend(messages) : []
+  return {
+    rendered,
+    schema: [
+      ...compositeSendSchemaFaults(messages, { maxMessages }),
+      ...sendDecisionFaults('request_review', messages),
+    ],
+    words: lintCompositeSend(messages),
   }
 }
 
@@ -2073,7 +2095,9 @@ function buildMcpServer(agent, ticket) {
   // differ, and the daemon composes every one of them from its own records.
   server.tool(
     'request_review',
-    'THE review gate: ask the human "is this done?" and BLOCK until they answer. curia shows them the pull request, the preview and the ticket — you do not pass links, it knows them. On approval you merge the pull request and then resolve the ticket. A rejection comes back as the human\'s own words: fix, commit, open_pull_request again, and call this again. If your diff changed a page — markup, styles, a component or a template — publish_preview FIRST: curia checks for one here, and a first call without it comes back asking for one.',
+    'THE review gate: ask the human "is this done?" and BLOCK until they answer. curia shows them the pull request, the preview and the ticket — you do not pass links, it knows them. On approval you merge the pull request and then resolve the ticket. A rejection comes back as the human\'s own words: fix, commit, open_pull_request again, and call this again. If your diff changed a page — markup, styles, a component or a template — publish_preview FIRST: curia checks for one here, and a first call without it comes back asking for one.'
+    + ` Answering a rejection is a SEND: put your reply to their words in \`messages\`, as a prose message that leads with its conclusion in bold. ${SEND_HINT} The gate card is this call's decision, so a send here decides nothing — curia posts your messages first and the card last, under them.`
+    + ' `summary` still says what CHANGED. The reply to the rejection is the send, not the summary.',
     {
       // #418, ADR-0019: `summary` and `charting` are Grade B block prose, and
       // the operator reads both on every ticket. Optional to zod for the same
@@ -2089,15 +2113,36 @@ function buildMcpServer(agent, ticket) {
         labels: z.array(z.string()).optional().describe('Every label proposed for this issue.'),
         after: z.array(z.string()).optional().describe('Ids of proposed issues that block this issue through native blocked-by edges.'),
       })).optional().describe('Every proposed tracker write. Curia validates edges, numbers items, and groups them into dispatch waves.'),
+      // The composite send (ADR-0026), with NO deciding message: the gate card
+      // curia composes IS the decision, and these post above it.
+      messages: sendSchema,
     },
-    async (raw, extra) => {
+    async ({ messages, ...raw }, extra) => {
+      const maxMessages = curiaConfig.dispatch.messages_per_send ?? 4
+      const send = messages
+        ? reviewSendFaults(messages, maxMessages)
+        : { rendered: [], schema: [], words: [] }
       // The same gate as `ask_human`, keyed on the same agent-and-kind pair the
       // supersession key uses (#336), so a rejected gate and a rejected question
-      // count apart.
+      // count apart. The send is judged INSIDE this one verdict rather than on a
+      // key of its own: it arrived on this call, so it spends this call's
+      // attempt, and an agent fixing both at once reads both faults at once.
       const floor = reviewFloorFaults(raw)
       const verdict = lintGate.judge({
-        agent, kind: REVIEW_KIND, faults: [...floor, ...lintRequestReview(raw)],
-        schema: floor.length > 0, hasText: hasText(raw), prompt: raw.summary ?? null, payload: raw,
+        agent, kind: REVIEW_KIND,
+        faults: [...floor, ...send.schema, ...lintRequestReview(raw), ...send.words],
+        schema: floor.length > 0 || send.schema.length > 0,
+        // A send carrying words is text that can reach the operator, so a gate
+        // whose own fields are empty is not the dead end it would be alone.
+        //
+        // This surface has no dead end the way `ask_human` does, and that is
+        // right rather than an oversight: the card opens with its own buttons
+        // whatever the send did, so a flagged send here never leaves a question
+        // with nobody. An agent that spends all three attempts on a deciding
+        // message gets the gate anyway, with its card posted as prose above it
+        // and the faults named — curia never drops a message it was given.
+        hasText: hasText(raw) || sendHasText(messages),
+        prompt: raw.summary ?? null, payload: messages ? { ...raw, messages } : raw,
       })
       if (verdict.reject || verdict.refuse) {
         return { content: [{ type: 'text', text: verdict.reject ?? verdict.refuse }] }
@@ -2109,12 +2154,32 @@ function buildMcpServer(agent, ticket) {
           const writes = trackerWriteWaves(raw.tracker_writes)
           charting = [charting, writes].filter((part) => part.trim()).join('\n\n')
         }
+        const refusals = []
+        if (messages) reduction.journal('composite_send', { agent, ticket, tool: 'request_review', messages })
+        // The preludes post from INSIDE the gate call, at the one instant the
+        // card is certain to open. `requestReview` refuses on five paths — a
+        // live cross-check, an unjudged verdict, a skill run with no tracker
+        // writes, a broken binding, the preview bounce — and every one of them
+        // returns before the card. Posting here rather than above the call is
+        // what keeps a refused gate from leaving the agent's reply in the
+        // thread with nothing under it.
         const r = await dispatcher.requestReview(agent, {
           summary: raw.summary ?? '', charting, body: composeReviewBody(raw),
           trackerWrites: raw.tracker_writes ?? null,
+          postPreludes: async () => {
+            for (const prelude of send.rendered) {
+              const outbound = outboundFiles(agent, prelude.attachments)
+              refusals.push(...outbound.refusals)
+              if (bridge) await bridge.notify(ticket, prelude.content, { files: outbound.files, as: speaker })
+              else log(`[notify ticket-${ticket}] ${prelude.content}`)
+            }
+          },
         })
         const flagNote = verdict.note ? [{ type: 'text', text: verdict.note }] : []
-        return { content: [...flagNote, { type: 'text', text: r.text }, ...drainNotes()] }
+        const refusalNote = refusals.length
+          ? [{ type: 'text', text: `(curia refused ${refusals.length} outbound file(s): ${refusals.join('; ')})` }]
+          : []
+        return { content: [...flagNote, ...refusalNote, { type: 'text', text: r.text }, ...drainNotes()] }
       } finally {
         stopKeepAlive()
       }

--- a/daemon/src/send.mjs
+++ b/daemon/src/send.mjs
@@ -165,6 +165,31 @@ export function sendFloorFaults(messages, { cap = MESSAGES_PER_SEND } = {}) {
   return faults
 }
 
+// Which message of a send may decide, per TOOL. This is the one rule the array
+// cannot hold on its own, because it is about the CALL rather than about the
+// messages: `ask_human` needs one decision and blocks on it, `notify` asks
+// nothing at all, and `request_review` decides through the gate card curia
+// composes from its own records, so a decision inside its send would be a
+// second answer surface for one press.
+//
+// It reads as a schema fault on every tool, because a send on the wrong tool is
+// a misplaced field rather than badly chosen words.
+export function sendDecisionFaults(tool, messages) {
+  if (tool === 'ask_human') {
+    const last = Array.isArray(messages) ? messages.at(-1) : null
+    return isDeciding(last)
+      ? []
+      : ['messages: `ask_human` needs one deciding message last. Use `notify` when no answer blocks the work.']
+  }
+  const decides = decidingIndex(Array.isArray(messages) ? messages : [])
+  if (decides < 0) return []
+  const format = messages[decides].format
+  if (tool === 'notify') {
+    return [`messages: \`notify\` decides nothing, and message ${decides + 1} is a ${format}. Use \`ask_human\` when an answer blocks the work.`]
+  }
+  return [`messages: the review gate is this call's decision, and message ${decides + 1} is a ${format}. Curia composes the gate card itself and posts it last, under your send. Put your reply to the rejection in a \`prose\` message.`]
+}
+
 // ---- the words ----------------------------------------------------------------
 
 // A prose message opens with one bold line, and the body comes after it.

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -4408,6 +4408,85 @@ describe('open_pull_request (#54 item 1)', () => {
   })
 })
 
+describe('the composite send a review gate carries (ADR-0026)', () => {
+  // "`request_review` composes one for the reply after a rejection." The gate
+  // card stays curia's, so the send is the messages ABOVE it, and the order is
+  // the whole point: the buttons have to sit at the thread bottom.
+  test('the send posts first, and the gate card opens under it', async () => {
+    const order = []
+    const d = makeDispatcher({}, {
+      askReview: async () => { order.push('gate'); return { text: 'approve', status: 'answered' } },
+    })
+    liveAgent(d)
+
+    await d.requestReview('curia-42', {
+      summary: 's', charting: 'none',
+      postPreludes: async () => { order.push('send') },
+    })
+
+    assert.deepEqual(order, ['send', 'gate'])
+  })
+
+  // The failure this seam exists to prevent. `requestReview` refuses on several
+  // paths before it ever composes a card, and a send posted above the call
+  // would leave the agent's reply in the thread with nothing under it — the
+  // operator reading an answer to a rejection and no gate to press.
+  test('a refused gate posts no send at all', async () => {
+    let posted = 0
+    const d = makeDispatcher({}, { askReview: async () => ({ text: 'approve', status: 'answered' }) })
+    // No live agent, so the binding fails before any card is composed.
+    const r = await d.requestReview('curia-42', {
+      summary: 's', charting: 'none',
+      postPreludes: async () => { posted += 1 },
+    })
+
+    assert.equal(r.ok, false)
+    assert.equal(posted, 0, 'a refusal must leave the thread untouched')
+  })
+
+  // A gate is the operator's way to judge the diff. A prelude that cannot post
+  // must not take that away: the card still opens, and the agent waits on their
+  // answer rather than on its own reply.
+  test('a send that fails to post does not take the gate with it', async () => {
+    let asked = null
+    const d = makeDispatcher({}, {
+      askReview: async (a, t, text) => { asked = text; return { text: 'approve', status: 'answered' } },
+    })
+    liveAgent(d)
+
+    const r = await d.requestReview('curia-42', {
+      summary: 'did it', charting: 'none',
+      postPreludes: async () => { throw new Error('discord said no') },
+    })
+
+    assert.ok(asked, 'the gate opened anyway')
+    assert.equal(r.approved, true)
+  })
+
+  // A rejection is the human's own words, and the next gate is the reply to
+  // them. This is the one moment the agent is about to write one, so it is
+  // where curia says where the reply goes — and where it does NOT go.
+  test('a rejection tells the agent to answer in the send, not in the summary', async () => {
+    const d = makeDispatcher({}, { askReview: async () => ({ text: 'reject: the cap is wrong', status: 'answered' }) })
+    liveAgent(d)
+
+    const r = await d.requestReview('curia-42', { summary: 'did it', charting: 'none' })
+
+    assert.equal(r.approved, false)
+    assert.match(r.text, /the cap is wrong/)
+    assert.match(r.text, /Answer their words in that call's `messages`/)
+    assert.match(r.text, /`summary` stays what changed/)
+    assert.match(r.text, /a send here\s+carries nothing that decides/)
+  })
+
+  test('a gate with no send behaves exactly as it did before', async () => {
+    const d = makeDispatcher({}, { askReview: async () => ({ text: 'approve', status: 'answered' }) })
+    liveAgent(d)
+    const r = await d.requestReview('curia-42', { summary: 'did it', charting: 'none' })
+    assert.equal(r.approved, true)
+  })
+})
+
 describe('request_review: the one gate (#54 item 2)', () => {
   test('every link is composed by the daemon — the agent passes none', async () => {
     let asked = null

--- a/daemon/test/send.test.mjs
+++ b/daemon/test/send.test.mjs
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict'
 import {
   MESSAGES_PER_SEND, MESSAGE_FORMATS, DECIDING_FORMATS, CONTENT_FIELDS,
   sendFloorFaults, lintSend, sendHasText, sendPrompt, decidingIndex, isComposite,
-  messageSchema, sendSchema,
+  sendDecisionFaults, messageSchema, sendSchema,
 } from '../src/send.mjs'
 import { CAPS } from '../src/lint.mjs'
 
@@ -260,5 +260,51 @@ describe('the shape a tool declares', () => {
     assert.equal(parsed.picture, 'a.png')
     assert.equal(parsed.table, 'a  b')
     assert.equal(parsed.diagram, 'a\nb')
+  })
+})
+
+// ADR-0026 names the tool each send belongs to: "`ask_human` sends an array
+// with the deciding message last. `notify` sends one with no deciding message
+// ... `request_review` composes one for the reply after a rejection."
+//
+// The array cannot check that on its own — the same three messages are a legal
+// `notify` and an illegal `ask_human` — so the rule reads the tool beside them.
+describe('which message of a send may decide, per tool (ADR-0026)', () => {
+  test('`ask_human` needs a decision, and it needs it last', () => {
+    assert.deepEqual(sendDecisionFaults('ask_human', [prose('answer'), round()]), [])
+    assert.match(
+      names(sendDecisionFaults('ask_human', [prose('answer'), prose('detail')])),
+      /`ask_human` needs one deciding message last\. Use `notify`/,
+    )
+    // The place of the decision is the array's own rule, so this one only
+    // reads whether the LAST message decides.
+    assert.match(names(sendDecisionFaults('ask_human', [round(), prose('after')])), /needs one deciding message last/)
+  })
+
+  test('`notify` decides nothing, and the refusal names the tool that does', () => {
+    assert.deepEqual(sendDecisionFaults('notify', [prose('a'), prose('b')]), [])
+    const faults = names(sendDecisionFaults('notify', [prose('answer'), round()]))
+    assert.match(faults, /`notify` decides nothing, and message 2 is a round/)
+    assert.match(faults, /Use `ask_human` when an answer blocks the work/)
+  })
+
+  // The gate card is curia's: it composes the pull request, the preview, the
+  // diff digest and the tracker-write waves from records no agent can author.
+  // So a decision inside a review send would be a second answer surface for
+  // one press, and the refusal points at the prose message instead.
+  test('a `request_review` send decides nothing, because the gate card does', () => {
+    assert.deepEqual(sendDecisionFaults('request_review', [prose('reply'), prose('what changed')]), [])
+    const faults = names(sendDecisionFaults('request_review', [prose('reply'), round()]))
+    assert.match(faults, /the review gate is this call's decision, and message 2 is a round/)
+    assert.match(faults, /Curia composes the gate card itself and posts it last/)
+    assert.match(faults, /Put your reply to the rejection in a `prose` message/)
+  })
+
+  test('an empty or absent send decides nothing on any tool but `ask_human`', () => {
+    for (const tool of ['notify', 'request_review']) {
+      assert.deepEqual(sendDecisionFaults(tool, []), [], tool)
+      assert.deepEqual(sendDecisionFaults(tool, undefined), [], tool)
+    }
+    assert.equal(sendDecisionFaults('ask_human', []).length, 1)
   })
 })

--- a/daemon/test/theflip.test.mjs
+++ b/daemon/test/theflip.test.mjs
@@ -226,6 +226,47 @@ describe('an untyped ask_human is refused since the flip (#422, real boot)', () 
     }
   })
 
+  // ADR-0026: "`request_review` composes one for the reply after a rejection."
+  // The gate card is curia's — it composes the pull request, the preview, the
+  // diff digest and the tracker-write waves from records no agent can author —
+  // so the send carries the reply and the card posts last, under it.
+  test('request_review declares a send, and a send that decides is refused by name', async () => {
+    const c = await client('curia-422-review-send', '422')
+    try {
+      const listed = await c.listTools()
+      const review = listed.tools.find((tool) => tool.name === 'request_review')
+      assert.ok(review.inputSchema.properties.messages, 'the gate takes a send since ADR-0026')
+      assert.match(review.description, /Answering a rejection is a SEND/)
+
+      const result = await c.callTool({
+        name: 'request_review',
+        arguments: {
+          headline: 'The reply is ready.',
+          summary: 'The lint gate now reads the send.',
+          charting: 'none',
+          messages: [
+            { format: 'prose', label: 'reply', prose: '**The cap was the fault.** The chunker reads the fence now.' },
+            {
+              format: 'choice', label: 'decision', headline: 'Which surface should answer?',
+              options: [
+                { label: 'Use Atlas.', handle: 'Atlas', consequence: 'The browser records the answer.' },
+                { label: 'Use Discord.', handle: 'Discord', consequence: 'The thread records the answer.' },
+              ],
+            },
+          ],
+        },
+      }, undefined, { timeout: 30_000 })
+
+      const text = result.content.map((part) => part.text ?? '').join('\n')
+      assert.match(text, /curia refused this call/)
+      assert.match(text, /the review gate is this call's decision, and message 2 is a choice/)
+      assert.match(text, /Put your reply to the rejection in a `prose` message/)
+      assert.deepEqual(await openEscalations(port), [], 'a refused gate asked nobody anything')
+    } finally {
+      await c.close().catch(() => {})
+    }
+  })
+
   test('a composite ask keeps its order and opens only its last decision', async () => {
     const c = await client('curia-422-composite', '422')
     const messages = [

--- a/docs/adr/0026-the-composite-send.md
+++ b/docs/adr/0026-the-composite-send.md
@@ -46,6 +46,12 @@ A question of a round takes an optional background block: Grade B, 600 character
 
 `ask_human` sends an array with the deciding message last. `notify` sends one with no deciding message, and a prose message carries the answer that never fit the 600-character status line. `request_review` composes one for the reply after a rejection. `report_result` and the verdict stay single messages.
 
+**On `request_review`, the gate card is the decision.** The card is curia's: it composes the pull request, the preview, the diff digest and the tracker-write waves from records no agent can author, so no agent could write it as a `preview-review` message. The send therefore carries the reply and nothing that decides, and the card posts last, under it. That is the ADR-0026 order read on this surface rather than an exception to it, and a send here that carries a deciding message is refused by name.
+
+The send is judged in the gate's own verdict rather than on a key of its own. A send and a gate arrive on one call, so they spend one of the three attempts together, and an agent fixing both reads both faults at once. `summary` still says what changed; the reply to the rejection is the send.
+
+The messages post from inside the gate call, at the instant the card is certain to open. `requestReview` refuses on five paths before it composes anything - a live cross-check, an unjudged verdict, a skill run with no tracker writes, a broken binding, the preview bounce - and posting above the call would leave the agent's reply in the thread with no gate under it. A send that fails to post does not take the card with it: the operator can still judge the diff.
+
 ### The disciplines
 
 `detail` carries facts only. A file carries an artifact: a diff, a mock, a log. The explanation lives in a prose message, never in the spoiler and never in an attached markdown file. A card stands alone without a download.


### PR DESCRIPTION
ADR-0026 says "\`request_review\` composes one for the reply after a rejection." The surface never got it. `notify` and `ask_human` took `messages` when #716 landed; the review gate stayed a single ADR-0019 card.

That mattered because a rejection comes back as the human's own words, and the gate the agent opens next is its reply to them - a reply with no field to go in. It went into the `summary` that is supposed to say what CHANGED, or into an attached markdown file the ADR itself calls counterproductive. The review gate is also the surface an agent hits on every ticket, so it is where the missing send showed most.

## What changed

`request_review` declares `messages`, the same send contract the other two tools take.

**The gate card stays curia's.** It composes the pull request, the preview, the diff digest and the tracker-write waves from records no agent can author, so the send carries the reply and nothing that decides, and the card posts last under it. That is the ADR-0026 order read on this surface rather than an exception to it. A send here that carries a deciding message is refused by name, pointing at the prose message.

**One verdict, not two.** The send is judged inside the gate's existing lint verdict rather than on a key of its own. Both arrive on one call, so they spend one of the three attempts together, and an agent fixing both reads both faults at once. There is no dead end on this surface: the card opens with its own buttons whatever the send did.

**The messages post from inside the gate call**, past every refusal, at the instant the card is certain to open. `requestReview` returns early on five paths - a live cross-check, an unjudged verdict, a skill run with no tracker writes, a broken binding, the preview bounce. Posting above the call would leave the agent's reply in the thread with no gate under it. A send that fails to post does not take the card with it.

**The rejection reply names where the reply goes**, since that is the one moment the agent is about to write one.

`sendDecisionFaults` moves to `send.mjs`, where the contract lives, and covers all three tools instead of an inline chain in `index.mjs`.

Atlas Chat needed no change: `transcript.mjs` reads `messages` off any curia tool call, so it was never tool-specific.

## Tests

Full daemon suite green: 3735 tests, 610 suites, 0 failures.

New coverage:
- `send.test.mjs` - the decision rule per tool, including that a review send decides nothing and that the refusal names the prose message.
- `dispatch.test.mjs` - the send posts before the card, a refused gate posts nothing at all, a send that throws does not take the gate with it, a gate with no send is unchanged, and the rejection reply names the send.
- `theflip.test.mjs` - on a real boot, `request_review` declares `messages` and a send that decides is refused by name with no card opened.

ADR-0026 records the shipped shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSy9jxByK8Eg8bVpAU91iq