### PR TITLE
Establish the Harness adapter registry and conformance boundary

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3173,6 +3173,10 @@ function settingsAction() {
   return [...actions.values()].find((action) => action.kind === "settings-save") ?? null;
 }
 
+function daemonRestartAction() {
+  return actionFor({ conflict_key: "daemon:lifecycle" });
+}
+
 /* ---- what the daemon is running (#362) --------------------------------------
 
    Applied is a fact curia measured, not a claim the save made. `GET /overview`
@@ -3240,6 +3244,10 @@ function saveDock() {
   if (s.phase === "restarting") {
     return dock("", `<span class="toast">The daemon exited nonzero and the supervisor respawns it.
       This page serves its last snapshot meanwhile.</span>`);
+  }
+  if (s.phase === "restart-unknown") {
+    return dock("", `<span class="toast">The daemon may have taken the restart order.</span>
+      <span class="why">${esc(s.error)}</span>`);
   }
   if (s.phase === "refused") {
     /* The loaders refused the candidate, so nothing on disk moved. The draft
@@ -3462,8 +3470,13 @@ function gistMaintenance(p) {
 function setMaintenance(p) {
   const differs = runningDiff(p);
   const run = p?.overview?.daemon?.config;
+  const restart = daemonRestartAction();
   let state;
-  if (differs === null) {
+  if (restart && !TERMINAL_ACTION.has(restart.status)) {
+    state = restart.projection?.transport_error
+      ? `<p class="unread">The daemon may have taken the restart order. Agent panes remain running in their own container.</p>`
+      : `<p class="unread">Restarting daemon. Agent panes remain running in their own container.</p>`;
+  } else if (differs === null) {
     state = `<p class="unread">curia cannot tell whether the daemon runs these files: ${
       p?.daemon_up === false ? "it is not answering." : "there is no reading of it yet."}</p>`;
   } else if (differs.length) {
@@ -3483,7 +3496,7 @@ function setMaintenance(p) {
     : "";
   return `${state}<div class="rows">
     <div class="row"><span class="grow"><button class="btn${differs?.length ? " restart-hot" : ""}"
-      ${UI.set.busy ? "disabled" : ""} onclick="doRestart()">Restart daemon</button></span>${qq("set-restart")}</div>
+      ${UI.set.busy || restart ? "disabled" : ""} onclick="doRestart()">${restart && !TERMINAL_ACTION.has(restart.status) ? "Restarting daemon…" : "Restart daemon"}</button></span>${qq("set-restart")}</div>
     ${qhint("set-restart", `A restart is for the keys a save cannot apply: the ports,
       <span class="mono">workspace_root</span>, <span class="mono">sandbox</span>,
       <span class="mono">identity</span>, and every routing key this screen does not write.
@@ -4827,6 +4840,34 @@ function reconcileSettingsActions() {
   }
 }
 
+function reconcileDaemonRestartActions(p) {
+  const shared = (p?.overview?.actions ?? [])
+    .filter((action) => action.kind === "daemon-restart")
+    .sort((a, b) => Number(b.revision ?? -1) - Number(a.revision ?? -1))[0] ?? null;
+  const local = daemonRestartAction();
+  const action = local ?? shared;
+  if (!action) return;
+
+  if (action.status === "refused" || action.status === "failed") {
+    UI.set.phase = "refused";
+    UI.set.error = action.reason || "The daemon restart did not finish.";
+    if (local) finishAction(local.action_id);
+    return;
+  }
+
+  const uptime = p?.overview?.daemon?.uptime_s;
+  const before = action.receipt?.uptime_s ?? action.projection?.uptime_s;
+  const freshLife = Number.isFinite(uptime) && (
+    action.receipt?.booted_at != null || (Number.isFinite(before) && uptime < before)
+  );
+  if (p?.daemon_up && freshLife && (action.status === "confirmed" || action.receipt?.requested_at)) {
+    UI.set.phase = "restarted";
+    UI.set.error = null;
+    UI.set.note = `The daemon restarted and is answering. Up ${dur(uptime)}.`;
+    if (local) finishAction(local.action_id);
+  }
+}
+
 async function doSave() {
   const patch = settingsPatch();
   if (!Object.keys(patch).length) return;
@@ -4895,24 +4936,42 @@ async function doSave() {
 async function doRestart() {
   const ask = "Restart the daemon? Running agents keep their tmux sessions — those live in their own container. Anything unsaved here is not written.";
   if (typeof confirm === "function" && !confirm(ask)) return;
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const uptime = payload?.overview?.daemon?.uptime_s;
+  const action = beginAction({
+    action_id: actionId,
+    kind: "daemon-restart",
+    target: "daemon",
+    conflict_key: "daemon:lifecycle",
+    projection: { uptime_s: Number.isFinite(uptime) ? uptime : null },
+  });
+  if (!action) return;
   UI.set.busy = true;
   render();
   try {
     const res = await fetch("/api/restart", {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },
-      body: "{}",
+      body: JSON.stringify({ action_id: actionId }),
     });
     const body = await res.json().catch(() => ({}));
-    if (!res.ok) throw new Error(body.error || ("the sidecar answered " + res.status));
-    UI.set.phase = "restarting";
+    observeActions(body.action ? [body.action] : []);
+    if (!res.ok) {
+      const current = actionFor({ action_id: actionId });
+      UI.set.phase = "refused";
+      UI.set.error = current?.reason || body.error || ("the sidecar answered " + res.status);
+      finishAction(actionId);
+      UI.set.busy = false;
+      return render();
+    }
     UI.set.error = null;
   } catch (e) {
     /* The daemon may have taken the order and died before answering. Say
        exactly that, and let the marker at the top of the page be the evidence:
        it reads the daemon, and this reads a socket. */
-    UI.set.phase = "refused";
+    UI.set.phase = "restart-unknown";
     UI.set.error = `${e.message} — the bar above says whether the daemon is answering`;
+    action.projection.transport_error = e.message;
   }
   UI.set.busy = false;
   render();
@@ -5067,6 +5126,7 @@ async function tick() {
     if (!res.ok) throw new Error("the sidecar answered " + res.status);
     payload = await res.json();
     observeActions(payload?.overview?.actions);
+    reconcileDaemonRestartActions(payload);
     recoverTerminalChatTakeBackActions(payload?.overview?.actions);
     reconcileStartActions(payload?.overview);
     reconcileAnswerActions(payload?.overview);

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -807,11 +807,11 @@ var UI = {
   /* Which `?` explanations are open, by row id. Page-wide, because the frame
      hands the same affordance to every section on every page. */
   hints: {},
-  /* The operator verbs (#266). `busy` names the ONE press in flight, keyed to
-     the control it came from; `said` is what curia answered, shown at that same
-     control. `note` and `tele` name the agent whose box is open, and `mode` is
-     the delivery ADR-0013 defaults to. */
-  act: { busy: null, said: null, note: null, mode: "queue", tele: null, diff: null,
+  /* The operator verbs (#266). `said` is what curia answered, shown at the
+     control that asked. In-flight bookkeeping lives in the Action map below.
+     `note` and `tele` name the agent whose box is open, and `mode` is the
+     delivery ADR-0013 defaults to. */
+  act: { said: null, note: null, mode: "queue", tele: null, diff: null,
     /* The handoff sheet (#718): the id of the item the operator just answered,
        or null when no sheet is up. The sheet draws nothing of its own — it
        reads the same `attentionItems` Home reads, minus this one id. */
@@ -825,6 +825,60 @@ var repos = null;     /* the watchable repos, read through the daemon on demand 
 var conversations = null; /* the browser conversations (#333), read on the Chat screen only */
 var aistack = null;   /* the aistack registration and sync verdict (#706), read on that section only */
 var aistackAct = { busy: null, said: null, poll: null }; /* which aistack press is in flight, and what it answered */
+
+/* Browser-local Action bookkeeping (#804). This map is the seam shared by
+   controls. It owns identity, conflict reservations, and evidence ordering.
+   Callers still own their projection, words, request, and reconciliation. */
+var actions = new Map(); /* action_id -> the latest visible Action */
+const TERMINAL_ACTION = new Set(["confirmed", "refused", "failed"]);
+const SHARED_ACTION = new Set(["accepted", "progress", ...TERMINAL_ACTION]);
+
+function beginAction(action) {
+  const actionId = String(action?.action_id ?? "");
+  const conflictKey = String(action?.conflict_key ?? "");
+  const target = String(action?.target ?? "");
+  if (!actionId || !conflictKey || !target || !String(action?.kind ?? "")) return null;
+  if (actions.has(actionId) || actionFor({ conflict_key: conflictKey })) return null;
+  const pending = { ...action, action_id: actionId, conflict_key: conflictKey, target, status: "pending", revision: null };
+  actions.set(actionId, pending);
+  return pending;
+}
+
+function observeActions(observed) {
+  for (const evidence of observed ?? []) {
+    const actionId = String(evidence?.action_id ?? "");
+    const revision = Number(evidence?.revision);
+    if (!actionId || !SHARED_ACTION.has(evidence?.status) || !Number.isFinite(revision)) continue;
+    const prior = actions.get(actionId);
+    if (!prior) {
+      if (TERMINAL_ACTION.has(evidence.status)) continue;
+      if (!String(evidence.kind ?? "") || !String(evidence.target ?? "") || !String(evidence.conflict_key ?? "")) continue;
+      actions.set(actionId, { ...evidence, action_id: actionId, revision });
+      continue;
+    }
+    if (TERMINAL_ACTION.has(prior.status)) continue;
+    if (prior.revision != null && revision <= prior.revision) continue;
+    actions.set(actionId, { ...prior, ...evidence, action_id: actionId, revision });
+  }
+}
+
+function actionFor({ action_id: actionId = null, target = null, conflict_key: conflictKey = null } = {}) {
+  if (actionId != null) return actions.get(String(actionId)) ?? null;
+  const matches = [...actions.values()].filter((action) =>
+    (target != null && action.target === String(target))
+      || (conflictKey != null && action.conflict_key === String(conflictKey)));
+  return matches.sort((a, b) => Number(b.revision ?? -1) - Number(a.revision ?? -1))[0] ?? null;
+}
+
+function finishAction(actionId) {
+  return actions.delete(String(actionId));
+}
+
+let localActionSequence = 0;
+function beginLocalAction(key) {
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  return beginAction({ action_id: actionId, kind: "browser", target: key, conflict_key: key });
+}
 
 /* ---- words ---------------------------------------------------------------- */
 
@@ -902,9 +956,8 @@ function needsYou(o) {
 
    Four rules run through all of them.
 
-   1. ONE ACT AT A TIME. `UI.act.busy` names the press in flight, keyed to the
-      control it came from, so a second press starts nothing and the control
-      that is working says so.
+   1. ONE ACT PER CONFLICT. The Action map reserves a control's conflict key,
+      so a duplicate starts nothing while unrelated controls remain available.
    2. CURIA'S OWN WORDS ARE THE OUTCOME. A command reply is a sentence the
       daemon composed. It is shown where the press was, as it stands. This page
       never writes its own account of what an act did.
@@ -932,8 +985,7 @@ const ALL_AS_RECOMMENDED = "all-as-recommended";
    escaping over it. */
 const js = (s) => esc(String(s ?? "").replace(/\\/g, "\\\\").replace(/'/g, "\\'"));
 
-const busy = (key) => UI.act.busy === key;
-const anyBusy = () => UI.act.busy !== null;
+const busy = (key) => actionFor({ conflict_key: key }) !== null;
 function said(key) {
   const s = UI.act.said;
   return s && s.key === key ? `<div class="said${s.ok ? "" : " bad"}">${mdLite(s.text)}</div>` : "";
@@ -949,8 +1001,8 @@ function mdLite(s) {
 }
 
 async function verb(key, path, body) {
-  if (anyBusy()) return null;
-  UI.act.busy = key;
+  const action = beginLocalAction(key);
+  if (!action) return null;
   UI.act.said = null;
   render();
   let out = null;
@@ -969,7 +1021,7 @@ async function verb(key, path, body) {
        mark the card carries, in place of a second question or an error. */
     UI.act.said = { key, text: e.receipt ? receiptLine(e.receipt) : e.message, ok: false };
   }
-  UI.act.busy = null;
+  finishAction(action.action_id);
   render();
   tick();
   return out;
@@ -1025,7 +1077,7 @@ const startTicket = (repo, ticket) => verb(`start:${repo}#${ticket}`, "/api/star
    so a Discord press and an Atlas tap resolve the same option. Files ride the
    answer inline, and the daemon writes them where the card said they land. */
 async function answerEsc(id, body) {
-  if (anyBusy()) return null;
+  if (busy("esc:" + id)) return null;
   const answer = typeof body === "string" ? { answer: body } : { ...body };
   try {
     answer.files = await replyFilesOf("files-" + id);
@@ -1445,7 +1497,7 @@ function nextReset(usage) {
 function answerButtons(r) {
   const key = "esc:" + r.id;
   const btn = (label, answer, cls) => `<button class="btn sm${cls ? " " + cls : ""}"
-    ${anyBusy() ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${js(answer)}')">${esc(label)}</button>`;
+    ${busy(key) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${js(answer)}')">${esc(label)}</button>`;
   const b = [];
   if (r.kind === "approve-reject" || r.kind === "preview-review") {
     b.push(btn("✅ Approve", APPROVE, "primary"), btn("❌ Reject", REJECT, "danger"));
@@ -1469,14 +1521,14 @@ function choiceControls(r) {
   const handle = (i) => r.option_handles?.[i] || opts[i];
   const label = (i) => `${optMarker(r, i)} · ${snip(handle(i), 80)}`;
   if (opts.length <= MAX_BUTTON_OPTIONS) {
-    return `<div class="act-row">${opts.map((_, i) => `<button class="btn sm" ${anyBusy() ? "disabled" : ""}
+    return `<div class="act-row">${opts.map((_, i) => `<button class="btn sm" ${busy("esc:" + r.id) ? "disabled" : ""}
       onclick="answerIndex('${js(r.id)}',${i})">${esc(label(i))}</button>`).join("")}</div>`;
   }
   if (opts.length <= MAX_SELECT_OPTIONS) {
     const id = "sel-" + r.id;
-    return `<div class="act-row"><select id="${esc(id)}" ${anyBusy() ? "disabled" : ""}>
+    return `<div class="act-row"><select id="${esc(id)}" ${busy("esc:" + r.id) ? "disabled" : ""}>
       <option value="">pick one…</option>${opts.map((_, i) => `<option value="${i}">${esc(label(i))}</option>`).join("")}</select>
-      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerSelect('${js(r.id)}','${js(id)}')">Answer</button></div>`;
+      <button class="btn sm primary" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerSelect('${js(r.id)}','${js(id)}')">Answer</button></div>`;
   }
   return `<ol class="opts numbered">${opts.map((o, i) => `<li><b>${esc(optMarker(r, i))}.</b> ${esc(snip(handle(i), 120))}</li>`).join("")}</ol>
     <div class="dim">Reply with ${r.typed ? "a letter or " : ""}a number.</div>`;
@@ -1486,7 +1538,7 @@ function choiceControls(r) {
    this line says where they land. */
 function replyFilesRow(r) {
   const where = r.files_dir ? ` They land under <code>${esc(r.files_dir)}/</code> and reach the agent as paths.` : "";
-  return `<div class="act-row files"><input type="file" id="files-${esc(r.id)}" multiple ${anyBusy() ? "disabled" : ""}>
+  return `<div class="act-row files"><input type="file" id="files-${esc(r.id)}" multiple ${busy("esc:" + r.id) ? "disabled" : ""}>
     <span class="dim">A reply may carry files.${where}</span></div>`;
 }
 
@@ -1496,8 +1548,8 @@ function replyFilesRow(r) {
 function answerField(r) {
   const id = "ans-" + r.id;
   return `<div class="act-row">
-    <input type="text" id="${esc(id)}" placeholder="answer in your own words…" ${anyBusy() ? "disabled" : ""}>
-    <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}',escRecord('${js(r.id)}'))">Answer</button>
+    <input type="text" id="${esc(id)}" placeholder="answer in your own words…" ${busy("esc:" + r.id) ? "disabled" : ""}>
+    <button class="btn sm primary" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}',escRecord('${js(r.id)}'))">Answer</button>
   </div>${replyFilesRow(r)}`;
 }
 
@@ -1692,12 +1744,12 @@ function gateCard(r) {
     ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview</a></div>` : ""}
     ${diffCard("esc:" + r.id, r.diff ?? null, r.diff_error ?? null, gateDiffQuery(r.id), r.pull_request)}
     <div class="act-row">
-      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${APPROVE}')">✅ Approve · merge</button>
-      <button class="btn sm" ${anyBusy() ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${CROSS_CHECK}')">🔎 Cross-check</button>
+      <button class="btn sm primary" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${APPROVE}')">✅ Approve · merge</button>
+      <button class="btn sm" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${CROSS_CHECK}')">🔎 Cross-check</button>
     </div>
     <div class="act-row">
-      <input type="text" id="${esc(id)}" placeholder="what to change — a rejection carries your words…" ${anyBusy() ? "disabled" : ""}>
-      <button class="btn sm danger" ${anyBusy() ? "disabled" : ""} onclick="rejectGate('${js(r.id)}','${js(id)}')">Reject</button>
+      <input type="text" id="${esc(id)}" placeholder="what to change — a rejection carries your words…" ${busy("esc:" + r.id) ? "disabled" : ""}>
+      <button class="btn sm danger" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="rejectGate('${js(r.id)}','${js(id)}')">Reject</button>
     </div>
     ${said("esc:" + r.id)}</div>`;
 }
@@ -2595,7 +2647,7 @@ function startRow(o, repo, n, showModel = true) {
     ? `<span class="dim-note mono">→ ${esc(n.model)} (${esc(typeOf(n))} default)</span>`
     : `<span class="dim-note">the routed model is not on this reading</span>`;
   return `<div class="act-row map-start">
-      <button class="btn sm primary" ${anyBusy() ? "disabled" : ""} onclick="startTicket('${js(repo)}','${js(n.number)}')">${
+      <button class="btn sm primary" ${busy(key) ? "disabled" : ""} onclick="startTicket('${js(repo)}','${js(n.number)}')">${
         busy(key) ? "Starting…" : "Start"}</button>${showModel ? model : ""}
     </div>
     ${live === undefined ? `<div class="dim-note">the fleet could not be read, so curia cannot say whether this one is already running</div>` : ""}
@@ -3208,7 +3260,7 @@ function setConnections(p) {
       ? `<p class="unread">GitHub App setup is pending until ${esc(ago(app.expires_at))}.</p>`
       : `<p class="unread">No GitHub App is configured. Create one from Atlas.</p>`;
   const create = app.configured ? "" : `<p><input id="github-app-name" value="curia-box" aria-label="GitHub App name">
-    <button class="btn primary" ${anyBusy() ? "disabled" : ""} onclick="doGitHubAppSetup()">Create GitHub App</button></p>
+    <button class="btn primary" ${busy("github-app") ? "disabled" : ""} onclick="doGitHubAppSetup()">Create GitHub App</button></p>
     ${said("github-app")}`;
   const manual = app.manual_url
     ? `<p class="qhint"><a href="${esc(app.manual_url)}" target="_blank" rel="noopener">Set up a GitHub App by hand on GitHub</a></p>` : "";
@@ -3218,7 +3270,7 @@ function setConnections(p) {
     : reading?.state === "failed"
       ? `<p class="unread">The installation read failed ${esc(ago(reading.at))}: ${esc(reading.error ?? "")}</p>`
       : `<p class="unread">Installations have not been read yet.</p>`;
-  const refresh = !app.configured ? "" : `<p><button class="btn" ${anyBusy() ? "disabled" : ""} onclick="doGitHubAppRefresh()">Re-read installations</button></p>
+  const refresh = !app.configured ? "" : `<p><button class="btn" ${busy("github-app-refresh") ? "disabled" : ""} onclick="doGitHubAppRefresh()">Re-read installations</button></p>
     ${said("github-app-refresh")}`;
   const owners = (app.owners ?? []).map((owner) => `<div class="row">
     <span class="key grow">${esc(owner.owner)}</span>
@@ -3647,7 +3699,7 @@ function chatList() {
 
 function newChatButton() {
   const k = "chat-new";
-  return `<p><button class="btn primary" ${anyBusy() ? "disabled" : ""} onclick="doNewConversation()">
+  return `<p><button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="doNewConversation()">
     ${busy(k) ? "Opening…" : "New conversation"}</button></p>${said(k)}`;
 }
 
@@ -3674,7 +3726,7 @@ function chatRow(c) {
   const facts = c.kind === "overseer"
     ? [c.key, ago(c.last_turn_at)]
     : [ticketName(c.repo, c.ticket), c.reviewer ? "reviewer" : null, c.live === false ? `ended · ${c.state ?? "archive"}` : (c.state ?? "working"), ago(c.last_turn_at)];
-  const remove = c.deletable === false ? "" : `<button class="btn sm" ${anyBusy() ? "disabled" : ""} onclick="doDeleteConversation('${js(c.key)}')">
+  const remove = c.deletable === false ? "" : `<button class="btn sm" ${busy(k) ? "disabled" : ""} onclick="doDeleteConversation('${js(c.key)}')">
       ${busy(k) ? "…" : "delete"}</button>`;
   return `<tr class="${c.live === false ? "ended" : ""}">
     <td><a href="${esc(chatHref(c.session))}">${label}</a>
@@ -3821,7 +3873,7 @@ function chatDialog(c) {
     return `<div class="chat-dialog">⚠ A native dialog owns the terminal. ${esc(d.reason || "Curia cannot parse its controls.")} ${terminal}
       <div class="dialog-note">Chat sends stay blocked while this dialog is open.</div></div>`;
   }
-  const options = d.card.options.map((o) => `<button class="btn sm ${o.index === d.card.selected_index ? "selected" : ""}" ${anyBusy() ? "disabled" : ""}
+  const options = d.card.options.map((o) => `<button class="btn sm ${o.index === d.card.selected_index ? "selected" : ""}" ${busy("chat-dialog") ? "disabled" : ""}
       onclick="doDialogAnswer('${js(d.card.id)}', ${Number(o.index)})">${esc(o.marker)} · ${esc(o.handle || o.label)}${o.index === d.card.selected_index ? " · selected now" : ""}</button>`).join("");
   return `<div class="chat-dialog card"><div class="dialog-kind">native dialog · choice</div>
     <strong class="dialog-headline">${esc(d.card.headline)}</strong>
@@ -3836,10 +3888,10 @@ function chatComposer(c, role, ended) {
     ${c.mirror ? `<div class="dim-note">the other device is typing…</div>` : ""}
     <textarea id="chat-box" rows="1" placeholder="type here, shared box" oninput="chatTyped(this.value)" onkeydown="chatKey(event)">${esc(c.draft)}</textarea>
     <div class="composer-row">
-      <button class="btn sm" ${anyBusy() ? "disabled" : ""} onclick="doTakeBack()" title="take back your last message">${busy("chat-take-back") ? "…" : "Take back"}</button>
-      ${role === "ticket" ? `<button class="btn sm" ${anyBusy() ? "disabled" : ""} onclick="doChatKey('escape')" title="send Escape to the agent">Esc</button>` : ""}
+      <button class="btn sm" ${busy("chat-take-back") ? "disabled" : ""} onclick="doTakeBack()" title="take back your last message">${busy("chat-take-back") ? "…" : "Take back"}</button>
+      ${role === "ticket" ? `<button class="btn sm" ${busy("chat-key") ? "disabled" : ""} onclick="doChatKey('escape')" title="send Escape to the agent">Esc</button>` : ""}
       <span class="grow"></span>
-      <button class="btn primary" ${anyBusy() ? "disabled" : ""} onclick="doChatSend()">${busy(k) ? "Sending…" : "Send"}</button>
+      <button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="doChatSend()">${busy(k) ? "Sending…" : "Send"}</button>
     </div>${said(k)}${said("chat-take-back")}${said("chat-key")}</div>`;
 }
 
@@ -3871,13 +3923,15 @@ function chatPost(p, extra) {
    failed keeps the words in the composer. */
 async function doChatSend() {
   const text = chat.draft;
-  if (!text.trim() || anyBusy()) return;
+  if (!text.trim()) return;
   if (chatEnded()) return refuse("chat-send", ENDED_SENTENCE(chat.session));
-  UI.act.busy = "chat-send"; UI.act.said = null;
+  const action = beginLocalAction("chat-send");
+  if (!action) return;
+  UI.act.said = null;
   chat.draft = "";
   render();
   const r = await chatPost("/send", { text });
-  UI.act.busy = null;
+  finishAction(action.action_id);
   if (r.error) {
     if (!r.unconfirmed) chat.draft = text;
     UI.act.said = { key: "chat-send", ok: false, text: (r.unconfirmed ? "send unconfirmed: " : "send failed: ") + r.error };
@@ -3886,11 +3940,12 @@ async function doChatSend() {
   render();
 }
 async function doTakeBack() {
-  if (anyBusy()) return;
-  UI.act.busy = "chat-take-back"; UI.act.said = null;
+  const action = beginLocalAction("chat-take-back");
+  if (!action) return;
+  UI.act.said = null;
   render();
   const r = await chatPost("/take-back", { target: null });
-  UI.act.busy = null;
+  finishAction(action.action_id);
   if (r.error) {
     UI.act.said = { key: "chat-take-back", ok: false, text: `take back failed: ${r.error}` };
   } else {
@@ -3901,20 +3956,22 @@ async function doTakeBack() {
   render();
 }
 async function doChatKey(key) {
-  if (anyBusy()) return;
-  UI.act.busy = "chat-key"; UI.act.said = null;
+  const action = beginLocalAction("chat-key");
+  if (!action) return;
+  UI.act.said = null;
   render();
   const r = await chatPost("/key", { key });
-  UI.act.busy = null;
+  finishAction(action.action_id);
   if (r.error) UI.act.said = { key: "chat-key", ok: false, text: r.error };
   render();
 }
 async function doDialogAnswer(dialog, index) {
-  if (anyBusy()) return;
-  UI.act.busy = "chat-dialog"; UI.act.said = null;
+  const action = beginLocalAction("chat-dialog");
+  if (!action) return;
+  UI.act.said = null;
   render();
   const r = await chatPost("/dialog-answer", { dialog, index });
-  UI.act.busy = null;
+  finishAction(action.action_id);
   if (r.receipt) chatReceive("dialog", { up: false, receipt: r.receipt });
   else UI.act.said = { key: "chat-dialog", ok: false, text: r.error || "Curia could not answer this native dialog." };
   render();
@@ -3929,12 +3986,12 @@ function chatAfterRender() {
 }
 
 async function doGitHubAppRefresh() {
-  if (anyBusy()) return;
+  if (busy("github-app-refresh")) return;
   await verb("github-app-refresh", "/api/github-app/refresh", {});
 }
 
 async function doGitHubAppSetup() {
-  if (anyBusy()) return;
+  if (busy("github-app")) return;
   const name = document.getElementById("github-app-name")?.value?.trim();
   if (!name) return refuse("github-app", "Enter a GitHub App name.");
   const out = await verb("github-app", "/api/github-app/start", { name });
@@ -4119,7 +4176,7 @@ function credSignIn(c, signer) {
   /* What curia answered sits at the control that asked, once — the press was on
      this row, and the other row of a shared provider offers no button to hang a
      second copy of it on. */
-  return `<button class="btn primary" ${anyBusy() ? "disabled" : ""} onclick="startReauth('${js(c.provider)}')">
+  return `<button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="startReauth('${js(c.provider)}')">
     ${busy(k) ? "…" : "Sign in from a browser"}</button>${said(k)}`;
 }
 const startReauth = (provider) => verb("reauth:" + provider, "/api/reauth", { provider });
@@ -4474,6 +4531,7 @@ async function tick() {
     const res = await fetch("/api/overview", { headers: { accept: "application/json" }, cache: "no-store" });
     if (!res.ok) throw new Error("the sidecar answered " + res.status);
     payload = await res.json();
+    observeActions(payload?.overview?.actions);
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3979,12 +3979,13 @@ function chatDialog(c) {
 function chatComposer(c, role, ended) {
   if (ended) return `<div class="composer ended"><span class="dim-note">${esc(ENDED_SENTENCE(c.session))}</span></div>`;
   const k = "chat-send";
+  const paneKey = actionFor({ conflict_key: `pane:${c.session}` });
   return `<div class="composer">
     ${c.mirror ? `<div class="dim-note">the other device is typing…</div>` : ""}
     <textarea id="chat-box" rows="1" placeholder="type here, shared box" oninput="chatTyped(this.value)" onkeydown="chatKey(event)">${esc(c.draft)}</textarea>
     <div class="composer-row">
       <button class="btn sm" ${busy("chat-take-back") ? "disabled" : ""} onclick="doTakeBack()" title="take back your last message">${busy("chat-take-back") ? "…" : "Take back"}</button>
-      ${role === "ticket" ? `<button class="btn sm" ${busy("chat-key") ? "disabled" : ""} onclick="doChatKey('escape')" title="send Escape to the agent">Esc</button>` : ""}
+      ${role === "ticket" ? `<button class="btn sm" ${paneKey ? "disabled" : ""} onclick="doChatKey('escape')" title="send Escape to the agent">${paneKey ? "Sending Esc…" : "Esc"}</button>` : ""}
       <span class="grow"></span>
       <button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="doChatSend()">${busy(k) ? "Sending…" : "Send"}</button>
     </div>${said(k)}${said("chat-take-back")}${said("chat-key")}</div>`;
@@ -4051,14 +4052,32 @@ async function doTakeBack() {
   render();
 }
 async function doChatKey(key) {
-  const action = beginLocalAction("chat-key");
+  const session = chat.session;
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "pane-key", target: session,
+    conflict_key: `pane:${session}`, projection: { key },
+  });
   if (!action) return;
   UI.act.said = null;
   render();
-  const r = await chatPost("/key", { key });
-  finishAction(action.action_id);
-  if (r.error) UI.act.said = { key: "chat-key", ok: false, text: r.error };
+  const r = await chatPost("/key", { key, action_id: actionId });
+  observeActions(r.action ? [r.action] : []);
+  reconcilePaneKeyActions();
+  if (actionFor({ action_id: actionId }) && !r.action) {
+    finishAction(actionId);
+    if (r.error) UI.act.said = { key: "chat-key", ok: false, text: r.error };
+  }
   render();
+}
+function reconcilePaneKeyActions() {
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "pane-key" || !TERMINAL_ACTION.has(action.status)) continue;
+    if (action.target === chat.session && action.status !== "confirmed") {
+      UI.act.said = { key: "chat-key", ok: false, text: action.reason || "Curia could not send the pane key." };
+    }
+    finishAction(action.action_id);
+  }
 }
 async function doDialogAnswer(dialog, index) {
   const action = beginLocalAction("chat-dialog");
@@ -4628,6 +4647,7 @@ async function tick() {
     payload = await res.json();
     observeActions(payload?.overview?.actions);
     reconcileStartActions(payload?.overview);
+    reconcilePaneKeyActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -793,7 +793,7 @@ var UI = {
   /* Which agent the detail half shows, and whether the phone is on it (#709).
      `open` is the route's, never a width's. */
   agents: { selected: null, open: false },
-  feed: { lastRead: null, operator: null, focus: null, family: "all" },
+  feed: { lastRead: null, operator: null, focus: null, family: "all", note: null },
   search: { open: false, q: "", loading: false, error: null, result: null },
   /* The settings screen's own state (#265). `phase` is what the banner says:
      clean and dirty before a save, then the three outcomes a save can have
@@ -2813,6 +2813,7 @@ function screenFeed(p) {
   if (!o) return noSnapshot(p, "Feed");
   const n = o.events?.length ?? 0;
   return `${head(p, "Feed", `<span class="dim-note">the journal's last ${esc(n)} event(s)</span>`)}
+    ${UI.feed.note ? `<div class="unread">${esc(UI.feed.note)}</div>` : ""}
     ${atlasFeed(o)}<details class="legacy-feed"><summary>Journal rows</summary>${feedList(o.events)}</details>`;
 }
 
@@ -5078,12 +5079,46 @@ function enter(k) {
    Feed draws the marker at the PREVIOUS stamp and posts this visit; the marker
    holds still until the next visit, so the page does not move it under the
    reader on every poll. */
-function recordFeedVisit() {
+async function recordFeedVisit() {
   const operator = payload?.operator;
   if (!operator) return;
   const previous = payload?.overview?.feed_reads?.[operator] ?? UI.feed.lastRead ?? null;
   UI.feed = { ...UI.feed, lastRead: previous, operator };
-  fetch("/api/feed/read", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" }).catch(() => {});
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "feed-read", target: operator,
+    conflict_key: "feed-read:" + operator, projection: { previous },
+  });
+  if (!action) return;
+  UI.feed.note = null;
+  try {
+    const res = await fetch("/api/feed/read", {
+      method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ action_id: actionId }),
+    });
+    const body = await res.json().catch(() => ({}));
+    observeActions(body.action ? [body.action] : []);
+    if (!body.action && !res.ok) throw new Error(body.error || ("the sidecar answered " + res.status));
+    reconcileFeedReadActions();
+  } catch (error) {
+    const current = actionFor({ action_id: actionId });
+    if (!current || current.status === "pending") {
+      UI.feed.note = `Could not confirm this Feed visit: ${error.message}. Your next visit will try again.`;
+      finishAction(actionId);
+    } else {
+      UI.feed.note = `Checking whether this Feed visit was recorded: ${error.message}`;
+    }
+  }
+  render();
+}
+
+function reconcileFeedReadActions() {
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "feed-read" || !TERMINAL_ACTION.has(action.status)) continue;
+    if (action.status === "confirmed") UI.feed.note = null;
+    else UI.feed.note = `Feed visit was not recorded: ${action.reason || "curia gave no reason"}.`;
+    finishAction(action.action_id);
+  }
 }
 /* Arriving at Maps from the nav is the LIST, always. The detail is a route of
    its own, so a tab press that did not name one must not land on the last one
@@ -5139,6 +5174,7 @@ async function tick() {
     reconcileConversationActions();
     reconcileSettingsActions();
     reconcileCredentialActions();
+    reconcileFeedReadActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3354,8 +3354,11 @@ function setConnections(p) {
     : app.status === "pending"
       ? `<p class="unread">GitHub App setup is pending until ${esc(ago(app.expires_at))}.</p>`
       : `<p class="unread">No GitHub App is configured. Create one from Atlas.</p>`;
+  const setupAction = actionFor({ conflict_key: "github-app:setup" });
+  const refreshAction = actionFor({ conflict_key: "github-app:installations" });
   const create = app.configured ? "" : `<p><input id="github-app-name" value="curia-box" aria-label="GitHub App name">
-    <button class="btn primary" ${busy("github-app") ? "disabled" : ""} onclick="doGitHubAppSetup()">Create GitHub App</button></p>
+    <button class="btn primary" ${setupAction ? "disabled" : ""} onclick="doGitHubAppSetup()">Create GitHub App</button></p>
+    ${setupAction ? `<p class="qhint">${esc(setupAction.progress || "Starting GitHub App setup")}</p>` : ""}
     ${said("github-app")}`;
   const manual = app.manual_url
     ? `<p class="qhint"><a href="${esc(app.manual_url)}" target="_blank" rel="noopener">Set up a GitHub App by hand on GitHub</a></p>` : "";
@@ -3365,7 +3368,8 @@ function setConnections(p) {
     : reading?.state === "failed"
       ? `<p class="unread">The installation read failed ${esc(ago(reading.at))}: ${esc(reading.error ?? "")}</p>`
       : `<p class="unread">Installations have not been read yet.</p>`;
-  const refresh = !app.configured ? "" : `<p><button class="btn" ${busy("github-app-refresh") ? "disabled" : ""} onclick="doGitHubAppRefresh()">Re-read installations</button></p>
+  const refresh = !app.configured ? "" : `<p><button class="btn" ${refreshAction ? "disabled" : ""} onclick="doGitHubAppRefresh()">Re-read installations</button></p>
+    ${refreshAction ? `<p class="qhint">${esc(refreshAction.progress || "Starting the installation read")}</p>` : ""}
     ${said("github-app-refresh")}`;
   const owners = (app.owners ?? []).map((owner) => `<div class="row">
     <span class="key grow">${esc(owner.owner)}</span>
@@ -4137,26 +4141,78 @@ function chatAfterRender() {
 }
 
 async function doGitHubAppRefresh() {
-  if (busy("github-app-refresh")) return;
-  await verb("github-app-refresh", "/api/github-app/refresh", {});
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "github-app-installations", target: "github-app-installations",
+    conflict_key: "github-app:installations", projection: { phase: "reading" },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
+  return githubAppAction("github-app-refresh", "/api/github-app/refresh", actionId, {});
 }
 
 async function doGitHubAppSetup() {
-  if (busy("github-app")) return;
   const name = document.getElementById("github-app-name")?.value?.trim();
   if (!name) return refuse("github-app", "Enter a GitHub App name.");
-  const out = await verb("github-app", "/api/github-app/start", { name });
-  if (!out?.action || !out?.manifest) return;
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "github-app-setup", target: "github-app-setup",
+    conflict_key: "github-app:setup", projection: { phase: "opening-github" },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
+  const out = await githubAppAction("github-app", "/api/github-app/start", actionId, { name });
+  const setup = out?.setup;
+  if (!setup?.action || !setup?.manifest) return;
   const form = document.createElement("form");
   form.method = "POST";
-  form.action = out.action;
+  form.action = setup.action;
   const manifest = document.createElement("input");
   manifest.type = "hidden";
   manifest.name = "manifest";
-  manifest.value = JSON.stringify(out.manifest);
+  manifest.value = JSON.stringify(setup.manifest);
   form.appendChild(manifest);
   document.body.appendChild(form);
   form.submit();
+}
+
+async function githubAppAction(key, path, actionId, body) {
+  try {
+    const res = await fetch(path, {
+      method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ ...body, action_id: actionId }),
+    });
+    const out = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(out.error || ("the console answered " + res.status));
+    observeActions(out.action ? [out.action] : []);
+    reconcileGitHubAppActions();
+    render();
+    tick();
+    return out;
+  } catch (error) {
+    const current = actionFor({ action_id: actionId });
+    if (!current || current.status === "pending") {
+      finishAction(actionId);
+      UI.act.said = { key, text: error.message, ok: false };
+    }
+    render();
+    return null;
+  }
+}
+
+function reconcileGitHubAppActions() {
+  for (const action of [...actions.values()]) {
+    if (!["github-app-setup", "github-app-installations"].includes(action.kind) || !TERMINAL_ACTION.has(action.status)) continue;
+    const key = action.kind === "github-app-setup" ? "github-app" : "github-app-refresh";
+    if (action.status !== "confirmed") {
+      UI.act.said = { key, ok: false, text: action.reason || "The GitHub App action failed." };
+    } else if (action.receipt?.reply) {
+      UI.act.said = { key, ok: true, text: action.receipt.reply };
+    }
+    finishAction(action.action_id);
+  }
 }
 
 /* ---- credentials (#661, the shape the #645 prototype settled) ---------------
@@ -4686,6 +4742,7 @@ async function tick() {
     reconcileStartActions(payload?.overview);
     reconcilePaneKeyActions();
     reconcileDialogAnswerActions();
+    reconcileGitHubAppActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -40,7 +40,7 @@
      2. Null is not empty. An unreadable fleet is not an idle box, and a frontier
         nobody has computed is not an empty frontier. Every section that can fail
         on its own says which of the two it is. -->
-<meta name="curia-dashboard" content="proto=14">
+<meta name="curia-dashboard" content="proto=15">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark light">
 <title>Atlas · Curia</title>
@@ -4559,13 +4559,16 @@ function credFlow(r) {
    look. It shows only on the rows of the provider it belongs to. */
 function credRow(c, signer, flow, ended) {
   const st = credState(c);
+  const signInAction = actionFor({ conflict_key: "reauth:" + c.provider });
   /* A login already running on this provider is the act. Offering a second
      Sign-in press beside the panel that is mid-flow would start nothing — the
      flow hands back the session it already has — and would read as two ways in
      where there is one. */
-  const signing = flow && flow.state === "waiting" && flow.provider === c.provider;
+  const signing = (flow && flow.state === "waiting" && flow.provider === c.provider)
+    || (signInAction && !TERMINAL_ACTION.has(signInAction.status));
+  const signingProgress = signInAction?.progress ?? (signInAction ? "Starting sign-in" : "signing in now");
   const act = signing
-    ? `<span class="dim-note">signing in now — the link is in the panel above</span>`
+    ? `<span class="dim-note">${esc(signingProgress)}${flow?.provider === c.provider ? " — the link is in the panel above" : "…"}</span>`
     : credWants(c)
       ? (c.provider && signer.has(c.provider)
         ? `<span class="dim-note">the same login signs this in</span>`
@@ -4611,7 +4614,53 @@ function credSignIn(c, signer) {
   return `<button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="startReauth('${js(c.provider)}')">
     ${busy(k) ? "…" : "Sign in from a browser"}</button>${said(k)}`;
 }
-const startReauth = (provider) => verb("reauth:" + provider, "/api/reauth", { provider });
+
+async function startReauth(provider) {
+  const key = "reauth:" + provider;
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "credential-sign-in", target: provider, conflict_key: key,
+    projection: { phase: "starting" },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
+  try {
+    const res = await fetch("/api/reauth", {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ provider, action_id: actionId }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(body.error || ("the console answered " + res.status));
+    observeActions(body.action ? [body.action] : []);
+    reconcileCredentialActions();
+  } catch (error) {
+    const current = actionFor({ action_id: actionId });
+    // Shared daemon progress outranks a sidecar timeout on the older request.
+    if (!current || current.status === "pending") {
+      UI.act.said = { key, text: error.message, ok: false };
+      finishAction(actionId);
+    }
+  }
+  render();
+  tick();
+  return actionFor({ action_id: actionId });
+}
+
+function reconcileCredentialActions() {
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "credential-sign-in" || !TERMINAL_ACTION.has(action.status)) continue;
+    if (action.status !== "confirmed") {
+      UI.act.said = {
+        key: action.conflict_key,
+        text: action.reason || "Curia could not complete this credential sign-in.",
+        ok: false,
+      };
+    }
+    finishAction(action.action_id);
+  }
+}
 
 function screenCredentials(p) {
   const o = p?.overview;
@@ -5029,6 +5078,7 @@ async function tick() {
     reconcileAistackActions();
     reconcileConversationActions();
     reconcileSettingsActions();
+    reconcileCredentialActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3689,7 +3689,14 @@ function chatReceive(name, d) {
   } else if (name === "parse") {
     c.parse = d;
   } else if (name === "dialog") {
-    if (d.receipt) { c.receipt = d.receipt; c.dialog = null; }
+    if (d.receipt) {
+      c.receipt = d.receipt; c.dialog = null;
+      for (const action of [...actions.values()]) {
+        if (action.kind === "native-dialog-answer" && action.target === `${c.session}:${d.receipt.dialog}`) {
+          finishAction(action.action_id);
+        }
+      }
+    }
     else if (!d.up) { c.dialog = null; }
     else { c.dialog = d; c.receipt = null; }
   } else if (name === "escalations") {
@@ -3968,12 +3975,16 @@ function chatDialog(c) {
     return `<div class="chat-dialog">⚠ A native dialog owns the terminal. ${esc(d.reason || "Curia cannot parse its controls.")} ${terminal}
       <div class="dialog-note">Chat sends stay blocked while this dialog is open.</div></div>`;
   }
-  const options = d.card.options.map((o) => `<button class="btn sm ${o.index === d.card.selected_index ? "selected" : ""}" ${busy("chat-dialog") ? "disabled" : ""}
+  const dialogAction = actionFor({ conflict_key: `dialog:${c.session}:${d.card.id}` });
+  const options = d.card.options.map((o) => `<button class="btn sm ${o.index === d.card.selected_index ? "selected" : ""}" ${dialogAction ? "disabled" : ""}
       onclick="doDialogAnswer('${js(d.card.id)}', ${Number(o.index)})">${esc(o.marker)} · ${esc(o.handle || o.label)}${o.index === d.card.selected_index ? " · selected now" : ""}</button>`).join("");
+  const progress = dialogAction
+    ? `<div class="dialog-note">${esc(dialogAction.progress || `Choosing ${dialogAction.projection?.marker ?? ""} · ${dialogAction.projection?.answer ?? ""}…`)}</div>`
+    : "";
   return `<div class="chat-dialog card"><div class="dialog-kind">native dialog · choice</div>
     <strong class="dialog-headline">${esc(d.card.headline)}</strong>
     <div class="dialog-options">${options}</div>
-    <div class="dialog-note">The first valid tap wins. The same receipt reaches every open Chat.</div>${terminal}${said("chat-dialog")}</div>`;
+    ${progress}<div class="dialog-note">The first valid tap wins. The same receipt reaches every open Chat.</div>${terminal}${said("chat-dialog")}</div>`;
 }
 
 function chatComposer(c, role, ended) {
@@ -4080,15 +4091,41 @@ function reconcilePaneKeyActions() {
   }
 }
 async function doDialogAnswer(dialog, index) {
-  const action = beginLocalAction("chat-dialog");
+  const session = chat.session;
+  const option = chat.dialog?.card?.id === dialog
+    ? chat.dialog.card.options.find((candidate) => candidate.index === index)
+    : null;
+  if (!option) return;
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "native-dialog-answer", target: `${session}:${dialog}`,
+    conflict_key: `dialog:${session}:${dialog}`,
+    projection: { index, marker: option.marker, answer: option.handle || option.label },
+  });
   if (!action) return;
   UI.act.said = null;
   render();
-  const r = await chatPost("/dialog-answer", { dialog, index });
-  finishAction(action.action_id);
-  if (r.receipt) chatReceive("dialog", { up: false, receipt: r.receipt });
-  else UI.act.said = { key: "chat-dialog", ok: false, text: r.error || "Curia could not answer this native dialog." };
+  const r = await chatPost("/dialog-answer", { dialog, index, action_id: actionId });
+  observeActions(r.action ? [r.action] : []);
+  reconcileDialogAnswerActions();
+  if (actionFor({ action_id: actionId }) && !r.action) {
+    finishAction(actionId);
+    if (r.receipt) chatReceive("dialog", { up: false, receipt: r.receipt });
+    else UI.act.said = { key: "chat-dialog", ok: false, text: r.error || "Curia could not answer this native dialog." };
+  }
   render();
+}
+function reconcileDialogAnswerActions() {
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "native-dialog-answer" || !TERMINAL_ACTION.has(action.status)) continue;
+    const receipt = action.receipt;
+    if (receipt && action.target === `${chat.session}:${receipt.dialog}`) {
+      chatReceive("dialog", { up: false, receipt });
+    } else if (action.target.startsWith(`${chat.session}:`) && action.status !== "confirmed") {
+      UI.act.said = { key: "chat-dialog", ok: false, text: action.reason || "Curia could not answer this native dialog." };
+    }
+    finishAction(action.action_id);
+  }
 }
 function chatScrolled(el) {
   chat.stick = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
@@ -4648,6 +4685,7 @@ async function tick() {
     observeActions(payload?.overview?.actions);
     reconcileStartActions(payload?.overview);
     reconcilePaneKeyActions();
+    reconcileDialogAnswerActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3804,7 +3804,7 @@ function chatList() {
 }
 
 function newChatButton() {
-  const k = "chat-new";
+  const k = "conversation-registry";
   return `<p><button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="doNewConversation()">
     ${busy(k) ? "Opening…" : "New conversation"}</button></p>${said(k)}`;
 }
@@ -3816,7 +3816,8 @@ function chatTitle(c) {
   return c.label || ticketName(c.repo, c.ticket) || c.session;
 }
 function chatRow(c) {
-  const k = "chat-del-" + c.key;
+  const k = "conversation:" + c.key;
+  const deleting = actionFor({ conflict_key: k })?.kind === "console-conversation-delete";
   const title = chatTitle(c);
   const label = title ? `<b>${esc(title)}</b>` : `<span class="dim-note">no turn yet</span>`;
   const answer = said(k);
@@ -3833,7 +3834,7 @@ function chatRow(c) {
     ? [c.key, ago(c.last_turn_at)]
     : [ticketName(c.repo, c.ticket), c.reviewer ? "reviewer" : null, c.live === false ? `ended · ${c.state ?? "archive"}` : (c.state ?? "working"), ago(c.last_turn_at)];
   const remove = c.deletable === false ? "" : `<button class="btn sm" ${busy(k) ? "disabled" : ""} onclick="doDeleteConversation('${js(c.key)}')">
-      ${busy(k) ? "…" : "delete"}</button>`;
+      ${deleting ? "deleting…" : "delete"}</button>`;
   return `<tr class="${c.live === false ? "ended" : ""}">
     <td><a href="${esc(chatHref(c.session))}">${label}</a>
       <span class="dim-note mono" style="display:block;margin:2px 0 0">${facts.filter(Boolean).map(esc).join(" · ")}</span>${dropped}</td>
@@ -3845,16 +3846,70 @@ function chatRow(c) {
 /* Mint, then walk through the door. Opening a conversation you then have to
    find in a list is two acts where the operator asked for one. */
 async function doNewConversation() {
-  const out = await verb("chat-new", "/api/console/new", {});
-  if (out?.session) location.hash = chatRoute(out.session);
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "console-conversation-open", target: "conversation-registry",
+    conflict_key: "conversation-registry", projection: { navigate: true },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
+  return conversationAction("conversation-registry", "/api/console/new", actionId, {});
 }
 
 async function doDeleteConversation(key) {
   const ask = `Delete ${key}? Its number is spent for good — a later conversation never reuses it. `
     + `curia stops offering the conversation, and its transcript stays on the box.`;
   if (typeof confirm === "function" && !confirm(ask)) return;
-  await verb("chat-del-" + key, "/api/console/delete", { key });
-  loadConversations();
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "console-conversation-delete", target: key,
+    conflict_key: `conversation:${key}`, projection: { deleting: true },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
+  return conversationAction(`conversation:${key}`, "/api/console/delete", actionId, { key });
+}
+
+async function conversationAction(key, path, actionId, body) {
+  try {
+    const res = await fetch(path, {
+      method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ ...body, action_id: actionId }),
+    });
+    const out = await res.json().catch(() => ({}));
+    if (!res.ok && !out.action) throw new Error(out.error || ("the console answered " + res.status));
+    observeActions(out.action ? [out.action] : []);
+    await reconcileConversationActions();
+    render();
+    tick();
+    return out;
+  } catch (error) {
+    const current = actionFor({ action_id: actionId });
+    if (!current || current.status === "pending") {
+      UI.act.said = { key, text: `Curia could not check the outcome yet: ${error.message}`, ok: false };
+    }
+    render();
+    return null;
+  }
+}
+
+async function reconcileConversationActions() {
+  for (const action of [...actions.values()]) {
+    if (!["console-conversation-open", "console-conversation-delete"].includes(action.kind)
+      || !TERMINAL_ACTION.has(action.status)) continue;
+    const key = action.conflict_key;
+    if (action.kind === "console-conversation-open" && action.status === "confirmed") {
+      if (action.projection?.navigate && action.receipt?.session) location.hash = chatRoute(action.receipt.session);
+    } else if (action.kind === "console-conversation-delete" && action.status === "confirmed") {
+      await loadConversations();
+    } else {
+      UI.act.said = { key, ok: false, text: action.reason || "Curia could not change the conversation." };
+      if (action.kind === "console-conversation-delete") await loadConversations();
+    }
+    finishAction(action.action_id);
+  }
 }
 
 /* ---- the room ---- */
@@ -4743,6 +4798,7 @@ async function tick() {
     reconcilePaneKeyActions();
     reconcileDialogAnswerActions();
     reconcileGitHubAppActions();
+    reconcileConversationActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3715,6 +3715,7 @@ function chatFresh(session) {
   };
 }
 var chat = chatFresh(null);
+var settledChatTakeBackActions = new Set();
 
 /* The route decides the view (#700's rule): a reload and a back press land
    where they were, and the tab press lands on the picker. */
@@ -4125,14 +4126,16 @@ function chatComposer(c, role, ended) {
   const k = `turn:${chatConversationKey(c.session)}`;
   const messageAction = actionFor({ conflict_key: k });
   const messageProgress = messageAction
-    ? `<div class="dialog-note">${esc(messageAction.progress || "Sending your message…")}</div>`
+    ? `<div class="dialog-note">${esc(messageAction.progress || (messageAction.kind === "chat-take-back"
+      ? messageAction.projection?.mode === "note-recovery" ? "Recovering your note…" : "Rewinding the conversation…"
+      : "Sending your message…"))}</div>`
     : "";
   const paneKey = actionFor({ conflict_key: `pane:${c.session}` });
   return `<div class="composer">
     ${c.mirror ? `<div class="dim-note">the other device is typing…</div>` : ""}
     <textarea id="chat-box" rows="1" placeholder="type here, shared box" oninput="chatTyped(this.value)" onkeydown="chatKey(event)">${esc(c.draft)}</textarea>
     <div class="composer-row">
-      <button class="btn sm" ${busy("chat-take-back") ? "disabled" : ""} onclick="doTakeBack()" title="take back your last message">${busy("chat-take-back") ? "…" : "Take back"}</button>
+      <button class="btn sm" ${messageAction ? "disabled" : ""} onclick="doTakeBack()" title="take back your last message">${messageAction?.kind === "chat-take-back" ? "Rewinding…" : "Take back"}</button>
       ${role === "ticket" ? `<button class="btn sm" ${paneKey ? "disabled" : ""} onclick="doChatKey('escape')" title="send Escape to the agent">${paneKey ? "Sending Esc…" : "Esc"}</button>` : ""}
       <span class="grow"></span>
       <button class="btn primary" ${messageAction ? "disabled" : ""} onclick="doChatSend()">${messageAction ? "Sending…" : "Send"}</button>
@@ -4207,21 +4210,52 @@ function reconcileChatMessageActions() {
     finishAction(action.action_id);
   }
 }
-async function doTakeBack() {
-  const action = beginLocalAction("chat-take-back");
+async function doTakeBack(target = null) {
+  if (chatEnded()) return refuse("chat-take-back", ENDED_SENTENCE(chat.session));
+  const warning = "Take back your last message? Curia rewinds the conversation, but commands, commits, and other effects that already ran still stand.";
+  if (typeof confirm === "function" && !confirm(warning)) return null;
+  const conversation = chatConversationKey(chat.session);
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "chat-take-back", target: conversation,
+    conflict_key: `turn:${conversation}`,
+    projection: { mode: target?.kind === "note" ? "note-recovery" : "rewind" },
+  });
   if (!action) return;
   UI.act.said = null;
   render();
-  const r = await chatPost("/take-back", { target: null });
-  finishAction(action.action_id);
-  if (r.error) {
-    UI.act.said = { key: "chat-take-back", ok: false, text: `take back failed: ${r.error}` };
-  } else {
-    chat.draft = r.composer || "";
-    chatPost("/draft", { text: chat.draft });
-    chatNote([r.receipt?.headline, r.receipt?.landing, ...(r.receipt?.remains || [])].filter(Boolean).join(" "));
+  const r = await chatPost("/take-back", { target, action_id: actionId });
+  observeActions(r.action ? [r.action] : []);
+  reconcileChatTakeBackActions();
+  if (actionFor({ action_id: actionId }) && !r.action && r.error) {
+    UI.act.said = { key: `turn:${conversation}`, ok: false, text: `Curia could not check the take back yet: ${r.error}` };
   }
   render();
+}
+function reconcileChatTakeBackActions() {
+  const conversation = chatConversationKey(chat.session);
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "chat-take-back" || action.target !== conversation || !TERMINAL_ACTION.has(action.status)) continue;
+    const receipt = action.receipt;
+    if (action.status === "confirmed" && receipt) {
+      chat.draft = receipt.composer || "";
+      const taken = receipt.take_back;
+      chatNote([taken?.headline, taken?.landing, ...(taken?.remains || [])].filter(Boolean).join(" "));
+    } else {
+      UI.act.said = { key: action.conflict_key, ok: false, text: action.reason || "Curia could not take back the message." };
+    }
+    settledChatTakeBackActions.add(action.action_id);
+    finishAction(action.action_id);
+  }
+}
+function recoverTerminalChatTakeBackActions(observed) {
+  const conversation = chatConversationKey(chat.session);
+  for (const evidence of observed ?? []) {
+    if (evidence?.kind !== "chat-take-back" || evidence.target !== conversation
+      || !TERMINAL_ACTION.has(evidence.status) || settledChatTakeBackActions.has(evidence.action_id)
+      || actionFor({ action_id: evidence.action_id })) continue;
+    actions.set(String(evidence.action_id), { ...evidence, action_id: String(evidence.action_id) });
+  }
 }
 async function doChatKey(key) {
   const session = chat.session;
@@ -4950,9 +4984,11 @@ async function tick() {
     if (!res.ok) throw new Error("the sidecar answered " + res.status);
     payload = await res.json();
     observeActions(payload?.overview?.actions);
+    recoverTerminalChatTakeBackActions(payload?.overview?.actions);
     reconcileStartActions(payload?.overview);
     reconcileAnswerActions(payload?.overview);
     reconcileChatMessageActions();
+    reconcileChatTakeBackActions();
     reconcilePaneKeyActions();
     reconcileDialogAnswerActions();
     reconcileGitHubAppActions();

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1071,7 +1071,40 @@ function typed(id) {
 
 /* ---- the verbs themselves ---- */
 
-const startTicket = (repo, ticket) => verb(`start:${repo}#${ticket}`, "/api/start", { repo, ticket: String(ticket) });
+async function startTicket(repo, ticket) {
+  const target = `${repo}#${ticket}`;
+  const key = `start:${target}`;
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "dispatch", target, conflict_key: `dispatch:${target}`,
+    projection: { phase: "starting" },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
+  try {
+    const res = await fetch("/api/start", {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ repo, ticket: String(ticket), action_id: actionId }),
+    });
+    const b = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(b.error || ("the console answered " + res.status));
+    observeActions(b.action ? [b.action] : []);
+    reconcileStartActions(payload?.overview);
+  } catch (e) {
+    const current = actionFor({ action_id: actionId });
+    /* Shared progress outranks a late transport warning. The overview poll can
+       observe acceptance while the original browser request is still ending. */
+    if (!current || current.status === "pending") {
+      UI.act.said = { key, text: e.message, ok: false };
+      finishAction(actionId);
+    }
+  }
+  render();
+  tick();
+  return actionFor({ action_id: actionId });
+}
 /* One answer, three shapes (#712, ADR-0025): words, an option index, or
    files. The index is what a button, a select and a numbered reply all send,
    so a Discord press and an Atlas tap resolve the same option. Files ride the
@@ -2409,6 +2442,67 @@ function mapSnapshot(o) {
 function mapsOf(o) {
   return mapSnapshot(o).maps ?? [];
 }
+
+function startActionFor(repo, number) {
+  const action = actionFor({ target: `${repo}#${number}` });
+  return action?.kind === "dispatch" ? action : null;
+}
+
+function projectedMap(map) {
+  const inFlight = (map.in_flight ?? []).map((item) => ({
+    ...item, action: startActionFor(map.repo, item.number),
+  }));
+  const promoted = [];
+  const takeable = (map.takeable ?? []).filter((item) => {
+    const action = startActionFor(map.repo, item.number);
+    if (!action || action.status === "refused" || action.status === "failed") return true;
+    if (!inFlight.some((running) => String(running.number) === String(item.number))) {
+      promoted.push({ ...item, action });
+    }
+    return false;
+  });
+  if (!promoted.length && takeable.length === (map.takeable ?? []).length) {
+    return { ...map, in_flight: inFlight };
+  }
+  return {
+    ...map,
+    in_flight: [...inFlight, ...promoted],
+    takeable,
+    counts: {
+      ...map.counts,
+      in_flight: Number(map.counts?.in_flight ?? inFlight.length) + promoted.length,
+      takeable: Math.max(0, Number(map.counts?.takeable ?? takeable.length) - promoted.length),
+    },
+  };
+}
+
+function reconcileStartActions(o) {
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "dispatch" || !TERMINAL_ACTION.has(action.status)) continue;
+    const split = /^(.*)#([^#]+)$/.exec(action.target);
+    if (!split) continue;
+    const [, repo, ticket] = split;
+    const key = `start:${action.target}`;
+    if (action.status === "refused" || action.status === "failed") {
+      UI.act.said = { key, text: action.reason ?? (action.status === "refused" ? "Start was refused." : "Start failed."), ok: false };
+      finishAction(action.action_id);
+      continue;
+    }
+    const running = agentOn(o, repo, ticket)
+      || mapsOf(o).some((map) => map.repo === repo
+        && (map.in_flight ?? []).some((item) => String(item.number) === ticket));
+    if (running) finishAction(action.action_id);
+  }
+}
+
+function startPhase(action) {
+  if (!action) return null;
+  if (action.status === "pending") return "starting";
+  if (action.status === "accepted") return "claimed · opening the thread";
+  if (action.status === "progress") return action.progress ?? "preparing the agent workspace";
+  if (action.status === "confirmed") return "running";
+  return null;
+}
 /* The fog is a list of facts, each with its own text — never a bare string,
    so a later reading can hang more on a patch without moving this page. */
 const fogText = (note) => String(note?.text ?? note ?? "");
@@ -2430,7 +2524,8 @@ function visibleMaps(o) {
   return mapsOf(o)
     .filter((map) => UI.maps.repo === "all" || map.repo === UI.maps.repo)
     .sort((a, b) => Number(mapNeeds(o, b)) - Number(mapNeeds(o, a))
-      || Date.parse(b.latest_event_at ?? 0) - Date.parse(a.latest_event_at ?? 0));
+      || Date.parse(b.latest_event_at ?? 0) - Date.parse(a.latest_event_at ?? 0))
+    .map(projectedMap);
 }
 
 function selectedMap(o, maps) {
@@ -2505,7 +2600,7 @@ function mapDetailRows(o, map, group) {
       const agent = item.agent ?? agentOn(o, map.repo, item.number);
       const who = (item.assignees ?? []).join(", ");
       return `<div class="map-detail-row">${issue}<span class="sub">${
-        mapNeeds(o, { ...map, in_flight: [item] }) ? "needs you" : "working"}${
+        startPhase(item.action) ?? (mapNeeds(o, { ...map, in_flight: [item] }) ? "needs you" : "working")}${
         who ? ` · ${esc(who)}` : ""}${agent?.model ? ` · ${esc(agent.model)}` : ""}</span></div>`;
     }
     return `<div class="map-detail-row">${issue}<span class="sub">done</span></div>`;
@@ -2520,7 +2615,7 @@ function mapDetail(o, map) {
     <a class="map-back" href="#maps" onclick="mapBack();return false">\u2039 maps</a>
     <h3>${esc(map.title)} · full map</h3>${mapBand(o, map, true)}<div class="map-rail">${MAP_GROUPS.map(([group, word]) => {
       const needs = group === "in_flight" && mapNeeds(o, map);
-      const working = group === "in_flight" && (map.in_flight ?? []).some((item) => item.agent ?? agentOn(o, map.repo, item.number));
+      const working = group === "in_flight" && (map.in_flight ?? []).some((item) => item.action ?? item.agent ?? agentOn(o, map.repo, item.number));
       const count = Number(map.counts?.[group] ?? 0);
       return `<section class="map-stage ${group.replace("_", "-")}${needs ? " needs" : ""}" style="--stage:${
         group === "walked" ? "var(--map-done-ink)" : group === "in_flight" ? "var(--map-run-line)" : group === "takeable" ? "var(--accent)" : group === "blocked" ? "color-mix(in srgb, var(--bad) 72%, var(--ink-dim))" : "var(--ink-dim)"}">
@@ -4532,6 +4627,7 @@ async function tick() {
     if (!res.ok) throw new Error("the sidecar answered " + res.status);
     payload = await res.json();
     observeActions(payload?.overview?.actions);
+    reconcileStartActions(payload?.overview);
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3531,6 +3531,8 @@ async function loadAistack() {
     const res = await fetch("/api/aistack", { headers: { accept: "application/json" }, cache: "no-store" });
     if (!res.ok) throw new Error("the sidecar answered " + res.status);
     aistack = await res.json();
+    observeActions(aistack.actions);
+    reconcileAistackActions();
   } catch (e) {
     aistack = { ok: false, error: e.message };
   }
@@ -3543,31 +3545,60 @@ async function loadAistack() {
    render would multiply. */
 function aistackWatch() {
   if (aistackAct.poll) { clearTimeout(aistackAct.poll); aistackAct.poll = null; }
-  if (aistack?.flow?.phase !== "waiting") return;
+  if (aistack?.flow?.phase !== "waiting" && !actionFor({ conflict_key: "aistack:machine-registration" })) return;
   aistackAct.poll = setTimeout(() => { aistackAct.poll = null; loadAistack(); }, AISTACK_WAIT_MS);
 }
 
 async function aistackDo(act) {
-  if (aistackAct.busy) return;
-  aistackAct.busy = act;
+  const flow = aistack?.flow ?? {};
+  const valid = act === "register" ? !aistack?.registered && flow.phase !== "waiting"
+    : act === "cancel" ? flow.phase === "waiting"
+      : act === "optin" ? Boolean(aistack?.registered) : false;
+  if (!valid) return null;
+  const conflict = actionFor({ conflict_key: "aistack:machine-registration" });
+  if (conflict && !(act === "cancel" && conflict.kind === "aistack-register")) return null;
+  if (conflict) finishAction(conflict.action_id);
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "aistack-" + act, target: "aistack-machine",
+    conflict_key: "aistack:machine-registration",
+    projection: { phase: act === "register" ? "starting-device-login" : act === "cancel" ? "stopping-wait" : "granting-permission" },
+  });
+  if (!action) return null;
   aistackAct.said = null;
   render();
   try {
     const res = await fetch("/api/aistack/" + act, {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },
-      body: "{}",
+      body: JSON.stringify({ action_id: actionId }),
     });
     const b = await res.json().catch(() => ({}));
+    observeActions(b.action ? [b.action] : b.receipt?.action ? [b.receipt.action] : []);
+    reconcileAistackActions();
     if (!res.ok) throw new Error(b.error || ("the sidecar answered " + res.status));
-    aistack = b;
-    if (b.said) aistackAct.said = { ok: true, text: b.said };
   } catch (e) {
-    aistackAct.said = { ok: false, text: e.message };
+    const current = actionFor({ action_id: actionId });
+    if (current) aistackAct.said = { ok: false, text: "Checking outcome: " + e.message };
+    else if (!aistackAct.said) aistackAct.said = { ok: false, text: e.message };
   }
-  aistackAct.busy = null;
   aistackWatch();
   render();
+  return action;
+}
+
+function reconcileAistackActions() {
+  for (const action of [...actions.values()]) {
+    if (!action.kind?.startsWith("aistack-") || !TERMINAL_ACTION.has(action.status)) continue;
+    if (action.status !== "confirmed") {
+      aistackAct.said = { ok: false, text: action.reason || "The aistack Action failed." };
+    } else if (action.kind === "aistack-optin") {
+      aistackAct.said = { ok: true, text: action.receipt?.said || "The standing permission is granted." };
+    } else if (action.kind === "aistack-cancel") {
+      aistackAct.said = { ok: true, text: "Stopped waiting for approval." };
+    }
+    finishAction(action.action_id);
+  }
 }
 
 /* What the last sync attempt came to, in one clause. Absent is not the same as
@@ -3600,16 +3631,19 @@ function setAistack() {
     ? `<p class="${aistackAct.said.ok ? "qhint" : "unread"}">${esc(aistackAct.said.text)}</p>`
     : "";
   const flow = aistack.flow ?? {};
-  const busy = aistackAct.busy;
+  const pending = actionFor({ conflict_key: "aistack:machine-registration" });
+  const pendingText = pending
+    ? `<p class="qhint">${esc(pending.progress || (pending.kind === "aistack-register" ? "Starting the device login"
+      : pending.kind === "aistack-cancel" ? "Stopping the device login" : "Granting the standing permission"))}</p>` : "";
   const btn = (act, label, extra) => `<button class="btn${extra ? " " + extra : ""}"${
-    busy ? " disabled" : ""} onclick="aistackDo('${esc(act)}')">${esc(busy === act ? "…" : label)}</button>`;
+    pending && !(act === "cancel" && pending.kind === "aistack-register") ? " disabled" : ""} onclick="aistackDo('${esc(act)}')">${esc(pending?.kind === "aistack-" + act ? "…" : label)}</button>`;
 
   /* The waiting half. The code and the link are the whole of what the operator
      needs, so they are the whole of what is on the screen — big enough to read
      off a phone across a room, and the link is the one the CLI printed rather
      than one this page composed. */
   if (flow.phase === "waiting") {
-    return `${said}<p class="unread">Approve this box on aistack. The code below is live for about three minutes;
+    return `${said}${pendingText}<p class="unread">Approve this box on aistack. The code below is live for about three minutes;
       after that, start a new registration.</p>
       <div class="rows">
         <div class="row"><span class="key">code</span><span class="grow mono" style="font-size:22px;letter-spacing:2px">${esc(flow.code ?? "—")}</span></div>
@@ -3631,7 +3665,7 @@ function setAistack() {
          Start a new one — a new login mints a new code.</p>`
       : `<p class="qhint">This box is not an aistack machine, so curia publishes nothing and says nothing about it.
          Registering it puts the agents' rolling 30-day token spend on your measured layer.</p>`;
-    return `${said}${why}<div class="rows">
+    return `${said}${pendingText}${why}<div class="rows">
       <div class="row"><span class="grow">${btn("register", "Register this box")}</span>${qq("set-aistack-reg")}</div>
       ${qhint("set-aistack-reg", `Curia runs the aistack CLI's device login on the box and shows you its code and link.
         You approve in a browser that is signed in to aistack. The token it hands back is written to a file under curia's
@@ -3653,7 +3687,7 @@ function setAistack() {
     : `<p class="qhint">This box is registered. Curia checks every
        ${esc(aistack.sync?.interval_hours ?? "?")}h; the stack's own frequency decides how often a check actually publishes.</p>`;
   const published = aistack.sync?.last?.published ?? null;
-  return `${said}${state}<div class="rows">
+  return `${said}${pendingText}${state}<div class="rows">
     <div class="row"><span class="key">machine</span><span class="grow mono">${esc(m.proposed ?? "unknown")}</span>${qq("set-aistack-machine")}</div>
     ${qhint("set-aistack-machine", `The name this box PROPOSED at registration, which is its hostname. The approval page can rename a
       machine and the credential file records no name, so the name aistack shows is the one on
@@ -4992,6 +5026,7 @@ async function tick() {
     reconcilePaneKeyActions();
     reconcileDialogAnswerActions();
     reconcileGitHubAppActions();
+    reconcileAistackActions();
     reconcileConversationActions();
     reconcileSettingsActions();
     reachable = true;

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3106,6 +3106,17 @@ function restartNeeds() {
   return out;
 }
 
+function settingsActionPaths(patch) {
+  const paths = [];
+  if (["dispatch", "overseer", "watch"].some((key) => Object.prototype.hasOwnProperty.call(patch, key))) paths.push("curia.local.yaml");
+  if (Object.prototype.hasOwnProperty.call(patch, "routing")) paths.push("routing.local.yaml");
+  return paths;
+}
+
+function settingsAction() {
+  return [...actions.values()].find((action) => action.kind === "settings-save") ?? null;
+}
+
 /* ---- what the daemon is running (#362) --------------------------------------
 
    Applied is a fact curia measured, not a claim the save made. `GET /overview`
@@ -3154,6 +3165,7 @@ function runningDiff(p) {
 function saveDock() {
   const n = changeCount();
   const s = UI.set;
+  const action = settingsAction();
   const dock = (cls, body) => `<div class="dock${cls ? " " + cls : ""}">${body}</div>`;
   const save = `<button class="btn primary" ${s.busy ? "disabled" : ""} onclick="doSave()">Save</button>`;
   const discard = `<a href="#settings" onclick="discardEdits();return false">discard</a>`;
@@ -3164,6 +3176,9 @@ function saveDock() {
   if (s.phase === "unread") {
     return dock("refused", `<span class="toast bad">The settings could not be read.</span>
       <span class="why">${esc(s.error)}</span>`);
+  }
+  if (action && !TERMINAL_ACTION.has(action.status)) {
+    return dock("", `<button class="btn" disabled>${esc(action.progress || "Saving settings…")}</button>`);
   }
   if (s.busy) return dock("", `<button class="btn" disabled>Saving\u2026</button>`);
   if (s.phase === "restarting") {
@@ -4611,19 +4626,71 @@ async function loadConversations() {
   render();
 }
 
+function reconcileSettingsActions() {
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "settings-save" || !TERMINAL_ACTION.has(action.status)) continue;
+    if (action.status === "refused" || action.status === "failed") {
+      UI.set.phase = "refused";
+      UI.set.error = action.reason || "The settings save did not finish.";
+      finishAction(action.action_id);
+      continue;
+    }
+    const receipt = action.receipt ?? {};
+    const written = receipt.written ?? [];
+    UI.set.error = null;
+    if (!written.length) {
+      UI.set.phase = "clean";
+      UI.set.note = "That was already what the files say.";
+    } else {
+      UI.set.note = `Wrote ${written.join(" and ")}, atomically, with the comments kept.`;
+      if (receipt.reload?.ok === false) {
+        UI.set.phase = "declined";
+        UI.set.error = receipt.reload.error || "the daemon gave no reason";
+      } else {
+        UI.set.phase = "applied";
+      }
+    }
+    finishAction(action.action_id);
+  }
+}
+
 async function doSave() {
   const patch = settingsPatch();
   if (!Object.keys(patch).length) return;
-  UI.set.busy = true;
+  const paths = settingsActionPaths(patch);
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId,
+    kind: "settings-save",
+    target: paths.join(","),
+    conflict_key: `settings:${paths.join("+")}`,
+    projection: { paths },
+  });
+  if (!action) return;
   render();
   try {
     const res = await fetch("/api/settings", {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },
-      body: JSON.stringify(patch),
+      body: JSON.stringify({ action_id: actionId, ...patch }),
     });
     const body = await res.json().catch(() => ({}));
-    if (!res.ok) throw new Error(body.error || ("the sidecar answered " + res.status));
+    const evidence = body.action ?? body.receipt?.action ?? null;
+    observeActions(evidence ? [evidence] : []);
+    if (!res.ok) {
+      const current = actionFor({ action_id: actionId });
+      UI.set.phase = "refused";
+      UI.set.error = current?.reason || body.error || ("the sidecar answered " + res.status);
+      finishAction(actionId);
+      return render();
+    }
+    const current = actionFor({ action_id: actionId });
+    if (current?.status === "refused" || current?.status === "failed") {
+      UI.set.phase = "refused";
+      UI.set.error = current.reason || "The settings save was refused.";
+      finishAction(actionId);
+      return render();
+    }
     /* The answer carries the re-read file, so the screen shows what landed
        rather than what was typed. */
     settings = body.settings ?? settings;
@@ -4642,11 +4709,13 @@ async function doSave() {
       else if (r?.reason === "daemon-down") { UI.set.phase = "offline"; UI.set.error = r.error; }
       else { UI.set.phase = "declined"; UI.set.error = r?.error ?? "the daemon gave no reason"; }
     }
+    if (TERMINAL_ACTION.has(actionFor({ action_id: actionId })?.status) || !body.action || r?.reason === "daemon-down") {
+      finishAction(actionId);
+    }
   } catch (e) {
     UI.set.phase = "refused";
     UI.set.error = e.message;
   }
-  UI.set.busy = false;
   render();
 }
 
@@ -4831,6 +4900,7 @@ async function tick() {
     reconcileDialogAnswerActions();
     reconcileGitHubAppActions();
     reconcileConversationActions();
+    reconcileSettingsActions();
     reachable = true;
     if (UI.screen === "feed" && UI.feed.operator !== payload.operator) recordFeedVisit();
   } catch {

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -1110,20 +1110,50 @@ async function startTicket(repo, ticket) {
    so a Discord press and an Atlas tap resolve the same option. Files ride the
    answer inline, and the daemon writes them where the card said they land. */
 async function answerEsc(id, body) {
-  if (busy("esc:" + id)) return null;
+  if (busy("answer:" + id)) return null;
   const answer = typeof body === "string" ? { answer: body } : { ...body };
+  const record = escRecord(id);
+  const projected = Number.isInteger(answer.index)
+    ? record?.options?.[answer.index] ?? `option ${answer.index + 1}`
+    : String(answer.answer ?? "").trim();
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "escalation-answer", target: id,
+    conflict_key: `answer:${id}`, projection: { answer: projected },
+  });
+  if (!action) return null;
+  UI.act.said = null;
+  render();
   try {
     answer.files = await replyFilesOf("files-" + id);
   } catch (e) {
+    finishAction(actionId);
     return refuse("esc:" + id, e.message);
   }
-  const out = await verb("esc:" + id, "/api/answer", { id, ...answer });
-  /* One successful answer opens the handoff sheet (#718). A refusal opens
-     nothing: the receipt under the card is the whole of what happened. */
-  if (out && out.ok !== false) {
-    UI.act.handoff = id;
-    render();
+  let out = null;
+  try {
+    const res = await fetch("/api/answer", {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ id, ...answer, action_id: actionId }),
+    });
+    const response = await res.json().catch(() => ({}));
+    observeActions(response.action ? [response.action] : []);
+    if (!response.action && !res.ok) throw Object.assign(new Error(response.error || ("the console answered " + res.status)), { receipt: response.receipt ?? null });
+    if (!response.action && res.ok) {
+      finishAction(actionId);
+      UI.act.handoff = id;
+    }
+    out = response;
+    reconcileAnswerActions(payload?.overview);
+  } catch (e) {
+    const current = actionFor({ action_id: actionId });
+    if (!current || current.status === "pending") {
+      UI.act.said = { key: "esc:" + id, text: e.receipt ? receiptLine(e.receipt) : e.message, ok: false };
+      finishAction(actionId);
+    }
   }
+  render();
   return out;
 }
 function answerIndex(id, index) { return answerEsc(id, { index: Number(index) }); }
@@ -1188,6 +1218,24 @@ function rejectGate(id, field) {
   const v = typed(field);
   if (!v) return refuse("esc:" + id, "A rejection carries your words — say what to change, then press Reject.");
   answerEsc(id, v);
+}
+
+function reconcileAnswerActions(o) {
+  const open = new Set([...(o?.escalations ?? []), ...(o?.review_gate ?? [])].map((record) => record.id));
+  for (const action of [...actions.values()]) {
+    if (action.kind !== "escalation-answer" || !TERMINAL_ACTION.has(action.status)) continue;
+    const key = "esc:" + action.target;
+    if (action.status !== "confirmed") {
+      UI.act.said = {
+        key, ok: false,
+        text: action.receipt ? receiptLine(action.receipt) : action.error || action.reason || "Curia could not answer this escalation.",
+      };
+      finishAction(action.action_id);
+    } else if (!open.has(action.target)) {
+      finishAction(action.action_id);
+      UI.act.handoff = action.target;
+    }
+  }
 }
 
 /* ---- the reading's own age ------------------------------------------------- */
@@ -1554,14 +1602,14 @@ function choiceControls(r) {
   const handle = (i) => r.option_handles?.[i] || opts[i];
   const label = (i) => `${optMarker(r, i)} · ${snip(handle(i), 80)}`;
   if (opts.length <= MAX_BUTTON_OPTIONS) {
-    return `<div class="act-row">${opts.map((_, i) => `<button class="btn sm" ${busy("esc:" + r.id) ? "disabled" : ""}
+    return `<div class="act-row">${opts.map((_, i) => `<button class="btn sm" ${busy("answer:" + r.id) ? "disabled" : ""}
       onclick="answerIndex('${js(r.id)}',${i})">${esc(label(i))}</button>`).join("")}</div>`;
   }
   if (opts.length <= MAX_SELECT_OPTIONS) {
     const id = "sel-" + r.id;
-    return `<div class="act-row"><select id="${esc(id)}" ${busy("esc:" + r.id) ? "disabled" : ""}>
+    return `<div class="act-row"><select id="${esc(id)}" ${busy("answer:" + r.id) ? "disabled" : ""}>
       <option value="">pick one…</option>${opts.map((_, i) => `<option value="${i}">${esc(label(i))}</option>`).join("")}</select>
-      <button class="btn sm primary" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerSelect('${js(r.id)}','${js(id)}')">Answer</button></div>`;
+      <button class="btn sm primary" ${busy("answer:" + r.id) ? "disabled" : ""} onclick="answerSelect('${js(r.id)}','${js(id)}')">Answer</button></div>`;
   }
   return `<ol class="opts numbered">${opts.map((o, i) => `<li><b>${esc(optMarker(r, i))}.</b> ${esc(snip(handle(i), 120))}</li>`).join("")}</ol>
     <div class="dim">Reply with ${r.typed ? "a letter or " : ""}a number.</div>`;
@@ -1571,7 +1619,7 @@ function choiceControls(r) {
    this line says where they land. */
 function replyFilesRow(r) {
   const where = r.files_dir ? ` They land under <code>${esc(r.files_dir)}/</code> and reach the agent as paths.` : "";
-  return `<div class="act-row files"><input type="file" id="files-${esc(r.id)}" multiple ${busy("esc:" + r.id) ? "disabled" : ""}>
+  return `<div class="act-row files"><input type="file" id="files-${esc(r.id)}" multiple ${busy("answer:" + r.id) ? "disabled" : ""}>
     <span class="dim">A reply may carry files.${where}</span></div>`;
 }
 
@@ -1581,8 +1629,8 @@ function replyFilesRow(r) {
 function answerField(r) {
   const id = "ans-" + r.id;
   return `<div class="act-row">
-    <input type="text" id="${esc(id)}" placeholder="answer in your own words…" ${busy("esc:" + r.id) ? "disabled" : ""}>
-    <button class="btn sm primary" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}',escRecord('${js(r.id)}'))">Answer</button>
+    <input type="text" id="${esc(id)}" placeholder="answer in your own words…" ${busy("answer:" + r.id) ? "disabled" : ""}>
+    <button class="btn sm primary" ${busy("answer:" + r.id) ? "disabled" : ""} onclick="answerTyped('${js(r.id)}','${js(id)}',escRecord('${js(r.id)}'))">Answer</button>
   </div>${replyFilesRow(r)}`;
 }
 
@@ -1591,7 +1639,14 @@ function escCard(r) {
     <span class="who">${esc(r.agent)}</span>${esc(snip(r.prompt, 260))}
     <div class="dim">${esc(r.kind)} · ${esc(ticketName(null, r.ticket))} · open ${esc(ago(r.opened_at))}${r.agent_died ? " · the agent died holding it" : ""}${r.rendered ? "" : " · not rendered in Discord yet"}</div>
     ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview it asks about</a></div>` : ""}
-    ${answerButtons(r)}${answerField(r)}${said("esc:" + r.id)}</div>`;
+    ${answerProjection(r.id)}${answerButtons(r)}${answerField(r)}${said("esc:" + r.id)}</div>`;
+}
+
+function answerProjection(id) {
+  const action = actionFor({ conflict_key: "answer:" + id });
+  if (!action) return "";
+  const selected = action.projection?.answer;
+  return `<div class="say">${selected ? `Answering: ${esc(selected)}…` : "Sending your file reply…"}</div>`;
 }
 
 /* ---- the diff digest (#355) ------------------------------------------------
@@ -1776,13 +1831,14 @@ function gateCard(r) {
     ${r.pull_request ? `<div class="opts"><a href="${esc(r.pull_request)}">${esc(r.pull_request)}</a></div>` : `<div class="opts">no pull request on this gate</div>`}
     ${r.preview_url ? `<div class="opts"><a href="${esc(r.preview_url)}">the preview</a></div>` : ""}
     ${diffCard("esc:" + r.id, r.diff ?? null, r.diff_error ?? null, gateDiffQuery(r.id), r.pull_request)}
+    ${answerProjection(r.id)}
     <div class="act-row">
-      <button class="btn sm primary" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${APPROVE}')">✅ Approve · merge</button>
-      <button class="btn sm" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${CROSS_CHECK}')">🔎 Cross-check</button>
+      <button class="btn sm primary" ${busy("answer:" + r.id) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${APPROVE}')">✅ Approve · merge</button>
+      <button class="btn sm" ${busy("answer:" + r.id) ? "disabled" : ""} onclick="answerEsc('${js(r.id)}','${CROSS_CHECK}')">🔎 Cross-check</button>
     </div>
     <div class="act-row">
-      <input type="text" id="${esc(id)}" placeholder="what to change — a rejection carries your words…" ${busy("esc:" + r.id) ? "disabled" : ""}>
-      <button class="btn sm danger" ${busy("esc:" + r.id) ? "disabled" : ""} onclick="rejectGate('${js(r.id)}','${js(id)}')">Reject</button>
+      <input type="text" id="${esc(id)}" placeholder="what to change — a rejection carries your words…" ${busy("answer:" + r.id) ? "disabled" : ""}>
+      <button class="btn sm danger" ${busy("answer:" + r.id) ? "disabled" : ""} onclick="rejectGate('${js(r.id)}','${js(id)}')">Reject</button>
     </div>
     ${said("esc:" + r.id)}</div>`;
 }
@@ -4895,6 +4951,7 @@ async function tick() {
     payload = await res.json();
     observeActions(payload?.overview?.actions);
     reconcileStartActions(payload?.overview);
+    reconcileAnswerActions(payload?.overview);
     reconcileChatMessageActions();
     reconcilePaneKeyActions();
     reconcileDialogAnswerActions();

--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -3715,6 +3715,9 @@ function chatReceive(name, d) {
     c.draft = d.text; c.mirror = !!d.text;
   } else if (name === "sent") {
     c.mirror = false;
+    const action = d.action_id ? actionFor({ action_id: d.action_id }) : null;
+    if (["chat-message", "chat-message-correction"].includes(action?.kind)
+      && c.draft === action.projection?.text) c.draft = "";
     if (d.by !== c.client) chatNote(`sent from the other device: ${snip(d.text, 80)}`);
     return render();
   } else {
@@ -4048,7 +4051,11 @@ function chatDialog(c) {
 
 function chatComposer(c, role, ended) {
   if (ended) return `<div class="composer ended"><span class="dim-note">${esc(ENDED_SENTENCE(c.session))}</span></div>`;
-  const k = "chat-send";
+  const k = `turn:${chatConversationKey(c.session)}`;
+  const messageAction = actionFor({ conflict_key: k });
+  const messageProgress = messageAction
+    ? `<div class="dialog-note">${esc(messageAction.progress || "Sending your message…")}</div>`
+    : "";
   const paneKey = actionFor({ conflict_key: `pane:${c.session}` });
   return `<div class="composer">
     ${c.mirror ? `<div class="dim-note">the other device is typing…</div>` : ""}
@@ -4057,8 +4064,13 @@ function chatComposer(c, role, ended) {
       <button class="btn sm" ${busy("chat-take-back") ? "disabled" : ""} onclick="doTakeBack()" title="take back your last message">${busy("chat-take-back") ? "…" : "Take back"}</button>
       ${role === "ticket" ? `<button class="btn sm" ${paneKey ? "disabled" : ""} onclick="doChatKey('escape')" title="send Escape to the agent">${paneKey ? "Sending Esc…" : "Esc"}</button>` : ""}
       <span class="grow"></span>
-      <button class="btn primary" ${busy(k) ? "disabled" : ""} onclick="doChatSend()">${busy(k) ? "Sending…" : "Send"}</button>
-    </div>${said(k)}${said("chat-take-back")}${said("chat-key")}</div>`;
+      <button class="btn primary" ${messageAction ? "disabled" : ""} onclick="doChatSend()">${messageAction ? "Sending…" : "Send"}</button>
+    </div>${messageProgress}${said(k)}${said("chat-take-back")}${said("chat-key")}</div>`;
+}
+
+function chatConversationKey(session) {
+  const match = /^curia-(console-[1-9][0-9]*)$/.exec(String(session ?? ""));
+  return match ? match[1] : String(session ?? "");
 }
 
 /* The shared composer (#73): the draft goes to the other device, 200ms after
@@ -4091,19 +4103,38 @@ async function doChatSend() {
   const text = chat.draft;
   if (!text.trim()) return;
   if (chatEnded()) return refuse("chat-send", ENDED_SENTENCE(chat.session));
-  const action = beginLocalAction("chat-send");
+  const conversation = chatConversationKey(chat.session);
+  const actionId = `atlas-${Date.now().toString(36)}-${(++localActionSequence).toString(36)}`;
+  const action = beginAction({
+    action_id: actionId, kind: "chat-message", target: conversation,
+    conflict_key: `turn:${conversation}`, projection: { text },
+  });
   if (!action) return;
   UI.act.said = null;
-  chat.draft = "";
   render();
-  const r = await chatPost("/send", { text });
-  finishAction(action.action_id);
-  if (r.error) {
-    if (!r.unconfirmed) chat.draft = text;
-    UI.act.said = { key: "chat-send", ok: false, text: (r.unconfirmed ? "send unconfirmed: " : "send failed: ") + r.error };
+  const r = await chatPost("/send", { text, action_id: actionId });
+  observeActions(r.action ? [r.action] : []);
+  reconcileChatMessageActions();
+  if (!r.action && r.error) {
+    UI.act.said = { key: `turn:${conversation}`, ok: false, text: `Curia could not check the outcome yet: ${r.error}` };
   }
   chat.stick = true;
   render();
+}
+function reconcileChatMessageActions() {
+  for (const action of [...actions.values()]) {
+    if (!["chat-message", "chat-message-correction"].includes(action.kind)) continue;
+    if (action.target !== chatConversationKey(chat.session)) continue;
+    const outcome = action.receipt?.outcome;
+    if (["delivered", "sent_unconfirmed"].includes(outcome) || action.status === "confirmed") {
+      if (chat.draft === action.projection?.text) chat.draft = "";
+    }
+    if (!TERMINAL_ACTION.has(action.status)) continue;
+    if (action.status !== "confirmed") {
+      UI.act.said = { key: action.conflict_key, ok: false, text: action.reason || "Curia could not deliver the message." };
+    }
+    finishAction(action.action_id);
+  }
 }
 async function doTakeBack() {
   const action = beginLocalAction("chat-take-back");
@@ -4795,6 +4826,7 @@ async function tick() {
     payload = await res.json();
     observeActions(payload?.overview?.actions);
     reconcileStartActions(payload?.overview);
+    reconcileChatMessageActions();
     reconcilePaneKeyActions();
     reconcileDialogAnswerActions();
     reconcileGitHubAppActions();

--- a/daemon/src/actions.mjs
+++ b/daemon/src/actions.mjs
@@ -56,7 +56,10 @@ export class ActionCoordinator {
       .then(() => work(controls))
       .then((out = {}) => {
         const current = this.get(actionId)
-        if (TERMINAL.has(current?.status)) return current
+        if (TERMINAL.has(current?.status)) {
+          release(current)
+          return current
+        }
         if (accepted) {
           if (out.status === 'accepted' || out.status === 'progress') return current
           const status = out.status === 'failed' ? 'failed' : 'confirmed'

--- a/daemon/src/actions.mjs
+++ b/daemon/src/actions.mjs
@@ -15,6 +15,12 @@ export class ActionCoordinator {
     return this.reduction.actionsOnWire()
   }
 
+  confirm(actionId, detail = {}) {
+    const current = this.get(actionId)
+    if (!current || TERMINAL.has(current.status)) return current
+    return this.reduction.recordAction({ ...current, ...detail, status: 'confirmed' })
+  }
+
   settled(actionId) {
     const running = this.running.get(String(actionId))
     if (running) return running.settled
@@ -52,6 +58,7 @@ export class ActionCoordinator {
         const current = this.get(actionId)
         if (TERMINAL.has(current?.status)) return current
         if (accepted) {
+          if (out.status === 'accepted' || out.status === 'progress') return current
           const status = out.status === 'failed' ? 'failed' : 'confirmed'
           return write(status, out)
         }

--- a/daemon/src/actions.mjs
+++ b/daemon/src/actions.mjs
@@ -1,0 +1,73 @@
+const TERMINAL = new Set(['confirmed', 'refused', 'failed'])
+
+export class ActionCoordinator {
+  constructor(reduction, { log = () => {} } = {}) {
+    this.reduction = reduction
+    this.log = log
+    this.running = new Map()
+  }
+
+  get(actionId) {
+    return this.reduction.action(actionId)
+  }
+
+  overview() {
+    return this.reduction.actionsOnWire()
+  }
+
+  settled(actionId) {
+    const running = this.running.get(String(actionId))
+    if (running) return running.settled
+    const evidence = this.get(actionId)
+    return TERMINAL.has(evidence?.status) ? Promise.resolve(evidence) : Promise.resolve(null)
+  }
+
+  async run(action, work) {
+    const actionId = String(action?.action_id ?? '')
+    if (!actionId) throw new Error('an Action needs an action_id')
+    const recorded = this.get(actionId)
+    if (recorded) return recorded
+    if (this.running.has(actionId)) return this.running.get(actionId).first
+
+    let release
+    const first = new Promise((resolve) => { release = resolve })
+    let accepted = false
+    const write = (status, detail = {}) => {
+      const evidence = this.reduction.recordAction({ ...action, ...detail, status })
+      if (!accepted && status === 'accepted') accepted = true
+      release(evidence)
+      return evidence
+    }
+    const controls = {
+      accept: (detail = {}) => write('accepted', detail),
+      progress: (progress, detail = {}) => {
+        if (!accepted) throw new Error('Action progress cannot precede acceptance')
+        return write('progress', { ...detail, progress })
+      },
+    }
+
+    const settled = Promise.resolve()
+      .then(() => work(controls))
+      .then((out = {}) => {
+        const current = this.get(actionId)
+        if (TERMINAL.has(current?.status)) return current
+        if (accepted) {
+          const status = out.status === 'failed' ? 'failed' : 'confirmed'
+          return write(status, out)
+        }
+        const status = ['confirmed', 'refused', 'failed'].includes(out.status) ? out.status : 'refused'
+        return write(status, out)
+      })
+      .catch((error) => {
+        const current = this.get(actionId)
+        return TERMINAL.has(current?.status)
+          ? current
+          : write(accepted ? 'failed' : 'refused', { reason: error.message })
+      })
+      .finally(() => this.running.delete(actionId))
+
+    this.running.set(actionId, { first, settled })
+    settled.catch((error) => this.log(`Action ${actionId} failed to settle: ${error.message}`))
+    return first
+  }
+}

--- a/daemon/src/aistack.mjs
+++ b/daemon/src/aistack.mjs
@@ -48,7 +48,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
-import { CFG_DIR, configRootEnvFor } from './workspace.mjs'
+import { CFG_DIR, HARNESS_NAMES, configRootEnvFor } from './workspace.mjs'
 
 // Rule 4. The npm package, its binary, and the runner that fetches it.
 export const CLI_PACKAGE = '@use-aistack/cli'
@@ -117,6 +117,17 @@ function cfgEntries(root) {
       continue
     }
     if (!stat.isDirectory()) continue
+    const harnessRoots = HARNESS_NAMES
+      .map((harness) => path.join(full, harness))
+      .filter((candidate) => {
+        try { return fs.statSync(candidate).isDirectory() } catch { return false }
+      })
+    if (harnessRoots.length) {
+      for (const candidate of harnessRoots) {
+        out.push({ name, path: candidate, at: fs.statSync(candidate).mtimeMs })
+      }
+      continue
+    }
     out.push({ name, path: full, at: stat.mtimeMs })
   }
   return out.sort((a, b) => b.at - a.at || a.name.localeCompare(b.name))

--- a/daemon/src/aistackreg.mjs
+++ b/daemon/src/aistackreg.mjs
@@ -176,6 +176,7 @@ export class AistackRegistration {
       flow: this.flow
         ? {
           phase: 'waiting', code: this.flow.code, url: this.flow.url,
+          action_id: this.flow.actionId,
           started_at: this.flow.startedAt, expires_at: this.flow.startedAt + LOGIN_TIMEOUT_MS,
         }
         : (this.last ? { ...this.last } : { phase: registered ? 'registered' : 'unregistered' }),
@@ -194,7 +195,7 @@ export class AistackRegistration {
   // A login already in flight is RETURNED, not replaced: a second `login` mints
   // a second session and would invalidate the code the operator is already
   // holding.
-  async begin() {
+  async begin({ actionId = null } = {}) {
     if (this.flow) return { ok: true, already: true, ...this.status() }
     if (this.registered()) {
       return { ok: false, error: 'this box is already registered with aistack — revoke the machine at aistack.to/settings/machines and delete the credential on the box before registering it again' }
@@ -212,7 +213,7 @@ export class AistackRegistration {
       return { ok: false, error: `${this.bin} did not run: ${e.message}` }
     }
 
-    const flow = { child, startedAt, code: null, url: null, text: '' }
+    const flow = { child, startedAt, code: null, url: null, text: '', actionId }
     this.flow = flow
 
     let settleDevice = () => {}
@@ -242,7 +243,7 @@ export class AistackRegistration {
       clearTimeout(kill)
       clearTimeout(giveUp)
       if (this.flow === flow) this.flow = null
-      this.#settle({ phase: 'failed', message: `${this.bin} did not run: ${e.message}` })
+      this.#settle({ phase: 'failed', message: `${this.bin} did not run: ${e.message}` }, flow.actionId)
       settleDevice({ ok: false, error: `${this.bin} did not run: ${e.message}` })
     })
     child.once('close', (code, signal) => {
@@ -263,19 +264,35 @@ export class AistackRegistration {
       return { ok: false, error: out.error }
     }
     this.log(`an aistack registration is waiting for approval: ${flow.url}`)
-    this.journal('aistack_login_started', { code: flow.code, url: flow.url, version: this.version })
+    this.journal('aistack_login_started', {
+      code: flow.code, url: flow.url, version: this.version,
+      ...(flow.actionId ? { action_id: flow.actionId } : {}),
+      started_at: flow.startedAt, expires_at: flow.startedAt + LOGIN_TIMEOUT_MS,
+    })
     return { ok: true, ...this.status() }
   }
 
   // Stop waiting. The session on aistack's side ages out on its own; this ends
   // the box's half so the screen is not left holding a code nobody will use.
-  cancel() {
+  cancel({ restored = null } = {}) {
     const flow = this.flow
-    if (!flow) return { ok: false, error: 'no aistack registration is waiting' }
+    if (!flow && restored?.phase !== 'waiting') return { ok: false, error: 'no aistack registration is waiting' }
+    if (!flow) {
+      this.last = { phase: 'cancelled', message: 'the registration was cancelled before it was approved', at: this.now() }
+      this.journal('aistack_login_cancelled', {
+        message: this.last.message,
+        ...(restored.action_id ? { action_id: restored.action_id } : {}),
+      })
+      return { ok: true, ...this.status() }
+    }
     flow.cancelled = true
     this.flow = null
     try { flow.child.kill('SIGKILL') } catch { /* already gone */ }
     this.last = { phase: 'cancelled', message: 'the registration was cancelled before it was approved', at: this.now() }
+    this.journal('aistack_login_cancelled', {
+      message: this.last.message,
+      ...(flow.actionId ? { action_id: flow.actionId } : {}),
+    })
     return { ok: true, ...this.status() }
   }
 
@@ -309,15 +326,18 @@ export class AistackRegistration {
     if (this.registered()) {
       const machine = this.hostname()
       this.log(`the box registered with aistack as ${machine}`)
-      this.journal('aistack_registered', { machine, servers: registeredServers(this.root) })
-      this.#settle({ phase: 'registered', message: null })
+      this.journal('aistack_registered', {
+        machine, servers: registeredServers(this.root),
+        ...(flow.actionId ? { action_id: flow.actionId } : {}),
+      })
+      this.#settle({ phase: 'registered', message: null }, flow.actionId)
       return
     }
     if (flow.timedOut) {
       this.#settle({
         phase: 'expired',
         message: 'nobody approved the login within three minutes, so the CLI stopped waiting',
-      })
+      }, flow.actionId)
       return
     }
     const why = lastLine(flow.text)
@@ -326,14 +346,17 @@ export class AistackRegistration {
       message: signal
         ? `the login was killed on ${signal}`
         : `the login exited ${code}${why ? `: ${why}` : ' without writing a credential'}`,
-    })
+    }, flow.actionId)
   }
 
-  #settle(entry) {
-    this.last = { ...entry, at: this.now() }
+  #settle(entry, actionId = null) {
+    this.last = { ...entry, ...(actionId ? { action_id: actionId } : {}), at: this.now() }
     if (entry.phase === 'failed' || entry.phase === 'expired') {
       this.log(`the aistack registration ended ${entry.phase}: ${entry.message}`)
-      this.journal('aistack_login_failed', { phase: entry.phase, message: entry.message })
+      this.journal('aistack_login_failed', {
+        phase: entry.phase, message: entry.message,
+        ...(actionId ? { action_id: actionId } : {}),
+      })
     }
   }
 

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -1655,6 +1655,21 @@ export class DiscordBridge {
     return { threadId: thread.id, messageId: msg.id }
   }
 
+  // A daemon restart loses the in-memory message id while Discord keeps the
+  // active line. The model button identifies that line without making Discord
+  // an Action store: Action state still comes only from the journal.
+  async findStatus(ticket) {
+    const thread = await this.ensureThread(ticket)
+    const messages = await thread.messages.fetch({ limit: 50 }).catch(() => null)
+    if (!messages) return null
+    const customId = `model|${ticket}|open`
+    const message = [...messages.values()].find((candidate) =>
+      candidate.author?.id === this.client.user?.id
+      && candidate.components?.some((row) => row.components?.some((component) =>
+        (component.customId ?? component.data?.custom_id) === customId)))
+    return message ? { threadId: thread.id, messageId: message.id } : null
+  }
+
   async editStatus(ids, text, { ticket = null, settled = false } = {}) {
     const thread = await this.client.channels.fetch(ids.threadId).catch(() => null)
     if (!thread) return false

--- a/daemon/src/commands.mjs
+++ b/daemon/src/commands.mjs
@@ -321,9 +321,10 @@ export function actionForCommand(canonical, actionId) {
   const id = String(actionId ?? '').trim()
   if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(id)) throw new Error('action_id is not a valid Action id')
   const cmd = parseCommand(canonical)
-  if (cmd?.verb !== 'start' || !cmd.repo || !cmd.ticket) {
-    throw new Error('Action evidence currently supports a repo-qualified start command')
+  if (cmd?.verb === 'reauth') {
+    return { action_id: id, kind: 'credential-sign-in', target: cmd.provider, conflict_key: `reauth:${cmd.provider}` }
   }
+  if (cmd?.verb !== 'start' || !cmd.repo || !cmd.ticket) throw new Error('Action evidence supports a repo-qualified start or credential sign-in command')
   const target = `${cmd.repo}#${cmd.ticket}`
   return { action_id: id, kind: 'dispatch', target, conflict_key: `dispatch:${target}` }
 }
@@ -440,7 +441,7 @@ export class CommandRouter {
           if (!this.deploy) return '❌ this daemon has no self-deploy seam — use bin/deploy.sh'
           return await this.deploy.run({ by: userId, interpreted })
         case 'reauth':
-          return await this.dispatcher.startReauth({ provider: cmd.provider, by: userId })
+          return await this.dispatcher.startReauth({ provider: cmd.provider, by: userId, ...(action ? { action } : {}) })
       }
     } catch (e) {
       this.log(`command "${canonical}" failed:`, e.message)

--- a/daemon/src/commands.mjs
+++ b/daemon/src/commands.mjs
@@ -317,6 +317,17 @@ export function parseCommand(text) {
   }
 }
 
+export function actionForCommand(canonical, actionId) {
+  const id = String(actionId ?? '').trim()
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(id)) throw new Error('action_id is not a valid Action id')
+  const cmd = parseCommand(canonical)
+  if (cmd?.verb !== 'start' || !cmd.repo || !cmd.ticket) {
+    throw new Error('Action evidence currently supports a repo-qualified start command')
+  }
+  const target = `${cmd.repo}#${cmd.ticket}`
+  return { action_id: id, kind: 'dispatch', target, conflict_key: `dispatch:${target}` }
+}
+
 const USAGE = [
   'commands:',
   '`tickets [repo]` — takeable tickets across the watch list (repo: any unambiguous part of the name)',
@@ -356,7 +367,7 @@ export class CommandRouter {
   // ctx.interpreted (#94): true when the text came out of a model (the
   // overseer's verb tools) rather than a typed slash command or REST call —
   // interpreted destructive verbs go through the button confirm.
-  async handle(canonical, userId, { threadId = null, interpreted = false } = {}) {
+  async handle(canonical, userId, { threadId = null, interpreted = false, action = null } = {}) {
     const cmd = parseCommand(canonical)
     if (!cmd) {
       let why = ''
@@ -391,7 +402,7 @@ export class CommandRouter {
           const repo = this.#dispatchRepo(cmd)
           if (repo.error) return repo.error
           return await this.dispatcher.start(cmd.ticket, {
-            repo: repo.repo, model: cmd.model, by: userId, threadId,
+            repo: repo.repo, model: cmd.model, by: userId, threadId, action,
           })
         }
         case 'map': {

--- a/daemon/src/config.mjs
+++ b/daemon/src/config.mjs
@@ -7,7 +7,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { parse } from 'yaml'
 import { DEFAULT_RANGE as DEFAULT_PREVIEW_RANGE, DEFAULT_PROXY_FROM } from './preview.mjs'
-import { DEFAULT_SKILLS, defaultSkillsRoot, HARNESS_NAMES, harnessProvider } from './workspace.mjs'
+import { DEFAULT_SKILLS, defaultSkillsRoot } from './workspace.mjs'
 import {
   LIMIT_PATTERNS, REASONING_EFFORTS, SAFE_SUBSTITUTION, harnessReasoningEffort,
 } from './routing.mjs'
@@ -21,6 +21,7 @@ import { readAllow } from './identity.mjs'
 import { readDashboard } from './dashboard.mjs'
 import { readOverseer } from './overseerservice.mjs'
 import { CONSUMER_NAMES, consumerContractFault, providerContractFault } from './credentials.mjs'
+import { HARNESS_REGISTRY } from './harnesses.mjs'
 
 // Exported because the settings screen writes this key (#265), and a second
 // list of the legal modes would be a second answer to one question.
@@ -662,8 +663,11 @@ export function loadRoutingConfig(file, { localFile } = {}) {
       fail(src, `harnesses.${name}.resume_template must include the {model} placeholder`)
     }
     b.resumeTemplate = b.resume_template
-    if (!HARNESS_NAMES.includes(name)) {
-      fail(src, `harnesses.${name} has no entry in the HARNESS table in workspace.mjs — an agent under it would get no config dir, no curia tools and no Stop hook. Known harnesses: ${HARNESS_NAMES.join(', ')}`)
+    let adapter
+    try {
+      adapter = HARNESS_REGISTRY.get(name)
+    } catch {
+      fail(src, `harnesses.${name} has no registered Harness adapter - registered Harnesses: ${HARNESS_REGISTRY.names.join(', ')}`)
     }
     // The credential half of that same question (#648). A harness whose provider
     // has no contract row would spawn agents curia cannot give a credential to,
@@ -672,8 +676,10 @@ export function loadRoutingConfig(file, { localFile } = {}) {
     // `models.<n>.provider` already performs against the usage-limit vocabulary
     // a few hundred lines above: adding a provider is a code change, and this
     // names it.
-    const credentialFault = providerContractFault(name, harnessProvider(name))
+    const credentialFault = providerContractFault(name, adapter.identity.provider)
     if (credentialFault) fail(src, credentialFault)
+    const consumerFault = consumerContractFault(adapter.identity.credentialConsumer)
+    if (consumerFault) fail(src, `Harness ${name} has an invalid credential consumer: ${consumerFault}`)
     // The readiness marker is per harness and REQUIRED, not defaulted (#57's
     // precedent: silence by omission is the failure this refuses). #33 lost
     // readiness live to a marker that matched nothing, and the symptom was
@@ -714,6 +720,10 @@ export function loadRoutingConfig(file, { localFile } = {}) {
   }
   for (const [name, m] of Object.entries(cfg.models)) {
     if (!cfg.harnesses[m.harness]) fail(src, `models.${name}.harness names unknown harness "${m.harness}"`)
+    const adapter = HARNESS_REGISTRY.get(m.harness)
+    if (m.provider !== adapter.identity.provider) {
+      fail(src, `models.${name}.provider names "${m.provider}", but the ${m.harness} Harness adapter declares "${adapter.identity.provider}"`)
+    }
   }
 
   // The consumer contract, checked at the same boot (#648). This table is code

--- a/daemon/src/credentials.mjs
+++ b/daemon/src/credentials.mjs
@@ -804,11 +804,12 @@ export class ReauthFlow {
   // why `finish` returns an expiry and not a token.
   state() {
     if (!this.flow) return null
-    const { provider, session, state, url, code, typed, startedAt, deadline } = this.flow
+    const { provider, session, state, url, code, typed, actionId, startedAt, deadline } = this.flow
     return {
       provider,
       session,
       state,
+      action_id: actionId ?? null,
       url,
       code,
       // Whether the operator has to type into this pane, which is the one thing
@@ -872,7 +873,7 @@ export class ReauthFlow {
   // anthropic lane has no such file to remove (#659 measured that `setup-token`
   // writes none) and clears the dir anyway, so a second attempt never starts on
   // the first one's `.claude.json`.
-  async start({ provider = CODEX_PROVIDER } = {}) {
+  async start({ provider = CODEX_PROVIDER, actionId = null } = {}) {
     const lane = this.laneFor(provider)
     if (!lane) throw new Error(`there is no re-authentication lane for provider "${provider}" — this daemon can sign in: ${this.providers.join(', ') || 'nothing'}`)
     const session = authSessionName(provider)
@@ -886,7 +887,7 @@ export class ReauthFlow {
       //
       // A session the journal never saw still gets adopted, on a fresh window.
       // A deadline nothing can date is worse than a generous one.
-      if (!this.flow && !this.#resume(provider)) this.#track(provider, session)
+      if (!this.flow && !this.#resume(provider)) this.#track(provider, session, this.now(), actionId)
       return { started: false, session, why: 'a re-authentication session is already open — attach to it' }
     }
     // THE SESSION IS THE LIVENESS, NOT THE RECORD, and the order above is what
@@ -901,17 +902,18 @@ export class ReauthFlow {
     })
     await this.newSession({ name: session, cwd: cfgDir, shellCmd })
     if (this.ending?.provider === provider) this.ending = null
-    this.#track(provider, session)
-    this.journal('reauth_started', { provider, session })
+    this.#track(provider, session, this.now(), actionId)
+    this.journal('reauth_started', { provider, session, ...(actionId ? { action_id: actionId } : {}) })
     this.log(`re-authentication started for ${provider} in tmux session ${session}`)
     return { started: true, session }
   }
 
-  #track(provider, session, startedAt = this.now()) {
+  #track(provider, session, startedAt = this.now(), actionId = null) {
     const lane = this.laneFor(provider)
     this.flow = {
       provider,
       session,
+      actionId,
       cfgDir: this.cfgDirFor(session),
       state: 'waiting',
       url: null,
@@ -960,7 +962,7 @@ export class ReauthFlow {
     // takes whichever record the journal hands it.
     if (provider && record.provider !== provider) return null
     const session = authSessionName(record.provider)
-    this.#track(record.provider, session, record.startedAt)
+    this.#track(record.provider, session, record.startedAt, record.actionId ?? null)
     this.log(`re-adopted the ${record.provider} re-authentication that began ${new Date(record.startedAt).toISOString()} — the session is ${session}`)
     return this.flow
   }
@@ -1035,7 +1037,10 @@ export class ReauthFlow {
     // something to act on without becoming a place the code is written down.
     if (code && !this.flow.codeSeen) {
       this.flow.codeSeen = true
-      this.journal('reauth_code_seen', { provider: this.flow.provider, session: this.flow.session })
+      this.journal('reauth_code_seen', {
+        provider: this.flow.provider, session: this.flow.session,
+        ...(this.flow.actionId ? { action_id: this.flow.actionId } : {}),
+      })
     }
     return pane
   }
@@ -1086,7 +1091,11 @@ export class ReauthFlow {
     const flow = this.flow
     flow.state = state
     const why = REAUTH_ENDING_WHY[state] ?? null
-    const detail = { provider: flow.provider, session: flow.session, after_s: Math.round((this.now() - flow.startedAt) / 1000), ...extra }
+    const detail = {
+      provider: flow.provider, session: flow.session,
+      ...(flow.actionId ? { action_id: flow.actionId } : {}),
+      after_s: Math.round((this.now() - flow.startedAt) / 1000), ...extra,
+    }
     if (why && !detail.why) detail.why = why
     this.journal(event, detail)
     // The ending the surfaces read. Only a login that produced no credential

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -1103,7 +1103,11 @@ export class DashboardSurface {
       // login, and the daemon journals the instant. The snapshot is dropped so
       // the next poll carries the new stamp back.
       if (url.pathname === '/api/feed/read') {
-        return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/feed/read', body: { by } }))
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const actionId = field(b.action_id, ACTION_ID_RE, 'an Action id')
+          return this.#daemon({ method: 'POST', path: '/feed/read', body: { by, action_id: actionId } })
+        })
       }
       if (url.pathname === '/api/note') {
         return this.#verb(res, async () => {

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -1060,9 +1060,13 @@ export class DashboardSurface {
           const index = Number.isInteger(b.index) && b.index >= 0 ? b.index : null
           const files = replyFiles(b.files)
           const answer = index === null && !files.length ? words(b.answer, 'an answer') : String(b.answer ?? '').trim().slice(0, MAX_WORDS)
+          const actionId = b.action_id == null ? null : field(b.action_id, ACTION_ID_RE, 'an Action id')
           const out = await this.#daemon({
-            method: 'POST', path: '/answer', body: { id, answer, index, files, by, via: 'dashboard' }, accept: [200, 400, 409],
+            method: 'POST', path: '/answer', body: {
+              id, answer, index, files, by, via: 'dashboard', ...(actionId ? { action_id: actionId } : {}),
+            }, accept: [200, 400, 409],
           })
+          if (out.action) return out
           if (out.ok === false) {
             // The first receipt rides the refusal, so the page shows the mark
             // rather than an error (#712, ADR-0025).

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -310,6 +310,13 @@ function reloadLine(reload) {
   return `the daemon declined to apply it: ${reload.error}`
 }
 
+function settingsPaths(patch) {
+  const paths = []
+  if (patch && ['dispatch', 'overseer', 'watch'].some((key) => Object.hasOwn(patch, key))) paths.push('curia.local.yaml')
+  if (patch && Object.hasOwn(patch, 'routing')) paths.push('routing.local.yaml')
+  return paths
+}
+
 function field(value, re, what) {
   const s = String(value ?? '').trim()
   if (!re.test(s)) throw refuse(`"${s}" is not ${what}`)
@@ -689,9 +696,12 @@ export class DashboardSurface {
   // process that can take a new one — this file only asks, and hands back
   // whatever it answers. A daemon that is not there is not a failure of the
   // save: the file is written, and the daemon reads it at its next boot.
-  async #reload(by) {
+  async #reload(by, { actionId = null, written = [] } = {}) {
     try {
-      const out = await this.#daemon({ method: 'POST', path: '/reload', body: { by } })
+      const out = await this.#daemon({
+        method: 'POST', path: '/reload',
+        body: { by, ...(actionId ? { action_id: actionId, written } : {}) },
+      })
       // The next page read must be a fresh one. The marker on the settings
       // screen compares the daemon's own six against the file, and a snapshot
       // taken before the reload would say they disagree for a whole interval
@@ -700,6 +710,31 @@ export class DashboardSurface {
       return out
     } catch (e) {
       return { ok: false, reason: 'daemon-down', error: e.message }
+    }
+  }
+
+  async #beginSettingsAction({ actionId, paths, by }) {
+    try {
+      return await this.#daemon({
+        method: 'POST', path: '/settings/action',
+        body: { action_id: actionId, paths, by },
+      })
+    } catch (e) {
+      return { action: null, offline: e.message }
+    }
+  }
+
+  async #finishSettingsAction(actionId, status, detail = {}) {
+    if (!actionId) return null
+    try {
+      const out = await this.#daemon({
+        method: 'POST', path: '/settings/action/finish',
+        body: { action_id: actionId, status, ...detail },
+        accept: [200, 404],
+      })
+      return out.action ?? null
+    } catch {
+      return null
     }
   }
 
@@ -875,20 +910,45 @@ export class DashboardSurface {
       if (url.pathname === '/api/settings') {
         return this.#write(res, async () => {
           if (!this.curiaFile || !this.routingFile) throw new Error('this sidecar was started without config file paths, so it cannot save')
-          const patch = await this.#body(req)
-          await this.#guardWatchRemoval(patch)
-          const out = saveSettings({ curiaFile: this.curiaFile, routingFile: this.routingFile, patch })
+          const body = await this.#body(req)
+          const actionId = body.action_id == null ? null : field(body.action_id, ACTION_ID_RE, 'an Action id')
+          const { action_id: _actionId, ...patch } = body
+          const paths = settingsPaths(patch)
+          const by = String(req.headers[LOGIN_HEADER] ?? '') || 'dashboard'
+          const begun = actionId ? await this.#beginSettingsAction({ actionId, paths, by }) : null
+          if (begun?.action && ['refused', 'failed'].includes(begun.action.status)) {
+            return {
+              written: [], reload: null, action: begun.action,
+              settings: readSettings({ curiaFile: this.curiaFile, routingFile: this.routingFile }),
+            }
+          }
+          let out
+          try {
+            await this.#guardWatchRemoval(patch)
+            out = saveSettings({ curiaFile: this.curiaFile, routingFile: this.routingFile, patch })
+          } catch (error) {
+            const settled = await this.#finishSettingsAction(actionId, 'refused', { reason: error.message })
+            if (settled) error.receipt = { action: settled }
+            throw error
+          }
           // The save APPLIES (#362). The daemon re-reads both files and takes
           // every setting this screen writes, so the restart stops being
           // phase two of every save. A save that wrote nothing asks for
           // nothing: the file did not move, so there is nothing to reload.
           const reload = out.written.length
-            ? await this.#reload(String(req.headers[LOGIN_HEADER] ?? '') || 'dashboard')
+            ? await this.#reload(by, { actionId, written: out.written })
             : null
+          const noChange = out.written.length ? null : await this.#finishSettingsAction(actionId, 'confirmed', {
+            receipt: { written: [], applied: [] },
+          })
           this.log(out.written.length
             ? `dashboard: saved ${out.written.join(' and ')} — ${reloadLine(reload)}`
             : 'dashboard: the save changed nothing')
-          return { ...out, reload, settings: readSettings({ curiaFile: this.curiaFile, routingFile: this.routingFile }) }
+          return {
+            ...out, reload,
+            ...(reload?.action || noChange || begun?.action ? { action: reload?.action ?? noChange ?? begun.action } : {}),
+            settings: readSettings({ curiaFile: this.curiaFile, routingFile: this.routingFile }),
+          }
         })
       }
       // The restart (#249 item 6). The sidecar orders it and the daemon does

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -1118,20 +1118,24 @@ export class DashboardSurface {
       // flow, stop waiting for it, and grant the standing permission once the
       // machine exists.
       //
-      // THE BROWSER SENDS NOTHING. Each of these is a bare press, and each one
-      // spawns a command whose arguments this box already decided — the pinned
-      // CLI version, curia's own HOME. There is no field for a browser to name
-      // a version, a home, or a server with, which is the whole reason these
-      // are three routes rather than one that takes a command.
+      // The browser sends only the Action identity it minted. Each route still
+      // decides the command, pinned CLI version, HOME, and server on this box.
+      // There is no field through which a browser can name any of those.
       if (url.pathname === '/api/aistack/register' || url.pathname === '/api/aistack/cancel'
         || url.pathname === '/api/aistack/optin') {
         const act = url.pathname.slice('/api/aistack/'.length)
         return this.#write(res, async () => {
+          const b = await this.#body(req)
+          const actionId = field(b.action_id, ACTION_ID_RE, 'an Action id')
           const out = await this.#daemon({
-            method: 'POST', path: `/aistack/${act}`, accept: [200, 409],
+            method: 'POST', path: `/aistack/${act}`, body: { action_id: actionId }, accept: [200, 409],
             timeout: AISTACK_ACT_TIMEOUT_MS,
           })
-          if (out.ok === false) throw refuse(out.error)
+          if (out.ok === false) {
+            const error = refuse(out.error)
+            if (out.action) error.receipt = { action: out.action }
+            throw error
+          }
           return out
         })
       }

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -960,12 +960,29 @@ export class DashboardSurface {
       // the page's own marker is what says whether it has.
       if (url.pathname === '/api/restart') {
         return this.#write(res, async () => {
-          const out = await this.#daemon({ method: 'POST', path: '/restart', body: { by: 'dashboard' } })
-          this.log('dashboard: the daemon took the restart order')
-          // The next page read must not be answered from a snapshot taken
-          // before the restart: it would say the daemon is up for as long as
-          // the interval lasts, at the one moment that is false.
+          const b = await this.#body(req)
+          const actionId = field(b.action_id, ACTION_ID_RE, 'an Action id')
+          // Drop the held reading before the order crosses the socket. If the
+          // daemon exits after taking the order but before its receipt arrives,
+          // the next poll still measures daemon health instead of holding the
+          // pre-restart snapshot through the ambiguous interval.
           this.snapshotAt = 0
+          const uptime = this.snapshot?.daemon?.uptime_s
+          const out = await this.#daemon({
+            method: 'POST',
+            path: '/restart',
+            body: {
+              by: 'dashboard',
+              action_id: actionId,
+              ...(typeof uptime === 'number' && Number.isFinite(uptime) && uptime >= 0 ? { uptime_s: uptime } : {}),
+            },
+            accept: [200, 409],
+          })
+          if (out.action && this.snapshot) {
+            const prior = (this.snapshot.actions ?? []).filter((action) => action.action_id !== out.action.action_id)
+            this.snapshot = { ...this.snapshot, actions: [...prior, out.action] }
+          }
+          this.log('dashboard: the daemon took the restart order')
           return out
         })
       }

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -1072,14 +1072,20 @@ export class DashboardSurface {
         })
       }
       if (url.pathname === '/api/console/new') {
-        return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/console/new' }))
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const actionId = field(b.action_id, /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/, 'an Action id')
+          return this.#daemon({ method: 'POST', path: '/console/new', body: { action_id: actionId } })
+        })
       }
       if (url.pathname === '/api/console/delete') {
         return this.#verb(res, async () => {
           const b = await this.#body(req)
           const key = field(b.key, CONSOLE_KEY_RE, 'a browser conversation key')
-          const out = await this.#daemon({ method: 'POST', path: '/console/delete', body: { key }, accept: [200, 409] })
-          if (out.ok === false) throw refuse(out.error)
+          const actionId = field(b.action_id, /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/, 'an Action id')
+          const out = await this.#daemon({
+            method: 'POST', path: '/console/delete', body: { key, action_id: actionId }, accept: [200, 409, 500],
+          })
           return out
         })
       }

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -38,6 +38,7 @@ import { readSettings, saveSettings } from './settings.mjs'
 import { readLayered } from './config.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
+const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/
 
 export const DEFAULT_DASHBOARD_INDEX = path.resolve(DIR, '..', 'assets', 'dashboard.html')
 
@@ -736,8 +737,11 @@ export class DashboardSurface {
   // verb that has a word in the operator's own catalogue goes through it rather
   // than around it, so a press from the console journals the same `command`
   // event a typed one does and lands in the feed for free.
-  #command(text, by) {
-    return this.#daemon({ method: 'POST', path: '/command', body: { text, by } })
+  #command(text, by, actionId = null) {
+    return this.#daemon({
+      method: 'POST', path: '/command',
+      body: { text, by, ...(actionId ? { action_id: actionId } : {}) },
+    })
   }
 
   // The chat, piped (#267). Headers travel unchanged in both directions, and
@@ -947,7 +951,8 @@ export class DashboardSurface {
           const b = await this.#body(req)
           const repo = field(b.repo, VERB_REPO_RE, 'an owner/name repo')
           const ticket = field(b.ticket, VERB_TICKET_RE, 'a ticket number')
-          return this.#command(`start ${repo}#${ticket}`, by)
+          const actionId = b.action_id == null ? null : field(b.action_id, ACTION_ID_RE, 'an Action id')
+          return this.#command(`start ${repo}#${ticket}`, by, actionId)
         })
       }
 

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -910,6 +910,7 @@ export class DashboardSurface {
         return this.#verb(res, async () => {
           const b = await this.#body(req)
           const name = field(b.name, APP_NAME_RE, 'a GitHub App name')
+          const actionId = field(b.action_id, ACTION_ID_RE, 'an Action id')
           // The redirect is THIS surface's own address, composed from curia's
           // own records (#68) rather than from the request headers. GitHub
           // sends the conversion code back to this URL, so a caller-named
@@ -918,14 +919,18 @@ export class DashboardSurface {
           // tailscale says this box is.
           const redirectUrl = new URL('api/github-app/complete', await this.link()).toString()
           return this.#daemon({
-            method: 'POST', path: '/github-app/start', body: { name, redirect_url: redirectUrl }, accept: [200, 400],
+            method: 'POST', path: '/github-app/start', body: { name, redirect_url: redirectUrl, action_id: actionId }, accept: [200, 400],
           })
         })
       }
       // The re-read of the app's installations (#762). No field crosses: the
       // press is the whole message.
       if (url.pathname === '/api/github-app/refresh') {
-        return this.#verb(res, () => this.#daemon({ method: 'POST', path: '/github-app/installations', body: {} }))
+        return this.#verb(res, async () => {
+          const b = await this.#body(req)
+          const actionId = field(b.action_id, ACTION_ID_RE, 'an Action id')
+          return this.#daemon({ method: 'POST', path: '/github-app/installations', body: { action_id: actionId } })
+        })
       }
       // ---- the operator verbs (#266) ---------------------------------------
       //

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -86,7 +86,10 @@ export const daemonPort = () => Number(process.env.PORT ?? DEFAULT_DAEMON_PORT)
 // the `#chat/<session>` route, the page reads the six timeline routes through
 // this sidecar, and it draws an ended agent from the `live` field of
 // `/api/console`, which a proto-12 daemon does not carry.
-export const DASHBOARD_PROTO = 14
+// Bumped to 15 by #809: credential sign-in now carries an Action identity
+// through `/api/reauth`. A proto-14 sidecar drops that identity and leaves the
+// optimistic projection pending with no daemon evidence that can settle it.
+export const DASHBOARD_PROTO = 15
 
 // The Credentials screen's own hash (#661). It is here rather than in the
 // daemon that links to it, because the page's screen names are this file's half
@@ -1107,7 +1110,8 @@ export class DashboardSurface {
         return this.#verb(res, async () => {
           const b = await this.#body(req)
           const provider = field(b.provider, VERB_PROVIDER_RE, 'a provider name')
-          return this.#command(`reauth ${provider}`, by)
+          const actionId = b.action_id == null ? null : field(b.action_id, ACTION_ID_RE, 'an Action id')
+          return this.#command(`reauth ${provider}`, by, actionId)
         })
       }
       // The browser conversations (#333). The Chat screen mints one and

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -25,10 +25,11 @@ import {
   deleteRemoteBranch, pullRequestDiff, approvePullRequest,
 } from './github.mjs'
 import {
-  resolveModel, candidates, buildSpawnCmd, buildResumeCmd, spawnModelId, parseUsageLimit, parseCreditGate,
+  resolveModel, candidates, spawnModelId, parseUsageLimit, parseCreditGate,
   carriesLimitPhrase, resolveReviewer, isActive, Cooling, SAME_PROVIDER_STAMP, namedModel,
   reasoningEffortFor, harnessReasoningEffort,
 } from './routing.mjs'
+import { HARNESS_REGISTRY, spawnIdentity } from './harnesses.mjs'
 import { hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey, paneShowsActiveTurn } from './tmux.mjs'
 import {
   createPrivateClone, removeWorkspace,
@@ -414,9 +415,10 @@ export class Dispatcher {
   // escalation and returns its record; lapseEscalation closes one as lapsed
   // (journal + message edit); confirmNote posts a line next to a record's
   // buttons; overseerNote journals a synthetic line for a thread's session.
-  constructor({ config, routing, reduction, notify, announce, openConfirm, openMapQuestion, lapseEscalation, confirmNote, overseerNote, askReview, cancelEscalation, threads, log = console.log, cooling, readings, dataDir, daemonPort, previews, attachLinks, attachSessionLink, dashboardLink, channelName, minter, credentials, anthropic, anthropicHealth, aistack, deps }) {
+  constructor({ config, routing, harnessRegistry, reduction, notify, announce, openConfirm, openMapQuestion, lapseEscalation, confirmNote, overseerNote, askReview, cancelEscalation, threads, log = console.log, cooling, readings, dataDir, daemonPort, previews, attachLinks, attachSessionLink, dashboardLink, channelName, minter, credentials, anthropic, anthropicHealth, aistack, deps }) {
     this.config = config
     this.routing = routing
+    this.harnesses = harnessRegistry ?? HARNESS_REGISTRY
     this.reduction = reduction
     this.notify = notify
     // The plain channel line, injected by index.mjs the way the backup's
@@ -1576,8 +1578,8 @@ export class Dispatcher {
     const useModel = cands[0]
     const harnessName = this.routing.models[useModel].harness
     const reasoningEffort = reasoningEffortFor(this.routing, labels, useModel)
-    if (!this.routing.harnesses[harnessName]) {
-      return `❌ unknown harness \`${harnessName}\` — configured harnesses: ${Object.keys(this.routing.harnesses).join(', ')}`
+    if (!this.routing.harnesses[harnessName] || !this.harnesses.has(harnessName)) {
+      return `❌ unknown harness \`${harnessName}\` — registered harnesses: ${this.harnesses.names.join(', ')}`
     }
 
     const login = this.claimLogin()
@@ -1622,7 +1624,7 @@ export class Dispatcher {
     })
     action?.progress('Preparing the agent workspace')
 
-    const cfgDir = cfgDirFor(this.root, session)
+    const cfgDir = cfgDirFor(this.root, session, harnessName)
     // Declared outside the try so the finally can release the pending
     // reservation (#allocatePorts) on BOTH endings — after `agents.set` the
     // ports are covered by the live-agent scan, and on a failed dispatch
@@ -1686,6 +1688,7 @@ export class Dispatcher {
       this.reduction.journal('agent_spawned', {
         repo, ticket: n, agent: session, instance,
         model: useModel, requested_model: modelName, harness: harnessName, reasoning_effort: reasoningEffort,
+        ...this.#journalHarnessIdentity(harnessName),
         prompt_carries_limit_text: textCarriesLimitPhrase(full.title, full.body),
         kind: spawnKind({ charting }), instruction: charting ? instruction : null,
         ...(skill ? { skill, skill_target: skillTarget } : {}),
@@ -1703,7 +1706,8 @@ export class Dispatcher {
       const agent = {
         repo, ticket: n, title: full.title, session, instance, wtPath, cfgDir, promptFile,
         model: useModel, requestedModel: modelName, harness: harnessName, reasoningEffort, labels,
-        provider: this.routing.models[useModel].provider,
+        ...spawnIdentity(this.#journalHarnessIdentity(harnessName)),
+        provider: this.harnesses.get(harnessName).identity.provider,
         // #156: the published loopback ports. #157 hands them to
         // `publish_preview` as its port bound.
         ports: container.ports,
@@ -1812,14 +1816,25 @@ export class Dispatcher {
   // `--env-file`, and a pane env would put every value of it in `ps` — the cost
   // #155 measured and asked #156 not to repeat.
   async #spawnPlan({ session, ticket, repo, harness, model, wtPath, cfgDir, promptFile, ports, reviewer = false, resume = false }) {
+    const adapter = this.harnesses.get(harness)
     const harnessCmd = resume
-      ? buildResumeCmd(this.routing, harness, model)
-      : buildSpawnCmd(this.routing, harness, model, path.join(GUEST_CFG, path.basename(promptFile)))
+      ? adapter.lifecycle.resumeCommand({ routing: this.routing, model })
+      : adapter.lifecycle.freshCommand({
+          routing: this.routing, model, promptFile: path.join(GUEST_CFG, path.basename(promptFile)),
+        })
     const container = await this.#prepareContainer({
       session, ticket, repo, harness, model, wtPath, cfgDir, spawnCmd: harnessCmd,
       sandbox: this.config.sandbox, ports, reviewer,
     })
     return { container, shellCmd: container.shellCmd, env: {} }
+  }
+
+  #journalHarnessIdentity(harness) {
+    const adapter = this.harnesses.get(harness)
+    return {
+      adapter: adapter.identity.name,
+      config_layout: adapter.identity.configLayoutVersion,
+    }
   }
 
   // ---- the agent's GitHub credential (#389, ADR-0018) -------------------------
@@ -2867,8 +2882,8 @@ export class Dispatcher {
       if (guard) return guard
 
       const harnessName = this.routing.models[useModel].harness
-      if (!this.routing.harnesses[harnessName]) {
-        return `❌ unknown harness \`${harnessName}\` — configured harnesses: ${Object.keys(this.routing.harnesses).join(', ')}`
+      if (!this.routing.harnesses[harnessName] || !this.harnesses.has(harnessName)) {
+        return `❌ unknown harness \`${harnessName}\` — registered harnesses: ${this.harnesses.names.join(', ')}`
       }
       return await this.#spawnReviewer({
         session, ticket, repo: theRepo, issue, model: useModel, builderModel,
@@ -2900,7 +2915,7 @@ export class Dispatcher {
   // made and leaves the builder untouched, because the cross-check owns nothing
   // the ticket depends on.
   async #spawnReviewer({ session, ticket, repo, issue, model, builderModel, harnessName, sameProvider, by, tellBuilder = true }) {
-    const cfgDir = cfgDirFor(this.root, session)
+    const cfgDir = cfgDirFor(this.root, session, harnessName)
     let checkout = null
     try {
       checkout = await this.deps.createReviewCheckout(this.root, repo, ticket)
@@ -2931,6 +2946,7 @@ export class Dispatcher {
       // home for exactly what tmux cannot re-derive (#reconcileReviewers).
       this.reduction.journal('reviewer_spawned', {
         repo, ticket, agent: session, builder: `curia-${ticket}`, model, harness: harnessName,
+        ...this.#journalHarnessIdentity(harnessName),
         reasoning_effort: reasoningEffort,
         builder_model: builderModel, same_provider: sameProvider, sha: checkout.sha,
         prompt_carries_limit_text: textCarriesLimitPhrase(issue.title, issue.body),
@@ -2942,14 +2958,16 @@ export class Dispatcher {
       this.reduction.journal('agent_spawned', {
         repo, ticket, agent: session, model, requested_model: model,
         prompt_carries_limit_text: textCarriesLimitPhrase(issue.title, issue.body),
-        harness: harnessName, kind: spawnKind({ reviewer: true }),
+        harness: harnessName, ...this.#journalHarnessIdentity(harnessName),
+        kind: spawnKind({ reviewer: true }),
       })
 
       const agent = {
         repo, ticket, title: issue.title, session, instance: `${session}@${Date.now()}`,
         wtPath: checkout.path, cfgDir, promptFile,
         model, requestedModel: model, harness: harnessName,
-        provider: this.routing.models[model].provider,
+        ...spawnIdentity(this.#journalHarnessIdentity(harnessName)),
+        provider: this.harnesses.get(harnessName).identity.provider,
         ports: null, sandbox: 'docker',
         promptHarness: harnessName,
         spawnedAt: Date.now(), state: 'spawning', resultReceived: false,
@@ -3607,6 +3625,7 @@ export class Dispatcher {
     const ports = agent.reviewer ? [] : (allocated ? await this.#allocatePorts() : agent.ports)
     try {
       const reasoningEffort = reasoningEffortFor(this.routing, agent.labels ?? [], next)
+      agent.cfgDir = cfgDirFor(this.root, agent.session, nextHarness)
       this.#armAgent({
         session: agent.session, ticket: agent.ticket, harness: nextHarness,
         model: next, reasoningEffort, wtPath: agent.wtPath, cfgDir: agent.cfgDir,
@@ -3645,7 +3664,8 @@ export class Dispatcher {
       agent.model = next
       agent.reasoningEffort = reasoningEffort
       agent.harness = nextHarness
-      agent.provider = this.routing.models[next].provider
+      Object.assign(agent, spawnIdentity(this.#journalHarnessIdentity(nextHarness)))
+      agent.provider = this.harnesses.get(nextHarness).identity.provider
       agent.spawnedAt = Date.now()
       agent.state = 'spawning'
       // A respawn is a NEW client process, so what the last one proved about its
@@ -3672,6 +3692,7 @@ export class Dispatcher {
         repo: agent.repo, ticket: agent.ticket, agent: agent.session,
         instance: agent.instance ?? null,
         model: next, requested_model: agent.requestedModel, harness: nextHarness,
+        ...this.#journalHarnessIdentity(nextHarness),
         reasoning_effort: reasoningEffort,
         prompt_carries_limit_text: Boolean(agent.promptCarriesLimitText),
         kind: spawnKind(agent), instruction: agent.instruction ?? null,
@@ -6537,7 +6558,7 @@ export class Dispatcher {
         }
       }
     }
-    this.deps.removeConfigDir(w?.cfgDir ?? cfgDirFor(this.root, session))
+    this.deps.removeConfigDir(cfgDirFor(this.root, session))
     this.deps.forgetAgentToken(this.dataDir, session)
     this.agents.delete(session)
     if (w && !charting) {
@@ -6602,7 +6623,7 @@ export class Dispatcher {
     }
     this.agents.delete(session)
     const removed = await this.#removeReviewCheckout(w?.repo ?? this.#epochRepo(ticket), ticket, w?.wtPath)
-    this.deps.removeConfigDir(w?.cfgDir ?? cfgDirFor(this.root, session))
+    this.deps.removeConfigDir(cfgDirFor(this.root, session))
     this.deps.forgetAgentToken(this.dataDir, session)
     this.reduction.journal('reviewer_cancelled', { repo: w?.repo, ticket, agent: session, by: by ?? 'unknown', tracked: Boolean(w) })
     this.lapseConfirmsFor(session, `\`${session}\` was cancelled`)
@@ -7751,12 +7772,17 @@ export class Dispatcher {
           // a FRESH instance id: any confirm bound before the restart lapses
           // at boot rather than matching an adopted agent it never described
           const instance = `${session}@adopted-${Date.now()}`
+          const identity = spawnIdentity(spawn)
+          const cfgDir = identity.legacy || !identity.adapter
+            ? cfgDirFor(this.root, session)
+            : cfgDirFor(this.root, session, identity.adapter)
           this.agents.set(session, {
             repo, ticket: n, title: issue.title, session, instance,
-            wtPath, cfgDir: cfgDirFor(this.root, session), promptFile: path.join(cfgDirFor(this.root, session), 'prompt.md'),
+            wtPath, cfgDir, promptFile: path.join(cfgDir, 'prompt.md'),
             model: spawn?.model ?? null,
             requestedModel: spawn?.requested_model ?? spawn?.model ?? null,
             harness: spawn?.harness ?? null,
+            ...identity,
             reasoningEffort: spawn?.reasoning_effort ?? null,
             labels,
             provider: this.routing.models[spawn?.model]?.provider ?? null,
@@ -7780,6 +7806,7 @@ export class Dispatcher {
               model: spawn.model,
               requested_model: spawn.requested_model ?? spawn.model,
               harness: spawn.harness,
+              ...this.#journalHarnessIdentity(spawn.harness),
               prompt_carries_limit_text: spawn.prompt_carries_limit_text
                 ?? textCarriesLimitPhrase(issue.title, issue.body),
               kind: spawn.kind ?? spawnKind({ charting }), instruction: spawn.instruction ?? instruction,
@@ -7904,14 +7931,19 @@ export class Dispatcher {
       })
       : []
     const instance = `${session}@adopted-${Date.now()}`
+    const identity = spawnIdentity(spawn)
+    const cfgDir = identity.legacy || !identity.adapter
+      ? cfgDirFor(this.root, session)
+      : cfgDirFor(this.root, session, identity.adapter)
     this.agents.set(session, {
       repo, ticket: handle, title, session, instance,
       wtPath: worktreePathFor(this.root, repo, handle),
-      cfgDir: cfgDirFor(this.root, session),
-      promptFile: path.join(cfgDirFor(this.root, session), 'prompt.md'),
+      cfgDir,
+      promptFile: path.join(cfgDir, 'prompt.md'),
       model: spawn?.model ?? null,
       requestedModel: spawn?.requested_model ?? spawn?.model ?? null,
       harness: spawn?.harness ?? null,
+      ...identity,
       provider: this.routing.models[spawn?.model]?.provider ?? null,
       ports: ports.length ? ports : null,
       sandbox: ports.length ? 'docker' : null,
@@ -7963,7 +7995,10 @@ export class Dispatcher {
         continue
       }
       const ticket = String(spawn.ticket)
-      const cfgDir = cfgDirFor(this.root, session)
+      const identity = spawnIdentity(spawn)
+      const cfgDir = identity.legacy || !identity.adapter
+        ? cfgDirFor(this.root, session)
+        : cfgDirFor(this.root, session, identity.adapter)
       this.agents.set(session, {
         repo: spawn.repo,
         ticket,
@@ -7978,6 +8013,7 @@ export class Dispatcher {
         model: spawn.model ?? null,
         requestedModel: spawn.requested_model ?? spawn.model ?? null,
         harness: spawn.harness ?? null,
+        ...identity,
         provider: this.routing.models[spawn.model]?.provider ?? null,
         ports: null,
         sandbox: spawn.sandbox ?? null,
@@ -8121,7 +8157,8 @@ export class Dispatcher {
       // builder's does, and it is abandoned by the same rule.
       if (!SESSION_RE.test(dir) && !REVIEW_SESSION_RE.test(dir)) continue
       if (sessions.includes(dir) || this.agents.has(dir) || this.inFlight.has(dir)) continue
-      const cfgDir = cfgDirFor(this.root, dir)
+      const sessionRoot = cfgDirFor(this.root, dir)
+      const configRoots = [sessionRoot, ...this.harnesses.names.map((harness) => cfgDirFor(this.root, dir, harness))]
       // One name per harness, plus the one the daemon mints itself. Two terminal
       // states KEEP the whole config dir for a post-mortem, so every credential
       // in it outlives its agent: the claude harness's `.credentials.json`, the
@@ -8130,10 +8167,10 @@ export class Dispatcher {
       // host credential in a container (#158, and every dispatch is one), so a
       // codex agent on a box still holding #155's PAT has no `gh` dir either —
       // it was stepped over here with a live host token on disk (#467).
-      const holds = ['.credentials.json', 'auth.json', GH_DIR]
-        .some((name) => fs.existsSync(path.join(cfgDir, name)))
-      if (!holds) continue
-      this.deps.removeCredentials(cfgDir)
+      const occupied = configRoots.filter((cfgDir) => ['.credentials.json', 'auth.json', GH_DIR]
+        .some((name) => fs.existsSync(path.join(cfgDir, name))))
+      if (!occupied.length) continue
+      for (const cfgDir of occupied) this.deps.removeCredentials(cfgDir)
       this.reduction.journal('credentials_swept', { agent: dir })
       this.log(`reconcile: swept the credentials of dead ${dir} (workspace kept)`)
     }

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -2176,13 +2176,15 @@ export class Dispatcher {
   // containers and the overseer, so there is no consumer named `anthropic` to
   // sign in. `openai` stays the bare default — it is the lane that can die on a
   // timer, so it is the one an operator reaches for without thinking.
-  async startReauth({ provider = CODEX_PROVIDER, by = null } = {}) {
+  async startReauth({ provider = CODEX_PROVIDER, by = null, action = null } = {}) {
     if (!this.reauth) return '❌ this daemon brokers no model credential, so it has nothing to sign back in'
     const lane = this.reauth.laneFor(provider)
     if (!lane) {
       return `❌ curia owns no \`${provider}\` credential, so there is nothing to sign back in. It can re-authenticate: ${this.reauth.providers.join(', ') || 'nothing'}`
     }
     if (!this.config.sandbox) return '❌ this daemon runs no containers, so it has nothing to run the login in'
+    action?.accept({ receipt: { provider } })
+    action?.progress('Preparing the agent image')
     let image
     try {
       image = await this.deps.ensureAgentImage(this.config.sandbox, {
@@ -2192,9 +2194,10 @@ export class Dispatcher {
       return `❌ the agent image is not available, so the login has nothing to run in (${e.message})`
     }
     this.reauth.image = image.ref
+    action?.progress('Starting the credential sign-in session')
     let started
     try {
-      started = await this.reauth.start({ provider })
+      started = await this.reauth.start({ provider, actionId: action?.actionId ?? null })
     } catch (e) {
       return `❌ the re-authentication session could not be started (${e.message})`
     }
@@ -2209,6 +2212,7 @@ export class Dispatcher {
     // through. Stamping it on the flow is what puts it on both, and keeps the
     // page out of the business of building a URL it cannot vouch for.
     this.reauth.noteTerminal(attach)
+    action?.progress('Waiting for browser sign-in')
     const where = attach
       ? `Terminal: ${attach}`
       : 'curia could not publish a terminal link for it. The dashboard card carries the link and the code.'

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -1175,7 +1175,7 @@ export class Dispatcher {
   //
   // `reuse` is the resume contract (#81): inherit the surviving worktree
   // instead of recreating it — see #dispatch.
-  async start(ticketArg, { repo, model, by, reuse = false, conversationResume = false, threadId = null } = {}) {
+  async start(ticketArg, { repo, model, by, reuse = false, conversationResume = false, threadId = null, action = null } = {}) {
     const n = String(ticketArg)
     const session = `curia-${n}`
     // Admission guard: synchronous check + insert BEFORE the first await, so a
@@ -1239,7 +1239,7 @@ export class Dispatcher {
       // #dispatch returns null only on exhaustion whose latched notify just
       // fired; the slash caller still deserves a reply.
       return (await this.#dispatch(theRepo, n, issue, {
-        model, by, reuse, conversationResume, threadId,
+        model, by, reuse, conversationResume, threadId, action,
       })) ?? this.#exhaustedReply()
     } finally {
       this.inFlight.delete(session)
@@ -1496,7 +1496,7 @@ export class Dispatcher {
   // recreated from origin; absent one, resume degrades to an ordinary dispatch.
   async #dispatch(repo, n, issue, {
     model, instruction = null, by, reuse = false, conversationResume = false,
-    threadId = null, charting = false, skill = null, skillTarget = null,
+    threadId = null, charting = false, skill = null, skillTarget = null, action = null,
   }) {
     const session = `curia-${n}`
     // #241: a new-map dispatch is charting with no map, so there is no number to
@@ -1601,6 +1601,7 @@ export class Dispatcher {
       this.reduction.journal('dispatch_claimed', {
         repo, ticket: n, title: issue.title, agent: session, by: by ?? 'unknown', kind: 'ticket',
       })
+      action?.accept()
     }
 
     // The ticket label goes on at the claim (#93): `start` binds the thread it
@@ -1619,6 +1620,7 @@ export class Dispatcher {
     this.reduction.journal('agent_dispatching', {
       repo, ticket: n, title: issue.title, agent: session, model: useModel, harness: harnessName,
     })
+    action?.progress('Preparing the agent workspace')
 
     const cfgDir = cfgDirFor(this.root, session)
     // Declared outside the try so the finally can release the pending

--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -269,13 +269,15 @@ export class GitHubAppSetup {
   status() {
     try {
       const record = this.#readState()
-      if (record.status === 'complete') return { status: 'complete', app: record.app }
+      const action = record.action_id ? { action_id: record.action_id } : {}
+      if (record.status === 'complete') return { status: 'complete', app: record.app, ...action }
       // `converting` and `converted` are this record's own steps between the
       // start and the finish. To the page, every one of them is a setup that
       // is still pending its one press on github.com.
       return {
         status: this.now() > record.expires_at ? 'expired' : 'pending',
         expires_at: new Date(record.expires_at).toISOString(),
+        ...action,
       }
     } catch (error) {
       if (/no GitHub App setup/.test(error?.message ?? '')) return { status: 'unconfigured' }
@@ -283,7 +285,7 @@ export class GitHubAppSetup {
     }
   }
 
-  start({ name, redirectUrl, organization = null } = {}) {
+  start({ name, redirectUrl, organization = null, actionId = null } = {}) {
     const appName = String(name ?? '').trim()
     if (!appName || appName.length > 34) throw new Error('the GitHub App name must contain 1 to 34 characters')
     let redirect
@@ -304,7 +306,7 @@ export class GitHubAppSetup {
     if (redirect.search || redirect.hash) throw new Error('the GitHub App redirect URL must carry no query or fragment')
     const state = Buffer.from(this.randomBytes(32)).toString('hex')
     const expires = this.now() + APP_SETUP_TTL_MS
-    this.#writeState({ state, expires_at: expires, status: 'pending' })
+    this.#writeState({ state, expires_at: expires, status: 'pending', ...(actionId ? { action_id: String(actionId) } : {}) })
     const ownerPath = organization
       ? `/organizations/${encodeURIComponent(String(organization))}/settings/apps/new`
       : '/settings/apps/new'

--- a/daemon/src/harnesses.mjs
+++ b/daemon/src/harnesses.mjs
@@ -1,0 +1,314 @@
+// The public Harness adapter seam (ADR-0029 and ADR-0030).
+//
+// This first migration step makes the contract executable while Claude and
+// Codex still delegate native setup and orchestration to their existing
+// implementations. Later migration steps move those implementations behind
+// the five facets without changing this interface.
+
+import { buildResumeCmd, buildSpawnCmd } from './routing.mjs'
+import { CONSUMER_NAMES, PROVIDER_CREDENTIALS } from './credentials.mjs'
+
+export const HARNESS_FACETS = Object.freeze([
+  'identity',
+  'setup',
+  'lifecycle',
+  'evidence',
+  'control',
+])
+
+export const HARNESS_CAPABILITIES = Object.freeze([
+  'modelSwitch',
+  'reasoningEffort',
+  'transcriptUsage',
+  'nativeSkills',
+  'richMetadata',
+])
+
+export const NORMALIZED_EVENT_TYPES = Object.freeze([
+  'user_message',
+  'assistant_message',
+  'tool_started',
+  'tool_completed',
+  'ready',
+  'active',
+  'stalled',
+  'process_died',
+  'usage_observed',
+  'unknown_native_evidence',
+])
+
+export const LEGACY_CONFIG_LAYOUT = 0
+export const CURRENT_CONFIG_LAYOUT = 1
+
+export class HarnessContractError extends Error {
+  constructor(message, { code = 'HARNESS_CONTRACT_INVALID', status = 500 } = {}) {
+    super(message)
+    this.name = 'HarnessContractError'
+    this.code = code
+    this.status = status
+  }
+}
+
+export class HarnessCapabilityError extends Error {
+  constructor(harness, capability) {
+    super(`the ${harness} Harness doesn't support ${capability}`)
+    this.name = 'HarnessCapabilityError'
+    this.code = 'HARNESS_CAPABILITY_UNAVAILABLE'
+    this.status = 409
+    this.harness = harness
+    this.capability = capability
+  }
+}
+
+function contractFault(message) {
+  throw new HarnessContractError(message)
+}
+
+function plainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function freeze(value, seen = new Set()) {
+  if (!plainObject(value) || seen.has(value)) return value
+  seen.add(value)
+  for (const child of Object.values(value)) freeze(child, seen)
+  return Object.freeze(value)
+}
+
+function requireFunction(facet, value, method) {
+  if (typeof value?.[method] !== 'function') contractFault(`Harness facet ${facet} needs a ${method}() operation`)
+}
+
+export function validateHarnessAdapter(adapter, {
+  providers = null,
+  credentialConsumers = null,
+} = {}) {
+  if (!plainObject(adapter)) contractFault('a Harness adapter must be an object')
+  for (const facet of HARNESS_FACETS) {
+    if (!plainObject(adapter[facet])) contractFault(`a Harness adapter needs the ${facet} facet`)
+  }
+
+  const { identity, setup, lifecycle, evidence, control } = adapter
+  for (const field of ['name', 'provider', 'credentialConsumer']) {
+    if (typeof identity[field] !== 'string' || !identity[field]) {
+      contractFault(`Harness identity needs a non-empty ${field}`)
+    }
+  }
+  if (!Number.isInteger(identity.configLayoutVersion) || identity.configLayoutVersion < 1) {
+    contractFault(`Harness ${identity.name} needs a positive integer configLayoutVersion`)
+  }
+  if (providers && !providers.includes(identity.provider)) {
+    contractFault(`Harness ${identity.name} names unknown provider "${identity.provider}"`)
+  }
+  if (credentialConsumers && !credentialConsumers.includes(identity.credentialConsumer)) {
+    contractFault(`Harness ${identity.name} names unknown credential consumer "${identity.credentialConsumer}"`)
+  }
+
+  for (const method of ['refuseRepository', 'prepare']) requireFunction('setup', setup, method)
+  for (const method of ['freshCommand', 'resumeCommand', 'isReady', 'processDied', 'interrupt', 'send']) {
+    requireFunction('lifecycle', lifecycle, method)
+  }
+  for (const method of ['discover', 'events', 'activity', 'usage']) requireFunction('evidence', evidence, method)
+  requireFunction('control', control, 'enforceCompletion')
+
+  if (!plainObject(control.capabilities)) contractFault(`Harness ${identity.name} control needs capabilities`)
+  if (!plainObject(control.operations)) contractFault(`Harness ${identity.name} control needs operations`)
+  for (const capability of HARNESS_CAPABILITIES) {
+    if (typeof control.capabilities[capability] !== 'boolean') {
+      contractFault(`Harness ${identity.name} must declare capability ${capability} as true or false`)
+    }
+  }
+  for (const [capability, supported] of Object.entries(control.capabilities)) {
+    if (!HARNESS_CAPABILITIES.includes(capability)) {
+      contractFault(`Harness ${identity.name} declares unknown capability "${capability}"`)
+    }
+    if (typeof supported !== 'boolean') {
+      contractFault(`Harness ${identity.name} capability ${capability} must be true or false`)
+    }
+    if (supported && typeof control.operations[capability] !== 'function') {
+      contractFault(`Harness ${identity.name} declares ${capability} without an operation`)
+    }
+  }
+  for (const capability of Object.keys(control.operations)) {
+    if (!HARNESS_CAPABILITIES.includes(capability)) {
+      contractFault(`Harness ${identity.name} implements unknown capability "${capability}"`)
+    }
+    if (control.capabilities[capability] !== true) {
+      contractFault(`Harness ${identity.name} implements ${capability} without declaring support`)
+    }
+  }
+  return adapter
+}
+
+export function defineHarnessAdapter(adapter, options = {}) {
+  validateHarnessAdapter(adapter, options)
+  return freeze(adapter)
+}
+
+export function createHarnessRegistry(adapters, options = {}) {
+  if (!Array.isArray(adapters) || !adapters.length) contractFault('a Harness registry needs at least one adapter')
+  const byName = new Map()
+  for (const candidate of adapters) {
+    const adapter = defineHarnessAdapter(candidate, options)
+    const name = adapter.identity.name
+    if (byName.has(name)) contractFault(`duplicate Harness adapter name "${name}"`)
+    byName.set(name, adapter)
+  }
+  const names = Object.freeze([...byName.keys()])
+  return Object.freeze({
+    names,
+    has: (name) => byName.has(name),
+    get(name) {
+      const adapter = byName.get(name)
+      if (!adapter) {
+        throw new HarnessContractError(
+          `unknown Harness "${name}" - registered Harnesses: ${names.join(', ')}`,
+          { code: 'HARNESS_UNKNOWN', status: 400 },
+        )
+      }
+      return adapter
+    },
+    values: () => [...byName.values()],
+  })
+}
+
+function createPort(name, operations, required) {
+  if (!plainObject(operations)) contractFault(`${name} port operations must be an object`)
+  for (const operation of required) {
+    if (typeof operations[operation] !== 'function') contractFault(`${name} port needs ${operation}()`)
+  }
+  return freeze({ ...operations })
+}
+
+export const createFilesystemPort = (operations) => createPort('filesystem', operations, [
+  'refuseRepository', 'prepare',
+])
+export const createProcessPort = (operations) => createPort('process', operations, [
+  'died', 'interrupt',
+])
+export const createPanePort = (operations) => createPort('pane', operations, [
+  'capture', 'send',
+])
+export const createTranscriptPort = (operations) => createPort('transcript', operations, [
+  'discover', 'events', 'activity', 'usage',
+])
+export const createToolChannelPort = (operations) => createPort('tool-channel', operations, [
+  'enforceCompletion',
+])
+
+export function createHarnessPorts({ filesystem, process, pane, transcript, toolChannel }) {
+  return freeze({
+    filesystem: createFilesystemPort(filesystem),
+    process: createProcessPort(process),
+    pane: createPanePort(pane),
+    transcript: createTranscriptPort(transcript),
+    toolChannel: createToolChannelPort(toolChannel),
+  })
+}
+
+export function normalizedEvent(type, fields = {}) {
+  if (!NORMALIZED_EVENT_TYPES.includes(type)) {
+    throw new HarnessContractError(`unknown normalized Harness event "${type}"`, {
+      code: 'HARNESS_EVENT_UNKNOWN',
+    })
+  }
+  if (!plainObject(fields)) contractFault('normalized Harness event fields must be an object')
+  return freeze({ ...fields, type })
+}
+
+export function unknownNativeEvidence(nativeType, fields = {}) {
+  return normalizedEvent('unknown_native_evidence', { ...fields, nativeType: String(nativeType ?? '') })
+}
+
+export function requireHarnessCapability(adapter, capability, ...args) {
+  const name = adapter?.identity?.name ?? 'unknown'
+  if (!HARNESS_CAPABILITIES.includes(capability)) {
+    throw new HarnessContractError(`unknown Harness capability "${capability}"`, {
+      code: 'HARNESS_CAPABILITY_UNKNOWN', status: 400,
+    })
+  }
+  if (adapter?.control?.capabilities?.[capability] !== true) {
+    throw new HarnessCapabilityError(name, capability)
+  }
+  const operation = adapter.control.operations[capability]
+  return args.length ? operation(...args) : operation
+}
+
+export function spawnIdentity(event = {}) {
+  const source = event ?? {}
+  const name = source.adapter ?? source.harness ?? null
+  return Object.freeze({
+    adapter: name,
+    configLayoutVersion: Number.isInteger(source.config_layout)
+      ? source.config_layout
+      : LEGACY_CONFIG_LAYOUT,
+    legacy: !Number.isInteger(source.config_layout),
+  })
+}
+
+const portCall = (ports, port, operation, ...args) => {
+  const fn = ports?.[port]?.[operation]
+  if (typeof fn !== 'function') contractFault(`Harness call needs ${port}.${operation}() through its ports`)
+  return fn(...args)
+}
+
+function legacyAdapter({ name, provider, capabilities }) {
+  const capabilityOperations = {
+    modelSwitch: (context, ports) => portCall(ports, 'pane', 'modelSwitch', context),
+    reasoningEffort: (context, ports) => portCall(ports, 'pane', 'reasoningEffort', context),
+    transcriptUsage: (context, ports) => portCall(ports, 'transcript', 'usage', context),
+    nativeSkills: (context, ports) => portCall(ports, 'filesystem', 'nativeSkills', context),
+    richMetadata: (context, ports) => portCall(ports, 'transcript', 'richMetadata', context),
+  }
+  return {
+    identity: {
+      name,
+      provider,
+      credentialConsumer: name,
+      configLayoutVersion: CURRENT_CONFIG_LAYOUT,
+    },
+    setup: {
+      refuseRepository: (context, ports) => portCall(ports, 'filesystem', 'refuseRepository', context),
+      prepare: (context, ports) => portCall(ports, 'filesystem', 'prepare', context),
+    },
+    lifecycle: {
+      freshCommand: ({ routing, model, promptFile }) => buildSpawnCmd(routing, name, model, promptFile),
+      resumeCommand: ({ routing, model }) => buildResumeCmd(routing, name, model),
+      isReady: ({ routing, paneText }) => Boolean(routing.harnesses?.[name]?.readyRe?.test(paneText)),
+      processDied: (context, ports) => portCall(ports, 'process', 'died', context),
+      interrupt: (context, ports) => portCall(ports, 'process', 'interrupt', context),
+      send: (context, ports) => portCall(ports, 'pane', 'send', context),
+    },
+    evidence: {
+      discover: (context, ports) => portCall(ports, 'transcript', 'discover', context),
+      events: (context, ports) => portCall(ports, 'transcript', 'events', context),
+      activity: (context, ports) => portCall(ports, 'transcript', 'activity', context),
+      usage: (context, ports) => portCall(ports, 'transcript', 'usage', context),
+    },
+    control: {
+      capabilities,
+      operations: Object.fromEntries(
+        Object.entries(capabilities)
+          .filter(([, supported]) => supported)
+          .map(([capability]) => [capability, capabilityOperations[capability]]),
+      ),
+      enforceCompletion: (context, ports) => portCall(ports, 'toolChannel', 'enforceCompletion', context),
+    },
+  }
+}
+
+const sharedCapabilities = Object.freeze({
+  modelSwitch: true,
+  reasoningEffort: true,
+  transcriptUsage: true,
+  nativeSkills: true,
+  richMetadata: true,
+})
+
+export const HARNESS_REGISTRY = createHarnessRegistry([
+  legacyAdapter({ name: 'claude', provider: 'anthropic', capabilities: sharedCapabilities }),
+  legacyAdapter({ name: 'codex', provider: 'openai', capabilities: sharedCapabilities }),
+], {
+  providers: Object.keys(PROVIDER_CREDENTIALS),
+  credentialConsumers: CONSUMER_NAMES,
+})

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -3598,13 +3598,81 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
     return json(200, { ok: true, said: out.said, ...aistackStatus() })
   }
 
+  if (url.pathname === '/settings/action' && req.method === 'POST') {
+    const body = await readBody(req).catch(() => ({}))
+    const actionId = String(body?.action_id ?? '')
+    const paths = [...new Set(Array.isArray(body?.paths) ? body.paths.map(String) : [])].sort()
+    const allowed = new Set(['curia.local.yaml', 'routing.local.yaml'])
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(actionId)) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    if (!paths.length || paths.some((candidate) => !allowed.has(candidate))) {
+      return json(400, { error: 'paths must name curia.local.yaml, routing.local.yaml, or both' })
+    }
+
+    const recorded = actions.get(actionId)
+    if (recorded) return json(200, { action: recorded })
+    const wanted = new Set(paths)
+    const conflict = actions.overview().find((candidate) =>
+      candidate.kind === 'settings-save'
+      && !['confirmed', 'refused', 'failed'].includes(candidate.status)
+      && String(candidate.target).split(',').some((candidatePath) => wanted.has(candidatePath)))
+    const action = {
+      action_id: actionId,
+      kind: 'settings-save',
+      target: paths.join(','),
+      conflict_key: `settings:${paths.join('+')}`,
+    }
+    if (conflict) {
+      const refused = reduction.recordAction({
+        ...action,
+        status: 'refused',
+        reason: `${paths.join(' and ')} is already being saved`,
+      })
+      return json(200, { action: refused })
+    }
+    reduction.recordAction({ ...action, status: 'accepted' })
+    const progress = reduction.recordAction({
+      ...action,
+      status: 'progress',
+      progress: `Writing ${paths.join(' and ')}`,
+    })
+    return json(200, { action: progress })
+  }
+
+  if (url.pathname === '/settings/action/finish' && req.method === 'POST') {
+    const body = await readBody(req).catch(() => ({}))
+    const action = actions.get(String(body?.action_id ?? ''))
+    if (!action || action.kind !== 'settings-save') return json(404, { error: 'settings Action not found' })
+    if (['confirmed', 'refused', 'failed'].includes(action.status)) return json(200, { action })
+    const status = ['confirmed', 'refused', 'failed'].includes(body?.status) ? body.status : 'failed'
+    const settled = reduction.recordAction({
+      ...action,
+      status,
+      ...(body?.reason != null ? { reason: String(body.reason) } : {}),
+      ...(body?.receipt != null ? { receipt: body.receipt } : {}),
+    })
+    return json(200, { action: settled })
+  }
+
   if (url.pathname === '/reload' && req.method === 'POST') {
     const body = await readBody(req).catch(() => ({}))
     const by = named(body?.by)
+    const actionId = String(body?.action_id ?? '')
+    const action = actionId ? actions.get(actionId) : null
+    const written = Array.isArray(body?.written) ? body.written.map(String) : []
+    if (action && !['confirmed', 'refused', 'failed'].includes(action.status)) {
+      reduction.recordAction({ ...action, status: 'progress', progress: 'Applying settings' })
+    }
+    const settle = (status, detail) => {
+      if (!action || ['confirmed', 'refused', 'failed'].includes(actions.get(actionId)?.status)) return null
+      return reduction.recordAction({ ...action, status, ...detail })
+    }
     const decline = (reason, detail) => {
       reduction.journal('config_reload_declined', { by, reason, ...detail })
       log(`reload declined for ${by}: ${detail.error ?? detail.key}`)
-      return json(200, { ok: false, reason, ...detail })
+      const evidence = settle('confirmed', { receipt: { written, applied: [], reload: { ok: false, reason, ...detail } } })
+      return json(200, { ok: false, reason, ...detail, ...(evidence ? { action: evidence } : {}) })
     }
 
     let nextCuria
@@ -3664,7 +3732,8 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
     log(applied.length
       ? `config reloaded by ${by}: ${applied.join(', ')}`
       : `config reloaded by ${by} — the file says what this daemon was already running`)
-    return json(200, { ok: true, by, applied, loaded_at: configLoadedAt })
+    const evidence = settle('confirmed', { receipt: { written, applied } })
+    return json(200, { ok: true, by, applied, loaded_at: configLoadedAt, ...(evidence ? { action: evidence } : {}) })
   }
 
   // The restart (#249 item 6, built by #265). No sudoers, no host change and no

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -3585,9 +3585,14 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
         return json(400, { error: error.message })
       }
       const evidence = await actions.run(action, async (controls) => {
-        const reply = await gate.command(text, named(by), { action: controls })
+        const reply = await gate.command(text, named(by), { action: { ...controls, actionId: action.action_id } })
         const current = actions.get(action.action_id)
         if (!current) return { status: 'refused', reason: reply }
+        if (action.kind === 'credential-sign-in') {
+          if (/^❌/.test(reply)) return { status: 'failed', reason: reply }
+          if (current.status === 'accepted' || current.status === 'progress') return { status: current.status }
+          return { status: 'confirmed' }
+        }
         if (/^⚙️ dispatched\b/.test(reply)) return { status: 'confirmed' }
         return { status: 'failed', reason: reply }
       })

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -42,7 +42,8 @@ import { Cooling, providerOf } from './routing.mjs'
 import { Dispatcher } from './dispatch.mjs'
 import { REVIEW_KIND, RESULT_KIND, NOTIFY_KIND } from './lifecycle.mjs'
 import { sameDigest } from './diffdigest.mjs'
-import { CommandRouter } from './commands.mjs'
+import { CommandRouter, actionForCommand } from './commands.mjs'
+import { ActionCoordinator } from './actions.mjs'
 import { SelfDeploy } from './deploy.mjs'
 import { OverseerClient, OverseerTurns, serveConversationMcp, serveVerbMcp } from './overseerclient.mjs'
 import { OverseerPaneHost } from './overseerpane.mjs'
@@ -395,6 +396,7 @@ log(`claims assign ${curiaConfig.dispatch.claim_login} (dispatch.claim_login) �
 // the journal file into the database. `log` is a hoisted function declaration,
 // so the conversion line reaches journalctl even from here.
 const reduction = new Reduction(DATA, { log })
+const actions = new ActionCoordinator(reduction, { log })
 
 // The boot line (#436). The journal is `node:sqlite`, which Node marks Stability
 // 1.2, so a patch update can change the API, the defaults and the bundled SQLite
@@ -2886,6 +2888,7 @@ async function overview() {
     token_warnings: reduction.standingTokenWarnings(),
     feed_reads: reduction.lastFeedReads(),
     events: reduction.recentEvents(),
+    actions: actions.overview(),
     maps: mapSnapshotOnWire,
     frontier: dispatcher.frontierSnapshot(),
     // The last self-deploy and any in-flight one (#562): the outcome used to
@@ -3406,8 +3409,24 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   // seam Discord uses — two hand-rolled copies of log+journal+dispatch had
   // already drifted apart.
   if (url.pathname === '/command' && req.method === 'POST') {
-    const { text, by } = await readBody(req)
+    const { text, by, action_id: actionId } = await readBody(req)
     if (typeof text !== 'string' || !text.trim()) return json(400, { error: 'body must carry {text}' })
+    if (actionId != null) {
+      let action
+      try {
+        action = actionForCommand(text, actionId)
+      } catch (error) {
+        return json(400, { error: error.message })
+      }
+      const evidence = await actions.run(action, async (controls) => {
+        const reply = await gate.command(text, named(by), { action: controls })
+        const current = actions.get(action.action_id)
+        if (!current) return { status: 'refused', reason: reply }
+        if (/^⚙️ dispatched\b/.test(reply)) return { status: 'confirmed' }
+        return { status: 'failed', reason: reply }
+      })
+      return json(200, { action: evidence })
+    }
     const reply = await gate.command(text, named(by))
     return json(200, { reply })
   }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -3899,10 +3899,46 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   if (url.pathname === '/restart' && req.method === 'POST') {
     const body = await readBody(req).catch(() => ({}))
     const by = typeof body?.by === 'string' ? body.by : 'loopback'
-    reduction.journal('restart_requested', { by, exit_code: RESTART_EXIT_CODE })
+    const actionId = body?.action_id == null ? null : String(body.action_id)
+    let evidence = null
+    if (actionId != null) {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(actionId)) {
+        return json(400, { error: 'action_id is not a valid Action id' })
+      }
+      const action = {
+        action_id: actionId,
+        kind: 'daemon-restart',
+        target: 'daemon',
+        conflict_key: 'daemon:lifecycle',
+      }
+      const uptime = body?.uptime_s
+      const recorded = actions.get(actionId)
+      if (recorded) return json(200, { ok: true, by, exit_code: RESTART_EXIT_CODE, action: recorded })
+      const conflict = actions.overview().find((candidate) =>
+        candidate.conflict_key === action.conflict_key
+        && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+      if (conflict) {
+        const refused = reduction.recordAction({
+          ...action,
+          status: 'refused',
+          reason: 'the daemon is already restarting',
+        })
+        return json(409, { ok: false, error: refused.reason, action: refused })
+      }
+      evidence = reduction.recordAction({
+        ...action,
+        status: 'accepted',
+        ...(typeof uptime === 'number' && Number.isFinite(uptime) && uptime >= 0 ? { receipt: { uptime_s: uptime } } : {}),
+      })
+    }
+    reduction.journal('restart_requested', {
+      by, exit_code: RESTART_EXIT_CODE, ...(actionId ? { action_id: actionId } : {}),
+    })
     log(`restart requested by ${by} — exiting ${RESTART_EXIT_CODE} so the supervisor respawns this process`)
     res.writeHead(200, { 'content-type': 'application/json' })
-    return res.end(JSON.stringify({ ok: true, by, exit_code: RESTART_EXIT_CODE }), () => {
+    return res.end(JSON.stringify({
+      ok: true, by, exit_code: RESTART_EXIT_CODE, ...(evidence ? { action: evidence } : {}),
+    }), () => {
       goodbyeThenExit('restart', RESTART_EXIT_CODE, RESTART_DELAY_MS)
     })
   }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -550,6 +550,7 @@ const statusLine = new StatusLine({
   post: (ticket, text, opts) => (bridge ? bridge.postStatus(ticket, text, opts) : null),
   edit: (ids, text, opts) => (bridge ? bridge.editStatus(ids, text, opts) : false),
   remove: (ids) => (bridge ? bridge.deleteStatus(ids) : null),
+  find: (ticket) => (bridge ? bridge.findStatus(ticket) : null),
   // The thread-name state glyph (#199): the status line derives the state,
   // the bridge renders it. With the bridge down the flag is dropped — the
   // next transition retries, and the name is display only.

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -3406,34 +3406,63 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   if (url.pathname === '/answer' && req.method === 'POST') {
     const body = await readBody(req)
     const { id, attachments, by, via, index, files: inline } = body
-    let answer = String(body.answer ?? '')
-    // An option index is the same answer a Discord button sends (#712,
-    // ADR-0025): every surface resolves a pick to the option's own words, so
-    // the record and the agent read one text whichever control was pressed.
-    const live = reduction.resolveLive(String(id ?? '')).record
-    const picked = Number.isInteger(index) ? live?.options?.[index] : undefined
-    if (picked !== undefined) answer = String(picked)
-    // A browser reply's files (#712) are written first, then walk the same
-    // containment gate the bridge's downloads walk, so one path reads them.
-    const written = live?.status === 'open' ? writeReplyFiles(live.id, inline) : { paths: [], refusals: [] }
-    if (written.refusals.length) return json(400, { ok: false, reason: 'files', error: written.refusals.join('; ') })
-    // Attachment paths get read and inlined into an agent's context, so they
-    // pass the same containment gate as outbound attachments rather than being
-    // trusted because the caller reached loopback.
-    const { files } = outboundFiles('rest', [...(attachments ?? []), ...written.paths])
-    if (written.paths.length) answer = [answer, ...written.paths.map((p) => `[attachment: ${p}]`)].filter(Boolean).join('\n')
-    // #266: the console names the operator who pressed and the surface they
-    // pressed on, so the journal and the feed say `answered by <login> via
-    // dashboard` rather than attributing every browser answer to `rest`. The
-    // default is what every caller before this one already sent.
-    const result = gate.answer(id, {
-      answer: String(answer), attachments: files.map((f) => f.attachment), by: named(by), via: named(via),
+    const settleAnswer = () => {
+      let answer = String(body.answer ?? '')
+      // An option index is the same answer a Discord button sends (#712,
+      // ADR-0025): every surface resolves a pick to the option's own words, so
+      // the record and the agent read one text whichever control was pressed.
+      const live = reduction.resolveLive(String(id ?? '')).record
+      const picked = Number.isInteger(index) ? live?.options?.[index] : undefined
+      if (picked !== undefined) answer = String(picked)
+      // A browser reply's files (#712) are written first, then walk the same
+      // containment gate the bridge's downloads walk, so one path reads them.
+      const written = live?.status === 'open' ? writeReplyFiles(live.id, inline) : { paths: [], refusals: [] }
+      if (written.refusals.length) return { ok: false, reason: 'files', error: written.refusals.join('; ') }
+      // Attachment paths get read and inlined into an agent's context, so they
+      // pass the same containment gate as outbound attachments rather than being
+      // trusted because the caller reached loopback.
+      const { files } = outboundFiles('rest', [...(attachments ?? []), ...written.paths])
+      if (written.paths.length) answer = [answer, ...written.paths.map((p) => `[attachment: ${p}]`)].filter(Boolean).join('\n')
+      // #266: the console names the operator who pressed and the surface they
+      // pressed on, so the journal and the feed say `answered by <login> via
+      // dashboard` rather than attributing every browser answer to `rest`. The
+      // default is what every caller before this one already sent.
+      const result = gate.answer(id, {
+        answer: String(answer), attachments: files.map((f) => f.attachment), by: named(by), via: named(via),
+      })
+      // A second answer gets the first receipt (#712, ADR-0025): the refusal
+      // carries who answered, where, when and what, so the surface that lost the
+      // race shows the mark and never a second question. Nothing is journalled.
+      if (!result.ok && result.record?.status === 'answered') result.receipt = answerReceipt(result.record)
+      return result
+    }
+
+    const actionId = body.action_id == null ? '' : String(body.action_id)
+    if (!actionId) {
+      const result = settleAnswer()
+      return json(result.ok ? 200 : result.reason === 'files' ? 400 : 409, result)
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(actionId)) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    const action = {
+      action_id: actionId, kind: 'escalation-answer', target: String(id ?? ''),
+      conflict_key: `answer:${String(id ?? '')}`,
+    }
+    const evidence = await actions.run(action, async () => {
+      const result = settleAnswer()
+      return result.ok
+        ? { status: 'confirmed', receipt: answerReceipt(result.record) }
+        : { status: 'refused', reason: result.reason, error: result.error, receipt: result.receipt ?? null }
     })
-    // A second answer gets the first receipt (#712, ADR-0025): the refusal
-    // carries who answered, where, when and what, so the surface that lost the
-    // race shows the mark and never a second question. Nothing is journalled.
-    if (!result.ok && result.record?.status === 'answered') result.receipt = answerReceipt(result.record)
-    return json(result.ok ? 200 : 409, result)
+    const ok = evidence.status === 'confirmed'
+    const result = {
+      ok, action: evidence,
+      ...(evidence.reason ? { reason: evidence.reason } : {}),
+      ...(evidence.error ? { error: evidence.error } : {}),
+      ...(evidence.receipt ? { receipt: evidence.receipt } : {}),
+    }
+    return json(ok ? 200 : evidence.reason === 'files' ? 400 : 409, result)
   }
 
   // The console's note (#266). A note in Discord is any message in an agent's

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1634,6 +1634,7 @@ const timeline = new TimelineSurface({
   workspaceRoot: curiaConfig.dispatch.workspace_root,
   log,
   deps: {
+    actions,
     journal: (type, detail) => reduction.journal(type, detail),
     harnessFor: (session) => dispatcher.agents.get(session)?.harness
       ?? detectHarness(path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)),

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1680,6 +1680,8 @@ const timeline = new TimelineSurface({
   deps: {
     actions,
     journal: (type, detail) => reduction.journal(type, detail),
+    draftFor: (session) => reduction.chatDraft(session),
+    recordDraft: (session, text) => reduction.recordChatDraft(session, text),
     harnessFor: (session) => dispatcher.agents.get(session)?.harness
       ?? detectHarness(path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)),
     // The dialog guard's composer veto (#75): a visible ready marker (#39)

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1685,6 +1685,7 @@ const timeline = new TimelineSurface({
       const key = consoleKeyForSession(session)
       if (!key) return null
       return {
+        key,
         cfgDir: overseerContainer.configDir,
         sessionId: reduction.overseerSession(key) ?? null,
         // #708, ADR-0024: the message goes into the conversation's own live

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -368,6 +368,18 @@ const githubAppSetup = new GitHubAppSetup({
   },
 })
 
+// A setup spans the trip through github.com, so its Action can outlive this
+// process. The setup record carries only the Action identity. The journal
+// still owns the evidence and the setup record still contains no credential.
+{
+  const setup = githubAppSetup.status()
+  const evidence = setup.action_id ? actions.get(setup.action_id) : null
+  if (evidence && !['confirmed', 'refused', 'failed'].includes(evidence.status)) {
+    if (setup.status === 'complete') reduction.recordAction({ ...evidence, status: 'confirmed' })
+    if (setup.status === 'expired') reduction.recordAction({ ...evidence, status: 'failed', reason: 'GitHub App setup expired after one hour' })
+  }
+}
+
 // #390: the DAEMON cuts over. Every `gh` child it spawns for a named repo now
 // carries that owner's minted write token, so the frontier reads, the claims,
 // the pull requests and the branch pushes all run as `curia-sh[bot]`.
@@ -3157,13 +3169,33 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   }
 
   if (url.pathname === '/github-app/start' && req.method === 'POST') {
-    const { name, redirect_url: redirectUrl } = await readBody(req)
+    const { name, redirect_url: redirectUrl, action_id: actionId } = await readBody(req)
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId ?? ''))) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    const action = {
+      action_id: String(actionId), kind: 'github-app-setup', target: 'github-app-setup',
+      conflict_key: 'github-app:setup',
+    }
+    const recorded = actions.get(action.action_id)
+    if (recorded) return json(200, { action: recorded })
+    const conflict = actions.overview().find((candidate) =>
+      candidate.conflict_key === action.conflict_key && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+    if (conflict) {
+      const refused = await actions.run(action, async () => ({
+        status: 'refused', reason: 'another GitHub App setup is already in progress',
+      }))
+      return json(200, { action: refused })
+    }
     try {
-      const started = githubAppSetup.start({ name, redirectUrl })
-      reduction.journal('github_app_setup_started', { expires_at: started.expires_at })
-      return json(200, started)
+      const started = githubAppSetup.start({ name, redirectUrl, actionId: action.action_id })
+      const accepted = reduction.recordAction({ ...action, status: 'accepted' })
+      reduction.recordAction({ ...action, status: 'progress', progress: 'Waiting for GitHub to complete setup' })
+      reduction.journal('github_app_setup_started', { expires_at: started.expires_at, action_id: action.action_id })
+      return json(200, { action: accepted, setup: started })
     } catch (e) {
-      return json(400, { error: e.message })
+      const refused = reduction.recordAction({ ...action, status: 'refused', reason: e.message })
+      return json(200, { action: refused })
     }
   }
 
@@ -3171,27 +3203,57 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   // the operator presses once and the kept reading is replaced, awaited here
   // so the answer states what the press measured.
   if (url.pathname === '/github-app/installations' && req.method === 'POST') {
-    if (!appMinter) return json(400, { error: 'no GitHub App is configured, so there is nothing to read installations for' })
-    appMinter.readFacts().catch((e) => log(`could not read the GitHub App's own facts (${e.message})`))
-    try {
-      const installs = await appMinter.refreshInstallations()
-      reduction.journal('github_app_installations_read', { owners: installs.map((i) => i.owner) })
-      return json(200, { ok: true, reply: `Read ${installs.length} installation${installs.length === 1 ? '' : 's'}: ${installs.map((i) => i.owner).join(', ') || 'none'}`, installations: appMinter.reading })
-    } catch (e) {
-      return json(200, { ok: false, reply: `The installation read failed: ${e.message}`, installations: appMinter.reading })
+    const { action_id: actionId } = await readBody(req)
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId ?? ''))) {
+      return json(400, { error: 'action_id is not a valid Action id' })
     }
+    const action = {
+      action_id: String(actionId), kind: 'github-app-installations', target: 'github-app-installations',
+      conflict_key: 'github-app:installations',
+    }
+    const evidence = await actions.run(action, async (controls) => {
+      const conflict = actions.overview().find((candidate) =>
+        candidate.action_id !== action.action_id && candidate.conflict_key === action.conflict_key
+        && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+      if (conflict) return { status: 'refused', reason: 'another GitHub App installation read is already in progress' }
+      if (!appMinter) return { status: 'refused', reason: 'no GitHub App is configured, so there is nothing to read installations for' }
+      controls.accept()
+      controls.progress('Reading GitHub App installations')
+      appMinter.readFacts().catch((e) => log(`could not read the GitHub App's own facts (${e.message})`))
+      try {
+        const installs = await appMinter.refreshInstallations()
+        const reply = `Read ${installs.length} installation${installs.length === 1 ? '' : 's'}: ${installs.map((i) => i.owner).join(', ') || 'none'}`
+        reduction.journal('github_app_installations_read', { owners: installs.map((i) => i.owner), action_id: action.action_id })
+        return { status: 'confirmed', receipt: { reply, installations: appMinter.reading } }
+      } catch (e) {
+        return {
+          status: 'failed', reason: `The installation read failed: ${e.message}`,
+          receipt: { reply: `The installation read failed: ${e.message}`, installations: appMinter.reading },
+        }
+      }
+    })
+    return json(200, { action: evidence })
   }
 
   if (url.pathname === '/github-app/complete' && req.method === 'GET') {
+    const setupActionId = githubAppSetup.status().action_id ?? null
     try {
       const completed = await githubAppSetup.complete({
         code: url.searchParams.get('code'),
         state: url.searchParams.get('state'),
       })
       reduction.journal('github_app_setup_completed', { app: completed.app, replay: !completed.ok })
+      const current = setupActionId ? actions.get(setupActionId) : null
+      if (current && !['confirmed', 'refused', 'failed'].includes(current.status)) {
+        reduction.recordAction({ ...current, status: 'confirmed', receipt: { app: completed.app } })
+      }
       return json(200, completed)
     } catch (e) {
       reduction.journal('github_app_setup_failed', { error: e.message })
+      const current = setupActionId ? actions.get(setupActionId) : null
+      if (current && !['confirmed', 'refused', 'failed'].includes(current.status)) {
+        reduction.recordAction({ ...current, status: 'failed', reason: e.message })
+      }
       return json(400, { error: e.message })
     }
   }

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -522,8 +522,9 @@ const modelWindows = new ModelWindows({ credentials: anthropic, log })
 
 // Same harness resolution the timeline uses: the dispatcher's word on what it
 // spawned, on-disk evidence for re-adopted and lab sessions.
-const cfgDirFor = (session) => path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)
-const harnessFor = (session) => dispatcher?.agents.get(session)?.harness ?? detectHarness(cfgDirFor(session))
+const agentCfgDirFor = (session) => dispatcher?.agents.get(session)?.cfgDir
+  ?? path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)
+const harnessFor = (session) => dispatcher?.agents.get(session)?.harness ?? detectHarness(agentCfgDirFor(session))
 
 // Everything the status line says about one agent beyond its state. Named
 // rather than inlined because `GET /overview` reads the same meters for the
@@ -538,7 +539,7 @@ const harnessFor = (session) => dispatcher?.agents.get(session)?.harness ?? dete
 // default only speaks when no record exists.
 const metersFor = (session, model) => agentMeters({
   harness: harnessFor(session),
-  cfgDir: cfgDirFor(session),
+  cfgDir: agentCfgDirFor(session),
   model: model ?? dispatcher?.agents.get(session)?.model ?? null,
   effort: dispatcher?.agents.get(session)?.reasoningEffort ?? null,
   routing: routingConfig,
@@ -1684,7 +1685,7 @@ const timeline = new TimelineSurface({
     draftFor: (session) => reduction.chatDraft(session),
     recordDraft: (session, text) => reduction.recordChatDraft(session, text),
     harnessFor: (session) => dispatcher.agents.get(session)?.harness
-      ?? detectHarness(path.join(curiaConfig.dispatch.workspace_root, 'cfg', session)),
+      ?? detectHarness(agentCfgDirFor(session)),
     // The dialog guard's composer veto (#75): a visible ready marker (#39)
     // says the pane is at its composer, so a dialog-footer phrase in the tail
     // is scrollback, not a dialog.
@@ -2951,7 +2952,7 @@ async function overview() {
 // lives in usage.mjs beside `ctxOnWire`; what stays here is the wiring — the
 // reduction this daemon holds and the overseer container's config dir and model.
 function ticketConversationOnWire({ session, repo, ticket, title = null, model = null, reasoningEffort = null, state, reviewer = false, cfgDir = null, harness = null, live = true }) {
-  const root = cfgDir ?? cfgDirFor(curiaConfig.dispatch.workspace_root, session)
+  const root = cfgDir ?? agentCfgDirFor(session)
   const detected = harness ?? detectHarness(root)
   const transcript = detected ? findTranscript(detected, root) : null
   let lastTurnAt = null

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -3520,7 +3520,26 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
     const body = await readBody(req)
     const by = typeof body.by === 'string' ? body.by.trim() : ''
     if (!by) return json(400, { error: 'a feed read names the operator login that read it' })
-    return json(200, reduction.markFeedRead(named(by)))
+    const actionId = String(body.action_id ?? '')
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(actionId)) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    const login = named(by).toLowerCase()
+    const action = {
+      action_id: actionId,
+      kind: 'feed-read',
+      target: login,
+      conflict_key: `feed-read:${login}`,
+    }
+    const evidence = await actions.run(action, async () => {
+      const conflict = actions.overview().find((candidate) =>
+        candidate.action_id !== action.action_id && candidate.conflict_key === action.conflict_key
+        && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+      if (conflict) return { status: 'refused', reason: 'another Feed visit for this login is already being recorded' }
+      const receipt = reduction.markFeedRead(login, { action })
+      return { status: 'confirmed', receipt }
+    })
+    return json(evidence.status === 'confirmed' ? 200 : 409, { action: evidence })
   }
 
   if (url.pathname === '/cancel' && req.method === 'POST') {

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1329,10 +1329,42 @@ const aistackReg = new AistackRegistration({
 // registration, and joining them anywhere else would give one of them a
 // reference to the other for no other reason.
 function aistackStatus() {
+  const live = aistackReg.status({ machine: reduction.registeredAistackMachine() })
+  const reducedFlow = reduction.aistackRegistration()
+  let flow = reducedFlow ?? (live.flow?.phase === 'waiting' && (!live.flow.code || !live.flow.url)
+    ? { phase: 'unregistered' }
+    : live.flow)
+  if (live.registered) flow = { phase: 'registered', action_id: flow?.action_id ?? null, at: live.machine?.at ?? null }
+  else if (live.flow?.phase === 'waiting') flow = live.flow
+
+  // A child process can't be reattached after a daemon restart. Keep its
+  // journal-reduced device code truthful until the CLI's own wait expires,
+  // then settle both the ceremony and its Action from shared facts.
+  const expiresAt = Number(flow?.expires_at)
+  if (flow?.phase === 'waiting' && !aistackReg.flow && Number.isFinite(expiresAt) && expiresAt > 0 && expiresAt <= Date.now()) {
+    const message = 'nobody approved the login within three minutes, so the CLI stopped waiting'
+    reduction.journal('aistack_login_failed', {
+      phase: 'expired', message, action_id: flow.action_id ?? null,
+    })
+    flow = reduction.aistackRegistration()
+  }
+
+  const registrationAction = flow?.action_id ? actions.get(flow.action_id) : null
+  if (registrationAction && !['confirmed', 'refused', 'failed'].includes(registrationAction.status)) {
+    if (live.registered) actions.confirm(registrationAction.action_id, { receipt: { outcome: 'registered' } })
+    else if (['failed', 'expired', 'cancelled'].includes(flow?.phase)) {
+      reduction.recordAction({
+        ...registrationAction, status: 'failed',
+        reason: flow.message ?? `The registration ${flow.phase}`,
+      })
+    }
+  }
   const alarm = reduction.standingAistackAlarm()
   return {
     ok: true,
-    ...aistackReg.status({ machine: reduction.registeredAistackMachine() }),
+    ...live,
+    flow,
+    actions: actions.overview().filter((action) => action.conflict_key === 'aistack:machine-registration'),
     sync: {
       last: reduction.lastAistackSync(),
       // The unrepaired failure, if there is one. Its message is the CLI's, and
@@ -3614,17 +3646,95 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
     return json(200, aistackStatus())
   }
   if (url.pathname === '/aistack/register' && req.method === 'POST') {
-    const out = await aistackReg.begin()
-    return json(out.ok === false ? 409 : 200, out.ok === false ? out : aistackStatus())
+    const { action_id: actionId } = await readBody(req).catch(() => ({}))
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId ?? ''))) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    const action = {
+      action_id: String(actionId), kind: 'aistack-register', target: 'aistack-machine',
+      conflict_key: 'aistack:machine-registration',
+    }
+    const recorded = actions.get(action.action_id)
+    if (recorded) return json(200, { action: recorded })
+    const conflict = actions.overview().find((candidate) => candidate.conflict_key === action.conflict_key
+      && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+    const reason = aistackReg.registered()
+      ? 'this box is already registered with aistack — revoke the machine at aistack.to/settings/machines and delete the credential on the box before registering it again'
+      : conflict ? 'another machine-registration Action is already in progress' : null
+    if (reason) {
+      const refused = reduction.recordAction({ ...action, status: 'refused', reason })
+      return json(409, { ok: false, error: reason, action: refused })
+    }
+    const evidence = await actions.run(action, async (controls) => {
+      controls.accept()
+      controls.progress('Starting the device login')
+      const out = await aistackReg.begin({ actionId: action.action_id })
+      if (!out.ok) return { status: 'failed', reason: out.error }
+      controls.progress('Waiting for approval', {
+        receipt: { code: out.flow.code, url: out.flow.url, expires_at: out.flow.expires_at },
+      })
+      return { status: 'progress' }
+    })
+    return json(200, { action: evidence })
   }
   if (url.pathname === '/aistack/cancel' && req.method === 'POST') {
-    const out = aistackReg.cancel()
-    return json(out.ok === false ? 409 : 200, out.ok === false ? out : aistackStatus())
+    const { action_id: actionId } = await readBody(req).catch(() => ({}))
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId ?? ''))) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    const action = {
+      action_id: String(actionId), kind: 'aistack-cancel', target: 'aistack-machine',
+      conflict_key: 'aistack:machine-registration',
+    }
+    const recorded = actions.get(action.action_id)
+    if (recorded) return json(200, { action: recorded })
+    const flow = aistackStatus().flow
+    const conflict = actions.overview().find((candidate) => candidate.conflict_key === action.conflict_key
+      && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+    const reason = flow?.phase !== 'waiting'
+      ? 'no aistack registration is waiting'
+      : conflict && conflict.kind !== 'aistack-register' ? 'another machine-registration Action is already in progress' : null
+    if (reason) {
+      const refused = reduction.recordAction({ ...action, status: 'refused', reason })
+      return json(409, { ok: false, error: reason, action: refused })
+    }
+    if (conflict) reduction.recordAction({ ...conflict, status: 'failed', reason: 'The registration was cancelled before approval' })
+    const evidence = await actions.run(action, async (controls) => {
+      controls.accept()
+      const out = aistackReg.cancel({ restored: flow })
+      if (!out.ok) return { status: 'failed', reason: out.error }
+      return { status: 'confirmed', receipt: { outcome: 'cancelled' } }
+    })
+    return json(200, { action: evidence })
   }
   if (url.pathname === '/aistack/optin' && req.method === 'POST') {
-    const out = await aistackReg.optIn()
-    if (out.ok === false) return json(409, out)
-    return json(200, { ok: true, said: out.said, ...aistackStatus() })
+    const { action_id: actionId } = await readBody(req).catch(() => ({}))
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId ?? ''))) {
+      return json(400, { error: 'action_id is not a valid Action id' })
+    }
+    const action = {
+      action_id: String(actionId), kind: 'aistack-optin', target: 'aistack-machine',
+      conflict_key: 'aistack:machine-registration',
+    }
+    const recorded = actions.get(action.action_id)
+    if (recorded) return json(200, { action: recorded })
+    const conflict = actions.overview().find((candidate) => candidate.conflict_key === action.conflict_key
+      && !['confirmed', 'refused', 'failed'].includes(candidate.status))
+    const reason = !aistackReg.registered()
+      ? "register the box with aistack first — the standing permission is granted with the box's own token"
+      : conflict ? 'another machine-registration Action is already in progress' : null
+    if (reason) {
+      const refused = reduction.recordAction({ ...action, status: 'refused', reason })
+      return json(409, { ok: false, error: reason, action: refused })
+    }
+    const evidence = await actions.run(action, async (controls) => {
+      controls.accept()
+      controls.progress('Granting the standing permission')
+      const out = await aistackReg.optIn()
+      if (!out.ok) return { status: 'failed', reason: out.error }
+      return { status: 'confirmed', receipt: { said: out.said } }
+    })
+    return json(200, { action: evidence })
   }
 
   if (url.pathname === '/settings/action' && req.method === 'POST') {

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -3315,6 +3315,27 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   // being looked at would spend a number every time the operator glanced at the
   // screen, and numbers only go up.
   if (url.pathname === '/console/new' && req.method === 'POST') {
+    const { action_id: actionId } = await readBody(req)
+    if (actionId != null) {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId))) {
+        return json(400, { error: 'action_id is not a valid Action id' })
+      }
+      const action = {
+        action_id: String(actionId), kind: 'console-conversation-open',
+        target: 'conversation-registry', conflict_key: 'conversation-registry',
+      }
+      const evidence = await actions.run(action, async () => {
+        const key = reduction.openConsoleConversation()
+        const session = sessionForConsoleKey(key)
+        log(`console: opened browser conversation ${key}`)
+        return { status: 'confirmed', receipt: { key, session } }
+      })
+      return json(200, {
+        action: evidence,
+        key: evidence.receipt?.key,
+        session: evidence.receipt?.session,
+      })
+    }
     const key = reduction.openConsoleConversation()
     log(`console: opened browser conversation ${key}`)
     return json(200, { key, session: sessionForConsoleKey(key) })
@@ -3325,8 +3346,28 @@ async function handleRequest(req, res, { fromContainer = false } = {}) {
   // 409 rather than a silent success, because the page may be showing a list
   // another device has already changed.
   if (url.pathname === '/console/delete' && req.method === 'POST') {
-    const key = String((await readBody(req)).key ?? '')
+    const { key: rawKey, action_id: actionId } = await readBody(req)
+    const key = String(rawKey ?? '')
     if (!isConsoleKey(key)) return json(400, { error: `\`${key}\` is not a browser conversation key` })
+    if (actionId != null) {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(String(actionId))) {
+        return json(400, { error: 'action_id is not a valid Action id' })
+      }
+      const action = {
+        action_id: String(actionId), kind: 'console-conversation-delete',
+        target: key, conflict_key: `conversation:${key}`,
+      }
+      const evidence = await actions.run(action, async () => {
+        if (!reduction.deleteConsoleConversation(key)) {
+          return { status: 'refused', reason: `there is no conversation \`${key}\` — it may already be deleted` }
+        }
+        revokeConversationToken(DATA, key)
+        log(`console: deleted browser conversation ${key} — its number is spent`)
+        return { status: 'confirmed', receipt: { key } }
+      })
+      const code = evidence.status === 'confirmed' ? 200 : evidence.status === 'failed' ? 500 : 409
+      return json(code, { action: evidence, ...(evidence.reason ? { error: evidence.reason } : {}) })
+    }
     if (!reduction.deleteConsoleConversation(key)) {
       return json(409, { ok: false, error: `there is no conversation \`${key}\` — it may already be deleted` })
     }

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -200,6 +200,7 @@ export class Reduction {
     this.aistackAt = null // when the last aistack sync attempt finished, or null (#695)
     this.aistackLast = null // how the last aistack sync attempt ENDED, or null (#706)
     this.aistackMachine = null // the registration this box holds, or null (#706)
+    this.aistackFlow = null // the journal-reduced machine-registration ceremony (#815)
     this.mapAlarms = new Map() // "repo#map" -> the stranded-map alarm that still stands (#485)
     this.transcriptLandings = new Map() // session -> rewind landing and transcript tail (#689)
     this.conversationTurns = new Map() // session -> sent operator turns and the queued notes each one carried (#702)
@@ -545,9 +546,38 @@ export class Reduction {
     // memory, so the machine name survives the restart the operator does right
     // after registering. The credential file records no name, so this is the
     // name the box PROPOSED, and the screen says as much.
+    if (ev.type === 'aistack_login_started') {
+      const startedAt = Number(ev.started_at ?? (ev.ts ? Date.parse(ev.ts) : NaN))
+      this.aistackFlow = {
+        phase: 'waiting', code: ev.code ?? null, url: ev.url ?? null,
+        action_id: ev.action_id ?? null,
+        started_at: Number.isFinite(startedAt) ? startedAt : null,
+        expires_at: Number.isFinite(Number(ev.expires_at)) ? Number(ev.expires_at) : null,
+      }
+    }
+    if (ev.type === 'aistack_login_failed') {
+      const at = ev.ts ? Date.parse(ev.ts) : NaN
+      this.aistackFlow = {
+        phase: ev.phase ?? 'failed', message: ev.message ?? null,
+        action_id: ev.action_id ?? this.aistackFlow?.action_id ?? null,
+        at: Number.isFinite(at) ? at : null,
+      }
+    }
+    if (ev.type === 'aistack_login_cancelled') {
+      const at = ev.ts ? Date.parse(ev.ts) : NaN
+      this.aistackFlow = {
+        phase: 'cancelled', message: ev.message ?? 'the registration was cancelled before it was approved',
+        action_id: ev.action_id ?? this.aistackFlow?.action_id ?? null,
+        at: Number.isFinite(at) ? at : null,
+      }
+    }
     if (ev.type === 'aistack_registered') {
       const at = ev.ts ? Date.parse(ev.ts) : NaN
       this.aistackMachine = { machine: ev.machine ?? null, at: Number.isFinite(at) ? at : null }
+      this.aistackFlow = {
+        phase: 'registered', action_id: ev.action_id ?? this.aistackFlow?.action_id ?? null,
+        at: Number.isFinite(at) ? at : null,
+      }
     }
 
     // The stranded-map alarm (#485). A reduction for the reason the backup's is
@@ -1883,6 +1913,13 @@ export class Reduction {
   // The aistack registration this box holds, or null (#706).
   registeredAistackMachine() {
     return this.aistackMachine ? { ...this.aistackMachine } : null
+  }
+
+  // The device ceremony's last shared position. Unlike the child process,
+  // this survives a daemon restart and gives every Atlas client the same code,
+  // expiry, and ending (#815).
+  aistackRegistration() {
+    return this.aistackFlow ? { ...this.aistackFlow } : null
   }
 
   // Every stranded-map alarm that still stands (#485). The frontier read

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -1127,7 +1127,26 @@ export class Reduction {
       // per login rather than per browser, so a phone and a laptop under the
       // same login agree on where "you left" was.
       case 'feed_read': {
-        if (typeof ev.by === 'string' && ev.by.trim() && ev.ts) this.feedReads.set(ev.by.trim().toLowerCase(), ev.ts)
+        if (typeof ev.by !== 'string' || !ev.by.trim() || !ev.ts) break
+        const login = ev.by.trim().toLowerCase()
+        const previous = this.feedReads.get(login) ?? null
+        this.feedReads.set(login, ev.ts)
+        // The read and its Action ending are one durable fact. If the response
+        // is lost, or the daemon restarts after this append, overview recovery
+        // still confirms the exact visit without stamping the cursor twice.
+        if (ev.action_id && ev.action_kind && ev.action_target && ev.action_conflict_key) {
+          this.actions.set(String(ev.action_id), {
+            action_id: String(ev.action_id),
+            kind: ev.action_kind,
+            target: ev.action_target,
+            conflict_key: ev.action_conflict_key,
+            status: 'confirmed',
+            revision: this.revision,
+            started_at: ev.ts,
+            updated_at: ev.ts,
+            receipt: { by: login, at: ev.ts, previous },
+          })
+        }
         break
       }
       case 'reauth_started': {
@@ -1949,11 +1968,22 @@ export class Reduction {
   // Stamp one login's Feed read. Answers the previous stamp, which is what the
   // page draws the marker at: the read that just happened is not "since you
   // left" until the next visit.
-  markFeedRead(by) {
+  markFeedRead(by, { action = null } = {}) {
     const login = String(by ?? '').trim().toLowerCase()
     if (!login) throw new Error('a feed read names the login that read it')
     const previous = this.feedReads.get(login) ?? null
-    const rec = this._append({ type: 'feed_read', by: login })
+    const now = Date.now()
+    const priorMs = Date.parse(previous ?? '')
+    const at = new Date(Number.isFinite(priorMs) ? Math.max(now, priorMs + 1) : now).toISOString()
+    const rec = this._append({
+      type: 'feed_read', by: login, ts: at,
+      ...(action ? {
+        action_id: action.action_id,
+        action_kind: action.kind,
+        action_target: action.target,
+        action_conflict_key: action.conflict_key,
+      } : {}),
+    })
     return { ok: true, by: login, at: rec.ts, previous }
   }
 

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -106,6 +106,8 @@ const FEED_SILENT = new Set([
   'conversation_turn_recorded', 'conversation_turn_taken_back', 'agent_notes_requeued',
   'overseer_notes_carried', 'overseer_notes_requeued',
   'overseer_pane_parked',
+  // Draft keystrokes are durable composer state, not operator-facing news.
+  'timeline_draft_changed',
   // The Feed's own read stamp (#704). Reading the feed is not news on it.
   'feed_read',
 ])
@@ -205,6 +207,7 @@ export class Reduction {
     this.transcriptLandings = new Map() // session -> rewind landing and transcript tail (#689)
     this.conversationTurns = new Map() // session -> sent operator turns and the queued notes each one carried (#702)
     this.carriedNotes = new Map() // session -> overseer notes a pane message took but no turn record has claimed yet (#702)
+    this.chatDrafts = new Map() // session -> latest shared Atlas Chat composer text (#821)
     this.actions = new Map() // action_id -> latest daemon-owned Action evidence (#803)
     this.revision = 0 // journal order, rebuilt identically on every boot (#803)
     this.seq = 0
@@ -285,6 +288,13 @@ export class Reduction {
         ...(ev.reason != null ? { reason: ev.reason } : {}),
         ...(ev.receipt != null ? { receipt: ev.receipt } : {}),
       })
+    }
+
+    if (ev.type === 'timeline_draft_changed' && ev.session) {
+      this.chatDrafts.set(String(ev.session), String(ev.text ?? ''))
+    }
+    if (ev.type === 'timeline_send' && ev.session && ['sent', 'unconfirmed', 'corrected'].includes(ev.outcome)) {
+      this.chatDrafts.set(String(ev.session), '')
     }
 
     // Credential sign-in Actions outlive the request that starts them. The
@@ -1823,6 +1833,15 @@ export class Reduction {
   // Generic operational events (notify, result, agent_done…) share the journal.
   journal(type, data) {
     return this._append({ type, ...data })
+  }
+
+  recordChatDraft(session, text) {
+    this._append({ type: 'timeline_draft_changed', session: String(session), text: String(text) })
+    return this.chatDraft(session)
+  }
+
+  chatDraft(session) {
+    return this.chatDrafts.get(String(session)) ?? ''
   }
 
   recordAction(evidence) {

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -287,6 +287,37 @@ export class Reduction {
       })
     }
 
+    // Credential sign-in Actions outlive the request that starts them. The
+    // flow's own journal facts advance the same evidence after a restart, and
+    // carry no device code or credential.
+    if (ev.action_id && ev.type.startsWith('reauth_')) {
+      const actionId = String(ev.action_id)
+      const prior = this.actions.get(actionId)
+      if (prior && !TERMINAL_ACTION_STATUSES.has(prior.status)) {
+        const progress = ev.type === 'reauth_started'
+          ? 'Waiting for browser sign-in'
+          : ev.type === 'reauth_code_seen' ? 'Waiting for browser completion' : null
+        const ending = ev.type === 'reauth_completed'
+          ? { status: 'confirmed' }
+          : ['reauth_failed', 'reauth_timed_out', 'reauth_code_expired', 'reauth_abandoned'].includes(ev.type)
+            ? { status: 'failed', reason: ev.why ?? {
+              reauth_failed: 'the fresh credential could not be adopted',
+              reauth_timed_out: 'the sign-in timed out',
+              reauth_code_expired: 'the one-time code expired',
+              reauth_abandoned: 'the sign-in session ended',
+            }[ev.type] }
+            : null
+        if (progress || ending) this.actions.set(actionId, {
+          ...prior,
+          status: ending?.status ?? 'progress',
+          revision: this.revision,
+          updated_at: ev.ts,
+          ...(progress ? { progress } : {}),
+          ...(ending?.reason ? { reason: ending.reason } : {}),
+        })
+      }
+    }
+
     // Start's authoritative domain events close the tiny crash gap between the
     // operation and its Action coordinator continuation. On a live run the
     // coordinator writes the same terminal answer. On rebuild, or after
@@ -1062,7 +1093,10 @@ export class Reduction {
       case 'reauth_started': {
         const startedAt = Date.parse(ev.ts ?? '')
         if (!ev.provider || !Number.isFinite(startedAt)) break
-        this.openLogins.set(ev.provider, { provider: ev.provider, session: ev.session ?? null, startedAt })
+        this.openLogins.set(ev.provider, {
+          provider: ev.provider, session: ev.session ?? null, startedAt,
+          actionId: ev.action_id ?? null,
+        })
         break
       }
       case 'reauth_completed':

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -43,6 +43,11 @@ export const RECENT_EVENTS = 100
 // ended, per kind and newest last.
 export const RECENT_OUTCOMES = 5
 
+export const RECENT_TERMINAL_ACTIONS = 100
+
+const ACTION_STATUSES = new Set(['accepted', 'progress', 'confirmed', 'refused', 'failed'])
+const TERMINAL_ACTION_STATUSES = new Set(['confirmed', 'refused', 'failed'])
+
 // The three endings those reads count, and what each one is called on a
 // surface. One name for one thing: the journal type is the daemon's word, and
 // the value here is the operator's.
@@ -199,6 +204,8 @@ export class Reduction {
     this.transcriptLandings = new Map() // session -> rewind landing and transcript tail (#689)
     this.conversationTurns = new Map() // session -> sent operator turns and the queued notes each one carried (#702)
     this.carriedNotes = new Map() // session -> overseer notes a pane message took but no turn record has claimed yet (#702)
+    this.actions = new Map() // action_id -> latest daemon-owned Action evidence (#803)
+    this.revision = 0 // journal order, rebuilt identically on every boot (#803)
     this.seq = 0
     this.noteSeq = 0
     this.turnSeq = 0
@@ -253,12 +260,58 @@ export class Reduction {
   }
 
   _apply(ev, { replay }) {
+    this.revision += 1
     // The feed's tail (#262). Every event passes here exactly once, on replay
     // and on append alike, so the ring is right the instant the boot replay
     // ends and stays right for the rest of the run.
     if (!FEED_SILENT.has(ev.type)) {
       this.recent.push(this.#feedShape(ev))
       if (this.recent.length > RECENT_EVENTS) this.recent.shift()
+    }
+
+    if (ev.type === 'action_evidence' && ev.action_id && ACTION_STATUSES.has(ev.status)) {
+      const prior = this.actions.get(String(ev.action_id))
+      this.actions.set(String(ev.action_id), {
+        action_id: String(ev.action_id),
+        kind: ev.kind ?? prior?.kind ?? null,
+        target: ev.target ?? prior?.target ?? null,
+        conflict_key: ev.conflict_key ?? prior?.conflict_key ?? null,
+        status: ev.status,
+        revision: this.revision,
+        started_at: prior?.started_at ?? ev.started_at ?? ev.ts,
+        updated_at: ev.ts,
+        ...(ev.progress != null ? { progress: ev.progress } : {}),
+        ...(ev.reason != null ? { reason: ev.reason } : {}),
+        ...(ev.receipt != null ? { receipt: ev.receipt } : {}),
+      })
+    }
+
+    // Start's authoritative domain events close the tiny crash gap between the
+    // operation and its Action coordinator continuation. On a live run the
+    // coordinator writes the same terminal answer. On rebuild, or after
+    // reconcile releases a claim left mid-preparation, these journalled facts
+    // are enough to settle the recovered Action without guessing.
+    const actionEnding = ev.type === 'agent_spawned'
+      ? { status: 'confirmed' }
+      : ['dispatch_unclaimed', 'unclaim_failed', 'dispatch_failed'].includes(ev.type)
+        ? { status: 'failed', reason: ev.reason ?? ev.error ?? 'dispatch preparation failed' }
+        : null
+    if (actionEnding && ev.repo && ev.ticket != null) {
+      const target = `${ev.repo}#${ev.ticket}`
+      for (const [actionId, prior] of this.actions) {
+        if (prior.target !== target || TERMINAL_ACTION_STATUSES.has(prior.status)) continue
+        this.actions.set(actionId, {
+          action_id: actionId,
+          kind: prior.kind,
+          target: prior.target,
+          conflict_key: prior.conflict_key,
+          status: actionEnding.status,
+          revision: this.revision,
+          started_at: prior.started_at,
+          updated_at: ev.ts,
+          ...(actionEnding.reason ? { reason: actionEnding.reason } : {}),
+        })
+      }
     }
 
     // The last thing the journal says about an agent (#236): the direct answer
@@ -1706,6 +1759,45 @@ export class Reduction {
   // Generic operational events (notify, result, agent_done…) share the journal.
   journal(type, data) {
     return this._append({ type, ...data })
+  }
+
+  recordAction(evidence) {
+    const actionId = String(evidence?.action_id ?? '')
+    if (!actionId) throw new Error('Action evidence needs an action_id')
+    if (!ACTION_STATUSES.has(evidence.status)) throw new Error(`unknown Action status ${evidence.status}`)
+    const prior = this.actions.get(actionId)
+    if (TERMINAL_ACTION_STATUSES.has(prior?.status)) {
+      throw new Error(`terminal Action evidence is immutable (${actionId} is ${prior.status})`)
+    }
+    if (!prior) {
+      for (const key of ['kind', 'target', 'conflict_key']) {
+        if (!String(evidence[key] ?? '')) throw new Error(`Action evidence needs ${key}`)
+      }
+    }
+    this._append({
+      type: 'action_evidence',
+      action_id: actionId,
+      kind: evidence.kind ?? prior?.kind,
+      target: evidence.target ?? prior?.target,
+      conflict_key: evidence.conflict_key ?? prior?.conflict_key,
+      status: evidence.status,
+      ...(evidence.progress != null ? { progress: evidence.progress } : {}),
+      ...(evidence.reason != null ? { reason: evidence.reason } : {}),
+      ...(evidence.receipt != null ? { receipt: evidence.receipt } : {}),
+    })
+    return this.action(actionId)
+  }
+
+  action(actionId) {
+    const evidence = this.actions.get(String(actionId))
+    return evidence ? { ...evidence } : null
+  }
+
+  actionsOnWire() {
+    const all = [...this.actions.values()].sort((a, b) => a.revision - b.revision)
+    const active = all.filter((a) => !TERMINAL_ACTION_STATUSES.has(a.status))
+    const terminal = all.filter((a) => TERMINAL_ACTION_STATUSES.has(a.status)).slice(-RECENT_TERMINAL_ACTIONS)
+    return [...active, ...terminal].map((evidence) => ({ ...evidence }))
   }
 
   // The feed the dashboard draws (#262): the journal's last events, oldest

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -290,6 +290,36 @@ export class Reduction {
       })
     }
 
+    // A restart kills the Action coordinator with the process it restarts.
+    // The request and the next boot are the durable lifecycle facts that move
+    // the Action across that gap, both on the live reduction and on rebuild.
+    if (ev.type === 'restart_requested' && ev.action_id) {
+      const actionId = String(ev.action_id)
+      const prior = this.actions.get(actionId)
+      if (prior?.kind === 'daemon-restart' && !TERMINAL_ACTION_STATUSES.has(prior.status)) {
+        this.actions.set(actionId, {
+          ...prior,
+          status: 'progress',
+          revision: this.revision,
+          updated_at: ev.ts,
+          progress: 'Restarting daemon',
+          receipt: { ...prior.receipt, requested_at: ev.ts, exit_code: ev.exit_code },
+        })
+      }
+    }
+    if (ev.type === 'daemon_boot') {
+      for (const [actionId, prior] of this.actions) {
+        if (prior.kind !== 'daemon-restart' || prior.status !== 'progress' || !prior.receipt?.requested_at) continue
+        this.actions.set(actionId, {
+          ...prior,
+          status: 'confirmed',
+          revision: this.revision,
+          updated_at: ev.ts,
+          receipt: { ...prior.receipt, booted_at: ev.ts },
+        })
+      }
+    }
+
     if (ev.type === 'timeline_draft_changed' && ev.session) {
       this.chatDrafts.set(String(ev.session), String(ev.text ?? ''))
     }

--- a/daemon/src/reduction.mjs
+++ b/daemon/src/reduction.mjs
@@ -23,6 +23,7 @@ import { nextConsoleKey } from './attach.mjs'
 import { openJournal, normalizeEvent } from './journal.mjs'
 import { Questions } from './questions.mjs'
 import { MAP_FOG_VERB } from './mapfog.mjs'
+import { spawnIdentity } from './harnesses.mjs'
 
 // The button-confirm kind (#94, per #89's messaging discipline). Its own kind
 // because a confirm behaves unlike every other escalation: no reminder, no
@@ -412,6 +413,7 @@ export class Reduction {
     }
     if (ev.type === 'agent_spawned' && ev.agent) {
       const previous = this.agentConversations.get(ev.agent) ?? {}
+      const identity = spawnIdentity(ev)
       this.agentConversations.set(ev.agent, {
         ...previous,
         session: ev.agent,
@@ -419,6 +421,9 @@ export class Reduction {
         ticket: String(ev.ticket ?? previous.ticket ?? ''),
         model: ev.model ?? previous.model ?? null,
         harness: ev.harness ?? previous.harness ?? null,
+        adapter: identity.adapter ?? previous.adapter ?? null,
+        configLayoutVersion: identity.configLayoutVersion,
+        legacyConfigLayout: identity.legacy,
         reviewer: ev.kind === 'reviewer' || previous.reviewer === true,
         state: 'active',
         updated_at: ev.ts ?? previous.updated_at ?? null,

--- a/daemon/src/searchsources.mjs
+++ b/daemon/src/searchsources.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { HARNESS_NAMES } from './workspace.mjs'
 
 import { detectHarness, parseLine } from './transcript.mjs'
 
@@ -112,7 +113,10 @@ export function transcriptSearchSource({ workspaceRoot, overseerSessions = () =>
         if (results.length >= 50) break
         const relative = path.relative(roots, file).split(path.sep)
         const cfgDir = path.join(roots, relative[0])
-        const harness = detectHarness(cfgDir)
+        const nativeRoot = HARNESS_NAMES.includes(relative[1])
+          ? path.join(cfgDir, relative[1])
+          : cfgDir
+        const harness = detectHarness(nativeRoot)
         if (!harness) continue
         let stat
         try { stat = await fs.promises.stat(file) } catch { continue }

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -141,12 +141,13 @@ export class StatusLine {
   // get(id) -> escalation record (esc_* events carry only the id)
   // meters(session, model) -> see usage.agentMeters; null drops every meter
   constructor({
-    post, edit, remove = async () => {}, get, log = console.log,
+    post, edit, remove = async () => {}, find = async () => null, get, log = console.log,
     meters = () => null, flag = () => {}, refreshMs = 60_000, now = () => Date.now(),
   }) {
     this.post = post
     this.edit = edit
     this.remove = remove
+    this.find = find
     this.get = get
     this.log = log
     this.meters = meters
@@ -269,6 +270,25 @@ export class StatusLine {
       }
       case 'dispatch_status':
         return this.#set(ev.agent, ev.ticket, 'dispatched', { model: ev.model })
+      case 'action_evidence': {
+        // An Action has a Discord representation only when its domain target
+        // names a ticket thread. Today that is dispatch. Other Action kinds
+        // stay on Atlas rather than teaching this renderer their domains.
+        if (ev.kind !== 'dispatch' || !['accepted', 'progress'].includes(ev.status)) return
+        const ticket = String(ev.target ?? '').match(/#(\d+)$/)?.[1]
+        const progress = String(ev.progress ?? '').trim()
+        if (!ticket || (ev.status === 'progress' && !progress)) return
+        const session = `curia-${ticket}`
+        const w = this.agents.get(session)
+        if (w?.action?.id === ev.action_id && Number(ev.revision) <= w.action.revision) return
+        const detail = ev.status === 'accepted'
+          ? { stage: 'accepted' }
+          : { stage: 'action-progress', progress }
+        const updated = this.#set(session, ticket, 'dispatched', detail, { recover: true })
+        const worker = this.agents.get(session)
+        if (worker) worker.action = { id: ev.action_id, revision: Number(ev.revision) || 0 }
+        return updated
+      }
       case 'agent_ready':
         // The spawn command carries the prompt, so the composer marker means
         // the agent is already at work — ready and working are one state.
@@ -437,6 +457,8 @@ export class StatusLine {
   #base(session, state, detail, model) {
     switch (state) {
       case 'dispatched':
+        if (detail.stage === 'accepted') return '⚙️ dispatch accepted'
+        if (detail.stage === 'action-progress') return `⚙️ ${detail.progress}`
         if (detail.stage === 'image') return '🧱 building the agent image, about four minutes'
         if (detail.stage === 'composer') return `⚙️ dispatched on **${model}** - waiting for the composer`
         return `⚙️ dispatched on **${model}**`
@@ -516,7 +538,7 @@ export class StatusLine {
 
   // One line per agent, edits serialized per agent so a fast transition
   // never lands under a slower one's edit.
-  #set(session, ticket, state, detail, { force = false, small = true } = {}) {
+  #set(session, ticket, state, detail, { force = false, small = true, recover = false } = {}) {
     let w = this.agents.get(session)
     if (!w) {
       w = {
@@ -566,13 +588,13 @@ export class StatusLine {
     }
     const composed = this.#text(session, state, detail, w.model, w)
     const text = small ? smallPrint(composed) : composed
-    w.chain = w.chain.then(() => this.#apply(w, text, { move, force })).catch((e) => {
+    w.chain = w.chain.then(() => this.#apply(w, text, { move, force, recover })).catch((e) => {
       this.log(`status line for ${session} failed: ${e.message}`)
     })
     return w.chain
   }
 
-  async #apply(w, text, { move, force = false, settled = false }) {
+  async #apply(w, text, { move, force = false, settled = false, recover = false }) {
     if (move && w.ids) {
       await this.remove(w.ids)
       w.ids = null
@@ -584,6 +606,7 @@ export class StatusLine {
     }
     w.text = text
     const opts = { ticket: w.ticket, settled }
+    if (!w.ids && recover) w.ids = await this.find(w.ticket)
     if (w.ids && await this.edit(w.ids, text, opts)) return
     w.ids = (await this.post(w.ticket, text, opts)) ?? null
   }

--- a/daemon/src/statusline.mjs
+++ b/daemon/src/statusline.mjs
@@ -104,6 +104,22 @@ function validPhase(phase) {
   return { phase: name, label }
 }
 
+function actionWords(value, fallback = '') {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim()
+  return (text || fallback).replace(/@/g, '@\u200b')
+}
+
+function winningReceipt(receipt) {
+  if (!receipt || typeof receipt !== 'object') return ''
+  const by = actionWords(receipt.by)
+  const via = actionWords(receipt.via)
+  const at = actionWords(receipt.at)
+  const answer = actionWords(receipt.answer)
+  if (!by && !via && !at && !answer) return ''
+  const actor = [by && `by ${by}`, via && `via ${via}`, at && `at ${at}`].filter(Boolean).join(' ')
+  return ` - first valid result${actor ? ` ${actor}` : ''}${answer ? `: ${answer}` : ''}`
+}
+
 // The literal the 🔎 button sends (#165). Matched here rather than imported as
 // the regex, because this file reads the ANSWER off a journal event and an
 // operator may have typed the word instead of pressing the button.
@@ -274,17 +290,26 @@ export class StatusLine {
         // An Action has a Discord representation only when its domain target
         // names a ticket thread. Today that is dispatch. Other Action kinds
         // stay on Atlas rather than teaching this renderer their domains.
-        if (ev.kind !== 'dispatch' || !['accepted', 'progress'].includes(ev.status)) return
+        if (ev.kind !== 'dispatch' || !['accepted', 'progress', 'refused', 'failed'].includes(ev.status)) return
         const ticket = String(ev.target ?? '').match(/#(\d+)$/)?.[1]
         const progress = String(ev.progress ?? '').trim()
         if (!ticket || (ev.status === 'progress' && !progress)) return
         const session = `curia-${ticket}`
         const w = this.agents.get(session)
         if (w?.action?.id === ev.action_id && Number(ev.revision) <= w.action.revision) return
+        const terminal = ['refused', 'failed'].includes(ev.status)
         const detail = ev.status === 'accepted'
           ? { stage: 'accepted' }
-          : { stage: 'action-progress', progress }
-        const updated = this.#set(session, ticket, 'dispatched', detail, { recover: true })
+          : ev.status === 'progress'
+            ? { stage: 'action-progress', progress }
+            : {
+                stage: `action-${ev.status}`,
+                reason: actionWords(ev.reason, 'no reason supplied'),
+                receipt: winningReceipt(ev.receipt),
+              }
+        const updated = this.#set(session, ticket, 'dispatched', detail, {
+          recover: true, settled: terminal,
+        })
         const worker = this.agents.get(session)
         if (worker) worker.action = { id: ev.action_id, revision: Number(ev.revision) || 0 }
         return updated
@@ -459,6 +484,8 @@ export class StatusLine {
       case 'dispatched':
         if (detail.stage === 'accepted') return '⚙️ dispatch accepted'
         if (detail.stage === 'action-progress') return `⚙️ ${detail.progress}`
+        if (detail.stage === 'action-refused') return `❌ dispatch refused: ${detail.reason}${detail.receipt}`
+        if (detail.stage === 'action-failed') return `❌ dispatch failed: ${detail.reason}${detail.receipt}`
         if (detail.stage === 'image') return '🧱 building the agent image, about four minutes'
         if (detail.stage === 'composer') return `⚙️ dispatched on **${model}** - waiting for the composer`
         return `⚙️ dispatched on **${model}**`
@@ -538,7 +565,9 @@ export class StatusLine {
 
   // One line per agent, edits serialized per agent so a fast transition
   // never lands under a slower one's edit.
-  #set(session, ticket, state, detail, { force = false, small = true, recover = false } = {}) {
+  #set(session, ticket, state, detail, {
+    force = false, small = true, recover = false, settled = false,
+  } = {}) {
     let w = this.agents.get(session)
     if (!w) {
       w = {
@@ -588,7 +617,7 @@ export class StatusLine {
     }
     const composed = this.#text(session, state, detail, w.model, w)
     const text = small ? smallPrint(composed) : composed
-    w.chain = w.chain.then(() => this.#apply(w, text, { move, force, recover })).catch((e) => {
+    w.chain = w.chain.then(() => this.#apply(w, text, { move, force, recover, settled })).catch((e) => {
       this.log(`status line for ${session} failed: ${e.message}`)
     })
     return w.chain

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -820,11 +820,17 @@ export class TimelineSurface {
       if (!validSessionName(String(b.session ?? ''))) return json(400, { error: 'bad session' })
       if (!this.deps.takeBack) return json(501, { error: 'message take back is not configured' })
       const s = this.#state(b.session)
-      try { this.#pump(b.session) } catch { /* the runtime reports transcript failures */ }
-      try {
+      const driver = this.#driver(b.session)
+      const actionId = b.action_id == null ? null : String(b.action_id)
+      if (actionId != null && !/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(actionId)) {
+        return json(400, { error: 'action_id is not a valid Action id' })
+      }
+      const perform = async (controls = null) => {
+        try { this.#pump(b.session) } catch { /* the runtime reports transcript failures */ }
+        controls?.accept({ progress: b.target?.kind === 'note' ? 'Recovering your note…' : 'Rewinding the conversation…' })
         const result = await this.deps.takeBack({
           session: b.session,
-          role: this.#driver(b.session) ? 'overseer' : 'agent',
+          role: driver ? 'overseer' : 'agent',
           harness: s.harness,
           source: s.lines.join('\n'),
           landing: this.deps.landingFor(b.session),
@@ -833,7 +839,34 @@ export class TimelineSurface {
         s.draft = result.composer ?? ''
         s.correction = result.correction?.kind === 'note' ? result.correction : null
         this.#broadcast(s, 'draft', { text: s.draft, by: b.client ?? null })
-        return json(200, result)
+        return controls
+          ? {
+              status: 'confirmed',
+              receipt: {
+                composer: s.draft,
+                correction: result.correction ?? null,
+                take_back: result.receipt ?? null,
+              },
+            }
+          : result
+      }
+
+      if (actionId && this.deps.actions) {
+        const conversation = driver?.key ?? b.session
+        const evidence = await this.deps.actions.run({
+          action_id: actionId,
+          kind: 'chat-take-back',
+          target: conversation,
+          conflict_key: `turn:${conversation}`,
+        }, perform)
+        const code = evidence.status === 'accepted' || evidence.status === 'progress'
+          ? 202
+          : evidence.status === 'confirmed' ? 200 : evidence.status === 'failed' ? 502 : 409
+        return json(code, { action: evidence, ...(evidence.reason ? { error: evidence.reason } : {}) })
+      }
+
+      try {
+        return json(200, await perform())
       } catch (e) {
         return json(e.status ?? 502, { error: e.message })
       }

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -834,59 +834,87 @@ export class TimelineSurface {
       const s = this.#state(b.session)
       const dialogId = String(b.dialog ?? '')
       const targetIndex = Number(b.index)
+      const perform = async (controls = null) => {
+        if (s.dialogReceipt?.dialog === dialogId) {
+          return { status: 'refused', reason: 'this native dialog already has an answer', receipt: s.dialogReceipt }
+        }
+        const dialog = await this.#probeDialog(b.session, s)
+        if (!dialog?.card) {
+          return {
+            status: 'refused',
+            reason: `${dialog?.reason ?? 'curia could not parse this native dialog'}; open the terminal to answer it`,
+            terminal: `/terminal/?arg=${encodeURIComponent(b.session)}`,
+          }
+        }
+        if (!dialogId || dialog.id !== dialogId) {
+          return { status: 'refused', reason: 'this native dialog changed; use the current card' }
+        }
+        if (!Number.isInteger(targetIndex)) return { status: 'bad-request', reason: 'the option index must be an integer' }
+        const option = dialog.card.options.find((candidate) => candidate.index === targetIndex)
+        if (!option) return { status: 'bad-request', reason: 'that option index is not on this native dialog' }
+        if (s.dialogAnswer === dialogId) {
+          return { status: 'refused', reason: 'the first valid native dialog answer is still being sent' }
+        }
 
-      if (s.dialogReceipt?.dialog === dialogId) {
-        return json(409, { error: 'this native dialog already has an answer', receipt: s.dialogReceipt })
-      }
-      const dialog = await this.#probeDialog(b.session, s)
-      if (!dialog?.card) {
-        return json(409, {
-          error: `${dialog?.reason ?? 'curia could not parse this native dialog'}; open the terminal to answer it`,
-          terminal: `/terminal/?arg=${encodeURIComponent(b.session)}`,
+        // Claim before the pane write. Two Chat clients can tap the same card
+        // together, and only one may reach tmux. Shared acceptance is emitted
+        // after that synchronous claim, so Atlas can return while the write is
+        // still pending without weakening first-valid-wins.
+        s.dialogAnswer = dialogId
+        controls?.accept({ progress: `Choosing ${option.marker} · ${option.label}…` })
+        try {
+          await this.deps.answerDialog(b.session, {
+            currentIndex: dialog.card.selected_index,
+            targetIndex,
+            harness: s.harness,
+          })
+        } catch (error) {
+          s.dialogAnswer = null
+          this.deps.journal('native_dialog_answer_failed', {
+            session: b.session, dialog: dialogId, index: targetIndex, error: error.message,
+          })
+          return { status: 'failed', reason: `curia could not answer the native dialog: ${error.message}` }
+        }
+
+        const receipt = {
+          dialog: dialogId,
+          index: targetIndex,
+          marker: option.marker,
+          answer: option.label,
+          by: String(b.client ?? 'atlas'),
+          at: new Date().toISOString(),
+        }
+        this.deps.journal('native_dialog_answered', {
+          session: b.session, dialog: dialogId, index: targetIndex,
+          answer: option.label, by: receipt.by, harness: s.harness,
         })
-      }
-      if (!dialogId || dialog.id !== dialogId) {
-        return json(409, { error: 'this native dialog changed; use the current card' })
-      }
-      if (!Number.isInteger(targetIndex)) return json(400, { error: 'the option index must be an integer' })
-      const option = dialog.card.options.find((candidate) => candidate.index === targetIndex)
-      if (!option) return json(400, { error: 'that option index is not on this native dialog' })
-      if (s.dialogAnswer === dialogId) {
-        return json(409, { error: 'the first valid native dialog answer is still being sent' })
+        s.dialogAnsweredKey = dialog.semanticKey
+        this.#setDialog(b.session, s, null, receipt)
+        return { status: 'confirmed', receipt }
       }
 
-      // Claim before the first await. Two Chat clients can tap the same card
-      // together, and only one may reach tmux.
-      s.dialogAnswer = dialogId
-      try {
-        await this.deps.answerDialog(b.session, {
-          currentIndex: dialog.card.selected_index,
-          targetIndex,
-          harness: s.harness,
-        })
-      } catch (error) {
-        s.dialogAnswer = null
-        this.deps.journal('native_dialog_answer_failed', {
-          session: b.session, dialog: dialogId, index: targetIndex, error: error.message,
-        })
-        return json(502, { error: `curia could not answer the native dialog: ${error.message}` })
+      const actionId = String(b.action_id ?? '')
+      if (actionId && this.deps.actions) {
+        const evidence = await this.deps.actions.run({
+          action_id: actionId,
+          kind: 'native-dialog-answer',
+          target: `${b.session}:${dialogId}`,
+          conflict_key: `dialog:${b.session}:${dialogId}`,
+        }, perform)
+        const code = evidence.status === 'accepted' || evidence.status === 'progress'
+          ? 202
+          : evidence.status === 'confirmed' ? 200 : evidence.status === 'failed' ? 502 : 409
+        return json(code, { action: evidence, ...(evidence.reason ? { error: evidence.reason } : {}) })
       }
 
-      const receipt = {
-        dialog: dialogId,
-        index: targetIndex,
-        marker: option.marker,
-        answer: option.label,
-        by: String(b.client ?? 'atlas'),
-        at: new Date().toISOString(),
-      }
-      this.deps.journal('native_dialog_answered', {
-        session: b.session, dialog: dialogId, index: targetIndex,
-        answer: option.label, by: receipt.by, harness: s.harness,
+      const outcome = await perform()
+      if (outcome.status === 'confirmed') return json(200, { ok: true, receipt: outcome.receipt })
+      const code = outcome.status === 'bad-request' ? 400 : outcome.status === 'failed' ? 502 : 409
+      return json(code, {
+        error: outcome.reason,
+        ...(outcome.receipt ? { receipt: outcome.receipt } : {}),
+        ...(outcome.terminal ? { terminal: outcome.terminal } : {}),
       })
-      s.dialogAnsweredKey = dialog.semanticKey
-      this.#setDialog(b.session, s, null, receipt)
-      return json(200, { ok: true, receipt })
     }
 
     if (url.pathname === '/send' && req.method === 'POST') {

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -520,6 +520,17 @@ export class TimelineSurface {
     if (!prefix) this.#broadcast(s, 'reset', { file: s.file, branch: true })
     const fresh = prefix ? next.slice(s.items.length) : next
     s.items = next
+    const prompt = fresh.find((item) => item.kind === 'prompt')
+    if (prompt && this.deps.actions) {
+      const conversation = this.#driver(name)?.key ?? name
+      const pending = this.deps.actions.overview().find((candidate) =>
+        candidate.kind === 'chat-message'
+        && candidate.conflict_key === `turn:${conversation}`
+        && candidate.status === 'progress'
+        && candidate.receipt?.outcome === 'sent_unconfirmed'
+        && new Date(prompt.at).getTime() >= new Date(candidate.started_at).getTime())
+      if (pending) this.deps.actions.confirm(pending.action_id, { receipt: { outcome: 'delivered' } })
+    }
     if (fresh.length) this.#broadcast(s, 'items', fresh)
   }
 
@@ -924,88 +935,118 @@ export class TimelineSurface {
       if (!text.trim()) return json(400, { error: 'empty' })
       const s = this.#state(b.session)
       const by = b.client ?? null
-      if (s.correction) {
-        if (!this.deps.correct) return json(501, { error: 'message correction is not configured' })
-        try {
-          await this.deps.correct({
-            session: b.session,
-            role: this.#driver(b.session) ? 'overseer' : 'agent',
-            correction: s.correction,
-            text,
-          })
-        } catch (e) {
-          return json(e.status ?? 502, { error: e.message })
-        }
-        this.deps.journal('timeline_send', {
-          session: b.session, by, outcome: 'corrected', target: s.correction.id, text: clip(text),
-        })
-        s.correction = null
-        s.draft = ''
-        this.#broadcast(s, 'draft', { text: '', by })
-        this.#broadcast(s, 'sent', { text, by })
-        return json(200, { ok: true })
-      }
-      // A driven session takes the words as a TURN (#267). There is no pane, so
-      // the #75 dialog guard has nothing to guard: it exists because keystrokes
-      // land wherever the pane's focus is, and a turn lands in exactly one
-      // place. The call runs to completion — an overseer turn is seconds, and
-      // the failure is the whole reason this waits: a turn that ends with no
-      // answer must reach the operator as words, not as silence on the page.
       const driver = this.#driver(b.session)
-      if (driver) {
-        try {
-          await driver.send(text)
-        } catch (e) {
-          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'failed', error: e.message, text: clip(text) })
-          return json(502, { error: e.message })
-        }
-        this.deps.recordTurn?.({ session: b.session, role: 'overseer', text })
-        this.deps.journal('timeline_send', { session: b.session, by, outcome: 'sent', text: clip(text) })
-        s.draft = ''
-        this.#broadcast(s, 'draft', { text: '', by })
-        this.#broadcast(s, 'sent', { text, by })
-        return json(200, { ok: true })
+      const actionId = b.action_id == null ? null : String(b.action_id)
+      if (actionId != null && !/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(actionId)) {
+        return json(400, { error: 'action_id is not a valid Action id' })
       }
-      // A pane that has ended takes no words (#711). The refusal is a sentence
-      // about the session, not a tmux error about a missing one.
-      if (await this.#ended(b.session)) {
-        this.deps.journal('timeline_send', { session: b.session, by, outcome: 'refused_ended', text: clip(text) })
-        return json(409, this.#endedRefusal(b.session))
-      }
-      // The #75 guard: fresh capture, positive evidence only. Typing into a
-      // dialog answers it blind or vanishes without a trace — refusing keeps
-      // the text in the composer, and the broadcast pins the banner on every
-      // device at the same moment.
-      const dialog = await this.#probeDialog(b.session, s)
-      if (dialog) {
-        this.deps.journal('timeline_send', { session: b.session, by, outcome: 'refused_dialog', hint: dialog.hint, text: clip(text) })
-        return json(409, { error: `the agent is in a terminal dialog ("${dialog.hint}") the timeline cannot show — open the terminal surface to answer it; your text was NOT sent`, dialog: true })
-      }
-      try {
-        const delivery = await this.deps.sendText(b.session, text)
-        if (delivery?.status === 'not-sent') {
-          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'not_sent', text: clip(text) })
-          return json(409, { error: 'the pane stayed active, so curia did not send the text' })
-        }
-        if (delivery?.status === 'unconfirmed') {
-          this.deps.recordTurn?.({ session: b.session, role: 'agent', text })
-          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'unconfirmed', text: clip(text) })
+      const action = actionId ? {
+        action_id: actionId,
+        kind: s.correction ? 'chat-message-correction' : 'chat-message',
+        target: driver?.key ?? b.session,
+        conflict_key: `turn:${driver?.key ?? b.session}`,
+      } : null
+      const perform = async (controls = null) => {
+        if (s.correction) {
+          if (!this.deps.correct) return { status: 'failed', reason: 'message correction is not configured', code: 501 }
+          try {
+            await this.deps.correct({
+              session: b.session,
+              role: driver ? 'overseer' : 'agent',
+              correction: s.correction,
+              text,
+            })
+          } catch (e) {
+            return { status: Number(e.status) >= 400 && Number(e.status) < 500 ? 'refused' : 'failed', reason: e.message, code: e.status ?? 502 }
+          }
+          this.deps.journal('timeline_send', {
+            session: b.session, by, outcome: 'corrected', target: s.correction.id, text: clip(text), action_id: actionId,
+          })
+          s.correction = null
           s.draft = ''
           this.#broadcast(s, 'draft', { text: '', by })
-          return json(202, { error: 'curia sent the keys, but the pane did not confirm a new turn', unconfirmed: true })
+          this.#broadcast(s, 'sent', { text, by, action_id: actionId })
+          return { status: 'confirmed', receipt: { outcome: 'delivered' }, code: 200 }
         }
-      } catch (e) {
-        this.deps.journal('timeline_send', { session: b.session, by, outcome: 'failed', error: e.message, text: clip(text) })
-        return json(502, { error: e.message })
+        // A driven session takes the words as a turn. Acceptance is durable
+        // before pane preparation starts, so Atlas does not hold this request
+        // open for the model's work.
+        if (driver) {
+          controls?.accept({ progress: 'Preparing the conversation' })
+          let delivered
+          try {
+            delivered = await driver.send(text)
+          } catch (e) {
+            this.deps.journal('timeline_send', { session: b.session, by, outcome: 'failed', error: e.message, text: clip(text), action_id: actionId })
+            return { status: 'failed', reason: e.message, code: 502 }
+          }
+          this.deps.recordTurn?.({ session: b.session, role: 'overseer', text })
+          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'sent', text: clip(text), action_id: actionId })
+          s.draft = ''
+          this.#broadcast(s, 'draft', { text: '', by })
+          this.#broadcast(s, 'sent', { text, by, action_id: actionId })
+          if (controls && delivered?.completion) {
+            controls.progress('Message delivered; waiting for the overseer response', { receipt: { outcome: 'delivered' } })
+            const completion = await delivered.completion
+            if (!completion?.ok) return { status: 'failed', reason: completion?.why || 'the overseer turn did not finish', code: 502 }
+          }
+          return { status: 'confirmed', receipt: { outcome: 'delivered' }, code: 200 }
+        }
+        if (await this.#ended(b.session)) {
+          const reason = this.#endedRefusal(b.session).error
+          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'refused_ended', text: clip(text), action_id: actionId })
+          return { status: 'refused', reason, ended: true, code: 409 }
+        }
+        const dialog = await this.#probeDialog(b.session, s)
+        if (dialog) {
+          const reason = `the agent is in a terminal dialog ("${dialog.hint}") the timeline cannot show — open the terminal surface to answer it; your text was NOT sent`
+          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'refused_dialog', hint: dialog.hint, text: clip(text), action_id: actionId })
+          return { status: 'refused', reason, dialog: true, code: 409 }
+        }
+        try {
+          const delivery = await this.deps.sendText(b.session, text)
+          if (delivery?.status === 'not-sent') {
+            this.deps.journal('timeline_send', { session: b.session, by, outcome: 'not_sent', text: clip(text), action_id: actionId })
+            return { status: 'refused', reason: 'the pane stayed active, so curia did not send the text', receipt: { outcome: 'not_sent' }, code: 409 }
+          }
+          if (delivery?.status === 'unconfirmed') {
+            this.deps.recordTurn?.({ session: b.session, role: 'agent', text })
+            this.deps.journal('timeline_send', { session: b.session, by, outcome: 'unconfirmed', text: clip(text), action_id: actionId })
+            s.draft = ''
+            this.#broadcast(s, 'draft', { text: '', by })
+            if (controls) {
+              controls.accept({ progress: 'Message sent; checking the transcript', receipt: { outcome: 'sent_unconfirmed' } })
+              controls.progress('Message sent; checking the transcript', { receipt: { outcome: 'sent_unconfirmed' } })
+              return { status: 'progress', receipt: { outcome: 'sent_unconfirmed' }, code: 202 }
+            }
+            return { status: 'unconfirmed', reason: 'curia sent the keys, but the pane did not confirm a new turn', unconfirmed: true, code: 202 }
+          }
+        } catch (e) {
+          this.deps.journal('timeline_send', { session: b.session, by, outcome: 'failed', error: e.message, text: clip(text), action_id: actionId })
+          return { status: 'failed', reason: e.message, code: 502 }
+        }
+        this.deps.recordTurn?.({ session: b.session, role: 'agent', text })
+        this.deps.journal('timeline_send', { session: b.session, by, outcome: 'sent', text: clip(text), action_id: actionId })
+        s.draft = ''
+        this.#broadcast(s, 'draft', { text: '', by })
+        this.#broadcast(s, 'sent', { text, by, action_id: actionId })
+        return { status: 'confirmed', receipt: { outcome: 'delivered' }, code: 200 }
       }
-      this.deps.recordTurn?.({ session: b.session, role: 'agent', text })
-      // The journal line #75 had to infer from four absences: whether the
-      // send even fired, one grep away.
-      this.deps.journal('timeline_send', { session: b.session, by, outcome: 'sent', text: clip(text) })
-      s.draft = ''
-      this.#broadcast(s, 'draft', { text: '', by })
-      this.#broadcast(s, 'sent', { text, by })
-      return json(200, { ok: true })
+
+      if (action) {
+        const evidence = await this.deps.actions.run(action, perform)
+        const code = evidence.status === 'accepted' || evidence.status === 'progress'
+          ? 202
+          : evidence.status === 'confirmed' ? 200 : evidence.status === 'failed' ? 502 : 409
+        return json(code, { action: evidence, ...(evidence.reason ? { error: evidence.reason } : {}) })
+      }
+      const outcome = await perform()
+      return json(outcome.code, {
+        ...(outcome.status === 'confirmed' ? { ok: true } : { error: outcome.reason }),
+        ...(outcome.unconfirmed ? { unconfirmed: true } : {}),
+        ...(outcome.ended ? { ended: true } : {}),
+        ...(outcome.dialog ? { dialog: true } : {}),
+      })
     }
 
     // The shared composer (#73 pass-bar item 4): tmux gives two attached

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -254,6 +254,10 @@ export class TimelineSurface {
       composerFor: () => null,
       // journal(type, detail): `Reduction#journal`, injected by index.mjs.
       journal: () => {},
+      // The shared composer is a daemon-owned durable fact. These two methods
+      // keep its high-frequency last-write-wins path outside Action conflicts.
+      draftFor: () => '',
+      recordDraft: () => {},
       // actions: the daemon's shared Action coordinator. Pane keys use it when
       // Atlas supplies an action_id; older callers keep the legacy response.
       actions: null,
@@ -440,7 +444,7 @@ export class TimelineSurface {
       s = {
         harness: null, file: null, offset: 0, rest: '', lines: [], items: [],
         activeKey: null, activeFailures: new Set(),
-        clients: new Set(), draft: '',
+        clients: new Set(), draft: String(this.deps.draftFor(name) ?? ''),
         correction: null,
         parse: null, // { reason, file, dropped } — current loud failure, if any
         journalled: new Set(), // parse failures journalled once per file+reason
@@ -837,6 +841,7 @@ export class TimelineSurface {
           target: b.target ?? null,
         })
         s.draft = result.composer ?? ''
+        this.deps.recordDraft(b.session, s.draft)
         s.correction = result.correction?.kind === 'note' ? result.correction : null
         this.#broadcast(s, 'draft', { text: s.draft, by: b.client ?? null })
         return controls
@@ -1090,6 +1095,7 @@ export class TimelineSurface {
       if (!validSessionName(String(b.session ?? ''))) return json(400, { error: 'bad session' })
       const s = this.#state(b.session)
       s.draft = String(b.text ?? '')
+      this.deps.recordDraft(b.session, s.draft)
       this.#broadcast(s, 'draft', { text: s.draft, by: b.client ?? null })
       return json(200, { ok: true })
     }

--- a/daemon/src/timeline.mjs
+++ b/daemon/src/timeline.mjs
@@ -254,6 +254,9 @@ export class TimelineSurface {
       composerFor: () => null,
       // journal(type, detail): `Reduction#journal`, injected by index.mjs.
       journal: () => {},
+      // actions: the daemon's shared Action coordinator. Pane keys use it when
+      // Atlas supplies an action_id; older callers keep the legacy response.
+      actions: null,
       // harnessFor(session): the dispatcher's word, with detectHarness as the
       // on-disk fallback for re-adopted and lab sessions.
       harnessFor: (session) => detectHarness(this.#cfgDir(session)),
@@ -998,33 +1001,55 @@ export class TimelineSurface {
       if (!key) return json(400, { error: 'unknown key' })
       const s = this.#state(b.session)
       const by = b.client ?? null
-      // No pane, no keys (#267). This is the one thing the console chat cannot
-      // do, and it says so rather than reporting a key nothing received: an
-      // overseer turn runs to its end, so there is nothing here to interrupt.
-      if (this.#driver(b.session)) {
-        this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_no_pane' })
-        return json(409, { error: `${b.session} is not a terminal — it takes words, and a turn runs to its end, so there is no key to send it` })
-      }
-      if (await this.#ended(b.session)) {
-        this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_ended' })
-        return json(409, this.#endedRefusal(b.session))
-      }
-      if (!DIALOG_SAFE_KEYS.has(key)) {
-        const dialog = await this.#probeDialog(b.session, s)
-        if (dialog) {
-          this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_dialog', hint: dialog.hint })
-          return json(409, { error: `the agent is in a terminal dialog ("${dialog.hint}") — ${key} would drive its selection blind; open the terminal surface`, dialog: true })
+      const perform = async () => {
+        // No pane, no keys (#267). This is the one thing the console chat cannot
+        // do, and it says so rather than reporting a key nothing received: an
+        // overseer turn runs to its end, so there is nothing here to interrupt.
+        if (this.#driver(b.session)) {
+          const reason = `${b.session} is not a terminal — it takes words, and a turn runs to its end, so there is no key to send it`
+          this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_no_pane' })
+          return { status: 'refused', reason, code: 409 }
         }
+        if (await this.#ended(b.session)) {
+          const reason = this.#endedRefusal(b.session).error
+          this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_ended' })
+          return { status: 'refused', reason, code: 409 }
+        }
+        if (!DIALOG_SAFE_KEYS.has(key)) {
+          const dialog = await this.#probeDialog(b.session, s)
+          if (dialog) {
+            const reason = `the agent is in a terminal dialog ("${dialog.hint}") — ${key} would drive its selection blind; open the terminal surface`
+            this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'refused_dialog', hint: dialog.hint })
+            return { status: 'refused', reason, code: 409, dialog: true }
+          }
+        }
+        try {
+          await this.deps.sendKey(b.session, key)
+        } catch (e) {
+          this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'failed', error: e.message })
+          return { status: 'failed', reason: e.message, code: 502 }
+        }
+        this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'sent' })
+        this.#broadcast(s, 'sent', { text: `⌨ ${key}`, by })
+        return { status: 'confirmed', receipt: { key }, code: 200 }
       }
-      try {
-        await this.deps.sendKey(b.session, key)
-      } catch (e) {
-        this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'failed', error: e.message })
-        return json(502, { error: e.message })
+
+      const actionId = String(b.action_id ?? '')
+      if (actionId && this.deps.actions) {
+        const evidence = await this.deps.actions.run({
+          action_id: actionId,
+          kind: 'pane-key',
+          target: b.session,
+          conflict_key: `pane:${b.session}`,
+        }, perform)
+        const code = evidence.status === 'confirmed' ? 200 : evidence.status === 'failed' ? 502 : 409
+        return json(code, { action: evidence, ...(evidence.reason ? { error: evidence.reason } : {}) })
       }
-      this.deps.journal('timeline_key', { session: b.session, by, key, outcome: 'sent' })
-      this.#broadcast(s, 'sent', { text: `⌨ ${key}`, by })
-      return json(200, { ok: true })
+
+      const outcome = await perform()
+      return json(outcome.code, outcome.status === 'confirmed'
+        ? { ok: true }
+        : { error: outcome.reason, ...(outcome.dialog ? { dialog: true } : {}) })
     }
 
     json(404, { error: 'not found' })

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -69,8 +69,13 @@ export function worktreePathFor(root, repo, n) {
 // roots a usage sync scans.
 export const CFG_DIR = 'cfg'
 
-export function cfgDirFor(root, session) {
-  return path.join(root, CFG_DIR, session)
+export function cfgDirFor(root, session, harness = null) {
+  const sessionRoot = path.join(root, CFG_DIR, session)
+  if (harness === null) return sessionRoot
+  if (!HARNESS_NAMES.includes(harness)) {
+    throw new Error(`no configuration root for Harness "${harness}" - known Harnesses: ${HARNESS_NAMES.join(', ')}`)
+  }
+  return path.join(sessionRoot, harness)
 }
 
 export function branchFor(n) {

--- a/daemon/test/actions.test.mjs
+++ b/daemon/test/actions.test.mjs
@@ -1,0 +1,143 @@
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { ActionCoordinator } from '../src/actions.mjs'
+import { Reduction } from '../src/reduction.mjs'
+
+const action = (id) => ({
+  action_id: id,
+  kind: 'dispatch',
+  target: 'alp82/curia#803',
+  conflict_key: 'dispatch:alp82/curia#803',
+})
+
+describe('shared Action evidence', () => {
+  let dir
+  let reduction
+  let actions
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-actions-'))
+    reduction = new Reduction(dir)
+    actions = new ActionCoordinator(reduction)
+  })
+
+  afterEach(() => {
+    reduction.close()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('accepted returns before slow work completes, and meaningful progress advances the shared record', async () => {
+    let finish
+    const terminal = new Promise((resolve) => { finish = resolve })
+    const response = await actions.run(action('act-accepted'), async ({ accept, progress }) => {
+      accept()
+      progress('Preparing the private clone')
+      await terminal
+      return { status: 'confirmed' }
+    })
+
+    assert.equal(response.status, 'accepted', 'the caller is released by durable acceptance, not terminal completion')
+    assert.equal(actions.get('act-accepted').status, 'progress')
+    assert.equal(actions.get('act-accepted').progress, 'Preparing the private clone')
+    assert.ok(actions.get('act-accepted').revision > response.revision)
+
+    finish()
+    await actions.settled('act-accepted')
+    assert.equal(actions.get('act-accepted').status, 'confirmed')
+  })
+
+  test('confirmed progress prevents a short caller timeout while the accepted operation keeps running', async () => {
+    let finish
+    const terminal = new Promise((resolve) => { finish = resolve })
+    const response = await Promise.race([
+      actions.run(action('act-timeout'), async ({ accept }) => {
+        accept()
+        await terminal
+        return { status: 'confirmed' }
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('no response')), 25)),
+    ])
+
+    assert.equal(response.status, 'accepted')
+    finish()
+    await actions.settled('act-timeout')
+  })
+
+  test('work that cannot accept records a refusal, while accepted work that breaks records a failure', async () => {
+    const refused = await actions.run(action('act-refused'), async () => ({
+      status: 'refused', reason: 'the ticket is already claimed', receipt: { by: 'alp', at: '2026-08-28T10:00:00.000Z' },
+    }))
+    assert.equal(refused.status, 'refused')
+    assert.equal(refused.reason, 'the ticket is already claimed')
+    assert.equal(refused.receipt.by, 'alp')
+
+    const accepted = await actions.run(action('act-failed'), async ({ accept }) => {
+      accept()
+      throw new Error('the container could not start')
+    })
+    assert.equal(accepted.status, 'accepted')
+    await actions.settled('act-failed')
+    assert.equal(actions.get('act-failed').status, 'failed')
+    assert.equal(actions.get('act-failed').reason, 'the container could not start')
+  })
+
+  test('a retry and a restarted reduction return journalled evidence without repeating the operation', async () => {
+    let calls = 0
+    await actions.run(action('act-retry'), async ({ accept, progress }) => {
+      calls += 1
+      accept()
+      progress('Preparing the agent image')
+      return new Promise(() => {})
+    })
+
+    const retry = await actions.run(action('act-retry'), async () => {
+      calls += 1
+      return { status: 'confirmed' }
+    })
+    assert.equal(retry.status, 'progress')
+    assert.equal(calls, 1, 'the same action identity never repeats its side effect')
+
+    reduction.close()
+    reduction = new Reduction(dir)
+    actions = new ActionCoordinator(reduction)
+    assert.deepEqual(actions.get('act-retry'), retry)
+    assert.deepEqual(actions.overview(), [retry], 'overview reads recover the nonterminal Action after restart')
+  })
+
+  test('dispatcher evidence reconciles an accepted Action whose coordinator was lost in a restart', async () => {
+    await actions.run(action('act-recovered-spawn'), async ({ accept }) => {
+      accept()
+      return new Promise(() => {})
+    })
+    reduction.journal('agent_spawned', { repo: 'alp82/curia', ticket: '803', agent: 'curia-803' })
+    assert.equal(actions.get('act-recovered-spawn').status, 'confirmed')
+
+    await actions.run(action('act-recovered-failure'), async ({ accept }) => {
+      accept()
+      return new Promise(() => {})
+    })
+    reduction.journal('dispatch_unclaimed', {
+      repo: 'alp82/curia', ticket: '803', agent: 'curia-803', reason: 'the daemon restarted during preparation',
+    })
+    assert.equal(actions.get('act-recovered-failure').status, 'failed')
+    assert.equal(actions.get('act-recovered-failure').reason, 'the daemon restarted during preparation')
+
+    reduction.close()
+    reduction = new Reduction(dir)
+    actions = new ActionCoordinator(reduction)
+    assert.equal(actions.get('act-recovered-spawn').status, 'confirmed')
+    assert.equal(actions.get('act-recovered-failure').status, 'failed')
+  })
+
+  test('terminal evidence is immutable', async () => {
+    await actions.run(action('act-terminal'), async () => ({ status: 'refused', reason: 'not takeable' }))
+    assert.throws(
+      () => reduction.recordAction({ ...action('act-terminal'), status: 'confirmed' }),
+      /terminal Action evidence is immutable/,
+    )
+  })
+})

--- a/daemon/test/actions.test.mjs
+++ b/daemon/test/actions.test.mjs
@@ -162,6 +162,16 @@ describe('shared Action evidence', () => {
     )
   })
 
+  test('a domain event that settles the Action releases the first response', async () => {
+    const evidence = await Promise.race([
+      actions.run(action('act-domain-ending'), async () => {
+        reduction.recordAction({ ...action('act-domain-ending'), status: 'confirmed' })
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('no response')), 25)),
+    ])
+    assert.equal(evidence.status, 'confirmed')
+  })
+
   test('credential sign-in facts reconcile progress and every ending after restart', async () => {
     const signIn = {
       action_id: 'atlas-reauth-openai', kind: 'credential-sign-in', target: 'openai', conflict_key: 'reauth:openai',

--- a/daemon/test/actions.test.mjs
+++ b/daemon/test/actions.test.mjs
@@ -140,4 +140,43 @@ describe('shared Action evidence', () => {
       /terminal Action evidence is immutable/,
     )
   })
+
+  test('credential sign-in facts reconcile progress and every ending after restart', async () => {
+    const signIn = {
+      action_id: 'atlas-reauth-openai', kind: 'credential-sign-in', target: 'openai', conflict_key: 'reauth:openai',
+    }
+    await actions.run(signIn, async ({ accept, progress }) => {
+      accept()
+      progress('Preparing the agent image')
+      return { status: 'progress' }
+    })
+    reduction.journal('reauth_started', { provider: 'openai', session: 'curia-auth-openai', action_id: signIn.action_id })
+    assert.equal(actions.get(signIn.action_id).progress, 'Waiting for browser sign-in')
+    reduction.journal('reauth_code_seen', { provider: 'openai', session: 'curia-auth-openai', action_id: signIn.action_id })
+    assert.equal(actions.get(signIn.action_id).progress, 'Waiting for browser completion')
+    reduction.journal('reauth_completed', { provider: 'openai', session: 'curia-auth-openai', action_id: signIn.action_id })
+    assert.equal(actions.get(signIn.action_id).status, 'confirmed')
+
+    for (const [event, reason] of [
+      ['reauth_failed', 'the fresh credential was refused'],
+      ['reauth_timed_out', 'the sign-in timed out'],
+      ['reauth_code_expired', 'the one-time code expired'],
+      ['reauth_abandoned', 'the sign-in session ended'],
+    ]) {
+      const id = `atlas-${event}`
+      await actions.run({ ...signIn, action_id: id }, async ({ accept }) => {
+        accept()
+        return { status: 'progress' }
+      })
+      reduction.journal(event, { provider: 'openai', session: 'curia-auth-openai', action_id: id, why: reason })
+      assert.equal(actions.get(id).status, 'failed')
+      assert.equal(actions.get(id).reason, reason)
+    }
+
+    reduction.close()
+    reduction = new Reduction(dir)
+    actions = new ActionCoordinator(reduction)
+    assert.equal(actions.get(signIn.action_id).status, 'confirmed')
+    assert.equal(actions.get('atlas-reauth_abandoned').status, 'failed')
+  })
 })

--- a/daemon/test/actions.test.mjs
+++ b/daemon/test/actions.test.mjs
@@ -133,6 +133,27 @@ describe('shared Action evidence', () => {
     assert.equal(actions.get('act-recovered-failure').status, 'failed')
   })
 
+  test('daemon lifecycle evidence reconciles a restart Action after the process exits', () => {
+    const restart = {
+      action_id: 'atlas-daemon-restart', kind: 'daemon-restart', target: 'daemon', conflict_key: 'daemon:lifecycle',
+    }
+    reduction.recordAction({ ...restart, status: 'accepted' })
+    reduction.journal('restart_requested', {
+      by: 'dashboard', exit_code: 75, action_id: restart.action_id,
+    })
+    assert.equal(actions.get(restart.action_id).status, 'progress')
+    assert.equal(actions.get(restart.action_id).progress, 'Restarting daemon')
+
+    reduction.close()
+    reduction = new Reduction(dir)
+    actions = new ActionCoordinator(reduction)
+    assert.equal(actions.get(restart.action_id).status, 'progress')
+
+    reduction.journal('daemon_boot', { pid: 4321 })
+    assert.equal(actions.get(restart.action_id).status, 'confirmed')
+    assert.equal(actions.get(restart.action_id).receipt.exit_code, 75)
+  })
+
   test('terminal evidence is immutable', async () => {
     await actions.run(action('act-terminal'), async () => ({ status: 'refused', reason: 'not takeable' }))
     assert.throws(

--- a/daemon/test/aistack.test.mjs
+++ b/daemon/test/aistack.test.mjs
@@ -147,6 +147,17 @@ describe('the roots are built per run (#695)', () => {
     assert.equal(env.CODEX_HOME, path.join(root, 'cfg', 'curia-3'))
   })
 
+  test('new per-Harness roots are scanned beside legacy roots', () => {
+    const claude = path.join(root, 'cfg', 'curia-4', 'claude')
+    const codex = path.join(root, 'cfg', 'curia-5', 'codex')
+    fs.mkdirSync(path.join(claude, 'projects'), { recursive: true })
+    fs.mkdirSync(path.join(codex, 'sessions'), { recursive: true })
+    fs.utimesSync(claude, 4, 4)
+    fs.utimesSync(codex, 5, 5)
+    assert.deepEqual(claudeRoots(root), [claude])
+    assert.equal(codexRoot(root), codex)
+  })
+
   test('a harness with no data sets no variable, so the CLI keeps its own default', () => {
     cfg('curia-1', 'claude')
     const env = syncEnv(root, { env: {} })

--- a/daemon/test/aistackreg.test.mjs
+++ b/daemon/test/aistackreg.test.mjs
@@ -205,6 +205,28 @@ describe('one login at a time, and each way it ends (#706)', () => {
     assert.deepEqual(landed[1], { machine: 'curia.sh', servers: ['aistack.to'] })
   })
 
+  test('the journal restores the device flow and its Action identity after a restart', async () => {
+    const data = path.join(root, 'data')
+    fs.mkdirSync(data, { recursive: true })
+    const reduction = new Reduction(data)
+    const r = reg({
+      bin: stubNpx({ print: DEVICE, sleep: 30 }),
+      journal: (type, detail) => reduction.journal(type, detail),
+    })
+
+    await r.begin({ actionId: 'atlas-aistack-register' })
+    const restarted = new Reduction(data)
+
+    assert.deepEqual(restarted.aistackRegistration(), {
+      phase: 'waiting', code: 'T72NNC', url: 'https://aistack.to/cli/auth?code=T72NNC',
+      action_id: 'atlas-aistack-register',
+      started_at: restarted.aistackRegistration().started_at,
+      expires_at: restarted.aistackRegistration().expires_at,
+    })
+    assert.ok(restarted.aistackRegistration().expires_at > restarted.aistackRegistration().started_at)
+    r.cancel()
+  })
+
   test('a login that exits without a credential is a failure that names the CLI\'s last word', async () => {
     const r = reg({ bin: stubNpx({ print: `${DEVICE}\nauth failed`, code: 4 }) })
     await r.begin()

--- a/daemon/test/commands.test.mjs
+++ b/daemon/test/commands.test.mjs
@@ -42,7 +42,7 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { parseCommand, CommandRouter } from '../src/commands.mjs'
+import { parseCommand, actionForCommand, CommandRouter } from '../src/commands.mjs'
 import { expandCommand } from '../src/bridge.mjs'
 import { validSessionName } from '../src/attach.mjs'
 import { lintReply } from '../src/messaging.mjs'
@@ -534,6 +534,15 @@ describe('parseCommand', () => {
 
   test('empty text is null', () => {
     assert.equal(parseCommand(''), null)
+  })
+})
+
+test('a browser credential sign-in reserves one provider and no other', () => {
+  assert.deepEqual(actionForCommand('reauth anthropic', 'atlas-reauth-anthropic'), {
+    action_id: 'atlas-reauth-anthropic',
+    kind: 'credential-sign-in',
+    target: 'anthropic',
+    conflict_key: 'reauth:anthropic',
   })
 })
 

--- a/daemon/test/config.test.mjs
+++ b/daemon/test/config.test.mjs
@@ -413,15 +413,25 @@ describe('routing config with a second harness (#39)', () => {
     assert.throws(() => load(lines), /is not a valid regex/)
   })
 
-  // A harness with no entry in the HARNESS table would get no config dir, no curia tools and no
-  // Stop hook — an agent that cannot be driven or ended.
-  test('a harness with no entry in the HARNESS table refuses the boot', () => {
+  // A Harness with no registered adapter would get no complete lifecycle. It
+  // is a code change, not a new routing row (ADR-0030).
+  test('a Harness with no registered adapter refuses the boot', () => {
     const lines = [...BASE.slice(0, -2),
       "  claude: { template: 'claude --model {model} \"$(cat {prompt_file})\"', resume_template: 'resume --model {model}', ready: 'x', tool_channel_grace_s: 15 }",
       "  cursor: { template: 'cursor --model {model} \"$(cat {prompt_file})\"', resume_template: 'resume --model {model}', ready: 'x', tool_channel_grace_s: 15 }",
       '  codex: { template: \'codex --model {model} "$(cat {prompt_file})"\', resume_template: \'resume --model {model}\', ready: \'x\', tool_channel_grace_s: 15 }',
     ]
-    assert.throws(() => load(lines), /harnesses\.cursor has no entry in the HARNESS table/)
+    assert.throws(() => load(lines), /harnesses\.cursor has no registered Harness adapter/)
+  })
+
+  test('a model provider must agree with its Harness adapter', () => {
+    const lines = BASE.map((line) => line === '  opus: { provider: anthropic, harness: claude }'
+      ? '  opus: { provider: openai, harness: claude }'
+      : line)
+    assert.throws(
+      () => load(lines),
+      /models\.opus\.provider names "openai", but the claude Harness adapter declares "anthropic"/,
+    )
   })
 
   // The credential half of the same question (#648). This one CANNOT be provoked

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -423,6 +423,7 @@ describe('the settings write and the restart (#265)', () => {
   let reloadAnswer
   let aistackAnswer
   let aistackRequestBody
+  let restartRequestBody
   let overviewAnswer
   const ALLOW = ['alp@example.com']
   const SERVE_PORT = 8445
@@ -462,7 +463,8 @@ describe('the settings write and the restart (#265)', () => {
     // that holds the credential, so this side never composes one of these.
     aistackAnswer = { ok: true, registered: false, flow: { phase: 'unregistered' }, sync: { last: null, alarm: null } }
     aistackRequestBody = null
-    overviewAnswer = async () => ({ daemon: { port: 4271 }, agents: [] })
+    restartRequestBody = null
+    overviewAnswer = async () => ({ daemon: { port: 4271, uptime_s: 90 }, agents: [] })
     daemon = http.createServer((r, res) => {
       daemonCalls.push({ method: r.method, url: r.url, origin: r.headers.origin ?? null })
       res.writeHead(200, { 'content-type': 'application/json' })
@@ -491,6 +493,23 @@ describe('the settings write and the restart (#265)', () => {
         })
       }
       if (r.url.startsWith('/aistack')) return res.end(JSON.stringify(aistackAnswer))
+      if (r.url === '/restart') {
+        let raw = ''
+        r.setEncoding('utf8')
+        r.on('data', (chunk) => { raw += chunk })
+        return r.on('end', () => {
+          restartRequestBody = JSON.parse(raw)
+          res.end(JSON.stringify({
+            ok: true,
+            exit_code: 75,
+            action: {
+              action_id: restartRequestBody.action_id,
+              kind: 'daemon-restart', target: 'daemon', conflict_key: 'daemon:lifecycle',
+              status: 'accepted', revision: 9,
+            },
+          }))
+        })
+      }
       res.end(JSON.stringify({ ok: true, exit_code: 75 }))
     })
     await new Promise((done) => daemon.listen(0, '127.0.0.1', done))
@@ -747,13 +766,22 @@ describe('the settings write and the restart (#265)', () => {
   // ---- the restart ---------------------------------------------------------
 
   test('the restart is the DAEMON\'s to take: the sidecar only orders it', async () => {
-    const res = await req(surface.port, '/api/restart', { method: 'POST', headers: writes(), body: {} })
+    await req(surface.port, '/api/overview', { headers: served() })
+    const res = await req(surface.port, '/api/restart', {
+      method: 'POST', headers: writes(), body: { action_id: 'atlas-daemon-restart' },
+    })
     assert.equal(res.status, 200)
+    assert.equal(JSON.parse(res.text).action.status, 'accepted')
     assert.deepEqual(daemonCalls, [{ method: 'POST', url: '/restart', origin: null }])
+    assert.deepEqual(restartRequestBody, { by: 'dashboard', action_id: 'atlas-daemon-restart', uptime_s: 90 })
+    assert.equal(surface.snapshot.actions[0].action_id, 'atlas-daemon-restart',
+      'a refresh during process downtime recovers the accepted Action from the held snapshot')
   })
 
   test('the order carries no Origin onward — the daemon refuses every request that does', async () => {
-    await req(surface.port, '/api/restart', { method: 'POST', headers: writes(), body: {} })
+    await req(surface.port, '/api/restart', {
+      method: 'POST', headers: writes(), body: { action_id: 'atlas-daemon-origin' },
+    })
     assert.equal(daemonCalls[0].origin, null,
       'the sidecar composes its own call from a route it names in code, never forwards a browser\'s')
   })
@@ -761,13 +789,17 @@ describe('the settings write and the restart (#265)', () => {
   test('after a restart order the next read re-reads: a held snapshot would say `up` at the one moment that is false', async () => {
     await req(surface.port, '/api/overview', { headers: served() })
     assert.ok(surface.snapshotAt > 0)
-    await req(surface.port, '/api/restart', { method: 'POST', headers: writes(), body: {} })
+    await req(surface.port, '/api/restart', {
+      method: 'POST', headers: writes(), body: { action_id: 'atlas-daemon-reread' },
+    })
     assert.equal(surface.snapshotAt, 0)
   })
 
   test('a daemon that is not answering makes the restart an error, never a silent success', async () => {
     await new Promise((done) => daemon.close(done))
-    const res = await req(surface.port, '/api/restart', { method: 'POST', headers: writes(), body: {} })
+    const res = await req(surface.port, '/api/restart', {
+      method: 'POST', headers: writes(), body: { action_id: 'atlas-daemon-offline' },
+    })
     assert.equal(res.status, 500)
     daemon = null
   })

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -1261,6 +1261,24 @@ describe('the operator verbs (#266)', () => {
     assert.deepEqual(sent('/answer').body.files, [])
   })
 
+  test('an answer Action identity and its shared refusal evidence cross the sidecar unchanged', async () => {
+    reply['/answer'] = [409, {
+      ok: false,
+      reason: 'answered',
+      action: {
+        action_id: 'atlas-answer-esc-7', kind: 'escalation-answer', target: 'esc-7',
+        conflict_key: 'answer:esc-7', status: 'refused', revision: 14,
+      },
+      receipt: { by: 'phone', via: 'button', at: 'T', answer: 'Preview' },
+    }]
+    const res = await press('/api/answer', { id: 'esc-7', index: 1, action_id: 'atlas-answer-esc-7' })
+    assert.equal(sent('/answer').body.action_id, 'atlas-answer-esc-7')
+    assert.equal(res.status, 200, 'Action evidence is data for Atlas, not a sidecar transport failure')
+    const body = JSON.parse(res.text)
+    assert.equal(body.action.status, 'refused')
+    assert.equal(body.receipt.by, 'phone')
+  })
+
   test('a reply of more than ten files is refused before the daemon is asked', async () => {
     const res = await press('/api/answer', { id: 'esc-7', files: Array.from({ length: 11 }, (_, i) => ({ name: `f${i}.txt`, data: 'eA==' })) })
     assert.equal(res.status, 409)

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -465,6 +465,19 @@ describe('the settings write and the restart (#265)', () => {
       daemonCalls.push({ method: r.method, url: r.url, origin: r.headers.origin ?? null })
       res.writeHead(200, { 'content-type': 'application/json' })
       if (r.url === '/repos') return res.end(JSON.stringify({ login: 'alp82', repos: ['o/r', 'o/other'], error: null }))
+      if (r.url === '/settings/action') return res.end(JSON.stringify({
+        action: {
+          action_id: 'atlas-settings-sidecar-1', kind: 'settings-save', target: 'curia.local.yaml',
+          conflict_key: 'settings:curia.local.yaml', status: 'progress', progress: 'Writing curia.local.yaml', revision: 1,
+        },
+      }))
+      if (r.url === '/settings/action/finish') return res.end(JSON.stringify({
+        action: {
+          action_id: 'atlas-settings-no-change-1', kind: 'settings-save', target: 'curia.local.yaml',
+          conflict_key: 'settings:curia.local.yaml', status: 'confirmed', revision: 2,
+          receipt: { written: [], applied: [] },
+        },
+      }))
       if (r.url === '/reload') return res.end(JSON.stringify(reloadAnswer))
       if (r.url.startsWith('/aistack')) return res.end(JSON.stringify(aistackAnswer))
       res.end(JSON.stringify({ ok: true, exit_code: 75 }))
@@ -609,11 +622,43 @@ describe('the settings write and the restart (#265)', () => {
     assert.deepEqual(body.reload.applied, ['dispatch.max_concurrent'])
   })
 
+  test('a save reserves its settings paths before writing and carries one Action through reload', async () => {
+    reloadAnswer = {
+      ok: true,
+      applied: ['dispatch.max_concurrent'],
+      action: {
+        action_id: 'atlas-settings-sidecar-1', kind: 'settings-save', target: 'curia.local.yaml',
+        conflict_key: 'settings:curia.local.yaml', status: 'confirmed', revision: 2,
+        receipt: { written: ['curia.local.yaml'], applied: ['dispatch.max_concurrent'] },
+      },
+    }
+    const res = await save({ action_id: 'atlas-settings-sidecar-1', dispatch: { max_concurrent: 4 } })
+    assert.equal(res.status, 200)
+    const body = JSON.parse(res.text)
+    assert.deepEqual(daemonCalls.filter((call) => ['/settings/action', '/reload'].includes(call.url)).map((call) => call.url), [
+      '/settings/action', '/reload',
+    ])
+    assert.equal(body.action.status, 'confirmed')
+    assert.deepEqual(body.action.receipt.written, ['curia.local.yaml'])
+  })
+
   test('a save that wrote nothing asks for nothing — the file did not move', async () => {
     const res = await save({ dispatch: { max_concurrent: 2 } })
     assert.equal(JSON.parse(res.text).written.length, 0)
     assert.equal(JSON.parse(res.text).reload, null)
     assert.deepEqual(reloadCalls(), [], 'there is nothing to apply')
+  })
+
+  test('an Action that finds no change settles without asking for a reload', async () => {
+    const res = await save({ action_id: 'atlas-settings-no-change-1', dispatch: { max_concurrent: 2 } })
+    assert.equal(res.status, 200)
+    const body = JSON.parse(res.text)
+    assert.equal(body.action.status, 'confirmed')
+    assert.deepEqual(body.action.receipt, { written: [], applied: [] })
+    assert.deepEqual(daemonCalls.filter((call) => call.url.startsWith('/settings/action')).map((call) => call.url), [
+      '/settings/action', '/settings/action/finish',
+    ])
+    assert.deepEqual(reloadCalls(), [])
   })
 
   test('a reload the daemon declines rides back as the decline, and the save still landed', async () => {

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -1118,28 +1118,29 @@ describe('the operator verbs (#266)', () => {
   })
 
   test('a new conversation is one press, and the daemon mints the number', async () => {
-    reply['/console/new'] = [200, { key: 'console-4', session: 'curia-console-4' }]
-    const res = await press('/api/console/new', {})
+    reply['/console/new'] = [200, { action: { status: 'confirmed' }, key: 'console-4', session: 'curia-console-4' }]
+    const res = await press('/api/console/new', { action_id: 'atlas-console-new-4' })
     assert.equal(res.status, 200)
     assert.equal(sent('/console/new').method, 'POST', 'never a GET — a page read must not spend a number')
+    assert.deepEqual(sent('/console/new').body, { action_id: 'atlas-console-new-4' })
     assert.equal(JSON.parse(res.text).session, 'curia-console-4')
   })
 
   test('a delete names one key, and a key the daemon does not hold comes back in words', async () => {
-    reply['/console/delete'] = [200, { ok: true, key: 'console-2' }]
-    assert.equal((await press('/api/console/delete', { key: 'console-2' })).status, 200)
-    assert.deepEqual(sent('/console/delete').body, { key: 'console-2' })
+    reply['/console/delete'] = [200, { action: { status: 'confirmed', receipt: { key: 'console-2' } } }]
+    assert.equal((await press('/api/console/delete', { key: 'console-2', action_id: 'atlas-console-delete-2' })).status, 200)
+    assert.deepEqual(sent('/console/delete').body, { key: 'console-2', action_id: 'atlas-console-delete-2' })
 
     calls = []
-    reply['/console/delete'] = [409, { ok: false, error: 'there is no conversation `console-2`' }]
-    const res = await press('/api/console/delete', { key: 'console-2' })
-    assert.equal(res.status, 409)
+    reply['/console/delete'] = [409, { action: { status: 'refused', reason: 'there is no conversation `console-2`' }, error: 'there is no conversation `console-2`' }]
+    const res = await press('/api/console/delete', { key: 'console-2', action_id: 'atlas-console-delete-stale' })
+    assert.equal(res.status, 200, 'the sidecar carries daemon Action evidence instead of reclassifying it')
     assert.match(JSON.parse(res.text).error, /no conversation/)
   })
 
   test('a key the sidecar does not name is refused here, before the wire', async () => {
     for (const key of ['chat-2', 'console', 'console-2; rm -rf /', 'curia-console-2', '../2']) {
-      const res = await press('/api/console/delete', { key })
+      const res = await press('/api/console/delete', { key, action_id: 'atlas-console-delete-invalid' })
       assert.equal(res.status, 409, key)
       assert.match(JSON.parse(res.text).error, /browser conversation key/)
     }

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -911,7 +911,8 @@ describe('the operator verbs (#266)', () => {
   })
 
   test('GitHub App setup keeps conversion inside the daemon', async () => {
-    const started = await press('/api/github-app/start', { name: 'curia-box' })
+    const actionId = 'atlas-github-app-setup'
+    const started = await press('/api/github-app/start', { name: 'curia-box', action_id: actionId })
     assert.equal(started.status, 200)
     // The redirect is composed from curia's own records - `attachBase()` and
     // the serve port - not from anything the caller sent.
@@ -919,6 +920,7 @@ describe('the operator verbs (#266)', () => {
     assert.deepEqual(sent('/github-app/start').body, {
       name: 'curia-box',
       redirect_url: 'https://box.tail1234.ts.net:8445/api/github-app/complete',
+      action_id: actionId,
     })
 
     const completed = await req(surface.port, '/api/github-app/complete?code=one-use&state=expected', { headers: served() })
@@ -929,7 +931,9 @@ describe('the operator verbs (#266)', () => {
   // A browser-named redirect is not a field this surface forwards, and a name
   // GitHub would refuse never reaches the daemon.
   test('the setup start forwards the name and nothing the browser said about the redirect', async () => {
-    await press('/api/github-app/start', { name: 'curia-box', redirect_url: 'https://evil.example.com/' })
+    await press('/api/github-app/start', {
+      name: 'curia-box', redirect_url: 'https://evil.example.com/', action_id: 'atlas-github-app-redirect',
+    })
     assert.equal(sent('/github-app/start').body.redirect_url, 'https://box.tail1234.ts.net:8445/api/github-app/complete')
     calls = []
     const bad = await press('/api/github-app/start', { name: '../evil' })
@@ -950,10 +954,10 @@ describe('the operator verbs (#266)', () => {
   // next page read is a fresh one so the owner rows show what was measured.
   test('the installation re-read reaches the daemon as a bare press and drops the snapshot', async () => {
     surface.snapshotAt = Date.now()
-    const out = await press('/api/github-app/refresh', { anything: 'ignored' })
+    const out = await press('/api/github-app/refresh', { anything: 'ignored', action_id: 'atlas-github-app-read' })
     assert.equal(out.status, 200)
     assert.equal(sent('/github-app/installations').method, 'POST')
-    assert.deepEqual(sent('/github-app/installations').body, {})
+    assert.deepEqual(sent('/github-app/installations').body, { action_id: 'atlas-github-app-read' })
     assert.equal(surface.snapshotAt, 0)
     assert.match(out.text, /Read 1 installation: alp82/)
   })
@@ -964,7 +968,9 @@ describe('the operator verbs (#266)', () => {
   // name this box does answer to, because that is the one the identity gate
   // lets through - the gate refuses the rest, which the second press shows.
   test('a caller-written Host header does not move the setup redirect', async () => {
-    await press('/api/github-app/start', { name: 'curia-box' }, { host: '100.98.118.33:8445' })
+    await press('/api/github-app/start', {
+      name: 'curia-box', action_id: 'atlas-github-app-host',
+    }, { host: '100.98.118.33:8445' })
     assert.equal(
       sent('/github-app/start').body.redirect_url,
       'https://box.tail1234.ts.net:8445/api/github-app/complete',

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -853,13 +853,18 @@ describe('the operator verbs (#266)', () => {
 
   // ---- what crosses the wire -----------------------------------------------
 
-  test('start composes the command — the browser names a repo and a number, never a line of text', async () => {
+  test('start composes the command and returns the daemon\'s first Action evidence unchanged', async () => {
+    const accepted = {
+      action_id: '0198f137-5664-7abc-8def-0123456789ab', kind: 'dispatch', target: 'alp82/curia#266',
+      conflict_key: 'dispatch:alp82/curia#266', status: 'accepted', revision: 42,
+    }
+    reply['/command'] = [200, { action: accepted }]
     const res = await press('/api/start', { repo: 'alp82/curia', ticket: '266', action_id: '0198f137-5664-7abc-8def-0123456789ab' })
     assert.equal(res.status, 200)
     assert.deepEqual(sent('/command').body.text, 'start alp82/curia#266')
     assert.equal(sent('/command').body.action_id, '0198f137-5664-7abc-8def-0123456789ab')
     assert.equal(sent('/command').origin, null, 'the daemon refuses every request carrying one')
-    assert.match(JSON.parse(res.text).reply, /spawned/, "curia's own sentence comes back whole")
+    assert.deepEqual(JSON.parse(res.text).action, accepted)
   })
 
   test('cancel and teleport go through the same seam, so both land in the journal', async () => {

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -422,6 +422,7 @@ describe('the settings write and the restart (#265)', () => {
   let cfgDir
   let reloadAnswer
   let aistackAnswer
+  let aistackRequestBody
   let overviewAnswer
   const ALLOW = ['alp@example.com']
   const SERVE_PORT = 8445
@@ -460,6 +461,7 @@ describe('the settings write and the restart (#265)', () => {
     // What it answers on the aistack routes (#706). The daemon is the process
     // that holds the credential, so this side never composes one of these.
     aistackAnswer = { ok: true, registered: false, flow: { phase: 'unregistered' }, sync: { last: null, alarm: null } }
+    aistackRequestBody = null
     overviewAnswer = async () => ({ daemon: { port: 4271 }, agents: [] })
     daemon = http.createServer((r, res) => {
       daemonCalls.push({ method: r.method, url: r.url, origin: r.headers.origin ?? null })
@@ -479,6 +481,15 @@ describe('the settings write and the restart (#265)', () => {
         },
       }))
       if (r.url === '/reload') return res.end(JSON.stringify(reloadAnswer))
+      if (r.url.startsWith('/aistack') && r.method === 'POST') {
+        let raw = ''
+        r.setEncoding('utf8')
+        r.on('data', (chunk) => { raw += chunk })
+        return r.on('end', () => {
+          aistackRequestBody = JSON.parse(raw)
+          res.end(JSON.stringify(aistackAnswer))
+        })
+      }
       if (r.url.startsWith('/aistack')) return res.end(JSON.stringify(aistackAnswer))
       res.end(JSON.stringify({ ok: true, exit_code: 75 }))
     })
@@ -800,15 +811,17 @@ describe('the settings write and the restart (#265)', () => {
     assert.ok(body.error)
   })
 
-  test('each press crosses the wire as a bare act — the browser names no command', async () => {
+  test('each press carries only its Action identity — the browser names no command', async () => {
     for (const act of ['register', 'cancel', 'optin']) {
       daemonCalls = []
+      aistackRequestBody = null
       const res = await req(surface.port, `/api/aistack/${act}`, {
-        method: 'POST', headers: writes(), body: { version: 'latest', home: '/etc' },
+        method: 'POST', headers: writes(), body: { action_id: `atlas-aistack-${act}`, version: 'latest', home: '/etc' },
       })
       assert.equal(res.status, 200)
       assert.deepEqual(daemonCalls, [{ method: 'POST', url: `/aistack/${act}`, origin: null }],
         'the route is the whole message, and the fields the browser sent went nowhere')
+      assert.deepEqual(aistackRequestBody, { action_id: `atlas-aistack-${act}` })
     }
   })
 
@@ -820,7 +833,9 @@ describe('the settings write and the restart (#265)', () => {
 
   test('a refusal from the daemon reads as one, not as this box failing', async () => {
     aistackAnswer = { ok: false, error: 'this box is already registered with aistack' }
-    const res = await req(surface.port, '/api/aistack/register', { method: 'POST', headers: writes(), body: {} })
+    const res = await req(surface.port, '/api/aistack/register', {
+      method: 'POST', headers: writes(), body: { action_id: 'atlas-aistack-refused' },
+    })
     assert.equal(res.status, 409)
     assert.match(JSON.parse(res.text).error, /already registered/)
   })

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -1045,11 +1045,18 @@ describe('the operator verbs (#266)', () => {
   // exists: the recovery from a dead model credential has no ssh in it, so the
   // act has to reach a phone. Through the command seam like every other verb,
   // so a press journals what a typed line journals.
-  test('sign-in composes `reauth <provider>` — the browser names a provider, never a line', async () => {
-    const res = await press('/api/reauth', { provider: 'anthropic' })
+  test('sign-in composes `reauth <provider>` and carries its Action identity', async () => {
+    const accepted = {
+      action_id: 'atlas-reauth-anthropic', kind: 'credential-sign-in', target: 'anthropic',
+      conflict_key: 'reauth:anthropic', status: 'accepted', revision: 42,
+    }
+    reply['/command'] = [200, { action: accepted }]
+    const res = await press('/api/reauth', { provider: 'anthropic', action_id: 'atlas-reauth-anthropic' })
     assert.equal(res.status, 200)
     assert.equal(sent('/command').body.text, 'reauth anthropic')
     assert.equal(sent('/command').body.by, 'alp@example.com')
+    assert.equal(sent('/command').body.action_id, 'atlas-reauth-anthropic')
+    assert.deepEqual(JSON.parse(res.text).action, accepted)
   })
 
   // The daemon refuses an unknown provider by naming what it CAN sign in, and

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -854,9 +854,10 @@ describe('the operator verbs (#266)', () => {
   // ---- what crosses the wire -----------------------------------------------
 
   test('start composes the command — the browser names a repo and a number, never a line of text', async () => {
-    const res = await press('/api/start', { repo: 'alp82/curia', ticket: '266' })
+    const res = await press('/api/start', { repo: 'alp82/curia', ticket: '266', action_id: '0198f137-5664-7abc-8def-0123456789ab' })
     assert.equal(res.status, 200)
     assert.deepEqual(sent('/command').body.text, 'start alp82/curia#266')
+    assert.equal(sent('/command').body.action_id, '0198f137-5664-7abc-8def-0123456789ab')
     assert.equal(sent('/command').origin, null, 'the daemon refuses every request carrying one')
     assert.match(JSON.parse(res.text).reply, /spawned/, "curia's own sentence comes back whole")
   })

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -984,10 +984,18 @@ describe('the operator verbs (#266)', () => {
     assert.equal(sent('/note').body.by, 'alp@example.com')
   })
 
-  test('a Feed read is journalled under the login, and the held snapshot is dropped so the next poll carries it (#704)', async () => {
-    const res = await press('/api/feed/read', {})
+  test('a Feed read carries its Action identity and drops the held snapshot for reconciliation (#704, #811)', async () => {
+    const actionId = 'atlas-feed-read-alp'
+    const evidence = {
+      action_id: actionId, kind: 'feed-read', target: 'alp@example.com',
+      conflict_key: 'feed-read:alp@example.com', status: 'confirmed', revision: 42,
+    }
+    reply['/feed/read'] = [200, { action: evidence }]
+    const res = await press('/api/feed/read', { action_id: actionId })
     assert.equal(res.status, 200)
     assert.equal(sent('/feed/read').body.by, 'alp@example.com')
+    assert.equal(sent('/feed/read').body.action_id, actionId)
+    assert.deepEqual(JSON.parse(res.text).action, evidence)
     assert.equal(surface.snapshotAt, 0)
   })
 

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -3558,6 +3558,160 @@ describe('the chat screen (#267, the picker of #333)', () => {
       page.finishAction('atlas-overseer-progress')
     })
 
+    test('Take back projects a rewind immediately and reconciles the shared composer and landing', async () => {
+      let sent
+      let answer
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        sent = JSON.parse(request.body)
+        return new Promise((resolve) => { answer = resolve })
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chat.draft = ''
+
+      const pending = room.doTakeBack()
+
+      const action = room.actionFor({ conflict_key: 'turn:curia-684' })
+      assert.equal(action.kind, 'chat-take-back')
+      assert.equal(action.projection.mode, 'rewind')
+      assert.equal(sent.action_id, action.action_id)
+      assert.match(text(room.screenChat(payload())), /Rewinding the conversation…/)
+      assert.match(room.screenChat(payload()), /onclick="doChatKey\('escape'\)"/, 'the independent pane control remains available')
+
+      answer({ json: async () => ({ action: {
+        ...action, status: 'confirmed', revision: 14,
+        receipt: {
+          composer: 'Keep this exact text.', correction: null,
+          take_back: {
+            headline: 'Took back your last message.',
+            landing: 'The conversation continues after “Start here.”',
+            remains: ['The tree stands.'],
+          },
+        },
+      } }) })
+      await pending
+
+      assert.equal(room.actionFor({ action_id: action.action_id }), null)
+      assert.equal(room.chat.draft, 'Keep this exact text.')
+      assert.match(text(room.screenChat(payload())), /Took back your last message.*conversation continues after.*tree stands/i)
+      room.applyChatRoute([])
+    })
+
+    test('taking back a note projects explicit note recovery under the same conversation conflict', () => {
+      let sent
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        sent = JSON.parse(request.body)
+        return new Promise(() => {})
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+
+      room.doTakeBack({ kind: 'note', id: 'note-7' })
+
+      const action = room.actionFor({ conflict_key: 'turn:curia-684' })
+      assert.equal(action.projection.mode, 'note-recovery')
+      assert.deepEqual(sent.target, { kind: 'note', id: 'note-7' })
+      assert.match(text(room.screenChat(payload())), /Recovering your note…/)
+      room.applyChatRoute([])
+    })
+
+    test('refresh recovers another device\'s pending take back and its terminal result', async () => {
+      const p = payload()
+      p.overview.actions = [{
+        action_id: 'atlas-phone-take-back', kind: 'chat-take-back', target: 'curia-684',
+        conflict_key: 'turn:curia-684', status: 'accepted', revision: 20,
+        progress: 'Rewinding the conversation…',
+      }]
+      const room = loadPage({ fetchImpl: async () => ({ ok: true, json: async () => p }) })
+      room.applyChatRoute(['chat', 'curia-684'])
+
+      await room.tick()
+
+      assert.equal(room.actionFor({ conflict_key: 'turn:curia-684' }).action_id, 'atlas-phone-take-back')
+      assert.match(text(room.screenChat(room.payload)), /Rewinding the conversation…/)
+
+      p.overview.actions = [{
+        ...p.overview.actions[0], status: 'confirmed', revision: 21,
+        receipt: {
+          composer: 'Edit these recovered words.', correction: null,
+          take_back: {
+            headline: 'Took back your last message.',
+            landing: 'The conversation continues after “Earlier turn.”',
+            remains: ['The tree stands.'],
+          },
+        },
+      }]
+      await room.tick()
+
+      assert.equal(room.actionFor({ action_id: 'atlas-phone-take-back' }), null)
+      assert.equal(room.chat.draft, 'Edit these recovered words.')
+      assert.match(text(room.screenChat(room.payload)), /conversation continues after “Earlier turn.”/i)
+      room.applyChatRoute([])
+    })
+
+    test('a cold refresh applies recent terminal take-back evidence once', async () => {
+      const p = payload()
+      p.overview.actions = [{
+        action_id: 'atlas-finished-take-back', kind: 'chat-take-back', target: 'curia-684',
+        conflict_key: 'turn:curia-684', status: 'confirmed', revision: 24,
+        receipt: {
+          composer: 'Recovered after refresh.', correction: null,
+          take_back: {
+            headline: 'Took back your last message.',
+            landing: 'The conversation continues after “Earlier turn.”',
+            remains: ['The tree stands.'],
+          },
+        },
+      }]
+      const room = loadPage({ fetchImpl: async () => ({ ok: true, json: async () => p }) })
+      room.applyChatRoute(['chat', 'curia-684'])
+
+      await room.tick()
+      await room.tick()
+
+      assert.equal(room.chat.draft, 'Recovered after refresh.')
+      assert.equal(room.chat.notes.filter((note) => /Took back/.test(note.text)).length, 1)
+      room.applyChatRoute([])
+    })
+
+    test('a refused take back stays with its conversation and leaves other rooms available', async () => {
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        const sent = JSON.parse(request.body)
+        return { json: async () => ({ action: {
+          action_id: sent.action_id, kind: 'chat-take-back', target: 'curia-684',
+          conflict_key: 'turn:curia-684', status: 'refused', revision: 22,
+          reason: 'the transcript has no operator message to take back',
+        } }) }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+
+      await room.doTakeBack()
+
+      assert.equal(room.actionFor({ conflict_key: 'turn:curia-684' }), null)
+      assert.match(text(room.screenChat(payload())), /transcript has no operator message to take back/)
+      room.applyChatRoute(['chat', 'curia-685'])
+      const other = room.screenChat(payload())
+      assert.match(other, /onclick="doTakeBack\(\)"/)
+      assert.doesNotMatch(other, /Rewinding…/)
+      room.applyChatRoute([])
+    })
+
+    test('a failed take back reconciles at the conversation control', async () => {
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        const sent = JSON.parse(request.body)
+        return { json: async () => ({ action: {
+          action_id: sent.action_id, kind: 'chat-take-back', target: 'curia-684',
+          conflict_key: 'turn:curia-684', status: 'failed', revision: 23,
+          reason: 'tmux could not open the rewind picker',
+        } }) }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+
+      await room.doTakeBack()
+
+      assert.equal(room.actionFor({ conflict_key: 'turn:curia-684' }), null)
+      assert.match(text(room.screenChat(payload())), /tmux could not open the rewind picker/)
+      room.applyChatRoute([])
+    })
+
     test('shared pane-key failure reconciles while the original request is still pending', async () => {
       let actionId
       const room = loadPage({ fetchImpl: async (url, request) => {

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2292,6 +2292,122 @@ describe('the operator verbs (#266)', () => {
       delete p.overview.maps.maps[0].takeable[0].model
       assert.match(text(takeable(p)), /the routed model is not on this reading/)
     })
+
+    test('a valid press moves the ticket to Running in the same turn and reserves only that Start', () => {
+      let sent
+      const local = loadPage({
+        fetchImpl: async (_path, request) => {
+          sent = JSON.parse(request.body)
+          return new Promise(() => {})
+        },
+      })
+      local.payload = payload()
+      local.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244 }, open: false }
+
+      vm.runInContext("startTicket('alp82/curia', '265')", local)
+
+      const action = local.actionFor({ target: 'alp82/curia#265' })
+      assert.equal(action.status, 'pending')
+      assert.equal(action.kind, 'dispatch')
+      assert.equal(action.conflict_key, 'dispatch:alp82/curia#265')
+      assert.equal(sent.action_id, action.action_id)
+      const html = local.screenMaps(local.payload)
+      const running = /<section class="map-stage in-flight[\s\S]*?(?=<section class="map-stage takeable)/.exec(html)?.[0]
+      const frontier = /<section class="map-stage takeable[\s\S]*?(?=<section class="map-stage blocked)/.exec(html)?.[0]
+      assert.match(text(running), /#265 The settings write starting/)
+      assert.doesNotMatch(frontier, /#265/)
+      assert.match(frontier, /startTicket\('alp82\/curia','266'\)/)
+    })
+
+    test('shared claim, preparation, and spawn evidence advance the Running row until the map catches up', async () => {
+      let actionId
+      const shared = (revision, status, extra = {}) => ({
+        action_id: actionId, kind: 'dispatch', target: 'alp82/curia#265',
+        conflict_key: 'dispatch:alp82/curia#265', status, revision,
+        started_at: '2026-08-28T10:00:00.000Z', updated_at: '2026-08-28T10:00:01.000Z',
+        ...extra,
+      })
+      const local = loadPage({
+        fetchImpl: async (path, request) => {
+          if (path !== '/api/start') return new Promise(() => {})
+          actionId = JSON.parse(request.body).action_id
+          return { ok: true, json: async () => ({ action: shared(10, 'accepted') }) }
+        },
+      })
+      local.payload = payload()
+      local.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244 }, open: false }
+
+      await vm.runInContext("startTicket('alp82/curia', '265')", local)
+      assert.match(text(local.screenMaps(local.payload)), /#265 The settings write claimed · opening the thread/)
+
+      local.observeActions([shared(11, 'progress', { progress: 'Preparing the agent workspace' })])
+      assert.match(text(local.screenMaps(local.payload)), /#265 The settings write Preparing the agent workspace/)
+
+      local.observeActions([shared(12, 'confirmed')])
+      assert.match(text(local.screenMaps(local.payload)), /#265 The settings write running/)
+
+      const caughtUp = payload()
+      const map = caughtUp.overview.maps.maps[0]
+      const item = map.takeable.shift()
+      map.in_flight.push({ ...item, assignees: ['curia-sh[bot]'], agent: { session: 'curia-265', model: item.model } })
+      map.counts.takeable -= 1
+      map.counts.in_flight += 1
+      local.reconcileStartActions(caughtUp.overview)
+      assert.equal(local.actionFor({ action_id: actionId }), null)
+      assert.match(text(local.screenMaps(caughtUp)), /#265 The settings write working/)
+    })
+
+    test('a refusal or post-claim failure returns the ticket to Frontier with the reason in context', async () => {
+      for (const [status, reason] of [
+        ['refused', 'the ticket is already assigned'],
+        ['failed', 'the agent workspace could not be prepared'],
+      ]) {
+        let actionId
+        const local = loadPage({
+          fetchImpl: async (path, request) => {
+            if (path !== '/api/start') return new Promise(() => {})
+            actionId = JSON.parse(request.body).action_id
+            return { ok: true, json: async () => ({ action: {
+              action_id: actionId, kind: 'dispatch', target: 'alp82/curia#265',
+              conflict_key: 'dispatch:alp82/curia#265', status, revision: 20, reason,
+            } }) }
+          },
+        })
+        local.payload = payload()
+        local.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244 }, open: false }
+
+        await vm.runInContext("startTicket('alp82/curia', '265')", local)
+
+        assert.equal(local.actionFor({ action_id: actionId }), null)
+        const html = local.screenMaps(local.payload)
+        assert.match(html, /startTicket\('alp82\/curia','265'\)/)
+        assert.match(html, /class="said bad"/)
+        assert.match(text(html), new RegExp(reason))
+      }
+    })
+
+    test('a late no-response error cannot overwrite shared progress', async () => {
+      let rejectStart
+      const local = loadPage({
+        fetchImpl: (path) => path === '/api/start'
+          ? new Promise((_resolve, reject) => { rejectStart = reject })
+          : new Promise(() => {}),
+      })
+      local.payload = payload()
+      local.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244 }, open: false }
+      const pending = vm.runInContext("startTicket('alp82/curia', '265')", local)
+      const action = local.actionFor({ target: 'alp82/curia#265' })
+      local.observeActions([{
+        ...action, status: 'progress', revision: 30, progress: 'Preparing the agent workspace',
+      }])
+
+      rejectStart(new Error('the daemon did not answer /command within 5s'))
+      await pending
+
+      assert.equal(local.UI.act.said, null)
+      assert.equal(local.actionFor({ action_id: action.action_id }).status, 'progress')
+      assert.doesNotMatch(text(local.screenMaps(local.payload)), /did not answer/)
+    })
   })
 
   // ---- answer --------------------------------------------------------------

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -3299,6 +3299,80 @@ describe('the chat screen (#267, the picker of #333)', () => {
     // The tap is the whole seam between the card and the daemon: it sends the
     // option index for the card the page holds, and a second tap gets the
     // first receipt (#712's rule) rather than a second answer.
+    test('a native dialog choice projects immediately under its own dialog conflict', () => {
+      let sent
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        sent = JSON.parse(request.body)
+        return new Promise(() => {})
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chatReceive('dialog', { up: true, hint: 'Enter to select', card: { id: 'native-3', kind: 'choice', headline: 'Which branch?', selected_index: 1, options: [{ index: 1, marker: 'A', label: 'Stable' }, { index: 2, marker: 'B', label: 'Preview' }] } })
+      room.beginLocalAction('chat-send')
+
+      room.doDialogAnswer('native-3', 2)
+
+      const action = room.actionFor({ conflict_key: 'dialog:curia-684:native-3' })
+      assert.equal(action.kind, 'native-dialog-answer')
+      assert.equal(action.projection.index, 2)
+      assert.equal(sent.action_id, action.action_id)
+      assert.match(text(room.screenChat(payload())), /Choosing B · Preview…/)
+      assert.ok(room.actionFor({ conflict_key: 'chat-send' }), 'an unrelated Chat action stays independent')
+      room.applyChatRoute([])
+    })
+
+    test('a shared native-dialog failure reconciles while its request is still pending', async () => {
+      let actionId
+      const room = loadPage({ fetchImpl: async (url, request) => {
+        if (url === '/dialog-answer') {
+          actionId = JSON.parse(request.body).action_id
+          return new Promise(() => {})
+        }
+        const p = payload()
+        p.overview.actions = [{
+          action_id: actionId, kind: 'native-dialog-answer',
+          target: 'curia-684:native-3', conflict_key: 'dialog:curia-684:native-3',
+          status: 'failed', revision: 12,
+          reason: 'curia could not answer the native dialog: tmux socket is unavailable',
+        }]
+        return { ok: true, json: async () => p }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chatReceive('dialog', { up: true, hint: 'Enter to select', card: { id: 'native-3', kind: 'choice', headline: 'Which branch?', selected_index: 1, options: [{ index: 1, marker: 'A', label: 'Stable' }, { index: 2, marker: 'B', label: 'Preview' }] } })
+      room.beginLocalAction('chat-send')
+
+      room.doDialogAnswer('native-3', 2)
+      await room.tick()
+
+      assert.equal(room.actionFor({ action_id: actionId }), null)
+      const html = room.screenChat(room.payload)
+      assert.match(html, /class="said bad"/)
+      assert.match(text(html), /tmux socket is unavailable/)
+      assert.match(html, /doDialogAnswer\('native-3', 2\)/, 'the dialog remains available after the failed pane write')
+      assert.ok(room.actionFor({ conflict_key: 'chat-send' }), 'the failure does not block an unrelated Chat action')
+      room.applyChatRoute([])
+    })
+
+    test('refresh recovers another client\'s native-dialog claim until the shared receipt arrives', async () => {
+      const p = payload()
+      p.overview.actions = [{
+        action_id: 'atlas-dialog-phone', kind: 'native-dialog-answer',
+        target: 'curia-684:native-3', conflict_key: 'dialog:curia-684:native-3',
+        status: 'accepted', revision: 11, progress: 'Choosing B · Preview…',
+      }]
+      const room = loadPage({ fetchImpl: async () => ({ ok: true, json: async () => p }) })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chatReceive('dialog', { up: true, hint: 'Enter to select', card: { id: 'native-3', kind: 'choice', headline: 'Which branch?', selected_index: 1, options: [{ index: 1, marker: 'A', label: 'Stable' }, { index: 2, marker: 'B', label: 'Preview' }] } })
+
+      await room.tick()
+
+      assert.equal(room.actionFor({ conflict_key: 'dialog:curia-684:native-3' }).action_id, 'atlas-dialog-phone')
+      assert.match(text(room.screenChat(room.payload)), /Choosing B · Preview…/)
+      room.chatReceive('dialog', { up: false, receipt: { dialog: 'native-3', index: 2, marker: 'B', answer: 'Preview', by: 'phone', at: at(1) } })
+      assert.equal(room.actionFor({ action_id: 'atlas-dialog-phone' }), null)
+      assert.match(text(room.screenChat(room.payload)), /answered · phone .* B · Preview/)
+      room.applyChatRoute([])
+    })
+
     test('a tap posts the measured option index, and a second tap shows the first receipt', async () => {
       const posts = []
       const receipt = { dialog: 'native-3', index: 2, marker: 'B', answer: 'Preview', by: 'phone', at: at(1) }

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1239,14 +1239,19 @@ describe('the read screens (#264)', () => {
   })
 
   describe('feed', () => {
-    test('the Feed marker comes from the journal stamp, and a visit posts the read under the login (#704)', async () => {
+    test('a Feed visit projects through a login-scoped Action before it posts the read (#704, #811)', async () => {
       const prior = at(3_600)
       const posts = []
       const p = loadPage({ fetchImpl: async (url, init) => { posts.push([url, init]); return { ok: true, json: async () => ({}) } } })
       p.payload = { ...payload({ feed_reads: { 'alp82@example.com': prior } }), operator: 'alp82@example.com' }
       p.enter('feed')
       assert.equal(p.UI.feed.lastRead, prior, 'the marker is the PREVIOUS read, not the one that just happened')
-      assert.deepEqual(posts.map(([u, i]) => [u, i.method]), [['/api/feed/read', 'POST']])
+      const action = p.actionFor({ conflict_key: 'feed-read:alp82@example.com' })
+      assert.equal(action.status, 'pending', 'the visit is visible in the same frame as entering Feed')
+      assert.equal(action.kind, 'feed-read')
+      assert.deepEqual(posts.map(([u, i]) => [u, i.method, JSON.parse(i.body).action_id]), [
+        ['/api/feed/read', 'POST', action.action_id],
+      ])
       assert.ok(!p.localStorage.getItem('atlas.feed.last-read:alp82@example.com'), 'no browser-local copy: the journal is the one record')
     })
 
@@ -1256,6 +1261,32 @@ describe('the read screens (#264)', () => {
       p.enter('feed')
       assert.equal(p.UI.feed.lastRead, null)
       assert.ok(!/Since you left/.test(p.screenFeed(p.payload)))
+    })
+
+    test('a refused visit reconciles in Feed and leaves the next visit available (#811)', async () => {
+      const requests = []
+      const p = loadPage({ fetchImpl: async (_url, init) => {
+        const sent = JSON.parse(init.body)
+        requests.push(sent)
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ action: {
+            action_id: sent.action_id, kind: 'feed-read', target: 'alp82@example.com',
+            conflict_key: 'feed-read:alp82@example.com', status: 'refused', revision: requests.length,
+            reason: 'the journal is read-only',
+          } }),
+        }
+      } })
+      p.payload = { ...payload(), operator: 'alp82@example.com' }
+
+      p.enter('feed')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      assert.equal(p.actionFor({ conflict_key: 'feed-read:alp82@example.com' }), null)
+      assert.match(text(p.screenFeed(p.payload)), /Feed visit was not recorded.*journal is read-only/)
+
+      p.enter('feed')
+      assert.equal(requests.length, 2, 'the failed bookkeeping does not disable another visit')
     })
 
     test('Feed separates news from mechanics and places the last-visit marker over a 24-hour density strip', () => {

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -4027,6 +4027,39 @@ describe('the Credentials screen (#661)', () => {
     assert.match(text(html), /the same login signs this in/)
   })
 
+  test('sign-in projects immediately and keeps shared progress through a late transport failure', async () => {
+    let rejectRequest
+    let sent
+    const local = loadPage({
+      fetchImpl: (_path, request) => {
+        sent = JSON.parse(request.body)
+        return new Promise((_resolve, reject) => { rejectRequest = reject })
+      },
+    })
+    local.payload = payload({
+      credentials: {
+        consumers: [{ consumer: 'claude', provider: 'anthropic', state: 'expired', why: 'the year is up', lane: LANE('anthropic') }],
+        reauth: null,
+      },
+    })
+
+    const pending = local.startReauth('anthropic')
+    const action = local.actionFor({ conflict_key: 'reauth:anthropic' })
+    assert.equal(action.kind, 'credential-sign-in')
+    assert.equal(sent.action_id, action.action_id)
+    assert.match(text(local.screenCredentials(local.payload)), /Starting sign-in/)
+
+    local.observeActions([{
+      ...action, status: 'progress', revision: 30, progress: 'Preparing the agent image',
+    }])
+    assert.match(text(local.screenCredentials(local.payload)), /Preparing the agent image/)
+    rejectRequest(new Error('the daemon did not answer /command within 5s'))
+    await pending
+
+    assert.equal(local.actionFor({ action_id: action.action_id }).status, 'progress')
+    assert.doesNotMatch(text(local.screenCredentials(local.payload)), /did not answer/)
+  })
+
   test('the press names the provider, because two of the three rows are anthropic', () => {
     const html = page.screenCredentials(payload({
       credentials: { consumers: [{ consumer: 'claude', provider: 'anthropic', state: 'absent', why: 'none on this box', lane: LANE('anthropic') }], reauth: null },

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2116,6 +2116,78 @@ describe('the settings screen (#265)', () => {
     assert.ok(!html.includes("aistackDo('optin')"), 'there is nothing to grant a permission on yet')
   })
 
+  test('Register this box projects immediately under the machine-registration conflict', async () => {
+    let release
+    let sent
+    const page = loadPage({ fetchImpl: (url, options) => {
+      sent = { url, body: JSON.parse(options.body) }
+      return new Promise((resolve) => { release = resolve })
+    } })
+    page.aistack = AISTACK()
+
+    const press = page.aistackDo('register')
+    const action = page.actionFor({ conflict_key: 'aistack:machine-registration' })
+
+    assert.equal(action.kind, 'aistack-register')
+    assert.equal(action.status, 'pending')
+    assert.match(text(page.setAistack()), /Starting the device login/)
+    assert.equal(sent.url, '/api/aistack/register')
+    assert.equal(sent.body.action_id, action.action_id)
+
+    release({ ok: true, json: async () => ({ action: {
+      ...action, status: 'accepted', revision: 1, started_at: 1, updated_at: 1,
+    } }) })
+    await press
+    page.finishAction(action.action_id)
+    page.aistackWatch()
+  })
+
+  test('Stop waiting replaces the pending registration with its own immediate projection', async () => {
+    let release
+    const page = loadPage({ fetchImpl: () => new Promise((resolve) => { release = resolve }) })
+    page.aistack = {
+      ...AISTACK(),
+      flow: { phase: 'waiting', code: 'T72NNC', url: 'https://aistack.to/cli/auth?code=T72NNC' },
+    }
+    page.beginAction({
+      action_id: 'atlas-register-in-flight', kind: 'aistack-register', target: 'aistack-machine',
+      conflict_key: 'aistack:machine-registration', projection: { phase: 'waiting' },
+    })
+
+    const press = page.aistackDo('cancel')
+    const action = page.actionFor({ conflict_key: 'aistack:machine-registration' })
+
+    assert.equal(action.kind, 'aistack-cancel')
+    assert.match(text(page.setAistack()), /Stopping the device login/)
+    release({ ok: true, json: async () => ({ action: {
+      ...action, status: 'accepted', revision: 2, started_at: 1, updated_at: 2,
+    } }) })
+    await press
+    page.finishAction(action.action_id)
+    page.aistackWatch()
+  })
+
+  test('Opt in projects immediately and a fresh page recovers its shared progress', async () => {
+    const registered = {
+      ...AISTACK(), registered: true,
+      machine: { proposed: 'curia.sh', servers: ['aistack.to'], at: 1 },
+      flow: { phase: 'registered' },
+    }
+    const shared = {
+      action_id: 'atlas-aistack-optin', kind: 'aistack-optin', target: 'aistack-machine',
+      conflict_key: 'aistack:machine-registration', status: 'progress', revision: 4,
+      progress: 'Granting the standing permission', started_at: 1, updated_at: 2,
+    }
+    const page = loadPage({ fetchImpl: async () => ({ ok: true, json: async () => ({ ...registered, actions: [shared] }) }) })
+
+    await page.loadAistack()
+
+    assert.equal(page.actionFor({ conflict_key: 'aistack:machine-registration' }).action_id, shared.action_id)
+    assert.match(text(page.setAistack()), /Granting the standing permission/)
+    page.finishAction(shared.action_id)
+    page.aistackWatch()
+  })
+
   test('a login in flight is the code and the link, and nothing else to do', () => {
     page.aistack = { ...AISTACK(), flow: { phase: 'waiting', code: 'T72NNC', url: 'https://aistack.to/cli/auth?code=T72NNC', started_at: 1, expires_at: 2 } }
     const html = screen('aistack')

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1923,6 +1923,64 @@ describe('the settings screen (#265)', () => {
     assert.match(fs.readFileSync(DEFAULT_DASHBOARD_INDEX, 'utf8'), /manifest\.name = "manifest"/)
   })
 
+  test('GitHub App setup starts immediately and does not reserve installation reads', () => {
+    const sent = []
+    const local = loadPage({
+      fetchImpl: async (path, request) => {
+        sent.push({ path, body: JSON.parse(request.body) })
+        return new Promise(() => {})
+      },
+    })
+    local.payload = payload()
+    local.document.getElementById = (id) => id === 'github-app-name' ? { value: 'curia-box' } : null
+
+    vm.runInContext('doGitHubAppSetup()', local)
+    vm.runInContext('doGitHubAppRefresh()', local)
+
+    const setup = local.actionFor({ conflict_key: 'github-app:setup' })
+    const refresh = local.actionFor({ conflict_key: 'github-app:installations' })
+    assert.equal(setup.status, 'pending')
+    assert.equal(setup.kind, 'github-app-setup')
+    assert.equal(refresh.status, 'pending')
+    assert.equal(refresh.kind, 'github-app-installations')
+    assert.equal(sent[0].body.action_id, setup.action_id)
+    assert.equal(sent[1].body.action_id, refresh.action_id)
+  })
+
+  test('an installation read recovers from shared progress and reconciles an explicit failure', () => {
+    const local = loadPage()
+    local.settings = SETTINGS()
+    local.draft = JSON.parse(JSON.stringify(local.settings))
+    local.UI.drill.settings = { open: 'connections', list: false }
+    const p = payload()
+    p.overview.github_app = {
+      configured: true, status: 'complete', app: { id: '42', key_file: '/keys/app.pem' },
+      installations: { state: 'unread', at: null, error: null }, owners: [], manual_url: null,
+    }
+    local.observeActions([{
+      action_id: 'atlas-github-app-read', kind: 'github-app-installations', target: 'github-app-installations',
+      conflict_key: 'github-app:installations', status: 'progress', revision: 4,
+      progress: 'Reading GitHub App installations',
+    }])
+
+    let html = local.screenSettings(p)
+    assert.match(text(html), /Reading GitHub App installations/)
+    assert.match(html, /Re-read installations<\/button>/)
+    assert.match(html, /button class="btn" disabled/)
+
+    local.observeActions([{
+      action_id: 'atlas-github-app-read', kind: 'github-app-installations', target: 'github-app-installations',
+      conflict_key: 'github-app:installations', status: 'failed', revision: 5,
+      reason: 'The installation read failed: GitHub answered 502',
+    }])
+    local.reconcileGitHubAppActions()
+
+    assert.equal(local.actionFor({ action_id: 'atlas-github-app-read' }), null)
+    html = local.screenSettings(p)
+    assert.match(text(html), /The installation read failed: GitHub answered 502/)
+    assert.doesNotMatch(html, /button class="btn" disabled/)
+  })
+
   // #762: the configured section states the app, the reading, and three owner
   // states, and the third is never drawn as the second.
   test('Connections states the app identity, the reading, and each owner in three states', () => {

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2533,6 +2533,37 @@ describe('the operator verbs (#266)', () => {
       assert.match(text(html), /2 · Post both with stamps/)
     })
 
+    test('a choice projects immediately and reconciles only when the shared escalation closes', async () => {
+      let answer
+      const p = payload()
+      const local = loadPage({ fetchImpl: async () => new Promise((resolve) => { answer = resolve }) })
+      local.payload = p
+
+      const sent = local.answerIndex('esc-7', 1)
+      const action = local.actionFor({ conflict_key: 'answer:esc-7' })
+      assert.ok(action)
+      assert.equal(action.kind, 'escalation-answer')
+      assert.equal(action.projection.answer, 'Post both with stamps')
+      assert.match(text(local.screenHome(p)), /Answering: Post both with stamps…/)
+
+      await Promise.resolve()
+      answer({ ok: true, json: async () => ({
+        ok: true,
+        action: {
+          ...action, status: 'confirmed', revision: 9,
+          receipt: { by: 'alp@example.com', via: 'dashboard', at: at(1), answer: 'Post both with stamps' },
+        },
+      }) })
+      await sent
+      assert.equal(local.actionFor({ action_id: action.action_id }).status, 'confirmed', 'the stale open record keeps the projection')
+
+      const fresh = payload()
+      fresh.overview.escalations = fresh.overview.escalations.filter((record) => record.id !== 'esc-7')
+      local.reconcileAnswerActions(fresh.overview)
+      assert.equal(local.actionFor({ action_id: action.action_id }), null)
+      assert.equal(local.UI.act.handoff, 'esc-7')
+    })
+
     // The typed card (#712, ADR-0025): the button says the letter and the
     // handle, the body keeps the consequence, and the band picks the control.
     describe('the typed card, one payload on every surface (#712)', () => {
@@ -2604,7 +2635,10 @@ describe('the operator verbs (#266)', () => {
         local.payload = p
         await local.answerIndex('esc-7', 1)
         assert.equal(posted.url, '/api/answer')
-        assert.deepEqual(posted.body, { id: 'esc-7', index: 1, files: [] })
+        assert.equal(posted.body.id, 'esc-7')
+        assert.equal(posted.body.index, 1)
+        assert.deepEqual(posted.body.files, [])
+        assert.match(posted.body.action_id, /^atlas-/)
         const t = text(local.screenHome(p))
         assert.match(t, /✅ answered by alp via button .*: Option 1, with its whole/)
         assert.doesNotMatch(t, /already answered/, 'the receipt, not the refusal')

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -29,13 +29,14 @@ function pageScript() {
   return script[1]
 }
 
-function loadPage({ fetchImpl = () => new Promise(() => {}) } = {}) {
+function loadPage({ fetchImpl = () => new Promise(() => {}), confirmImpl = undefined } = {}) {
   const storage = new Map()
   const ctx = vm.createContext({
     document: { title: '', getElementById: () => null, addEventListener() {}, visibilityState: 'hidden' },
     window: { addEventListener() {} },
     location: { hash: '' },
     fetch: fetchImpl,
+    confirm: confirmImpl,
     setTimeout,
     clearTimeout,
     console,
@@ -2315,6 +2316,95 @@ describe('the settings screen (#265)', () => {
     assert.equal(page.runningDiff(p), null)
     page.UI.drill.settings = { open: 'maintenance', list: false }
     assert.match(text(page.screenSettings(p)), /cannot tell whether the daemon runs these files: it is not answering/)
+  })
+
+  test('restart projects immediately under the daemon lifecycle conflict', async () => {
+    let release
+    let sent
+    page = loadPage({
+      fetchImpl: async (url, options) => new Promise((resolve) => {
+        sent = { url, body: JSON.parse(options.body) }
+        release = resolve
+      }),
+    })
+    page.settings = SETTINGS()
+    page.draft = JSON.parse(JSON.stringify(page.settings))
+    page.payload = payload()
+
+    const pressed = page.doRestart()
+
+    const action = page.actionFor({ conflict_key: 'daemon:lifecycle' })
+    assert.equal(action.status, 'pending')
+    assert.equal(action.projection.uptime_s, 7200)
+    assert.match(text(screen('maintenance')), /Restarting daemon/)
+    assert.deepEqual(sent, { url: '/api/restart', body: { action_id: action.action_id } })
+
+    release({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        action: { ...action, status: 'accepted', revision: 15, receipt: { uptime_s: 7200 } },
+      }),
+    })
+    await pressed
+    assert.equal(page.actionFor({ conflict_key: 'daemon:lifecycle' }).status, 'accepted')
+  })
+
+  test('restart keeps its destructive confirmation in front of the Action', async () => {
+    let requests = 0
+    page = loadPage({
+      fetchImpl: async () => { requests += 1 },
+      confirmImpl: () => false,
+    })
+    page.payload = payload()
+
+    await page.doRestart()
+
+    assert.equal(requests, 0)
+    assert.equal(page.actionFor({ conflict_key: 'daemon:lifecycle' }), null)
+  })
+
+  test('restart recovers after refresh and settles from daemon health and fresh uptime', () => {
+    const shared = {
+      action_id: 'atlas-daemon-recovery', kind: 'daemon-restart', target: 'daemon', conflict_key: 'daemon:lifecycle',
+      status: 'progress', progress: 'Restarting daemon', revision: 20,
+      receipt: { uptime_s: 7200, requested_at: at(5), exit_code: 75 },
+    }
+    let reading = payload({ actions: [shared] })
+    reading.daemon_up = false
+    page.observeActions(reading.overview.actions)
+    page.reconcileDaemonRestartActions(reading)
+
+    assert.equal(page.actionFor({ conflict_key: 'daemon:lifecycle' }).status, 'progress')
+    assert.match(text(screen('maintenance')), /Restarting daemon/)
+
+    reading = payload({
+      actions: [{
+        ...shared, status: 'confirmed', revision: 25,
+        receipt: { ...shared.receipt, booted_at: at(1) },
+      }],
+      daemon: { ...OVERVIEW().daemon, uptime_s: 3 },
+    })
+    page.observeActions(reading.overview.actions)
+    page.reconcileDaemonRestartActions(reading)
+
+    assert.equal(page.actionFor({ conflict_key: 'daemon:lifecycle' }), null)
+    assert.match(text(screen('maintenance')), /The daemon restarted and is answering/)
+  })
+
+  test('a lost restart receipt remains ambiguous until health evidence arrives', async () => {
+    page = loadPage({ fetchImpl: async () => { throw new Error('socket hang up') } })
+    page.settings = SETTINGS()
+    page.draft = JSON.parse(JSON.stringify(page.settings))
+    page.payload = payload()
+
+    await page.doRestart()
+
+    assert.equal(page.actionFor({ conflict_key: 'daemon:lifecycle' }).status, 'pending')
+    const t = text(screen('maintenance'))
+    assert.match(t, /may have taken the restart order/)
+    assert.match(t, /bar above says whether the daemon is answering/)
+    assert.doesNotMatch(t, /Refused — nothing was written/)
   })
 
   test('the settings nav item carries a marker while the daemon and the files disagree', () => {

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -3078,6 +3078,92 @@ describe('the chat screen (#267, the picker of #333)', () => {
     assert.match(text(page.screenChat(payload())), /Deleting one spends its number for good/)
   })
 
+  test('New conversation projects immediately, reserves the registry, and navigates on confirmation', async () => {
+    let sent
+    let answer
+    const local = loadPage({ fetchImpl: async (url, request) => {
+      assert.equal(url, '/api/console/new')
+      sent = JSON.parse(request.body)
+      return new Promise((resolve) => { answer = resolve })
+    } })
+    local.conversations = { conversations: [conv()] }
+
+    const pending = local.doNewConversation()
+    const action = local.actionFor({ conflict_key: 'conversation-registry' })
+
+    assert.equal(action.kind, 'console-conversation-open')
+    assert.equal(sent.action_id, action.action_id)
+    assert.match(text(local.screenChat(payload())), /Opening…/)
+    assert.equal(local.beginAction({
+      action_id: 'another-new', kind: 'console-conversation-open',
+      target: 'conversation-registry', conflict_key: 'conversation-registry',
+    }), null)
+
+    answer({ ok: true, json: async () => ({
+      action: { ...action, status: 'confirmed', revision: 8, receipt: { key: 'console-3', session: 'curia-console-3' } },
+      key: 'console-3', session: 'curia-console-3',
+    }) })
+    await pending
+
+    assert.equal(local.location.hash, 'chat/curia-console-3')
+    assert.equal(local.actionFor({ action_id: action.action_id }), null)
+  })
+
+  test('deleting one conversation leaves another delete available and keeps the row pending until confirmation', async () => {
+    const requests = new Map()
+    const local = loadPage({ fetchImpl: async (url, request) => {
+      if (url === '/api/console/delete') {
+        const body = JSON.parse(request.body)
+        return new Promise((resolve) => requests.set(body.key, { body, resolve }))
+      }
+      if (url === '/api/console') return { ok: true, json: async () => ({ conversations: [conv({ key: 'console-3', session: 'curia-console-3' })] }) }
+      throw new Error(`unexpected request ${url}`)
+    } })
+    local.confirm = () => true
+    local.conversations = { conversations: [conv(), conv({ key: 'console-3', session: 'curia-console-3' })] }
+
+    const first = local.doDeleteConversation('console-2')
+    const second = local.doDeleteConversation('console-3')
+    const action = local.actionFor({ conflict_key: 'conversation:console-2' })
+
+    assert.ok(action)
+    assert.ok(local.actionFor({ conflict_key: 'conversation:console-3' }), 'another conversation remains independent')
+    assert.equal(requests.get('console-2').body.action_id, action.action_id)
+    assert.match(text(local.screenChat(payload())), /console-2.*deleting/s)
+
+    requests.get('console-2').resolve({ ok: true, json: async () => ({ action: {
+      ...action, status: 'confirmed', revision: 9, receipt: { key: 'console-2' },
+    } }) })
+    await first
+
+    assert.equal(local.actionFor({ action_id: action.action_id }), null)
+    assert.doesNotMatch(text(local.screenChat(payload())), /console-2/)
+
+    const other = local.actionFor({ conflict_key: 'conversation:console-3' })
+    requests.get('console-3').resolve({ ok: true, json: async () => ({ action: {
+      ...other, status: 'refused', revision: 10, reason: 'there is no conversation `console-3`',
+    } }) })
+    await second
+    assert.match(text(local.screenChat(payload())), /no conversation console-3/)
+  })
+
+  test('a fresh Console read recovers conversation changes made on another device', async () => {
+    const local = loadPage({ fetchImpl: async (url) => {
+      assert.equal(url, '/api/console')
+      return { ok: true, json: async () => ({ conversations: [
+        conv({ key: 'console-4', session: 'curia-console-4', label: 'opened on the phone' }),
+      ] }) }
+    } })
+    local.conversations = { conversations: [conv()] }
+
+    await local.loadConversations()
+
+    const html = local.screenChat(payload())
+    assert.match(text(html), /opened on the phone/)
+    assert.doesNotMatch(html, /console-2/)
+    assert.equal(local.actionFor({ conflict_key: 'conversation-registry' }), null)
+  })
+
   test('it states the one thing the overseer cannot do, rather than leaving it to be found', () => {
     // #315: the overseer holds a reading shell now, so the limit that is left
     // is the write — the read-only token, and every effect crossing the daemon.

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -3377,6 +3377,99 @@ describe('the chat screen (#267, the picker of #333)', () => {
       room.applyChatRoute([])
     })
 
+    test('Send preserves the operator text while its conversation Action is pending', async () => {
+      let sent
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        sent = JSON.parse(request.body)
+        return new Promise(() => {})
+      } })
+      room.applyChatRoute(['chat', 'curia-console-2'])
+      room.chat.draft = 'keep these words'
+
+      room.doChatSend()
+
+      const action = room.actionFor({ conflict_key: 'turn:console-2' })
+      assert.equal(action.kind, 'chat-message')
+      assert.equal(action.projection.text, 'keep these words')
+      assert.equal(sent.action_id, action.action_id)
+      assert.equal(room.chat.draft, 'keep these words')
+      assert.match(room.screenChat(payload()), /keep these words<\/textarea>/)
+      assert.match(text(room.screenChat(payload())), /Sending…/)
+      room.applyChatRoute([])
+    })
+
+    test('a refused Send keeps the operator text and explains that it was not sent', async () => {
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        const sent = JSON.parse(request.body)
+        return { json: async () => ({ action: {
+          action_id: sent.action_id, kind: 'chat-message', target: 'curia-684',
+          conflict_key: 'turn:curia-684', status: 'refused', revision: 8,
+          reason: 'the pane stayed active, so curia did not send the text',
+          receipt: { outcome: 'not_sent' },
+        } }) }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chat.draft = 'do not lose this'
+
+      await room.doChatSend()
+
+      assert.equal(room.chat.draft, 'do not lose this')
+      assert.equal(room.actionFor({ conflict_key: 'turn:curia-684' }), null)
+      assert.match(text(room.screenChat(payload())), /did not send the text/)
+      room.applyChatRoute([])
+    })
+
+    test('confirmed Send evidence clears only the text that Action delivered', async () => {
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        const sent = JSON.parse(request.body)
+        return { json: async () => ({ action: {
+          action_id: sent.action_id, kind: 'chat-message', target: 'curia-684',
+          conflict_key: 'turn:curia-684', status: 'confirmed', revision: 9,
+          receipt: { outcome: 'delivered' },
+        } }) }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.chat.draft = 'deliver this text'
+
+      await room.doChatSend()
+
+      assert.equal(room.chat.draft, '')
+      assert.equal(room.actionFor({ conflict_key: 'turn:curia-684' }), null)
+      room.applyChatRoute([])
+    })
+
+    test('shared sent evidence clears the matching pending text before the next overview', () => {
+      page.chat.draft = 'sent through the stream'
+      page.beginAction({
+        action_id: 'atlas-stream-send', kind: 'chat-message', target: 'curia-684',
+        conflict_key: 'turn:curia-684', projection: { text: 'sent through the stream' },
+      })
+
+      page.chatReceive('sent', {
+        text: 'sent through the stream', by: page.chat.client, action_id: 'atlas-stream-send',
+      })
+
+      assert.equal(page.chat.draft, '')
+      assert.ok(page.actionFor({ action_id: 'atlas-stream-send' }), 'overview still owns terminal reconciliation')
+      page.finishAction('atlas-stream-send')
+    })
+
+    test('shared message progress is visible at the conversation composer', () => {
+      page.beginAction({
+        action_id: 'atlas-overseer-progress', kind: 'chat-message', target: 'curia-684',
+        conflict_key: 'turn:curia-684', projection: { text: 'inspect the map' },
+      })
+      page.observeActions([{
+        action_id: 'atlas-overseer-progress', kind: 'chat-message', target: 'curia-684',
+        conflict_key: 'turn:curia-684', status: 'progress', revision: 11,
+        progress: 'Message delivered; waiting for the overseer response',
+        receipt: { outcome: 'delivered' },
+      }])
+
+      assert.match(text(page.screenChat(payload())), /Message delivered; waiting for the overseer response/)
+      page.finishAction('atlas-overseer-progress')
+    })
+
     test('shared pane-key failure reconciles while the original request is still pending', async () => {
       let actionId
       const room = loadPage({ fetchImpl: async (url, request) => {

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -1846,6 +1846,60 @@ describe('the settings screen (#265)', () => {
     assert.ok(!html.includes('doRestart()'), 'the bar is just Save — the restart lives in Maintenance now')
   })
 
+  test('Save projects immediately under a settings-path conflict and leaves unrelated Actions available', async () => {
+    let answer
+    const response = new Promise((resolve) => { answer = resolve })
+    page = loadPage({ fetchImpl: () => response })
+    page.settings = SETTINGS()
+    page.draft = JSON.parse(JSON.stringify(page.settings))
+    page.setDispatchField('max_concurrent', '4')
+
+    const saving = page.doSave()
+    const action = page.actionFor({ conflict_key: 'settings:curia.local.yaml' })
+    assert.equal(action.status, 'pending')
+    assert.match(text(screen('dispatch')), /Saving settings/)
+    assert.ok(page.beginAction({
+      action_id: 'atlas-unrelated-action-1', kind: 'chat-message', target: 'console-1', conflict_key: 'turn:console-1',
+    }), 'a settings file reservation does not take the global Action lock')
+
+    answer({
+      ok: true,
+      json: async () => ({
+        written: ['curia.local.yaml'],
+        settings: { ...SETTINGS(), dispatch: { ...SETTINGS().dispatch, max_concurrent: 4 } },
+        reload: { ok: true, applied: ['dispatch.max_concurrent'] },
+        action: {
+          ...action, status: 'confirmed', revision: 2,
+          receipt: { written: ['curia.local.yaml'], applied: ['dispatch.max_concurrent'] },
+        },
+      }),
+    })
+    await saving
+    assert.equal(page.actionFor({ action_id: action.action_id }), null)
+    assert.match(text(screen('dispatch')), /The daemon is running it/)
+  })
+
+  test('a refresh recovers settings write progress and reconciles the daemon apply receipt', () => {
+    const shared = {
+      action_id: 'atlas-settings-recovered-1', kind: 'settings-save', target: 'curia.local.yaml',
+      conflict_key: 'settings:curia.local.yaml', status: 'progress', revision: 10,
+      progress: 'Applying settings',
+    }
+    page.observeActions([shared])
+    assert.match(text(screen('dispatch')), /Applying settings/)
+
+    page.observeActions([{
+      ...shared, status: 'confirmed', revision: 11,
+      receipt: {
+        written: ['curia.local.yaml'], applied: [],
+        reload: { ok: false, reason: 'restart-needed', error: 'curia.yaml `sandbox.image` needs a restart' },
+      },
+    }])
+    page.reconcileSettingsActions()
+    assert.equal(page.actionFor({ action_id: shared.action_id }), null)
+    assert.match(text(screen('dispatch')), /The daemon did not apply it.*sandbox\.image/)
+  })
+
   test('applied: one sentence, and no button — the daemon took it', () => {
     page.UI.set.phase = 'applied'
     page.UI.set.note = 'Wrote curia.local.yaml, atomically, with the comments kept.'

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -3201,6 +3201,68 @@ describe('the chat screen (#267, the picker of #333)', () => {
       assert.doesNotMatch(html, /doChatKey/, 'an overseer conversation has no pane key to send')
     })
 
+    test('Esc projects pending on its pane immediately and reconciles confirmed daemon evidence', async () => {
+      let sent
+      let answer
+      const room = loadPage({ fetchImpl: async (_url, request) => {
+        sent = JSON.parse(request.body)
+        return new Promise((resolve) => { answer = resolve })
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.conversations = { conversations: [
+        conv({ kind: 'ticket', deletable: false, key: 'alp82/curia#684', session: 'curia-684', state: 'working', label: 'Build Atlas', repo: 'alp82/curia', ticket: 684, live: true }),
+      ] }
+      room.beginLocalAction('chat-send')
+
+      const pending = room.doChatKey('escape')
+
+      const action = room.actionFor({ conflict_key: 'pane:curia-684' })
+      assert.equal(action.kind, 'pane-key')
+      assert.equal(action.target, 'curia-684')
+      assert.equal(sent.action_id, action.action_id)
+      assert.match(text(room.screenChat(payload())), /Sending Esc…/)
+      assert.ok(room.actionFor({ conflict_key: 'chat-send' }), 'a conversation action stays independent')
+
+      answer({ json: async () => ({ action: {
+        ...action, status: 'confirmed', revision: 8, receipt: { key: 'Escape' },
+      } }) })
+      await pending
+
+      assert.equal(room.actionFor({ action_id: action.action_id }), null)
+      assert.doesNotMatch(text(room.screenChat(payload())), /Sending Esc…/)
+      room.applyChatRoute([])
+    })
+
+    test('shared pane-key failure reconciles while the original request is still pending', async () => {
+      let actionId
+      const room = loadPage({ fetchImpl: async (url, request) => {
+        if (url === '/key') {
+          actionId = JSON.parse(request.body).action_id
+          return new Promise(() => {})
+        }
+        const p = payload()
+        p.overview.actions = [{
+          action_id: actionId, kind: 'pane-key', target: 'curia-684',
+          conflict_key: 'pane:curia-684', status: 'failed', revision: 12,
+          reason: 'tmux socket is unavailable',
+        }]
+        return { ok: true, json: async () => p }
+      } })
+      room.applyChatRoute(['chat', 'curia-684'])
+      room.conversations = { conversations: [
+        conv({ kind: 'ticket', deletable: false, key: 'alp82/curia#684', session: 'curia-684', state: 'working', label: 'Build Atlas', repo: 'alp82/curia', ticket: 684, live: true }),
+      ] }
+
+      room.doChatKey('escape')
+      await room.tick()
+
+      assert.equal(room.actionFor({ action_id: actionId }), null)
+      const html = room.screenChat(room.payload)
+      assert.match(html, /class="said bad"/)
+      assert.match(text(html), /tmux socket is unavailable/)
+      room.applyChatRoute([])
+    })
+
     test('the composer is shared: a draft from the other device mirrors, a sent line is noted', () => {
       page.chatReceive('draft', { text: 'typing from the phone', by: 'other' })
       let t = text(page.screenChat(payload()))

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -2163,6 +2163,84 @@ describe('the settings screen (#265)', () => {
   })
 })
 
+describe('Atlas Action bookkeeping', () => {
+  let page
+  beforeEach(() => { page = loadPage() })
+
+  const local = (id, conflict = `dispatch:${id}`, target = id) => ({
+    action_id: id, kind: 'dispatch', target, conflict_key: conflict,
+    projection: { phase: 'starting' },
+  })
+  const evidence = (id, revision, status = 'accepted', conflict = `dispatch:${id}`, target = id) => ({
+    action_id: id, kind: 'dispatch', target, conflict_key: conflict, status, revision,
+    started_at: '2026-08-28T10:00:00.000Z', updated_at: '2026-08-28T10:00:01.000Z',
+  })
+
+  test('beginAction records the pending projection in the same frame', () => {
+    const started = page.beginAction(local('act-local'))
+
+    assert.equal(started.status, 'pending')
+    assert.equal(page.actionFor({ target: 'act-local' }).action_id, 'act-local')
+    assert.equal(page.actionFor({ conflict_key: 'dispatch:act-local' }).projection.phase, 'starting')
+  })
+
+  test('independent conflict keys can remain pending together', () => {
+    assert.ok(page.beginAction(local('act-one')))
+    assert.ok(page.beginAction(local('act-two')))
+    assert.equal(page.actionFor({ conflict_key: 'dispatch:act-one' }).action_id, 'act-one')
+    assert.equal(page.actionFor({ conflict_key: 'dispatch:act-two' }).action_id, 'act-two')
+  })
+
+  test('a duplicate conflict is refused without replacing the first Action', () => {
+    assert.ok(page.beginAction(local('act-first', 'dispatch:ticket')))
+    assert.equal(page.beginAction(local('act-second', 'dispatch:ticket')), null)
+    assert.equal(page.actionFor({ conflict_key: 'dispatch:ticket' }).action_id, 'act-first')
+  })
+
+  test('older daemon evidence cannot replace a newer reading', () => {
+    page.beginAction(local('act-order'))
+    page.observeActions([evidence('act-order', 8, 'progress')])
+    page.observeActions([evidence('act-order', 7, 'accepted')])
+
+    assert.equal(page.actionFor({ action_id: 'act-order' }).status, 'progress')
+    assert.equal(page.actionFor({ action_id: 'act-order' }).revision, 8)
+  })
+
+  test('terminal evidence is immutable', () => {
+    page.beginAction(local('act-terminal'))
+    page.observeActions([evidence('act-terminal', 4, 'refused')])
+    page.observeActions([evidence('act-terminal', 5, 'confirmed')])
+
+    assert.equal(page.actionFor({ action_id: 'act-terminal' }).status, 'refused')
+    assert.equal(page.actionFor({ action_id: 'act-terminal' }).revision, 4)
+  })
+
+  test('nonterminal evidence from another device reserves its conflict key', () => {
+    page.observeActions([evidence('act-remote', 11, 'progress', 'dispatch:shared', 'alp82/curia#804')])
+
+    assert.equal(page.actionFor({ target: 'alp82/curia#804' }).status, 'progress')
+    assert.equal(page.beginAction(local('act-local', 'dispatch:shared')), null)
+  })
+
+  test('an overview refresh recovers a nonterminal Action', async () => {
+    const recovered = evidence('act-refresh', 12, 'accepted', 'dispatch:refresh', 'alp82/curia#804')
+    page = loadPage({ fetchImpl: async () => ({ ok: true, json: async () => payload({ actions: [recovered] }) }) })
+
+    await page.tick()
+
+    assert.equal(page.actionFor({ conflict_key: 'dispatch:refresh' }).action_id, 'act-refresh')
+  })
+
+  test('finishAction removes bookkeeping only after caller reconciliation', () => {
+    page.beginAction(local('act-finish'))
+    page.observeActions([evidence('act-finish', 3, 'confirmed')])
+    assert.equal(page.actionFor({ action_id: 'act-finish' }).status, 'confirmed')
+
+    assert.equal(page.finishAction('act-finish'), true)
+    assert.equal(page.actionFor({ action_id: 'act-finish' }), null)
+  })
+})
+
 // The operator verbs on the page (#266). What a human looking at the preview
 // can judge is that a button is there and reads well. What they cannot judge by
 // looking is the half pinned here: that the words a button SENDS are the words
@@ -2551,10 +2629,13 @@ describe('the operator verbs (#266)', () => {
       assert.equal(/queued/.test(said), false)
     })
 
-    test('one act at a time: while a press is in flight every other control is disabled', () => {
-      page.UI.act.busy = 'esc:esc-7'
+    test('an in-flight answer leaves an independent Start control available', () => {
+      page.beginAction({
+        action_id: 'act-answer', kind: 'answer', target: 'esc-7', conflict_key: 'esc:esc-7',
+      })
       page.UI.maps = { repo: 'all', selected: { repo: 'alp82/curia', map: 244, group: 'takeable' }, open: false }
-      assert.match(page.screenMaps(payload()), /button class="btn sm primary" disabled/)
+      assert.match(page.screenMaps(payload()), /button class="btn sm primary"  onclick="startTicket/)
+      page.finishAction('act-answer')
     })
   })
 

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -8101,6 +8101,33 @@ describe('signing the anthropic lane back in (#660)', () => {
     assert.ok(events.some((e) => e.type === 'reauth_requested' && e.provider === 'anthropic'))
   })
 
+  test('the browser receives acceptance and image progress before the login session can start', async () => {
+    let finishImage
+    const image = new Promise((resolve) => { finishImage = resolve })
+    const d = makeDispatcher({ ensureAgentImage: async () => image })
+    d.reauth.newSession = async () => {}
+    d.reauth.hasSession = async () => false
+    const seen = []
+    const action = {
+      actionId: 'atlas-reauth-anthropic',
+      accept: () => seen.push('accepted'),
+      progress: (progress) => seen.push(progress),
+    }
+
+    const pending = d.startReauth({ provider: 'anthropic', by: 'u1', action })
+    await Promise.resolve()
+    assert.deepEqual(seen, ['accepted', 'Preparing the agent image'])
+
+    finishImage({ ref: 'curia-agent:test' })
+    await pending
+    assert.deepEqual(seen, [
+      'accepted', 'Preparing the agent image', 'Starting the credential sign-in session', 'Waiting for browser sign-in',
+    ])
+    assert.ok(events.some((event) => event.type === 'reauth_started'
+      && event.action_id === 'atlas-reauth-anthropic'))
+    assert.equal(d.credentialsStatus().reauth.action_id, 'atlas-reauth-anthropic')
+  })
+
   // #661, closing #645 finding 4. The terminal is the path that ALWAYS works —
   // everything else on the card is scraped off a pane, and a scrape is a guess
   // about somebody else's wording. The daemon had been composing this link for

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -1907,11 +1907,11 @@ describe('the claim assigns dispatch.claim_login (#390)', () => {
 
 describe('the agent mints its GitHub token (#389)', () => {
   const envFileOf = (session) => {
-    const file = path.join(tmp, 'work', 'cfg', session, ENV_FILE)
+    const file = path.join(tmp, 'work', 'cfg', session, 'claude', ENV_FILE)
     return Object.fromEntries(fs.readFileSync(file, 'utf8').split('\n')
       .filter(Boolean).map((l) => [l.slice(0, l.indexOf('=')), l.slice(l.indexOf('=') + 1)]))
   }
-  const cfgOf = (session) => path.join(tmp, 'work', 'cfg', session)
+  const cfgOf = (session) => path.join(tmp, 'work', 'cfg', session, 'claude')
   const hostsOf = (session) => path.join(cfgOf(session), GH_DIR, 'hosts.yml')
 
   // A minter shaped like the real one and reaching no GitHub: a fresh token per
@@ -2167,12 +2167,12 @@ describe('every spawn path authenticates the agent the same way (#53, #156)', ()
   // is frozen for the agent's life by construction, and a file in the config dir
   // is what the dispatch tick can rewrite under a running agent (#659).
   const envFileOf = (session) => {
-    const file = path.join(tmp, 'work', 'cfg', session, ENV_FILE)
+    const file = path.join(tmp, 'work', 'cfg', session, 'claude', ENV_FILE)
     return Object.fromEntries(fs.readFileSync(file, 'utf8').split('\n')
       .filter(Boolean).map((l) => [l.slice(0, l.indexOf('=')), l.slice(l.indexOf('=') + 1)]))
   }
   const credentialOf = (session) => JSON.parse(
-    fs.readFileSync(path.join(tmp, 'work', 'cfg', session, '.credentials.json'), 'utf8'),
+    fs.readFileSync(path.join(tmp, 'work', 'cfg', session, 'claude', '.credentials.json'), 'utf8'),
   ).claudeAiOauth
 
   test('the initial spawn puts nothing in the pane, no credential in the env file, and the credential in a file', async () => {
@@ -3489,6 +3489,24 @@ describe('reconcile sweeps abandoned credential copies (W6)', () => {
 
     assert.deepEqual(swept, ['curia-77'], 'the codex credential copy outlived its agent')
     assert.ok(events.some((e) => e.type === 'credentials_swept' && e.agent === 'curia-77'))
+  })
+
+  test('a dead agent loses credentials from every per-Harness root', async () => {
+    const sessionRoot = path.join(tmp, 'work', 'cfg', 'curia-77')
+    for (const [harness, file] of [['claude', '.credentials.json'], ['codex', 'auth.json']]) {
+      const dir = path.join(sessionRoot, harness)
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(path.join(dir, file), '{}')
+    }
+    const swept = []
+    const d = makeDispatcher({
+      listSessions: async () => [],
+      removeCredentials: (dir) => swept.push(path.relative(sessionRoot, dir)),
+    })
+
+    await d.reconcile({ boot: false })
+
+    assert.deepEqual(swept.sort(), ['claude', 'codex'])
   })
 
   test('an INDETERMINATE session list sweeps nothing (the W1 interaction)', async () => {
@@ -5843,12 +5861,15 @@ describe('dispatching across two harnesses (#39)', () => {
     await d.start('42', { repo: 'o/r', by: 'test' })
     assert.deepEqual(seeded, ['codex'])
     assert.deepEqual(harnessed, ['codex'])
+    const journalled = events.find((event) => event.type === 'agent_spawned')
+    assert.equal(journalled.adapter, 'codex')
+    assert.equal(journalled.config_layout, 1)
     // the CLI model id, not the routing name
     assert.match(spawn.shellCmd, /codex --model gpt-5\.5/)
     // #195: the pane carries NO environment at all — the container's env file
     // carries CODEX_HOME, and a pane env would show every value in `ps`
     assert.deepEqual(spawn.env, {})
-    assert.match(fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', ENV_FILE), 'utf8'), /^CODEX_HOME=/m)
+    assert.match(fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'codex', ENV_FILE), 'utf8'), /^CODEX_HOME=/m)
   })
 
   // The bug this ordering fixes: `harness` used to be read off the REQUESTED
@@ -5906,10 +5927,12 @@ describe('dispatching across two harnesses (#39)', () => {
     // #195: the pane carries no environment either time — the claude
     // variables are in the container env file the respawn rewrote
     assert.deepEqual(spawns[1].env, {})
-    const envFile = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', ENV_FILE), 'utf8')
+    const envFile = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'claude', ENV_FILE), 'utf8')
     assert.match(envFile, /^CLAUDE_CONFIG_DIR=/m)
     assert.match(envFile, /^CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=/m)
     assert.equal(/^CLAUDE_SECURESTORAGE_CONFIG_DIR=/m.test(envFile), false, 'the container denies the host HOME')
+    assert.equal(fs.existsSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'codex')), true,
+      'the fallback preserves the source Harness root instead of reusing its native state')
     // and the watchdog that follows must read the NEW harness's marker
     assert.ok(events.some((e) => e.type === 'agent_spawned' && e.harness === 'claude'))
   })

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -524,6 +524,37 @@ describe('ticketless skill dispatch (#684)', () => {
 })
 
 describe('in-flight admission guard (criterion 3)', () => {
+  test('an Action is accepted after the claim and reports progress before slow preparation finishes', async () => {
+    let releaseClone
+    const clone = new Promise((resolve) => { releaseClone = resolve })
+    const evidence = []
+    const d = makeDispatcher({
+      createPrivateClone: async (root, repo, ticket) => {
+        await clone
+        return fakePrivateClone(root, repo, ticket)
+      },
+    })
+
+    const start = d.start('42', {
+      repo: 'o/r', by: 'test',
+      action: {
+        accept: () => evidence.push(['accepted']),
+        progress: (message) => evidence.push(['progress', message]),
+      },
+    })
+    await waitFor(() => evidence.length >= 2)
+
+    assert.deepEqual(evidence, [
+      ['accepted'],
+      ['progress', 'Preparing the agent workspace'],
+    ])
+    assert.ok(events.some((event) => event.type === 'dispatch_claimed'), 'acceptance follows the durable claim')
+    assert.ok(!events.some((event) => event.type === 'agent_spawned'), 'the slow operation is still running')
+
+    releaseClone()
+    assert.match(await start, /dispatched/)
+  })
+
   test('a second start() interleaving with the first is refused, and the ticket is claimed exactly once', async () => {
     let claims = 0
     let spawns = 0

--- a/daemon/test/githubappsetup.test.mjs
+++ b/daemon/test/githubappsetup.test.mjs
@@ -96,6 +96,17 @@ describe('the manifest (#694)', () => {
     assert.deepEqual(setup.status(), { status: 'pending', expires_at: started.expires_at })
   })
 
+  test('the setup action identity survives the GitHub redirect and daemon restart', () => {
+    const setup = new GitHubAppSetup(paths('action'))
+    setup.start({
+      name: 'curia-alp', redirectUrl: 'https://box.example/github-app/complete',
+      actionId: 'atlas-github-app-setup',
+    })
+
+    const restarted = new GitHubAppSetup(paths('action'))
+    assert.equal(restarted.status().action_id, 'atlas-github-app-setup')
+  })
+
   test('a redirect that is not https, or that carries more than a path, refuses', () => {
     const setup = new GitHubAppSetup(paths('redirect'))
     assert.throws(() => setup.start({ name: 'x', redirectUrl: 'http://box.example/complete' }), /must use HTTPS/)

--- a/daemon/test/harnesses.test.mjs
+++ b/daemon/test/harnesses.test.mjs
@@ -1,0 +1,169 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  CURRENT_CONFIG_LAYOUT,
+  HARNESS_REGISTRY,
+  HarnessCapabilityError,
+  HarnessContractError,
+  createHarnessPorts,
+  createHarnessRegistry,
+  normalizedEvent,
+  requireHarnessCapability,
+  spawnIdentity,
+  unknownNativeEvidence,
+} from '../src/harnesses.mjs'
+import { Reduction } from '../src/reduction.mjs'
+
+const methods = (names) => Object.fromEntries(names.map((name) => [name, () => name]))
+
+function fakeAdapter(name = 'fake', overrides = {}) {
+  const capabilities = {
+    modelSwitch: false,
+    reasoningEffort: false,
+    transcriptUsage: false,
+    nativeSkills: false,
+    richMetadata: false,
+  }
+  return {
+    identity: {
+      name,
+      provider: 'test-provider',
+      credentialConsumer: 'test-consumer',
+      configLayoutVersion: 1,
+    },
+    setup: methods(['refuseRepository', 'prepare']),
+    lifecycle: methods(['freshCommand', 'resumeCommand', 'isReady', 'processDied', 'interrupt', 'send']),
+    evidence: methods(['discover', 'events', 'activity', 'usage']),
+    control: {
+      capabilities,
+      operations: {},
+      enforceCompletion: () => 'complete',
+    },
+    ...overrides,
+  }
+}
+
+describe('the Harness adapter registry', () => {
+  test('the static registry returns frozen Claude and Codex adapters', () => {
+    assert.deepEqual(HARNESS_REGISTRY.names, ['claude', 'codex'])
+    const claude = HARNESS_REGISTRY.get('claude')
+    assert.equal(claude.identity.provider, 'anthropic')
+    assert.equal(claude.identity.credentialConsumer, 'claude')
+    assert.equal(claude.identity.configLayoutVersion, CURRENT_CONFIG_LAYOUT)
+    assert.equal(Object.isFrozen(claude), true)
+    assert.equal(Object.isFrozen(claude.lifecycle), true)
+  })
+
+  test('duplicate names and missing facets refuse registry construction', () => {
+    assert.throws(
+      () => createHarnessRegistry([fakeAdapter(), fakeAdapter()]),
+      /duplicate Harness adapter name "fake"/,
+    )
+    const broken = fakeAdapter()
+    delete broken.evidence
+    assert.throws(() => createHarnessRegistry([broken]), /needs the evidence facet/)
+  })
+
+  test('providers, credential consumers, and capability declarations validate at construction', () => {
+    assert.throws(
+      () => createHarnessRegistry([fakeAdapter()], { providers: ['another'] }),
+      /unknown provider "test-provider"/,
+    )
+    assert.throws(
+      () => createHarnessRegistry([fakeAdapter()], { credentialConsumers: ['another'] }),
+      /unknown credential consumer "test-consumer"/,
+    )
+    const control = {
+      capabilities: {
+        modelSwitch: true,
+        reasoningEffort: false,
+        transcriptUsage: false,
+        nativeSkills: false,
+        richMetadata: false,
+      },
+      operations: {},
+      enforceCompletion: () => {},
+    }
+    assert.throws(
+      () => createHarnessRegistry([fakeAdapter('fake', { control })]),
+      /declares modelSwitch without an operation/,
+    )
+  })
+
+  test('an unknown lookup fails before native behavior runs', () => {
+    assert.throws(
+      () => HARNESS_REGISTRY.get('other'),
+      (error) => error instanceof HarnessContractError && error.code === 'HARNESS_UNKNOWN',
+    )
+  })
+})
+
+describe('Harness ports and normalized evidence', () => {
+  test('fake ports construct without tmux, a container, or a command-line interface', () => {
+    const ports = createHarnessPorts({
+      filesystem: methods(['refuseRepository', 'prepare']),
+      process: methods(['died', 'interrupt']),
+      pane: methods(['capture', 'send']),
+      transcript: methods(['discover', 'events', 'activity', 'usage']),
+      toolChannel: methods(['enforceCompletion']),
+    })
+    assert.equal(ports.pane.capture(), 'capture')
+    assert.equal(Object.isFrozen(ports), true)
+    assert.throws(() => createHarnessPorts({
+      filesystem: {}, process: {}, pane: {}, transcript: {}, toolChannel: {},
+    }), /filesystem port needs refuseRepository/)
+  })
+
+  test('unknown native evidence stays visible in the shared vocabulary', () => {
+    assert.deepEqual(unknownNativeEvidence('future_item', { source: 'fixture' }), {
+      type: 'unknown_native_evidence', nativeType: 'future_item', source: 'fixture',
+    })
+    assert.throws(() => normalizedEvent('made_up'), /unknown normalized Harness event/)
+  })
+})
+
+describe('Harness capabilities and durable identity', () => {
+  test('unsupported controls refuse before a pane operation can run', () => {
+    const adapter = createHarnessRegistry([fakeAdapter()]).get('fake')
+    assert.throws(
+      () => requireHarnessCapability(adapter, 'modelSwitch'),
+      (error) => error instanceof HarnessCapabilityError
+        && error.code === 'HARNESS_CAPABILITY_UNAVAILABLE'
+        && error.status === 409,
+    )
+  })
+
+  test('new records state the layout, while old records take the legacy route', () => {
+    assert.deepEqual(spawnIdentity({ adapter: 'codex', config_layout: 1 }), {
+      adapter: 'codex', configLayoutVersion: 1, legacy: false,
+    })
+    assert.deepEqual(spawnIdentity({ harness: 'claude' }), {
+      adapter: 'claude', configLayoutVersion: 0, legacy: true,
+    })
+  })
+
+  test('the journal reduction keeps adapter identity and the legacy-layout decision', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-harness-reduction-'))
+    const reduction = new Reduction(dir)
+    reduction.journal('agent_spawned', {
+      agent: 'curia-1', ticket: '1', harness: 'codex', adapter: 'codex', config_layout: 1,
+    })
+    reduction.journal('agent_spawned', { agent: 'curia-2', ticket: '2', harness: 'claude' })
+    const conversations = reduction.retainedAgentConversations()
+    assert.deepEqual(
+      conversations.map(({ adapter, configLayoutVersion, legacyConfigLayout }) => ({
+        adapter, configLayoutVersion, legacyConfigLayout,
+      })),
+      [
+        { adapter: 'codex', configLayoutVersion: 1, legacyConfigLayout: false },
+        { adapter: 'claude', configLayoutVersion: 0, legacyConfigLayout: true },
+      ],
+    )
+    reduction.close()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -62,6 +62,7 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
     const shim = path.join(tmp, 'shim')
     fs.mkdirSync(cfgDir, { recursive: true })
     fs.mkdirSync(shim, { recursive: true })
+    fs.mkdirSync(path.join(tmp, 'work', 'home'), { recursive: true })
     // inert failing stubs: boot reconcile's gh/tmux reads come back
     // indeterminate (a failed pass, by design), tailscale serve fails non-fatally
     for (const bin of ['gh', 'tmux', 'tailscale']) {
@@ -69,6 +70,16 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
       fs.writeFileSync(p, '#!/bin/sh\nexit 1\n')
       fs.chmodSync(p, 0o755)
     }
+    const npx = path.join(shim, 'npx')
+    fs.writeFileSync(npx, [
+      '#!/bin/sh',
+      'if [ "$3" = "login" ]; then',
+      '  printf "CODE T72NNC\\nOPEN https://aistack.to/cli/auth?code=T72NNC\\n"',
+      '  exec sleep 30',
+      'fi',
+      'printf "auto-sync on\\n"',
+    ].join('\n'))
+    fs.chmodSync(npx, 0o755)
     const [daemonPort, ttydPort, servePort, proxyPort] = await freePorts(4)
     port = daemonPort
     fs.writeFileSync(path.join(cfgDir, 'curia.yaml'), [
@@ -177,6 +188,43 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
     })
     assert.equal(res.status, 200)
     assert.ok(JSON.parse(res.body).id, 'the request went through to the real route')
+  })
+
+  test('machine registration exposes one durable Action and refuses a conflicting press', async () => {
+    const post = (route, actionId) => request(port, 'POST', route, {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ action_id: actionId }),
+    })
+    const started = await post('/aistack/register', 'atlas-aistack-register-1')
+    assert.equal(started.status, 200)
+    assert.equal(JSON.parse(started.body).action.status, 'accepted')
+
+    let status
+    for (let i = 0; i < 100; i++) {
+      status = JSON.parse((await request(port, 'GET', '/aistack')).body)
+      if (status.flow?.code) break
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.equal(status.flow.code, 'T72NNC')
+    assert.equal(status.flow.action_id, 'atlas-aistack-register-1')
+    assert.equal(status.actions.find((action) => action.action_id === 'atlas-aistack-register-1').status, 'progress')
+
+    const conflict = await post('/aistack/register', 'atlas-aistack-register-2')
+    assert.equal(conflict.status, 409)
+    assert.equal(JSON.parse(conflict.body).action.status, 'refused')
+
+    const cancelled = await post('/aistack/cancel', 'atlas-aistack-cancel-1')
+    assert.equal(cancelled.status, 200)
+    assert.equal(JSON.parse(cancelled.body).action.status, 'accepted')
+
+    for (let i = 0; i < 100; i++) {
+      status = JSON.parse((await request(port, 'GET', '/aistack')).body)
+      const action = status.actions.find((candidate) => candidate.action_id === 'atlas-aistack-cancel-1')
+      if (action?.status === 'confirmed') break
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.equal(status.flow.phase, 'cancelled')
+    assert.equal(status.actions.find((action) => action.action_id === 'atlas-aistack-cancel-1').status, 'confirmed')
   })
 
   test('Sec-Fetch-Site: none (a direct navigation-style value) passes', async () => {

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -824,12 +824,15 @@ describe('POST /restart: the daemon journals and exits nonzero (#265, real boot)
   test('the order is answered first and the process exits nonzero after it', async () => {
     const res = await request(port, 'POST', '/restart', {
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ by: 'dashboard' }),
+      body: JSON.stringify({ by: 'dashboard', action_id: 'atlas-daemon-restart', uptime_s: 91 }),
     })
     assert.equal(res.status, 200, 'the answer leaves before the exit takes the socket')
     const body = JSON.parse(res.body)
     assert.equal(body.ok, true)
     assert.equal(body.by, 'dashboard')
+    assert.equal(body.action.status, 'accepted')
+    assert.equal(body.action.conflict_key, 'daemon:lifecycle')
+    assert.equal(body.action.receipt.uptime_s, 91)
 
     const code = await new Promise((done) => child.once('close', (c) => done(c)))
     assert.equal(code, body.exit_code)
@@ -840,6 +843,7 @@ describe('POST /restart: the daemon journals and exits nonzero (#265, real boot)
     const logged = events.filter((e) => e.type === 'restart_requested')
     assert.equal(logged.length, 1)
     assert.equal(logged[0].by, 'dashboard')
+    assert.equal(logged[0].action_id, body.action.action_id)
   })
 })
 

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -945,13 +945,18 @@ describe('the console verbs on the loopback surface (#266, real boot)', () => {
       id = JSON.parse(res.body).id
     })
 
-    test('an option index resolves to the option\'s words, and the files land under the question\'s own directory', async () => {
+    test('an Atlas answer and a later Discord answer agree on the shared winner', async () => {
       const data = Buffer.from('a: 1\n').toString('base64')
       const res = await post('/answer', {
-        id, index: 1, answer: '', by: 'alp@example.com', via: 'dashboard',
+        id, index: 1, answer: '', by: 'alp@example.com', via: 'dashboard', action_id: 'atlas-answer-esc-choice',
         files: [{ name: '../../notes.txt', data }, { name: 'shot.png', data: Buffer.from('png').toString('base64') }],
       })
       assert.equal(res.status, 200, res.body)
+      const atlas = JSON.parse(res.body)
+      assert.equal(atlas.action.status, 'confirmed')
+      assert.equal(atlas.action.kind, 'escalation-answer')
+      assert.equal(atlas.action.target, id)
+      assert.equal(atlas.action.conflict_key, `answer:${id}`)
       const answered = journal().filter((e) => e.type === 'esc_answer' && e.id === id)
       assert.equal(answered.length, 1)
       const dir = path.join(dataDir, 'attachments', id)
@@ -962,10 +967,12 @@ describe('the console verbs on the loopback surface (#266, real boot)', () => {
     })
 
     test('a second answer is refused with the first receipt, and journals nothing', async () => {
-      const res = await post('/answer', { id, index: 0, by: 'other@example.com', via: 'dashboard', files: [{ name: 'late.txt', data: Buffer.from('x').toString('base64') }] })
+      const res = await post('/answer', { id, index: 0, by: 'other', via: 'button', action_id: 'discord-answer-esc-choice', files: [{ name: 'late.txt', data: Buffer.from('x').toString('base64') }] })
       assert.equal(res.status, 409)
       const body = JSON.parse(res.body)
       assert.equal(body.reason, 'answered')
+      assert.equal(body.action.status, 'refused')
+      assert.equal(body.action.conflict_key, `answer:${id}`)
       assert.equal(body.receipt.by, 'alp@example.com')
       assert.equal(body.receipt.via, 'dashboard')
       assert.match(body.receipt.answer, /^Preview/)

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -227,6 +227,26 @@ describe('CSRF gate on the loopback surface (index.mjs, real boot)', () => {
     assert.equal(status.actions.find((action) => action.action_id === 'atlas-aistack-cancel-1').status, 'confirmed')
   })
 
+  test('Feed reads are idempotent login-scoped Actions with monotonic cross-device cursors (#811)', async () => {
+    const visit = (actionId) => request(port, 'POST', '/feed/read', {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ by: 'Tester@Example.com', action_id: actionId }),
+    })
+
+    const first = JSON.parse((await visit('atlas-feed-read-device-one')).body).action
+    assert.equal(first.status, 'confirmed')
+    assert.equal(first.target, 'tester@example.com')
+    assert.equal(first.conflict_key, 'feed-read:tester@example.com')
+    assert.equal(first.receipt.previous, null)
+
+    const retry = JSON.parse((await visit('atlas-feed-read-device-one')).body).action
+    assert.deepEqual(retry, first, 'the same Action cannot stamp the cursor twice')
+
+    const second = JSON.parse((await visit('atlas-feed-read-device-two')).body).action
+    assert.equal(second.receipt.previous, first.receipt.at)
+    assert.ok(second.receipt.at > first.receipt.at)
+  })
+
   test('Sec-Fetch-Site: none (a direct navigation-style value) passes', async () => {
     const res = await request(port, 'GET', '/state', { headers: { 'sec-fetch-site': 'none' } })
     assert.equal(res.status, 200)

--- a/daemon/test/index.test.mjs
+++ b/daemon/test/index.test.mjs
@@ -1014,18 +1014,54 @@ describe('the console verbs on the loopback surface (#266, real boot)', () => {
     assert.equal(journal().filter((e) => e.type === 'console_conversation_opened').length, 2)
   })
 
+  test('a mint Action is idempotent and carries the new conversation for immediate navigation', async () => {
+    const action_id = 'atlas-console-new-1'
+    const first = JSON.parse((await post('/console/new', { action_id })).body)
+
+    assert.equal(first.action.status, 'confirmed')
+    assert.equal(first.action.kind, 'console-conversation-open')
+    assert.equal(first.action.conflict_key, 'conversation-registry')
+    assert.match(first.key, /^console-\d+$/)
+    assert.equal(first.session, `curia-${first.key}`)
+
+    const retried = JSON.parse((await post('/console/new', { action_id })).body)
+    assert.equal(retried.action.action_id, action_id)
+    assert.equal(retried.key, first.key)
+    assert.equal(journal().filter((e) => e.type === 'console_conversation_opened' && e.key === first.key).length, 1)
+  })
+
   test('a deleted number is spent — the next conversation counts past it', async () => {
     assert.equal((await post('/console/delete', { key: 'console-1' })).status, 200)
     const list = JSON.parse((await request(port, 'GET', '/console')).body).conversations
-    assert.deepEqual(list.map((c) => c.key), ['console-2'])
+    assert.deepEqual(list.map((c) => c.key), ['console-3', 'console-2'])
     const next = JSON.parse((await post('/console/new', {})).body)
-    assert.equal(next.key, 'console-3', 'never console-1 again — that would wake the deleted memory')
+    assert.equal(next.key, 'console-4', 'never console-1 again — that would wake the deleted memory')
   })
 
   test('deleting one that is not there is a refusal in words, not a silent success', async () => {
     const res = await post('/console/delete', { key: 'console-1' })
     assert.equal(res.status, 409)
     assert.match(JSON.parse(res.body).error, /no conversation/)
+  })
+
+  test('delete Actions conflict per conversation and a stale delete is refused', async () => {
+    const created = JSON.parse((await post('/console/new', { action_id: 'atlas-console-new-delete' })).body)
+    const deleted = JSON.parse((await post('/console/delete', {
+      key: created.key, action_id: 'atlas-console-delete-1',
+    })).body)
+
+    assert.equal(deleted.action.status, 'confirmed')
+    assert.equal(deleted.action.target, created.key)
+    assert.equal(deleted.action.conflict_key, `conversation:${created.key}`)
+    assert.equal(deleted.action.receipt.key, created.key)
+
+    const stale = await post('/console/delete', {
+      key: created.key, action_id: 'atlas-console-delete-stale',
+    })
+    assert.equal(stale.status, 409)
+    const refusal = JSON.parse(stale.body)
+    assert.equal(refusal.action.status, 'refused')
+    assert.match(refusal.action.reason, /no conversation/)
   })
 
   test('a key this daemon would never mint is refused before anything is journalled', async () => {

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -186,7 +186,7 @@ describe('GET /overview (index.mjs, real boot)', () => {
       defaults: [{ type: 'untyped', model: 'sonnet' }],
       models: [{ name: 'sonnet', active: true }],
     })
-    for (const key of ['agents', 'untracked', 'recent', 'escalations', 'review_gate', 'usage', 'pre_cooling', 'events']) {
+    for (const key of ['agents', 'untracked', 'recent', 'escalations', 'review_gate', 'usage', 'pre_cooling', 'events', 'actions']) {
       assert.ok(Array.isArray(o[key]), `${key} is a list`)
     }
     assert.equal(o.maps.computed_at, null)

--- a/daemon/test/overview.test.mjs
+++ b/daemon/test/overview.test.mjs
@@ -395,6 +395,28 @@ describe('the Feed read stamp (#704)', () => {
     assert.deepEqual(new Reduction(dir).lastFeedReads(), { 'alp@example.com': second.at })
     assert.throws(() => a.markFeedRead('  '), /names the login/)
   })
+
+  test('a visit advances a monotonic login cursor and rebuilds its confirmed Action from the same record (#811)', () => {
+    const a = new Reduction(dir)
+    const future = new Date(Date.now() + 60_000).toISOString()
+    a.journal('feed_read', { by: 'alp@example.com', ts: future })
+    const action = {
+      action_id: 'atlas-feed-read-monotonic', kind: 'feed-read', target: 'alp@example.com',
+      conflict_key: 'feed-read:alp@example.com',
+    }
+
+    const visit = a.markFeedRead('Alp@Example.com', { action })
+    assert.ok(visit.at > future, 'a clock correction cannot move the shared cursor backward')
+    assert.equal(a.action(action.action_id).status, 'confirmed')
+    assert.equal(a.action(action.action_id).receipt.previous, future)
+
+    a.close()
+    const rebuilt = new Reduction(dir)
+    assert.equal(rebuilt.lastFeedReads()['alp@example.com'], visit.at)
+    assert.equal(rebuilt.action(action.action_id).status, 'confirmed')
+    assert.equal(rebuilt.action(action.action_id).receipt.at, visit.at)
+    rebuilt.close()
+  })
 })
 
 describe('the journal tail the feed reads (#262)', () => {

--- a/daemon/test/reload.test.mjs
+++ b/daemon/test/reload.test.mjs
@@ -57,6 +57,7 @@ describe('POST /reload (index.mjs, real boot)', () => {
   const write = (file, lines) => fs.writeFileSync(file, `${lines.join('\n')}\n`)
 
   const reload = async (by = 'alp@example.com') => JSON.parse((await request(port, 'POST', '/reload', { body: { by } })).body)
+  const settingsAction = async (body) => JSON.parse((await request(port, 'POST', '/settings/action', { body })).body)
   const running = async () => JSON.parse((await request(port, 'GET', '/overview')).body).daemon
   const events = async () => JSON.parse((await request(port, 'GET', '/overview')).body).events
 
@@ -197,6 +198,52 @@ describe('POST /reload (index.mjs, real boot)', () => {
     assert.equal(after.auto_dispatch, true)
     assert.equal(after.max_concurrent, 4)
     assert.notEqual(after.config.loaded_at, before.config.loaded_at, 'the stamp says when this reading was taken')
+  })
+
+  test('a settings save advances from write to apply through durable Action evidence', async () => {
+    const action = {
+      action_id: 'atlas-settings-action-1',
+      paths: ['curia.local.yaml'],
+      by: 'alp@example.com',
+    }
+    const accepted = await settingsAction(action)
+    assert.equal(accepted.action.status, 'progress')
+    assert.equal(accepted.action.progress, 'Writing curia.local.yaml')
+
+    write(overCuria(), ['dispatch:', '  max_concurrent: 5'])
+    const applied = JSON.parse((await request(port, 'POST', '/reload', {
+      body: { by: action.by, action_id: action.action_id, written: action.paths },
+    })).body)
+    assert.equal(applied.ok, true)
+    assert.equal(applied.action.status, 'confirmed')
+    assert.deepEqual(applied.action.receipt.written, action.paths)
+    assert.deepEqual(applied.action.receipt.applied, ['dispatch.max_concurrent'])
+
+    const recovered = JSON.parse((await request(port, 'GET', '/overview')).body)
+      .actions.find((candidate) => candidate.action_id === action.action_id)
+    assert.deepEqual(recovered, applied.action)
+  })
+
+  test('settings Actions conflict by affected path, not through a global lock', async () => {
+    const curia = await settingsAction({
+      action_id: 'atlas-settings-conflict-1', paths: ['curia.local.yaml'], by: 'alp@example.com',
+    })
+    assert.equal(curia.action.status, 'progress')
+
+    const samePath = await settingsAction({
+      action_id: 'atlas-settings-conflict-2', paths: ['curia.local.yaml'], by: 'alp@example.com',
+    })
+    assert.equal(samePath.action.status, 'refused')
+    assert.match(samePath.action.reason, /already being saved/)
+
+    const routing = await settingsAction({
+      action_id: 'atlas-settings-conflict-3', paths: ['routing.local.yaml'], by: 'alp@example.com',
+    })
+    assert.equal(routing.action.status, 'progress', 'an unrelated settings path stays available')
+
+    for (const action_id of [curia.action.action_id, routing.action.action_id]) {
+      await request(port, 'POST', '/settings/action/finish', { body: { action_id, status: 'failed', reason: 'test cleanup' } })
+    }
   })
 
   test('the journal names who reloaded and what moved', async () => {

--- a/daemon/test/sandbox.test.mjs
+++ b/daemon/test/sandbox.test.mjs
@@ -701,7 +701,7 @@ describe('a sandboxed dispatch (#156)', () => {
   test('the prompt tells the agent the path it can actually see', async () => {
     const { d } = makeDispatcher()
     await d.start('42', { repo: 'o/r' })
-    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'prompt.md'), 'utf8')
+    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'claude', 'prompt.md'), 'utf8')
     assert.match(prompt, new RegExp(`Your worktree is ${GUEST_WT}`))
     assert.ok(!prompt.includes(path.join(tmp, 'work', 'repos')), 'the prompt names a host path the container cannot reach')
   })
@@ -724,7 +724,7 @@ describe('a sandboxed dispatch (#156)', () => {
   test('the env file holds no model credential, and the config dir holds the file instead', async () => {
     const { d, spawns } = makeDispatcher()
     await d.start('42', { repo: 'o/r' })
-    const cfg = path.join(tmp, 'work', 'cfg', 'curia-42')
+    const cfg = path.join(tmp, 'work', 'cfg', 'curia-42', 'claude')
     const env = fs.readFileSync(path.join(cfg, 'container.env'), 'utf8')
     assert.doesNotMatch(env, /ANTHROPIC_API_KEY/)
     assert.doesNotMatch(env, /CLAUDE_CODE_OAUTH_TOKEN/)
@@ -761,7 +761,7 @@ describe('a sandboxed dispatch (#156)', () => {
   test('the dispatch seeds the kill guard and points BASH_ENV at it (#385)', async () => {
     const { d } = makeDispatcher()
     await d.start('42', { repo: 'o/r' })
-    const cfg = path.join(tmp, 'work', 'cfg', 'curia-42')
+    const cfg = path.join(tmp, 'work', 'cfg', 'curia-42', 'claude')
     const env = fs.readFileSync(path.join(cfg, 'container.env'), 'utf8')
     assert.match(env, /BASH_ENV=\/cfg\/bin\/bashenv\.sh/)
     for (const name of ['kill', 'pkill', 'bashenv.sh']) {
@@ -877,7 +877,7 @@ describe('the agent is told its ports (#157)', () => {
   test('the prompt names the three ports and the address to bind them on', async () => {
     const { d } = makeDispatcher()
     await d.start('42', { repo: 'o/r' })
-    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'prompt.md'), 'utf8')
+    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'claude', 'prompt.md'), 'utf8')
     assert.match(prompt, /\*\*9000, 9001, 9002\*\*/, 'an agent cannot discover its ports — the prompt is the only place they exist for it')
     assert.match(prompt, /bind `0\.0\.0\.0`/, 'a localhost bind inside the container is unreachable, and fails where the agent cannot see it')
     assert.match(prompt, /publish_preview` takes no other port/)
@@ -895,7 +895,7 @@ describe('the agent is told its ports (#157)', () => {
     })
     await d.start('42', { repo: 'o/r' })
     assert.deepEqual(order, ['allocate', 'prompt'])
-    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'prompt.md'), 'utf8')
+    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'claude', 'prompt.md'), 'utf8')
     assert.match(prompt, /9010, 9011, 9012/)
     assert.match(spawns[0].shellCmd, /-p 127\.0\.0\.1:9010:9010/)
   })
@@ -954,7 +954,7 @@ describe('the ports belong to the agent, not to one container (#157)', () => {
     await waitFor(() => spawns.length > 1)
     assert.equal(allocations, 1, 'a second allocation would leave the prompt naming ports nothing publishes')
     assert.match(spawns[1].shellCmd, /-p 127\.0\.0\.1:9010:9010/)
-    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'prompt.md'), 'utf8')
+    const prompt = fs.readFileSync(path.join(tmp, 'work', 'cfg', 'curia-42', 'claude', 'prompt.md'), 'utf8')
     assert.match(prompt, /9010, 9001, 9002/)
     assert.deepEqual(d.agents.get('curia-42').ports, [9010, 9001, 9002])
   })

--- a/daemon/test/searchsources.test.mjs
+++ b/daemon/test/searchsources.test.mjs
@@ -49,6 +49,17 @@ test('transcript search returns only operator-facing parsed text', async () => {
   assert.equal(rows[0].conversation, 'curia-7')
 })
 
+test('transcript search reads a new per-Harness configuration root', async () => {
+  const dir = path.join(root, 'cfg', 'curia-8', 'claude', 'projects', 'workspace')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'session.jsonl'), JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'text', text: 'Nested Harness transcript' }] },
+  }))
+  const rows = await transcriptSearchSource({ workspaceRoot: root }).search('Nested Harness')
+  assert.equal(rows[0].conversation, 'curia-8')
+})
+
 test('overseer transcript search lands on the Atlas session name', async () => {
   const session = '11111111-2222-4333-8444-555555555555'
   const dir = path.join(root, 'cfg', 'curia-overseer', 'projects', 'workspace')

--- a/daemon/test/settings.test.mjs
+++ b/daemon/test/settings.test.mjs
@@ -603,7 +603,7 @@ describe('the closed set a reload applies (#362)', () => {
     ['the sandbox image', () => overCuriaFile(['sandbox:', '  image: something-else']), 'sandbox.image'],
     ['the identity allowlist', () => overCuriaFile(['identity:', '  allow: [someone@example.com]']), 'identity.allow'],
     ['a model the routing table did not have', () => overRoutingFile(['models:', '  haiku:', '    provider: anthropic', '    harness: claude']), 'models.haiku'],
-    ['a model key that is not the switch', () => overRoutingFile(['models:', '  sonnet:', '    harness: codex']), 'models.sonnet.harness'],
+    ['a model key that is not the switch', () => overRoutingFile(['models:', '  sonnet:', '    provider: openai', '    harness: codex']), 'models.sonnet.provider'],
     // The screen edits the rows that are there and adds none, so a row that
     // appears is a hand edit — outside the set like every other hand edit.
     ['a defaults row nobody could add from the screen', () => overRoutingFile(['defaults:', '  grilling: opus']), 'defaults.grilling'],

--- a/daemon/test/statusline.test.mjs
+++ b/daemon/test/statusline.test.mjs
@@ -87,6 +87,83 @@ describe('StatusLine', () => {
     assert.match(posts.at(-1).text, /🧭 `reads the ticket`/)
   })
 
+  test('dispatch Action acceptance posts promptly and meaningful progress edits it in place', async () => {
+    line.onEvent({
+      type: 'action_evidence', action_id: 'atlas-start-822', kind: 'dispatch',
+      target: 'alp82/curia#822', conflict_key: 'dispatch:alp82/curia#822',
+      status: 'accepted', revision: 10,
+    })
+    await drain()
+
+    assert.equal(posts.length, 1)
+    assert.equal(posts[0].ticket, '822')
+    assert.match(posts[0].text, /accepted/)
+
+    line.onEvent({
+      type: 'action_evidence', action_id: 'atlas-start-822', kind: 'dispatch',
+      target: 'alp82/curia#822', conflict_key: 'dispatch:alp82/curia#822',
+      status: 'progress', progress: 'Preparing the agent workspace', revision: 11,
+    })
+    await drain()
+
+    assert.equal(posts.length, 1, 'progress keeps one status message')
+    assert.equal(removals.length, 0, 'progress does not reposition accepted evidence')
+    assert.match(edits.at(-1).text, /Preparing the agent workspace/)
+  })
+
+  test('dispatch Action progress after a daemon rebuild recovers the existing Discord message', async () => {
+    const recovered = { threadId: 't1', messageId: 'before-restart' }
+    const rebuilt = new StatusLine({
+      post: async (ticket, text) => { posts.push({ ticket, text }); return { threadId: 't1', messageId: 'new' } },
+      edit: async (ids, text) => { edits.push({ ids, text }); return true },
+      find: async () => recovered,
+      get: () => null,
+      log: () => {},
+    })
+
+    rebuilt.onEvent({
+      type: 'action_evidence', action_id: 'atlas-start-822', kind: 'dispatch',
+      target: 'alp82/curia#822', conflict_key: 'dispatch:alp82/curia#822',
+      status: 'progress', progress: 'Preparing the agent workspace', revision: 11,
+    })
+    await rebuilt.settle()
+
+    assert.equal(posts.length, 0, 'restart recovery does not add a second status message')
+    assert.deepEqual(edits[0].ids, recovered)
+    assert.match(edits[0].text, /Preparing the agent workspace/)
+  })
+
+  test('dispatch Action evidence is monotonic and repeated evidence is quiet', async () => {
+    const action = {
+      type: 'action_evidence', action_id: 'atlas-start-822', kind: 'dispatch',
+      target: 'alp82/curia#822', conflict_key: 'dispatch:alp82/curia#822',
+    }
+    line.onEvent({ ...action, status: 'accepted', revision: 20 })
+    line.onEvent({ ...action, status: 'progress', progress: 'Preparing the agent workspace', revision: 22 })
+    await drain()
+
+    line.onEvent({ ...action, status: 'accepted', revision: 21 })
+    line.onEvent({ ...action, status: 'progress', progress: 'Preparing the agent workspace', revision: 22 })
+    await drain()
+
+    assert.equal(posts.length, 1)
+    assert.equal(edits.length, 1, 'stale and repeated evidence make no Discord call')
+    assert.match(edits[0].text, /Preparing the agent workspace/)
+  })
+
+  test('Actions without a Discord representation stay off the status line', async () => {
+    for (const kind of ['settings-save', 'feed-read', 'credential-sign-in']) {
+      line.onEvent({
+        type: 'action_evidence', action_id: `atlas-${kind}`, kind,
+        target: kind, conflict_key: kind, status: 'accepted', revision: 30,
+      })
+    }
+    await drain()
+
+    assert.equal(posts.length, 0)
+    assert.equal(edits.length, 0)
+  })
+
   test('the lifecycle receipt is the status line last edit and keeps final meters', async () => {
     meters = { effort: 'high', ctxPct: 63, windows: [{ label: '5h', pct: 72, elapsedPct: 50 }] }
     line.onEvent({ type: 'agent_ready', agent: 'curia-690', ticket: '690', model: 'gpt', ts: 'T' })

--- a/daemon/test/statusline.test.mjs
+++ b/daemon/test/statusline.test.mjs
@@ -151,6 +151,77 @@ describe('StatusLine', () => {
     assert.match(edits[0].text, /Preparing the agent workspace/)
   })
 
+  test('a refused dispatch Action renders its reason and winning receipt once', async () => {
+    const refusal = {
+      type: 'action_evidence', action_id: 'atlas-start-refused', kind: 'dispatch',
+      target: 'alp82/curia#823', conflict_key: 'dispatch:alp82/curia#823',
+      status: 'refused', reason: 'the ticket is already claimed', revision: 30,
+      receipt: {
+        by: 'alp82', via: 'dashboard', at: '2026-08-28T10:00:00.000Z',
+        answer: 'Start with gpt',
+      },
+    }
+
+    line.onEvent(refusal)
+    await drain()
+    line.onEvent(refusal)
+    await drain()
+
+    assert.equal(posts.length, 1)
+    assert.equal(posts[0].ticket, '823')
+    assert.equal(posts[0].opts.settled, true)
+    assert.match(posts[0].text, /dispatch refused: the ticket is already claimed/)
+    assert.match(posts[0].text, /alp82 via dashboard/)
+    assert.match(posts[0].text, /Start with gpt/)
+    assert.equal(edits.length, 0, 'a repeated terminal reading makes no Discord call')
+  })
+
+  test('accepted dispatch work that fails settles the existing line with one safe reason', async () => {
+    const action = {
+      type: 'action_evidence', action_id: 'atlas-start-failed', kind: 'dispatch',
+      target: 'alp82/curia#823', conflict_key: 'dispatch:alp82/curia#823',
+    }
+    line.onEvent({ ...action, status: 'accepted', revision: 40 })
+    await drain()
+    line.onEvent({
+      ...action, status: 'failed', revision: 41,
+      reason: 'the container could not start\n@everyone should not be pinged',
+    })
+    await drain()
+
+    assert.equal(posts.length, 1, 'failure settles the accepted line instead of adding another')
+    assert.equal(edits.length, 1)
+    assert.equal(edits[0].opts.settled, true)
+    assert.match(edits[0].text, /dispatch failed: the container could not start @/)
+    assert.doesNotMatch(edits[0].text, /@everyone/, 'domain text cannot create a Discord mention')
+  })
+
+  test('a terminal dispatch Action recovers its pre-restart line and confirmed stays quiet', async () => {
+    const recovered = { threadId: 't1', messageId: 'before-restart' }
+    const rebuilt = new StatusLine({
+      post: async (ticket, text) => { posts.push({ ticket, text }); return { threadId: 't1', messageId: 'new' } },
+      edit: async (ids, text, opts) => { edits.push({ ids, text, opts }); return true },
+      find: async () => recovered,
+      get: () => null,
+      log: () => {},
+    })
+    const action = {
+      type: 'action_evidence', action_id: 'atlas-start-recovered', kind: 'dispatch',
+      target: 'alp82/curia#823', conflict_key: 'dispatch:alp82/curia#823',
+    }
+
+    rebuilt.onEvent({ ...action, status: 'failed', reason: 'preparation stopped', revision: 51 })
+    await rebuilt.settle()
+    rebuilt.onEvent({ ...action, action_id: 'atlas-start-confirmed', status: 'confirmed', revision: 52 })
+    await rebuilt.settle()
+
+    assert.equal(posts.length, 0, 'rebuild recovery does not add a terminal line')
+    assert.deepEqual(edits[0].ids, recovered)
+    assert.equal(edits[0].opts.settled, true)
+    assert.match(edits[0].text, /dispatch failed: preparation stopped/)
+    assert.equal(edits.length, 1, 'confirmed evidence emits no routine Discord line')
+  })
+
   test('Actions without a Discord representation stay off the status line', async () => {
     for (const kind of ['settings-save', 'feed-read', 'credential-sign-in']) {
       line.onEvent({

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -685,6 +685,7 @@ describe('TimelineSurface', () => {
   let drivenSessionId = 'browser-1111'
   const landings = new Map()
   const takeBackCalls = []
+  let takeBackGate = null
   const correctionCalls = []
   const recordedTurns = []
   let takeBackReply = {
@@ -720,6 +721,7 @@ describe('TimelineSurface', () => {
         landingFor: (session) => landings.get(session) ?? null,
         takeBack: async (request) => {
           takeBackCalls.push(request)
+          if (takeBackGate) await takeBackGate
           return takeBackReply
         },
         correct: async (request) => { correctionCalls.push(request); return { ok: true } },
@@ -859,6 +861,60 @@ describe('TimelineSurface', () => {
     assert.equal(takeBackCalls.at(-1).role, 'agent')
     assert.equal(takeBackCalls.at(-1).harness, 'claude')
     assert.match(takeBackCalls.at(-1).source, /Good\. Now rename the maps effort to Atlas\./)
+  })
+
+  test('take back accepts before the rewind and keeps its result as shared Action evidence', async () => {
+    const session = 'curia-703'
+    const actionId = 'atlas-chat-take-back-1'
+    const cfg = path.join(workspaceRoot(), 'cfg', session, 'projects', 'p')
+    fs.mkdirSync(cfg, { recursive: true })
+    fs.writeFileSync(path.join(cfg, 'run.jsonl'), recordedTranscript('transcript-1-after-rewind.jsonl'))
+    let release
+    takeBackGate = new Promise((resolve) => { release = resolve })
+    const before = takeBackCalls.length
+    try {
+      const accepted = await fetch(`http://127.0.0.1:${port}/take-back`, {
+        method: 'POST',
+        body: JSON.stringify({ session, target: null, action_id: actionId }),
+      })
+
+      assert.equal(accepted.status, 202)
+      assert.deepEqual(await accepted.json(), { action: {
+        action_id: actionId,
+        kind: 'chat-take-back',
+        target: session,
+        conflict_key: `turn:${session}`,
+        status: 'accepted',
+        revision: actions.get(actionId).revision,
+        started_at: actions.get(actionId).started_at,
+        updated_at: actions.get(actionId).updated_at,
+        progress: 'Rewinding the conversation…',
+      } })
+
+      release()
+      const settled = await actions.settled(actionId)
+      assert.equal(settled.status, 'confirmed')
+      assert.deepEqual(settled.receipt, {
+        composer: 'Keep this exact text.',
+        correction: null,
+        take_back: {
+          headline: 'Took back your last message.',
+          landing: 'The conversation continues after “Start here.”',
+          remains: ['The tree stands.'],
+        },
+      })
+
+      const retried = await fetch(`http://127.0.0.1:${port}/take-back`, {
+        method: 'POST',
+        body: JSON.stringify({ session, target: null, action_id: actionId }),
+      })
+      assert.equal(retried.status, 200)
+      assert.equal((await retried.json()).action.status, 'confirmed')
+      assert.equal(takeBackCalls.length, before + 1, 'the same Action does not rewind twice')
+    } finally {
+      takeBackGate = null
+      release?.()
+    }
   })
 
   test('the next send delivers a read-note correction with Curia framing', async () => {

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -20,6 +20,7 @@ import {
   TimelineSurface, pageRefusal, detectDialog, parseNativeDialog,
   DEFAULT_TIMELINE_INDEX, TIMELINE_PROTO,
 } from '../src/timeline.mjs'
+import { ActionCoordinator } from '../src/actions.mjs'
 import { Reduction } from '../src/reduction.mjs'
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
@@ -647,6 +648,8 @@ async function sse(port, params) {
 
 describe('TimelineSurface', () => {
   let surface
+  let actionReduction
+  let actions
   let port
   const journal = []
   const sent = []
@@ -657,6 +660,7 @@ describe('TimelineSurface', () => {
   let escHistory = []
   let pane = PANE_COMPOSER // what capturePane returns; a function to throw
   let delivery = null
+  let keyFailure = null
   const workspaceRoot = () => path.join(tmp, 'work')
   const installRecordedTranscript = (session, name) => {
     const cfg = path.join(workspaceRoot(), 'cfg', session, 'projects', 'p')
@@ -692,6 +696,8 @@ describe('TimelineSurface', () => {
 
   before(async () => {
     fs.mkdirSync(path.join(tmp, 'work', 'cfg'), { recursive: true })
+    actionReduction = new Reduction(path.join(tmp, 'timeline-actions'))
+    actions = new ActionCoordinator(actionReduction)
     surface = new TimelineSurface({
       port: 0,
       servePort: 8444,
@@ -701,6 +707,7 @@ describe('TimelineSurface', () => {
       log: () => {},
       pollMs: 50,
       deps: {
+        actions,
         journal: (type, detail) => journal.push({ type, ...detail }),
         // #151's check has its own suite (identity.test.mjs); these tests drive
         // the surface over bare loopback, so the predicate is out of their way.
@@ -719,7 +726,10 @@ describe('TimelineSurface', () => {
           sent.push({ session, text })
           return delivery
         },
-        sendKey: async (session, key) => sent.push({ session, key }),
+        sendKey: async (session, key) => {
+          if (keyFailure) throw new Error(keyFailure)
+          sent.push({ session, key })
+        },
         answerDialog: async (session, answer) => {
           dialogAnswers.push({ session, ...answer })
           if (session !== 'curia-slow-dialog') pane = PANE_COMPOSER
@@ -747,7 +757,10 @@ describe('TimelineSurface', () => {
     port = surface.port
   })
 
-  after(() => surface.stop())
+  after(() => {
+    surface.stop()
+    actionReduction.close()
+  })
 
   test('GET / serves the committed page with its stamp, no-store', async () => {
     const res = await fetch(`http://127.0.0.1:${port}/`)
@@ -984,16 +997,73 @@ describe('TimelineSurface', () => {
     })
   })
 
-  test('the key route knows its keys', async () => {
+  test('a pane key returns shared confirmed Action evidence under its pane conflict', async () => {
     const bad = await fetch(`http://127.0.0.1:${port}/key`, {
       method: 'POST', body: JSON.stringify({ session: 'curia-9', key: 'delete-everything' }),
     })
     assert.equal(bad.status, 400)
     const esc = await fetch(`http://127.0.0.1:${port}/key`, {
-      method: 'POST', body: JSON.stringify({ session: 'curia-9', key: 'escape' }),
+      method: 'POST', body: JSON.stringify({
+        session: 'curia-9', key: 'escape', action_id: 'atlas-pane-key-1',
+      }),
     })
     assert.equal(esc.status, 200)
+    assert.deepEqual(await esc.json(), {
+      action: {
+        action_id: 'atlas-pane-key-1', kind: 'pane-key', target: 'curia-9',
+        conflict_key: 'pane:curia-9', status: 'confirmed', revision: 1,
+        started_at: actions.get('atlas-pane-key-1').started_at,
+        updated_at: actions.get('atlas-pane-key-1').updated_at,
+        receipt: { key: 'Escape' },
+      },
+    })
     assert.deepEqual(sent.at(-1), { session: 'curia-9', key: 'Escape' })
+
+    const sentCount = sent.length
+    const retry = await fetch(`http://127.0.0.1:${port}/key`, {
+      method: 'POST', body: JSON.stringify({
+        session: 'curia-9', key: 'escape', action_id: 'atlas-pane-key-1',
+      }),
+    })
+    assert.equal(retry.status, 200)
+    assert.equal((await retry.json()).action.status, 'confirmed')
+    assert.equal(sent.length, sentCount, 'the same Action identity sends the key once')
+  })
+
+  test('pane-key Action evidence distinguishes no pane, ended, unsafe dialog, and tmux failure', async () => {
+    const act = async (actionId, session, key = 'escape') => {
+      const res = await fetch(`http://127.0.0.1:${port}/key`, {
+        method: 'POST', body: JSON.stringify({ session, key, action_id: actionId }),
+      })
+      return { status: res.status, body: await res.json() }
+    }
+
+    const noPane = await act('atlas-pane-no-pane', DRIVEN)
+    assert.equal(noPane.status, 409)
+    assert.equal(noPane.body.action.status, 'refused')
+    assert.equal(noPane.body.action.conflict_key, `pane:${DRIVEN}`)
+    assert.match(noPane.body.action.reason, /not a terminal/)
+
+    endedSessions.add('curia-ended')
+    const ended = await act('atlas-pane-ended', 'curia-ended')
+    endedSessions.delete('curia-ended')
+    assert.equal(ended.status, 409)
+    assert.equal(ended.body.action.status, 'refused')
+    assert.match(ended.body.action.reason, /has ended/)
+
+    pane = PANE_TRUST
+    const dialog = await act('atlas-pane-dialog', 'curia-9', 'enter')
+    pane = PANE_COMPOSER
+    assert.equal(dialog.status, 409)
+    assert.equal(dialog.body.action.status, 'refused')
+    assert.match(dialog.body.action.reason, /would drive its selection blind/)
+
+    keyFailure = 'tmux socket is unavailable'
+    const failed = await act('atlas-pane-tmux-failed', 'curia-9')
+    keyFailure = null
+    assert.equal(failed.status, 502)
+    assert.equal(failed.body.action.status, 'failed')
+    assert.equal(failed.body.action.reason, 'tmux socket is unavailable')
   })
 
   // ---- the #75 dialog guard over real HTTP ---------------------------------

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -679,6 +679,7 @@ describe('TimelineSurface', () => {
   const drivenCfg = () => path.join(tmp, 'overseer-config')
   const turns = [] // every text handed to the driver
   let turnFails = null // a message to throw from send()
+  let driverDelivery = null
   // The conversation key's live session id, as the daemon journals it (#332).
   // Read per driverFor call, exactly as index.mjs reads it off the reduction.
   let drivenSessionId = 'browser-1111'
@@ -746,11 +747,13 @@ describe('TimelineSurface', () => {
         sessionAlive: async (session) => !endedSessions.has(session),
         driverFor: (session) => (session === DRIVEN
           ? {
+            key: 'console-2',
             cfgDir: drivenCfg(),
             sessionId: drivenSessionId,
             send: async (text) => {
               if (turnFails) throw new Error(turnFails)
               turns.push(text)
+              return driverDelivery
             },
           }
           : null),
@@ -876,10 +879,15 @@ describe('TimelineSurface', () => {
       assert.equal(taken.status, 200)
 
       const res = await fetch(`http://127.0.0.1:${port}/send`, {
-        method: 'POST', body: JSON.stringify({ session: 'curia-9', text: 'Use production instead.' }),
+        method: 'POST', body: JSON.stringify({
+          session: 'curia-9', text: 'Use production instead.', action_id: 'atlas-chat-correction',
+        }),
       })
 
       assert.equal(res.status, 200)
+      const action = (await res.json()).action
+      assert.equal(action.kind, 'chat-message-correction')
+      assert.equal(action.status, 'confirmed')
       assert.deepEqual(correctionCalls.at(-1), {
         session: 'curia-9', role: 'agent',
         correction: { kind: 'note', id: 'note-4', prefix: 'Correction to the note above:' },
@@ -1001,6 +1009,25 @@ describe('TimelineSurface', () => {
     })
   })
 
+  test('a delivered message returns confirmed Action evidence and retry does not send twice', async () => {
+    const body = {
+      session: 'curia-9', text: 'hello once', action_id: 'atlas-chat-send-1',
+    }
+    const first = await post('/send', body)
+    assert.equal(first.status, 200)
+    const evidence = (await first.json()).action
+    assert.equal(evidence.kind, 'chat-message')
+    assert.equal(evidence.target, 'curia-9')
+    assert.equal(evidence.conflict_key, 'turn:curia-9')
+    assert.equal(evidence.status, 'confirmed')
+    assert.deepEqual(evidence.receipt, { outcome: 'delivered' })
+
+    const count = sent.length
+    const retry = await post('/send', body)
+    assert.equal((await retry.json()).action.status, 'confirmed')
+    assert.equal(sent.length, count, 'the same Action identity delivers the message once')
+  })
+
   test('a pane key returns shared confirmed Action evidence under its pane conflict', async () => {
     const bad = await fetch(`http://127.0.0.1:${port}/key`, {
       method: 'POST', body: JSON.stringify({ session: 'curia-9', key: 'delete-everything' }),
@@ -1015,7 +1042,7 @@ describe('TimelineSurface', () => {
     assert.deepEqual(await esc.json(), {
       action: {
         action_id: 'atlas-pane-key-1', kind: 'pane-key', target: 'curia-9',
-        conflict_key: 'pane:curia-9', status: 'confirmed', revision: 1,
+        conflict_key: 'pane:curia-9', status: 'confirmed', revision: actions.get('atlas-pane-key-1').revision,
         started_at: actions.get('atlas-pane-key-1').started_at,
         updated_at: actions.get('atlas-pane-key-1').updated_at,
         receipt: { key: 'Escape' },
@@ -1131,6 +1158,32 @@ describe('TimelineSurface', () => {
     }
   })
 
+  test('an unconfirmed message stays progressing until shared evidence confirms delivery', async () => {
+    delivery = { status: 'unconfirmed', pane: PANE_COMPOSER }
+    try {
+      const r = await post('/send', {
+        session: 'curia-9', text: 'check this action once', action_id: 'atlas-chat-unconfirmed',
+      })
+      assert.equal(r.status, 202)
+      await new Promise((resolve) => setImmediate(resolve))
+      const action = actions.get('atlas-chat-unconfirmed')
+      assert.equal(action.status, 'progress')
+      assert.deepEqual(action.receipt, { outcome: 'sent_unconfirmed' })
+
+      const dir = path.join(workspaceRoot(), 'cfg', 'curia-9', 'projects', 'p')
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(path.join(dir, 'action-confirm.jsonl'), `${JSON.stringify({
+        type: 'user', timestamp: new Date(Date.now() + 1000).toISOString(),
+        message: { content: 'check this action once' },
+      })}\n`)
+      await sse(port, 'session=curia-9&once=1')
+      assert.equal(actions.get('atlas-chat-unconfirmed').status, 'confirmed')
+      assert.deepEqual(actions.get('atlas-chat-unconfirmed').receipt, { outcome: 'delivered' })
+    } finally {
+      delivery = null
+    }
+  })
+
   test('a pane that stays active reports that no text was sent', async () => {
     delivery = { status: 'not-sent', pane: '✻ Working' }
     try {
@@ -1138,6 +1191,21 @@ describe('TimelineSurface', () => {
       assert.equal(r.status, 409)
       assert.match((await r.json()).error, /did not send/)
       assert.equal(journal.findLast((x) => x.type === 'timeline_send').outcome, 'not_sent')
+    } finally {
+      delivery = null
+    }
+  })
+
+  test('a pane that stays active refuses its message Action as not sent', async () => {
+    delivery = { status: 'not-sent', pane: '✻ Working' }
+    try {
+      const r = await post('/send', {
+        session: 'curia-9', text: 'keep this', action_id: 'atlas-chat-not-sent',
+      })
+      assert.equal(r.status, 409)
+      const action = (await r.json()).action
+      assert.equal(action.status, 'refused')
+      assert.deepEqual(action.receipt, { outcome: 'not_sent' })
     } finally {
       delivery = null
     }
@@ -1436,6 +1504,30 @@ describe('TimelineSurface', () => {
     const j = journal.findLast((x) => x.type === 'timeline_send')
     assert.equal(j.session, DRIVEN)
     assert.equal(j.outcome, 'sent')
+  })
+
+  test('an overseer message returns accepted evidence before its long turn finishes', async () => {
+    let complete
+    driverDelivery = { completion: new Promise((resolve) => { complete = resolve }) }
+    try {
+      const r = await post('/send', {
+        session: DRIVEN, text: 'inspect the frontier', action_id: 'atlas-chat-overseer',
+      })
+      assert.equal(r.status, 202)
+      const accepted = (await r.json()).action
+      assert.equal(accepted.status, 'accepted')
+      assert.equal(accepted.target, 'console-2')
+      assert.equal(accepted.conflict_key, 'turn:console-2')
+
+      await new Promise((resolve) => setImmediate(resolve))
+      assert.equal(actions.get('atlas-chat-overseer').status, 'progress')
+      assert.match(actions.get('atlas-chat-overseer').progress, /waiting for the overseer response/i)
+
+      complete({ ok: true })
+      assert.equal((await actions.settled('atlas-chat-overseer')).status, 'confirmed')
+    } finally {
+      driverDelivery = null
+    }
   })
 
   test('a turn that ends without an answer comes back as WORDS, never as silence', async () => {

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -1159,6 +1159,284 @@ describe('TimelineSurface', () => {
     method: 'POST', body: JSON.stringify(body),
   })
 
+  test('the latest shared draft survives a daemon restart', async () => {
+    const dataDir = path.join(tmp, 'timeline-draft-recovery')
+    const session = 'curia-draft-recovery'
+    const start = async (reduction) => {
+      const instance = new TimelineSurface({
+        port: 0,
+        servePort: 8444,
+        atlasServePort: 8445,
+        index: DEFAULT_TIMELINE_INDEX,
+        workspaceRoot: workspaceRoot(),
+        log: () => {},
+        deps: {
+          identityCheck: () => null,
+          draftFor: (name) => reduction.chatDraft(name),
+          recordDraft: (name, text) => reduction.recordChatDraft(name, text),
+        },
+      })
+      await instance.start()
+      return instance
+    }
+
+    let reduction = new Reduction(dataDir)
+    let instance = await start(reduction)
+    try {
+      await fetch(`http://127.0.0.1:${instance.port}/draft`, {
+        method: 'POST', body: JSON.stringify({ session, client: 'phone', text: 'first device' }),
+      })
+      await fetch(`http://127.0.0.1:${instance.port}/draft`, {
+        method: 'POST', body: JSON.stringify({ session, client: 'laptop', text: 'last device wins' }),
+      })
+      const live = await sse(instance.port, `session=${session}`)
+      assert.equal(live.events.find((event) => event.event === 'hello').data.draft, 'last device wins')
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+
+    reduction = new Reduction(dataDir)
+    instance = await start(reduction)
+    try {
+      const recovered = await sse(instance.port, `session=${session}`)
+      assert.equal(recovered.events.find((event) => event.event === 'hello').data.draft, 'last device wins')
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+  })
+
+  test('a delivered message does not resurrect its cleared draft after restart', async () => {
+    const dataDir = path.join(tmp, 'timeline-draft-send-clear')
+    const session = 'curia-draft-send-clear'
+    const start = async (reduction) => {
+      const instance = new TimelineSurface({
+        port: 0,
+        servePort: 8444,
+        atlasServePort: 8445,
+        index: DEFAULT_TIMELINE_INDEX,
+        workspaceRoot: workspaceRoot(),
+        log: () => {},
+        deps: {
+          identityCheck: () => null,
+          draftFor: (name) => reduction.chatDraft(name),
+          recordDraft: (name, text) => reduction.recordChatDraft(name, text),
+          journal: (type, detail) => reduction.journal(type, detail),
+          sendText: async () => null,
+        },
+      })
+      await instance.start()
+      return instance
+    }
+
+    let reduction = new Reduction(dataDir)
+    reduction.recordChatDraft(session, 'send these words')
+    let instance = await start(reduction)
+    try {
+      const sent = await fetch(`http://127.0.0.1:${instance.port}/send`, {
+        method: 'POST', body: JSON.stringify({ session, text: 'send these words' }),
+      })
+      assert.equal(sent.status, 200)
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+
+    reduction = new Reduction(dataDir)
+    instance = await start(reduction)
+    try {
+      const recovered = await sse(instance.port, `session=${session}`)
+      assert.equal(recovered.events.find((event) => event.event === 'hello').data.draft, '')
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+  })
+
+  test('the durable send outcome clears recovery without a second draft write', async () => {
+    const dataDir = path.join(tmp, 'timeline-draft-send-outcome')
+    const session = 'curia-draft-send-outcome'
+    let reduction = new Reduction(dataDir)
+    reduction.recordChatDraft(session, 'send exactly once')
+    let instance = new TimelineSurface({
+      port: 0,
+      servePort: 8444,
+      atlasServePort: 8445,
+      index: DEFAULT_TIMELINE_INDEX,
+      workspaceRoot: workspaceRoot(),
+      log: () => {},
+      deps: {
+        identityCheck: () => null,
+        draftFor: (name) => reduction.chatDraft(name),
+        recordDraft: () => {}, // models a stop after the send fact but before a separate clear
+        journal: (type, detail) => reduction.journal(type, detail),
+        sendText: async () => null,
+      },
+    })
+    await instance.start()
+    try {
+      const sent = await fetch(`http://127.0.0.1:${instance.port}/send`, {
+        method: 'POST', body: JSON.stringify({ session, text: 'send exactly once' }),
+      })
+      assert.equal(sent.status, 200)
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+
+    reduction = new Reduction(dataDir)
+    instance = new TimelineSurface({
+      port: 0,
+      servePort: 8444,
+      atlasServePort: 8445,
+      index: DEFAULT_TIMELINE_INDEX,
+      workspaceRoot: workspaceRoot(),
+      log: () => {},
+      deps: {
+        identityCheck: () => null,
+        draftFor: (name) => reduction.chatDraft(name),
+      },
+    })
+    await instance.start()
+    try {
+      const recovered = await sse(instance.port, `session=${session}`)
+      assert.equal(recovered.events.find((event) => event.event === 'hello').data.draft, '')
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+  })
+
+  test('take back restores a draft that survives restart', async () => {
+    const dataDir = path.join(tmp, 'timeline-draft-take-back')
+    const session = 'curia-draft-take-back'
+    const start = async (reduction) => {
+      const instance = new TimelineSurface({
+        port: 0,
+        servePort: 8444,
+        atlasServePort: 8445,
+        index: DEFAULT_TIMELINE_INDEX,
+        workspaceRoot: workspaceRoot(),
+        log: () => {},
+        deps: {
+          identityCheck: () => null,
+          draftFor: (name) => reduction.chatDraft(name),
+          recordDraft: (name, text) => reduction.recordChatDraft(name, text),
+          takeBack: async () => ({
+            ok: true,
+            composer: 'edit these recovered words',
+            receipt: { headline: 'Took back your last message.', landing: null, remains: [] },
+          }),
+        },
+      })
+      await instance.start()
+      return instance
+    }
+
+    let reduction = new Reduction(dataDir)
+    let instance = await start(reduction)
+    try {
+      const takenBack = await fetch(`http://127.0.0.1:${instance.port}/take-back`, {
+        method: 'POST', body: JSON.stringify({ session, target: null }),
+      })
+      assert.equal(takenBack.status, 200)
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+
+    reduction = new Reduction(dataDir)
+    instance = await start(reduction)
+    try {
+      const recovered = await sse(instance.port, `session=${session}`)
+      assert.equal(recovered.events.find((event) => event.event === 'hello').data.draft, 'edit these recovered words')
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+  })
+
+  test('every accepted delivery path keeps its draft clear after restart', async () => {
+    const dataDir = path.join(tmp, 'timeline-draft-all-clears')
+    const sessions = {
+      unconfirmed: 'curia-draft-unconfirmed',
+      driven: 'curia-console-91',
+      correction: 'curia-draft-correction',
+    }
+    const start = async (reduction) => {
+      const instance = new TimelineSurface({
+        port: 0,
+        servePort: 8444,
+        atlasServePort: 8445,
+        index: DEFAULT_TIMELINE_INDEX,
+        workspaceRoot: workspaceRoot(),
+        log: () => {},
+        deps: {
+          identityCheck: () => null,
+          draftFor: (name) => reduction.chatDraft(name),
+          recordDraft: (name, text) => reduction.recordChatDraft(name, text),
+          journal: (type, detail) => reduction.journal(type, detail),
+          sendText: async () => ({ status: 'unconfirmed', pane: PANE_COMPOSER }),
+          driverFor: (name) => name === sessions.driven
+            ? { key: 'console-91', cfgDir: drivenCfg(), sessionId: null, send: async () => null }
+            : null,
+          takeBack: async () => ({
+            ok: true,
+            composer: 'edit this correction',
+            correction: { kind: 'note', id: 'note-91' },
+            receipt: { headline: 'Recovered your note.', landing: null, remains: [] },
+          }),
+          correct: async () => ({ ok: true }),
+        },
+      })
+      await instance.start()
+      return instance
+    }
+
+    let reduction = new Reduction(dataDir)
+    let instance = await start(reduction)
+    try {
+      for (const session of Object.values(sessions)) {
+        await fetch(`http://127.0.0.1:${instance.port}/draft`, {
+          method: 'POST', body: JSON.stringify({ session, text: `draft for ${session}` }),
+        })
+      }
+      const unconfirmed = await fetch(`http://127.0.0.1:${instance.port}/send`, {
+        method: 'POST', body: JSON.stringify({ session: sessions.unconfirmed, text: 'sent to the pane' }),
+      })
+      assert.equal(unconfirmed.status, 202)
+      const driven = await fetch(`http://127.0.0.1:${instance.port}/send`, {
+        method: 'POST', body: JSON.stringify({ session: sessions.driven, text: 'sent to the overseer' }),
+      })
+      assert.equal(driven.status, 200)
+      await fetch(`http://127.0.0.1:${instance.port}/take-back`, {
+        method: 'POST', body: JSON.stringify({ session: sessions.correction, target: { kind: 'note', id: 'note-91' } }),
+      })
+      const corrected = await fetch(`http://127.0.0.1:${instance.port}/send`, {
+        method: 'POST', body: JSON.stringify({ session: sessions.correction, text: 'edited correction' }),
+      })
+      assert.equal(corrected.status, 200)
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+
+    reduction = new Reduction(dataDir)
+    instance = await start(reduction)
+    try {
+      const recovered = []
+      for (const session of Object.values(sessions)) {
+        const { events } = await sse(instance.port, `session=${session}`)
+        recovered.push(events.find((event) => event.event === 'hello').data.draft)
+      }
+      assert.deepEqual(recovered, ['', '', ''])
+    } finally {
+      instance.stop()
+      reduction.close()
+    }
+  })
+
   test('a /send while a dialog owns the pane is refused, journalled, and pins the banner', async () => {
     pane = PANE_ASK_QUESTION
     try {

--- a/daemon/test/timeline.test.mjs
+++ b/daemon/test/timeline.test.mjs
@@ -656,6 +656,8 @@ describe('TimelineSurface', () => {
   const offs = [] // every serve port the surface withdrew (#711)
   const endedSessions = new Set() // panes that are gone, as sessionAlive answers
   const dialogAnswers = []
+  let dialogAnswerGate = null
+  let dialogAnswerFailure = null
   let escalations = []
   let escHistory = []
   let pane = PANE_COMPOSER // what capturePane returns; a function to throw
@@ -732,6 +734,8 @@ describe('TimelineSurface', () => {
         },
         answerDialog: async (session, answer) => {
           dialogAnswers.push({ session, ...answer })
+          if (dialogAnswerGate) await dialogAnswerGate
+          if (dialogAnswerFailure) throw new Error(dialogAnswerFailure)
           if (session !== 'curia-slow-dialog') pane = PANE_COMPOSER
         },
         capturePane: async () => (typeof pane === 'function' ? pane() : pane),
@@ -1182,6 +1186,82 @@ describe('TimelineSurface', () => {
       const replay = await sse(port, 'session=curia-9')
       assert.deepEqual(replay.events.find((event) => event.event === 'dialog')?.data.receipt, receipt)
     } finally {
+      pane = PANE_COMPOSER
+    }
+  })
+
+  test('two native-dialog Action clients race under one dialog conflict and share the winning receipt', async () => {
+    pane = PANE_ASK_OPTIONS
+    let releaseAnswer
+    dialogAnswerGate = new Promise((resolve) => { releaseAnswer = resolve })
+    try {
+      const opened = await sse(port, 'session=curia-action-race')
+      const card = opened.events.find((event) => event.event === 'dialog').data.card
+      const firstRequest = post('/dialog-answer', {
+        session: 'curia-action-race', dialog: card.id, index: 2, client: 'phone',
+        action_id: 'atlas-dialog-phone',
+      })
+      while (!dialogAnswers.some((answer) => answer.session === 'curia-action-race')) {
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+      const secondRequest = post('/dialog-answer', {
+        session: 'curia-action-race', dialog: card.id, index: 1, client: 'desktop',
+        action_id: 'atlas-dialog-desktop',
+      })
+
+      const second = await secondRequest
+      assert.equal(second.status, 409)
+      const refused = (await second.json()).action
+      assert.equal(refused.status, 'refused')
+      assert.equal(refused.conflict_key, `dialog:curia-action-race:${card.id}`)
+      assert.match(refused.reason, /first valid native dialog answer is still being sent/)
+
+      releaseAnswer()
+      const first = await firstRequest
+      assert.equal(first.status, 202)
+      assert.equal((await first.json()).action.status, 'accepted')
+      const won = await actions.settled('atlas-dialog-phone')
+      assert.equal(won.status, 'confirmed')
+      assert.equal(won.receipt.answer, 'Preview')
+      assert.equal(dialogAnswers.filter((answer) => answer.session === 'curia-action-race').length, 1)
+
+      const refreshed = await sse(port, 'session=curia-action-race')
+      assert.deepEqual(refreshed.events.find((event) => event.event === 'dialog').data.receipt, won.receipt)
+    } finally {
+      releaseAnswer?.()
+      dialogAnswerGate = null
+      pane = PANE_COMPOSER
+    }
+  })
+
+  test('a native-dialog pane-write failure becomes shared evidence and leaves the card retryable', async () => {
+    pane = PANE_ASK_OPTIONS
+    dialogAnswerFailure = 'tmux socket is unavailable'
+    try {
+      const opened = await sse(port, 'session=curia-action-failure')
+      const card = opened.events.find((event) => event.event === 'dialog').data.card
+      const response = await post('/dialog-answer', {
+        session: 'curia-action-failure', dialog: card.id, index: 2, client: 'phone',
+        action_id: 'atlas-dialog-failure',
+      })
+      assert.equal(response.status, 202)
+      assert.equal((await response.json()).action.status, 'accepted')
+
+      const failed = await actions.settled('atlas-dialog-failure')
+      assert.equal(failed.status, 'failed')
+      assert.match(failed.reason, /tmux socket is unavailable/)
+      const refreshed = await sse(port, 'session=curia-action-failure')
+      assert.equal(refreshed.events.find((event) => event.event === 'dialog').data.card.id, card.id)
+
+      dialogAnswerFailure = null
+      const retry = await post('/dialog-answer', {
+        session: 'curia-action-failure', dialog: card.id, index: 1, client: 'desktop',
+        action_id: 'atlas-dialog-retry',
+      })
+      assert.equal(retry.status, 202)
+      assert.equal((await actions.settled('atlas-dialog-retry')).status, 'confirmed')
+    } finally {
+      dialogAnswerFailure = null
       pane = PANE_COMPOSER
     }
   })

--- a/daemon/test/workspace.test.mjs
+++ b/daemon/test/workspace.test.mjs
@@ -14,12 +14,21 @@ import {
   checkoutTicketBranch, remoteBranchExists, defaultBranchOf,
   // #649, ADR-0028
   hasUncommittedChanges, hasUnpushedCommits, salvageBranchFor, salvageLocalOnlyWork,
+  cfgDirFor,
 } from '../src/workspace.mjs'
 
 describe('per-agent config dir (#53)', () => {
   let tmp
   before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-ws-')) })
   after(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
+
+  test('new roots are isolated by agent and Harness, while the legacy root stays addressable', () => {
+    const root = path.join(tmp, 'work')
+    assert.equal(cfgDirFor(root, 'curia-1'), path.join(root, 'cfg', 'curia-1'))
+    assert.equal(cfgDirFor(root, 'curia-1', 'claude'), path.join(root, 'cfg', 'curia-1', 'claude'))
+    assert.equal(cfgDirFor(root, 'curia-1', 'codex'), path.join(root, 'cfg', 'curia-1', 'codex'))
+    assert.notEqual(cfgDirFor(root, 'curia-1', 'claude'), cfgDirFor(root, 'curia-1', 'codex'))
+  })
 
   test('seeding writes the no-dialog config and NO credential of its own', () => {
     const cfgDir = path.join(tmp, 'cfg', 'curia-1')


### PR DESCRIPTION
## Summary

- add the immutable five-facet Harness adapter interface and validated static registry
- expose injected filesystem, process, pane, transcript, and tool-channel ports with normalized evidence and capability refusal
- journal adapter and configuration-layout identity, preserve legacy roots, and isolate new roots by agent and Harness
- route launch and resume command selection through registered adapters while Claude and Codex delegate to existing implementations

## Verification

- `npm test` in `daemon/` passes with zero failures, cancellations, or skips

Closes #831