### PR TITLE
Extract Claude into a conforming Harness adapter

### DIFF
--- a/daemon/src/claudeharness.mjs
+++ b/daemon/src/claudeharness.mjs
@@ -1,0 +1,95 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const call = (ports, port, operation, ...args) => {
+  const fn = ports?.[port]?.[operation]
+  if (typeof fn !== 'function') throw new Error(`Claude Harness needs ${port}.${operation}()`)
+  return fn(...args)
+}
+
+export const CLAUDE_READY_RE = /(?:⏵⏵|bypass permissions)/i
+
+export const CLAUDE_CAPABILITIES = Object.freeze({
+  modelSwitch: true,
+  reasoningEffort: true,
+  transcriptUsage: true,
+  nativeSkills: true,
+  richMetadata: true,
+})
+
+const ready = (paneText) => {
+  CLAUDE_READY_RE.lastIndex = 0
+  return CLAUDE_READY_RE.test(String(paneText ?? ''))
+}
+
+async function switchModel({ session, model, readbackMs = 15_000 }, ports) {
+  await call(ports, 'pane', 'key', session, 'C-u')
+  try {
+    const sent = await call(ports, 'pane', 'send', session, `/model ${model}`, { readbackMs: 0 })
+    if (sent?.status === 'not-sent') return { status: 'active' }
+
+    const deadline = Date.now() + readbackMs
+    let confirmed = false
+    let pane = ''
+    while (true) {
+      try {
+        pane = await call(ports, 'pane', 'capture', session)
+      } catch {
+        pane = ''
+      }
+      const tail = String(pane ?? '').split('\n').slice(-25).join('\n')
+      if (/Set model to /.test(tail)) return { status: 'switched' }
+      const error = tail.match(/(API error:[^\n]*(?:\n[^\n]*){0,3}|Unable to validate model[^\n]*)/)
+      if (error && !/Switch model\?/.test(tail)) {
+        return { status: 'refused', why: error[1].replace(/\s+/g, ' ').trim().slice(0, 200) }
+      }
+      if (!confirmed && /Switch model\?/.test(tail)) {
+        confirmed = true
+        await call(ports, 'pane', 'key', session, 'Enter')
+      }
+      if (Date.now() >= deadline) return { status: 'unconfirmed', pane: tail }
+      await sleep(Math.min(250, Math.max(1, deadline - Date.now())))
+    }
+  } finally {
+    await Promise.resolve(call(ports, 'pane', 'key', session, 'C-y')).catch(() => {})
+  }
+}
+
+export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeCommand }) {
+  return {
+    identity: {
+      name: 'claude',
+      provider: 'anthropic',
+      credentialConsumer: 'claude',
+      configLayoutVersion: 1,
+    },
+    setup: {
+      refuseRepository: (context, ports) => call(ports, 'filesystem', 'refuseRepository', context),
+      prepare: (context, ports) => call(ports, 'filesystem', 'prepare', context),
+    },
+    lifecycle: {
+      freshCommand: (context) => buildFreshCommand(context),
+      resumeCommand: (context) => buildResumeCommand(context),
+      isReady: ({ paneText }) => ready(paneText),
+      processDied: (context, ports) => call(ports, 'process', 'died', context),
+      interrupt: (context, ports) => call(ports, 'process', 'interrupt', context),
+      send: (context, ports) => call(ports, 'pane', 'send', context),
+    },
+    evidence: {
+      discover: (context, ports) => call(ports, 'transcript', 'discover', context),
+      events: (context, ports) => call(ports, 'transcript', 'events', context),
+      activity: (context, ports) => call(ports, 'transcript', 'activity', context),
+      usage: (context, ports) => call(ports, 'transcript', 'usage', context),
+    },
+    control: {
+      capabilities: CLAUDE_CAPABILITIES,
+      operations: {
+        modelSwitch: switchModel,
+        reasoningEffort: (context, ports) => call(ports, 'pane', 'reasoningEffort', context),
+        transcriptUsage: (context, ports) => call(ports, 'transcript', 'usage', context),
+        nativeSkills: (context, ports) => call(ports, 'filesystem', 'nativeSkills', context),
+        richMetadata: (context, ports) => call(ports, 'transcript', 'richMetadata', context),
+      },
+      enforceCompletion: (context, ports) => call(ports, 'toolChannel', 'enforceCompletion', context),
+    },
+  }
+}

--- a/daemon/src/claudetranscript.mjs
+++ b/daemon/src/claudetranscript.mjs
@@ -1,0 +1,110 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  curiaSendBrief,
+  curiaToolSend,
+  curiaToolText,
+  firstTranscriptLine,
+  isCuriaSend,
+} from './transcriptformat.mjs'
+
+const UNRENDERED = new Set([
+  'system', 'ai-title', 'attachment', 'file-history-delta',
+  'file-history-snapshot', 'last-prompt', 'mode', 'permission-mode', 'summary',
+])
+
+const readdirSafe = (dir) => {
+  try { return fs.readdirSync(dir) } catch { return [] }
+}
+
+export function claudeTranscriptFiles(cfgDir) {
+  const projects = path.join(cfgDir, 'projects')
+  const files = []
+  for (const project of readdirSafe(projects)) {
+    for (const file of readdirSafe(path.join(projects, project))) {
+      if (file.endsWith('.jsonl')) files.push(path.join(projects, project, file))
+    }
+  }
+  return files
+}
+
+export const claudeTranscriptForSession = (base, id) => base === `${id}.jsonl`
+
+export const claudeTranscriptPresent = (cfgDir) => fs.existsSync(path.join(cfgDir, 'projects'))
+
+function toolBrief(name, input = {}) {
+  if (name === 'Bash') return firstTranscriptLine(input.command)
+  if (name === 'Read' || name === 'Write' || name === 'Edit' || name === 'NotebookEdit') {
+    return String(input.file_path ?? '')
+  }
+  if (name === 'Grep' || name === 'Glob') return `${input.pattern ?? ''} ${input.path ?? ''}`.trim()
+  if (name === 'TodoWrite') return `${input.todos?.length ?? 0} items`
+  if (name?.startsWith('mcp__curia__')) {
+    if (isCuriaSend(input)) return curiaSendBrief(input)
+    return firstTranscriptLine(input.prompt ?? input.summary ?? input.message ?? JSON.stringify(input))
+  }
+  if (name === 'Task' || name === 'Agent') return firstTranscriptLine(input.description ?? input.prompt)
+  return firstTranscriptLine(JSON.stringify(input), 160)
+}
+
+function resultText(content) {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content.map((item) => (item?.type === 'text' ? item.text : `[${item?.type}]`)).join('\n')
+  }
+  return JSON.stringify(content ?? '')
+}
+
+export function parseClaudeTranscriptEvent(event) {
+  const at = event.timestamp ?? null
+  if (event.type === 'assistant') {
+    const items = []
+    for (const content of event.message?.content ?? []) {
+      if (content.type === 'text' && content.text?.trim()) {
+        items.push({ kind: 'say', at, text: content.text })
+      } else if (content.type === 'thinking' && content.thinking?.trim()) {
+        items.push({ kind: 'think', at, text: content.thinking })
+      } else if (content.type === 'tool_use') {
+        const item = {
+          kind: 'tool', at, id: content.id, name: content.name,
+          brief: toolBrief(content.name, content.input),
+        }
+        if (content.name?.startsWith('mcp__curia__')) {
+          const text = curiaToolText(content.input)
+          if (text) item.text = text
+          const send = curiaToolSend(content.input)
+          if (send) item.send = send
+        }
+        items.push(item)
+      }
+    }
+    return items
+  }
+  if (event.type === 'user') {
+    const content = event.message?.content
+    if (typeof content === 'string') return content.trim() ? [{ kind: 'prompt', at, text: content }] : []
+    const items = []
+    for (const item of content ?? []) {
+      if (item.type === 'tool_result') {
+        const text = resultText(item.content)
+        items.push({
+          kind: 'result', at, forId: item.tool_use_id, ok: !item.is_error,
+          brief: firstTranscriptLine(text, 300), lines: text.split('\n').length,
+        })
+      } else if (item.type === 'text' && item.text?.trim()) {
+        items.push({ kind: 'prompt', at, text: item.text })
+      } else if (item.type === 'image') {
+        items.push({ kind: 'note', at, text: '[image]' })
+      }
+    }
+    return items
+  }
+  if (event.type === 'queue-operation') {
+    return event.operation === 'enqueue' && event.content
+      ? [{ kind: 'queued', at, text: String(event.content) }]
+      : []
+  }
+  if (UNRENDERED.has(event.type)) return []
+  return null
+}

--- a/daemon/src/claudeworkspace.mjs
+++ b/daemon/src/claudeworkspace.mjs
@@ -1,0 +1,112 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { TOKEN_HEADER } from './agenttoken.mjs'
+
+export const CLAUDE_CONFIG_ROOT_ENV = 'CLAUDE_CONFIG_DIR'
+export const CLAUDE_MEMORY_FILE = 'CLAUDE.md'
+export const CLAUDE_API_KEY_TAIL_LENGTH = 20
+export const CURIA_MCP_SERVER_NAME = 'curia'
+export const LOOPBACK_HOST = '127.0.0.1'
+export const CLAUDE_REPO_SKILL_ROOTS = Object.freeze([['.claude', 'skills']])
+
+const mcpUrl = (daemonPort, agent, ticket, host = LOOPBACK_HOST) => (
+  `http://${host}:${daemonPort}/mcp?agent=${agent}&ticket=${ticket}`
+)
+
+const stopHookCommand = (daemonPort, agent, host = LOOPBACK_HOST, token) => [
+  `curl -s -X POST 'http://${host}:${daemonPort}/agent_done?agent=${agent}'`,
+  `-H 'Content-Type: application/json'`,
+  `-H '${TOKEN_HEADER}: ${token}'`,
+  '-d @-',
+].join(' ')
+
+const writeSecretFile = (file, data) => {
+  fs.writeFileSync(file, data, { mode: 0o600 })
+  fs.chmodSync(file, 0o600)
+}
+
+export function claudeApiKeyApproval(apiKey) {
+  if (!apiKey) return null
+  if (apiKey.length < CLAUDE_API_KEY_TAIL_LENGTH) {
+    throw new Error(`the deployed Claude API key is shorter than ${CLAUDE_API_KEY_TAIL_LENGTH} characters`)
+  }
+  return apiKey.slice(-CLAUDE_API_KEY_TAIL_LENGTH)
+}
+
+export function writeClaudeConnection({
+  dir, serverName, url, header, token, hooks = null, env = null,
+}) {
+  fs.mkdirSync(dir, { recursive: true })
+  const mcpFile = path.join(dir, '.mcp.json')
+  writeSecretFile(mcpFile, JSON.stringify({
+    mcpServers: { [serverName]: { type: 'http', url, headers: { [header]: token } } },
+  }, null, 2))
+  const settingsDir = path.join(dir, '.claude')
+  fs.mkdirSync(settingsDir, { recursive: true })
+  writeSecretFile(path.join(settingsDir, 'settings.json'), JSON.stringify({
+    enableAllProjectMcpServers: true,
+    permissions: { defaultMode: 'bypassPermissions' },
+    ...(env ? { env } : {}),
+    ...(hooks ? { hooks } : {}),
+  }, null, 2))
+  return mcpFile
+}
+
+export const CLAUDE_WORKSPACE = Object.freeze({
+  memoryFile: CLAUDE_MEMORY_FILE,
+  provider: 'anthropic',
+  hostStore: () => path.join(os.homedir(), '.claude'),
+  env: (cfgDir, { sandboxed = false } = {}) => ({
+    [CLAUDE_CONFIG_ROOT_ENV]: cfgDir,
+    ...(sandboxed ? {} : { CLAUDE_SECURESTORAGE_CONFIG_DIR: path.join(os.homedir(), '.claude') }),
+    CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT: String(86_400_000),
+  }),
+  seed: (cfgDir, wtPath, { apiKey = null } = {}) => {
+    const approvedApiKey = claudeApiKeyApproval(apiKey)
+    fs.writeFileSync(path.join(cfgDir, '.claude.json'), JSON.stringify({
+      hasCompletedOnboarding: true,
+      installMethod: 'native',
+      autoUpdates: false,
+      theme: 'dark',
+      numStartups: 1,
+      projects: {
+        [wtPath]: {
+          hasTrustDialogAccepted: true,
+          hasCompletedProjectOnboarding: true,
+          hasClaudeMdExternalIncludesApproved: true,
+          hasClaudeMdExternalIncludesWarningShown: true,
+        },
+      },
+      ...(approvedApiKey ? {
+        customApiKeyResponses: { approved: [approvedApiKey], rejected: [] },
+      } : {}),
+    }, null, 2))
+    fs.writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify({
+      skipDangerousModePermissionPrompt: true,
+      disableClaudeAiConnectors: true,
+      allowedMcpServers: [{ serverName: CURIA_MCP_SERVER_NAME }],
+      cleanupPeriodDays: 36500,
+    }, null, 2))
+  },
+  connectionSettings: ({ wtPath, agent, ticket, daemonPort, daemonHost, reasoningEffort, token }) => {
+    writeClaudeConnection({
+      dir: wtPath,
+      serverName: CURIA_MCP_SERVER_NAME,
+      url: mcpUrl(daemonPort, agent, ticket, daemonHost),
+      header: TOKEN_HEADER,
+      token,
+      env: reasoningEffort ? { CLAUDE_CODE_EFFORT_LEVEL: reasoningEffort } : null,
+      hooks: {
+        Stop: [{ hooks: [{
+          type: 'command', command: stopHookCommand(daemonPort, agent, daemonHost, token),
+        }] }],
+      },
+    })
+  },
+})
+
+export const claudeUntrustedProjectConfig = (wtPath) => (
+  path.join(wtPath, '.claude', 'settings.local.json')
+)

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -29,7 +29,7 @@ import {
   carriesLimitPhrase, resolveReviewer, isActive, Cooling, SAME_PROVIDER_STAMP, namedModel,
   reasoningEffortFor, harnessReasoningEffort,
 } from './routing.mjs'
-import { HARNESS_REGISTRY, spawnIdentity } from './harnesses.mjs'
+import { HARNESS_REGISTRY, requireHarnessCapability, spawnIdentity } from './harnesses.mjs'
 import { hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey, paneShowsActiveTurn } from './tmux.mjs'
 import {
   createPrivateClone, removeWorkspace,
@@ -340,10 +340,13 @@ function reTest(re, text) {
 
 // Pane text confirms a stalled transcript only when it shows a narrow idle or
 // error signal. An active marker vetoes the match.
-export function paneConfirmsStall(pane, readyRe) {
+export function paneConfirmsStall(pane, readyClassifier) {
   const tail = paneTail(pane)
   if (paneShowsActiveTurn(pane, STALL_ACTIVE_LINES)) return false
-  return STALL_ERROR_RE.test(tail) || reTest(readyRe, tail)
+  const ready = typeof readyClassifier === 'function'
+    ? readyClassifier(tail)
+    : reTest(readyClassifier, tail)
+  return STALL_ERROR_RE.test(tail) || ready
 }
 
 // A nudge reached the harness when the pane changed from the confirmed stall
@@ -1795,19 +1798,31 @@ export class Dispatcher {
   // there is since #195. Shared by the first dispatch and by the cross-harness
   // respawn a usage limit forces.
   #armAgent({ session, ticket, harness, model, reasoningEffort = null, wtPath, cfgDir }) {
-    this.deps.seedConfigDir(cfgDir, GUEST_WT, this.config.skills, harness, { sandboxed: true })
     // A FRESH secret per arm (#159), minted before the connection settings that carry it.
     // The cross-harness respawn arms again, so the pane a usage limit killed
     // stops being able to speak for this name the moment its successor is armed.
     const token = this.deps.mintAgentToken(this.dataDir, session)
-    this.deps.writeConnectionSettings({
-      wtPath: GUEST_WT, hostWtPath: wtPath, cfgDir, agent: session, ticket,
-      daemonPort: this.daemonPort, daemonHost: GUEST_DAEMON_HOST, token,
-      harness, reasoningEffort: harnessReasoningEffort(harness,
+    const adapter = this.harnesses.get(harness)
+    adapter.setup.prepare({
+      session, ticket, harness, model, wtPath, cfgDir, token,
+      reasoningEffort: harnessReasoningEffort(harness,
         reasoningEffort ?? this.routing.models[model].reasoning_effort ?? null),
-      // The codex harness turns this into its skill deny list (#171); the
-      // claude harness does not read it.
       skills: this.config.skills,
+    }, {
+      filesystem: {
+        prepare: (context) => {
+          this.deps.seedConfigDir(
+            context.cfgDir, GUEST_WT, context.skills, context.harness, { sandboxed: true },
+          )
+          this.deps.writeConnectionSettings({
+            wtPath: GUEST_WT, hostWtPath: context.wtPath, cfgDir: context.cfgDir,
+            agent: context.session, ticket: context.ticket,
+            daemonPort: this.daemonPort, daemonHost: GUEST_DAEMON_HOST, token: context.token,
+            harness: context.harness, reasoningEffort: context.reasoningEffort,
+            skills: context.skills,
+          })
+        },
+      },
     })
   }
 
@@ -2611,12 +2626,24 @@ export class Dispatcher {
     const wayOut = where === 'respawn'
       ? 'The harness this agent was dispatched on does not load it, and the fallback harness does. Remove the file from the repo, or dispatch the ticket again once a harness that does not load it is warm'
       : 'Remove the file from the repo, or dispatch on another harness if only one harness loads it (`/start <ticket> <model>`)'
-    const planted = untrustedProjectConfig(wtPath, harnessName)
+    const adapter = this.harnesses.get(harnessName)
+    const { planted, plants } = adapter.setup.refuseRepository({
+      wtPath, harness: harnessName, skills: this.config.skills?.install,
+    }, {
+      filesystem: {
+        refuseRepository: ({ wtPath: target, harness, skills }) => {
+          const planted = untrustedProjectConfig(target, harness)
+          return {
+            planted,
+            plants: planted ? [] : plantedSkills(target, harness, skills),
+          }
+        },
+      },
+    })
     // #224: the same family, one step milder — a repo skill under a name curia
     // installs impersonates the seeded tooling, and on the codex harness it is
     // listed to the model beside and before the installed copy. A repo skill
     // under any other name stays welcome.
-    const plants = planted ? [] : plantedSkills(wtPath, harnessName, this.config.skills?.install)
     if (!planted && !plants.length) return
     const e = planted
       ? new Error(`${planted} is a config file curia did not write, and the ${harnessName} harness loads it with no prompt — hooks in it would run unreviewed, with no model in the loop. ${wayOut}`)
@@ -3212,10 +3239,8 @@ export class Dispatcher {
   async #watchdog(agent) {
     // Resolved once, and loudly: readiness that silently never matches is #33's
     // live-only defect, and its whole symptom was silence.
-    const readyRe = this.routing.harnesses[agent.harness]?.readyRe
-    if (!readyRe) {
-      throw new Error(`no readiness marker for harness "${agent.harness}" on ${agent.session} — refusing to watch a pane against nothing`)
-    }
+    const adapter = this.harnesses.get(agent.harness)
+    const isReady = (paneText) => adapter.lifecycle.isReady({ paneText, routing: this.routing })
     const deadline = Date.now() + this.config.dispatch.ready_timeout_s * 1000
     while (Date.now() < deadline) {
       await sleep(2000)
@@ -3293,7 +3318,7 @@ export class Dispatcher {
       }
       // Per harness (#39): the claude composer's `⏵⏵` marker never appears in a
       // codex pane, whose composer says `<model> <effort> · <cwd>`.
-      if (readyRe.test(tail)) {
+      if (isReady(tail)) {
         agent.state = 'ready'
         // The anchor the tool-channel grace window is measured from (#194).
         agent.readyAt = Date.now()
@@ -6709,13 +6734,14 @@ export class Dispatcher {
       return `ℹ️ \`${session}\` already runs on **${spawnModelId(this.routing, model)}**.`
     }
 
+    const adapter = this.harnesses.get(agent.harness)
+    if (agent.harness === 'claude') return this.#switchInPane(adapter, agent, model, by)
+
     try {
       await this.deps.sendKey(session, 'C-u')
     } catch (e) {
       return `❌ could not clear pending composer text in \`${session}\`: ${failureProse(e.message)}`
     }
-
-    if (agent.harness === 'claude') return this.#switchInPane(agent, model, by)
 
     try {
       await this.deps.killSession(session)
@@ -6747,23 +6773,27 @@ export class Dispatcher {
   // says none of them inside the budget is reported as unconfirmed and the
   // record is left alone, because a record that names a model the pane never
   // took is the lie the status line exists to avoid.
-  async #switchInPane(agent, model, by) {
+  async #switchInPane(adapter, agent, model, by) {
     const session = agent.session
     const id = spawnModelId(this.routing, model)
     const from = agent.model
-    let sent
+    let verdict
     try {
-      sent = await this.deps.sendText(session, `/model ${id}`, { readbackMs: 0 })
+      verdict = await requireHarnessCapability(adapter, 'modelSwitch', {
+        session, model: id, readbackMs: this.switchReadbackMs,
+      }, {
+        pane: {
+          capture: this.deps.capturePane,
+          key: this.deps.sendKey,
+          send: this.deps.sendText,
+        },
+      })
     } catch (e) {
-      return `❌ could not type the switch into \`${session}\`: ${failureProse(e.message)}`
+      return `❌ could not switch \`${session}\`: ${failureProse(e.message)}`
     }
-    if (sent?.status === 'not-sent') {
+    if (verdict.status === 'active') {
       return `⏳ \`${session}\` is mid-turn, so the switch was not typed. Pick again when the turn ends.`
     }
-    const verdict = await this.#switchVerdict(session, from)
-    // Whatever the pane said, the cut text goes back: the operator's queued
-    // words are not the switch's to spend.
-    await this.deps.sendKey(session, 'C-y').catch(() => {})
     if (verdict.status === 'refused') {
       this.reduction.journal('model_switch_refused', {
         repo: agent.repo, ticket: agent.ticket, agent: session, model, from, by: by ?? 'unknown', why: verdict.why,
@@ -6793,33 +6823,6 @@ export class Dispatcher {
       reasoning_effort: agent.reasoningEffort ?? null, by: by ?? 'unknown', operator_model_switch: true, live: true,
     })
     return this.#switchedLine(agent, model, { resumed: false })
-  }
-
-  // Read the pane until it states the switch's outcome. The confirm is
-  // answered here, once: the CLI asks it only after its validation passed.
-  async #switchVerdict(session, from) {
-    const deadline = Date.now() + this.switchReadbackMs
-    let confirmed = false
-    let pane = ''
-    while (true) {
-      try {
-        pane = await this.deps.capturePane(session)
-      } catch {
-        pane = ''
-      }
-      const tail = String(pane ?? '').split('\n').slice(-25).join('\n')
-      if (/Set model to /.test(tail)) return { status: 'switched' }
-      const err = tail.match(/(API error:[^\n]*(?:\n[^\n]*){0,3}|Unable to validate model[^\n]*)/)
-      if (err && !/Switch model\?/.test(tail)) {
-        return { status: 'refused', why: err[1].replace(/\s+/g, ' ').trim().slice(0, 200) }
-      }
-      if (!confirmed && /Switch model\?/.test(tail)) {
-        confirmed = true
-        await this.deps.sendKey(session, 'Enter')
-      }
-      if (Date.now() >= deadline) return { status: 'unconfirmed', pane: tail }
-      await sleepFor(Math.min(250, Math.max(1, deadline - Date.now())))
-    }
   }
 
   #switchedLine(agent, model, { resumed }) {
@@ -7116,7 +7119,12 @@ export class Dispatcher {
 
       let activity
       try {
-        activity = this.deps.transcriptActivity(w.harness, w.cfgDir)
+        const adapter = this.harnesses.get(w.harness)
+        activity = adapter.evidence.activity({ harness: w.harness, cfgDir: w.cfgDir }, {
+          transcript: {
+            activity: ({ harness, cfgDir }) => this.deps.transcriptActivity(harness, cfgDir),
+          },
+        })
       } catch {
         continue
       }
@@ -7124,8 +7132,9 @@ export class Dispatcher {
       const lastGrowth = Math.max(activity.mtimeMs, w.readyAt ?? 0, w.spawnedAt ?? 0)
       if (Date.now() - lastGrowth < this.stallTimeoutMs) continue
 
-      const readyRe = this.routing.harnesses[w.harness]?.readyRe
-      if (!paneConfirmsStall(pane, readyRe)) continue
+      const adapter = this.harnesses.get(w.harness)
+      const isReady = (paneText) => adapter.lifecycle.isReady({ paneText, routing: this.routing })
+      if (!paneConfirmsStall(pane, isReady)) continue
       if (this.agents.get(w.session) !== w || w.state !== 'ready') continue
 
       this.reduction.journal('stall_detected', {
@@ -7133,7 +7142,7 @@ export class Dispatcher {
         idle_ms: Math.round(Date.now() - lastGrowth),
       })
       if (!recovery.nudged) {
-        const accepted = await this.#nudgeStalledAgent(w, pane, readyRe)
+        const accepted = await this.#nudgeStalledAgent(w, pane, isReady)
         if (accepted) continue
       }
       if (!recovery.respawned) {

--- a/daemon/src/harnesses.mjs
+++ b/daemon/src/harnesses.mjs
@@ -1,12 +1,11 @@
 // The public Harness adapter seam (ADR-0029 and ADR-0030).
 //
-// This first migration step makes the contract executable while Claude and
-// Codex still delegate native setup and orchestration to their existing
-// implementations. Later migration steps move those implementations behind
-// the five facets without changing this interface.
+// Claude now owns its native behavior behind this seam. Codex still delegates
+// to its legacy implementation until the next migration step.
 
 import { buildResumeCmd, buildSpawnCmd } from './routing.mjs'
 import { CONSUMER_NAMES, PROVIDER_CREDENTIALS } from './credentials.mjs'
+import { createClaudeHarnessAdapter } from './claudeharness.mjs'
 
 export const HARNESS_FACETS = Object.freeze([
   'identity',
@@ -306,7 +305,10 @@ const sharedCapabilities = Object.freeze({
 })
 
 export const HARNESS_REGISTRY = createHarnessRegistry([
-  legacyAdapter({ name: 'claude', provider: 'anthropic', capabilities: sharedCapabilities }),
+  createClaudeHarnessAdapter({
+    buildFreshCommand: ({ routing, model, promptFile }) => buildSpawnCmd(routing, 'claude', model, promptFile),
+    buildResumeCommand: ({ routing, model }) => buildResumeCmd(routing, 'claude', model),
+  }),
   legacyAdapter({ name: 'codex', provider: 'openai', capabilities: sharedCapabilities }),
 ], {
   providers: Object.keys(PROVIDER_CREDENTIALS),

--- a/daemon/src/transcript.mjs
+++ b/daemon/src/transcript.mjs
@@ -27,7 +27,19 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { renderCompositeSend } from './composite.mjs'
+import {
+  claudeTranscriptFiles,
+  claudeTranscriptForSession,
+  claudeTranscriptPresent,
+  parseClaudeTranscriptEvent,
+} from './claudetranscript.mjs'
+import {
+  curiaSendBrief,
+  curiaToolSend,
+  curiaToolText,
+  firstTranscriptLine as firstLine,
+  isCuriaSend,
+} from './transcriptformat.mjs'
 
 export const TRANSCRIPT_HARNESSES = ['claude', 'codex']
 
@@ -42,7 +54,7 @@ function readdirSafe(dir) {
 // it has one (it knows what it spawned); this is the fallback for re-adopted
 // and lab sessions.
 export function detectHarness(cfgDir) {
-  if (fs.existsSync(path.join(cfgDir, 'projects'))) return 'claude'
+  if (claudeTranscriptPresent(cfgDir)) return 'claude'
   if (fs.existsSync(path.join(cfgDir, 'sessions'))) return 'codex'
   return null
 }
@@ -61,17 +73,6 @@ function newestFile(files) {
 }
 
 // Every transcript a config dir holds, per harness.
-function claudeFiles(cfgDir) {
-  const projects = path.join(cfgDir, 'projects')
-  const files = []
-  for (const proj of readdirSafe(projects)) {
-    for (const f of readdirSafe(path.join(projects, proj))) {
-      if (f.endsWith('.jsonl')) files.push(path.join(projects, proj, f))
-    }
-  }
-  return files
-}
-
 // A spawned codex subagent writes a second rollout into its parent's config
 // directory. Its first line identifies it, so it must not win the parent's
 // newest-file lookup while the parent waits (#544, #545).
@@ -109,7 +110,7 @@ function codexFiles(cfgDir) {
   return files
 }
 
-const FILES = { claude: claudeFiles, codex: codexFiles }
+const FILES = { claude: claudeTranscriptFiles, codex: codexFiles }
 
 // What each harness NAMES a session's transcript. The claude harness names the
 // file after the session id — measured on the box (docs/live-checks/
@@ -118,7 +119,7 @@ const FILES = { claude: claudeFiles, codex: codexFiles }
 // rather than measured: no codex conversation is keyed today, because the
 // overseer is the one thing curia keys and it runs the claude harness.
 const NAMES_SESSION = {
-  claude: (base, id) => base === `${id}.jsonl`,
+  claude: claudeTranscriptForSession,
   codex: (base, id) => base.startsWith('rollout-') && base.endsWith(`-${id}.jsonl`),
 }
 
@@ -215,137 +216,6 @@ export function firstPrompt(harness, file, { max = 90, bytes = LABEL_BYTES } = {
     }
   }
   return null
-}
-
-function firstLine(s, n = 200) {
-  const line = String(s ?? '').split('\n').find((l) => l.trim()) ?? ''
-  return line.length > n ? `${line.slice(0, n)}…` : line
-}
-
-// ---------------------------------------------------------------------------
-// claude harness
-// ---------------------------------------------------------------------------
-
-// Line types the claude CLI writes that carry nothing a timeline shows —
-// enumerated from real agent transcripts on this box. `summary` is the
-// compaction artifact; the file-history pair is checkpointing; the rest are
-// UI bookkeeping.
-const CLAUDE_UNRENDERED = new Set([
-  'system', 'ai-title', 'attachment', 'file-history-delta',
-  'file-history-snapshot', 'last-prompt', 'mode', 'permission-mode', 'summary',
-])
-
-// One line that says what a tool call is DOING, per tool — the only place this
-// harness's tool vocabulary is known (spike shape).
-function claudeToolBrief(name, input = {}) {
-  if (name === 'Bash') return firstLine(input.command)
-  if (name === 'Read' || name === 'Write' || name === 'Edit' || name === 'NotebookEdit') {
-    return String(input.file_path ?? '')
-  }
-  if (name === 'Grep' || name === 'Glob') return `${input.pattern ?? ''} ${input.path ?? ''}`.trim()
-  if (name === 'TodoWrite') return `${input.todos?.length ?? 0} items`
-  if (name?.startsWith('mcp__curia__')) {
-    if (isCuriaSend(input)) return curiaSendBrief(input)
-    return firstLine(input.prompt ?? input.summary ?? input.message ?? JSON.stringify(input))
-  }
-  if (name === 'Task' || name === 'Agent') return firstLine(input.description ?? input.prompt)
-  return firstLine(JSON.stringify(input), 160)
-}
-
-// The full operator-facing text of a curia surface call (#108 item 1): notify
-// and its siblings carry prose written FOR the timeline's reader, so the
-// one-line brief must not be all that survives. ask_human keeps only the brief
-// here — its full body renders from the daemon's own escalation record.
-function curiaToolText(input = {}) {
-  const t = input.prompt ?? input.message ?? input.summary
-  return typeof t === 'string' && t.trim() ? t : null
-}
-
-// The composite send a curia call carries (#716, ADR-0026), rendered by the
-// one renderer Discord posts from, so Atlas Chat draws the same sequence under
-// the same rails. The deciding message is marked rather than dropped: the
-// page draws it from the daemon's escalation record, as it draws every card.
-// A `messages` value the renderer cannot read is no sequence, and the brief
-// stands alone, because a transcript line must never break the room.
-function curiaToolSend(input = {}) {
-  if (!Array.isArray(input.messages) || !input.messages.length) return null
-  try {
-    return renderCompositeSend(input.messages)
-      .map(({ rail, body, deciding, format, label }) => ({ rail, body, deciding, format, label }))
-  } catch {
-    return null
-  }
-}
-
-// One line for a send: how many messages, and their labels in order.
-function curiaSendBrief(input = {}) {
-  const labels = input.messages.map((m) => String(m?.label ?? m?.format ?? '?').trim())
-  return `send of ${input.messages.length}: ${labels.join(' · ')}`
-}
-
-const isCuriaSend = (input) => Array.isArray(input?.messages) && input.messages.length > 0
-
-function claudeResultText(content) {
-  if (typeof content === 'string') return content
-  if (Array.isArray(content)) {
-    return content.map((c) => (c?.type === 'text' ? c.text : `[${c?.type}]`)).join('\n')
-  }
-  return JSON.stringify(content ?? '')
-}
-
-function claudeItems(e) {
-  const at = e.timestamp ?? null
-  if (e.type === 'assistant') {
-    const out = []
-    for (const c of e.message?.content ?? []) {
-      if (c.type === 'text' && c.text?.trim()) out.push({ kind: 'say', at, text: c.text })
-      // Real agents store thinking signature-only with empty text (#72/#73
-      // measured 41 of 41), so this arm almost never fires — kept because a
-      // transcript that DOES carry text should show it.
-      else if (c.type === 'thinking' && c.thinking?.trim()) out.push({ kind: 'think', at, text: c.thinking })
-      else if (c.type === 'tool_use') {
-        const item = { kind: 'tool', at, id: c.id, name: c.name, brief: claudeToolBrief(c.name, c.input) }
-        if (c.name?.startsWith('mcp__curia__')) {
-          const text = curiaToolText(c.input)
-          if (text) item.text = text
-          const send = curiaToolSend(c.input)
-          if (send) item.send = send
-        }
-        out.push(item)
-      }
-    }
-    return out
-  }
-  if (e.type === 'user') {
-    const content = e.message?.content
-    if (typeof content === 'string') {
-      return content.trim() ? [{ kind: 'prompt', at, text: content }] : []
-    }
-    const out = []
-    for (const c of content ?? []) {
-      if (c.type === 'tool_result') {
-        const text = claudeResultText(c.content)
-        out.push({
-          kind: 'result', at, forId: c.tool_use_id, ok: !c.is_error,
-          brief: firstLine(text, 300), lines: text.split('\n').length,
-        })
-      } else if (c.type === 'text' && c.text?.trim()) {
-        out.push({ kind: 'prompt', at, text: c.text })
-      } else if (c.type === 'image') {
-        out.push({ kind: 'note', at, text: '[image]' })
-      }
-    }
-    return out
-  }
-  // A message driven in mid-turn is ENQUEUED, then removed when the turn picks
-  // it up and it reappears as a plain user message. Only the enqueue is
-  // rendered — the moment the other device's input became visible.
-  if (e.type === 'queue-operation') {
-    if (e.operation === 'enqueue' && e.content) return [{ kind: 'queued', at, text: String(e.content) }]
-    return []
-  }
-  if (CLAUDE_UNRENDERED.has(e.type)) return []
-  return null // unknown vocabulary — the caller reports it
 }
 
 // ---------------------------------------------------------------------------
@@ -471,7 +341,7 @@ function codexItems(e) {
 
 // ---------------------------------------------------------------------------
 
-const READERS = { claude: claudeItems, codex: codexItems }
+const READERS = { claude: parseClaudeTranscriptEvent, codex: codexItems }
 
 // Read the messages that the Chat surface can render from transcript lines.
 // The branch selection lives here so agent and overseer conversations don't

--- a/daemon/src/transcriptformat.mjs
+++ b/daemon/src/transcriptformat.mjs
@@ -1,0 +1,28 @@
+import { renderCompositeSend } from './composite.mjs'
+
+export function firstTranscriptLine(value, max = 200) {
+  const line = String(value ?? '').split('\n').find((candidate) => candidate.trim()) ?? ''
+  return line.length > max ? `${line.slice(0, max)}…` : line
+}
+
+export function curiaToolText(input = {}) {
+  const text = input.prompt ?? input.message ?? input.summary
+  return typeof text === 'string' && text.trim() ? text : null
+}
+
+export function curiaToolSend(input = {}) {
+  if (!isCuriaSend(input)) return null
+  try {
+    return renderCompositeSend(input.messages)
+      .map(({ rail, body, deciding, format, label }) => ({ rail, body, deciding, format, label }))
+  } catch {
+    return null
+  }
+}
+
+export function curiaSendBrief(input = {}) {
+  const labels = input.messages.map((message) => String(message?.label ?? message?.format ?? '?').trim())
+  return `send of ${input.messages.length}: ${labels.join(' · ')}`
+}
+
+export const isCuriaSend = (input) => Array.isArray(input?.messages) && input.messages.length > 0

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -34,6 +34,19 @@ import { daemonGhEnv } from './daemongh.mjs'
 // the salvage branch's stamp (#649). One stamp shape for the whole daemon: UTC,
 // colons folded to hyphens, sorting in write order.
 import { stampFor } from './backup.mjs'
+import {
+  CLAUDE_API_KEY_TAIL_LENGTH,
+  CLAUDE_CONFIG_ROOT_ENV,
+  CLAUDE_REPO_SKILL_ROOTS,
+  CLAUDE_WORKSPACE,
+  CURIA_MCP_SERVER_NAME,
+  LOOPBACK_HOST,
+  claudeApiKeyApproval,
+  claudeUntrustedProjectConfig,
+  writeClaudeConnection,
+} from './claudeworkspace.mjs'
+
+export { CLAUDE_API_KEY_TAIL_LENGTH, claudeApiKeyApproval, writeClaudeConnection }
 
 // The mandatory communication rules (#133): a curia-owned copy of the
 // operator's STE writing standard, seeded into every config dir as the CLI's
@@ -558,7 +571,7 @@ export const HARNESS_NAMES = ['claude', 'codex']
 // time — a harness whose CLI reads a different variable is then answered here,
 // once, for the agent spawn and the usage sync alike.
 export const CONFIG_ROOT_ENV = Object.freeze({
-  claude: 'CLAUDE_CONFIG_DIR',
+  claude: CLAUDE_CONFIG_ROOT_ENV,
   codex: 'CODEX_HOME',
 })
 
@@ -639,13 +652,13 @@ function toml(value) {
 // The daemon's own address, as the agent reaches it. A bare pane reaches it on
 // loopback; a container's loopback is the container, so it reaches the same
 // listener through the docker host gateway instead (#156).
-export const LOOPBACK = '127.0.0.1'
+export const LOOPBACK = LOOPBACK_HOST
 
 // The name curia's own MCP server carries in the agent's `.mcp.json`, and the
 // one name the claude harness's allowlist admits (#180). One constant, because the
 // two must never drift: an allowlist that does not name the server curia writes
 // leaves the agent with no tools at all.
-export const MCP_SERVER_NAME = 'curia'
+export const MCP_SERVER_NAME = CURIA_MCP_SERVER_NAME
 
 function curiaMcpUrl(daemonPort, agent, ticket, host = LOOPBACK) {
   return `http://${host}:${daemonPort}/mcp?agent=${agent}&ticket=${ticket}`
@@ -687,26 +700,11 @@ function curiaMcpUrl(daemonPort, agent, ticket, host = LOOPBACK) {
 // SIGKILL, and this deadline is still the only bound there.
 const CODEX_TOOL_TIMEOUT_S = 86_400
 
-// Claude Code stores only the final 20 characters when the operator approves
-// a custom API key. Keep that upstream storage shape here, rather than writing
-// the complete secret into a durable config file.
-export const CLAUDE_API_KEY_TAIL_LENGTH = 20
-
-export function claudeApiKeyApproval(apiKey) {
-  if (!apiKey) return null
-  if (apiKey.length < CLAUDE_API_KEY_TAIL_LENGTH) {
-    throw new Error(`the deployed Claude API key is shorter than ${CLAUDE_API_KEY_TAIL_LENGTH} characters`)
-  }
-  return apiKey.slice(-CLAUDE_API_KEY_TAIL_LENGTH)
+function writeSecretFile(file, data) {
+  fs.writeFileSync(file, data, { mode: 0o600 })
+  fs.chmodSync(file, 0o600)
 }
 
-// The Stop hook, identical on both harnesses: POST the hook's own stdin payload to
-// the daemon, which answers `{decision:"block", reason}` while a step of the
-// ending is outstanding (#54).
-//
-// The token header rides beside the ticket's own content type (#159). Both
-// values are quote-free by construction — a hex token and a daemon-owned port —
-// so the single-quoted curl arguments need no escaping rule.
 function stopHookCommand(daemonPort, agent, host = LOOPBACK, token) {
   return [
     `curl -s -X POST 'http://${host}:${daemonPort}/agent_done?agent=${agent}'`,
@@ -716,191 +714,8 @@ function stopHookCommand(daemonPort, agent, host = LOOPBACK, token) {
   ].join(' ')
 }
 
-// The four connection-settings files now carry the agent's secret, so none of them is
-// world-readable. On the bare path that is belt only (a sibling agent runs as
-// the same host user); in a container the mount arrives owned by the same uid the
-// agent runs as, so 0600 is still readable by the one agent that needs it.
-function writeSecretFile(file, data) {
-  fs.writeFileSync(file, data, { mode: 0o600 })
-  fs.chmodSync(file, 0o600) // the mode applies only on create; a reused config dir already has one
-}
-
-// THE CLAUDE HARNESS'S WHOLE REACH BACK INTO THE DAEMON, in one writer.
-//
-// A `.mcp.json` beside a `.claude/settings.json` that says
-// `enableAllProjectMcpServers` — the pair is what makes the CLI trust a project
-// server with no prompt, and either file alone is a harness with no tools. Two
-// callers write it: an agent worktree here, and a conversation's own project
-// directory (`overseeridentity.mjs`). They differ in the directory, the server
-// name and whether a Stop hook rides along; everything else — the shape of the
-// server entry, the header that carries the secret, the bypass mode, the 0600
-// on both files — is one rule and lives here.
-//
-// Returns the path of the `.mcp.json` it wrote.
-export function writeClaudeConnection({
-  dir, serverName, url, header, token, hooks = null, env = null,
-}) {
-  fs.mkdirSync(dir, { recursive: true })
-  const mcpFile = path.join(dir, '.mcp.json')
-  writeSecretFile(mcpFile, JSON.stringify({
-    mcpServers: {
-      // #159. Claude Code sends a per-server `headers` object on every request
-      // to an http MCP server (`claude mcp add --header` writes this exact
-      // shape).
-      [serverName]: { type: 'http', url, headers: { [header]: token } },
-    },
-  }, null, 2))
-  const dotClaude = path.join(dir, '.claude')
-  fs.mkdirSync(dotClaude, { recursive: true })
-  writeSecretFile(path.join(dotClaude, 'settings.json'), JSON.stringify({
-    enableAllProjectMcpServers: true,
-    permissions: { defaultMode: 'bypassPermissions' },
-    ...(env ? { env } : {}),
-    ...(hooks ? { hooks } : {}),
-  }, null, 2))
-  return mcpFile
-}
-
 const HARNESS = {
-  claude: {
-    // The CLI's global-memory file, and the ONLY per-session channel either
-    // harness keeps outside the conversation (#340). Codex carries `AGENTS.md`
-    // as world state and restates it every turn ("These AGENTS.md instructions
-    // replace all previously provided AGENTS.md instructions"); a user message
-    // is conversation, and conversation goes stale — codex tells the model that
-    // the last user request is current and previous ones are stale. So curia's
-    // standing orders live HERE, not in `prompt.md`.
-    //
-    // A new harness must name its own file. That is the whole reason this is a
-    // table row rather than a ternary: a lane whose CLI has no such file cannot
-    // carry standing orders that survive turn one, and this row is where that
-    // has to be answered.
-    memoryFile: 'CLAUDE.md',
-    // Which PROVIDER's credential this harness runs on (#648). It is a row here
-    // rather than a ternary at the two call sites for the reason `memoryFile`
-    // is: a new harness has to answer it, and `config.mjs` refuses a configured
-    // harness whose provider has no contract row. A harness added with no
-    // credential story is how the #641 bug returns.
-    provider: 'anthropic',
-    // CLAUDE_SECURESTORAGE_CONFIG_DIR is what separates config from credentials.
-    // Claude Code resolves its credential store through it and falls back to
-    // CLAUDE_CONFIG_DIR only when it is unset, so pointing it at the host's
-    // ~/.claude puts the agent on the host's *exact* credentials path — the
-    // same file, the same refresh lineage, the same atomic-rename write. That is
-    // precisely what a second host session does, which is why several host
-    // sessions coexist for days while an agent holding a frozen copy died at the
-    // first host-side refresh (#34). Everything else stays isolated by
-    // CLAUDE_CONFIG_DIR: settings, allowlist, permission mode, CLAUDE.md, MCP
-    // connectors, projects (#23/#29).
-    //
-    // An absolute path, not the empty string that also selects ~/.claude:
-    // explicit beats HOME-dependent, and `env K=` through tmux is a needless
-    // edge. Porting to macOS would want the empty form instead — a non-empty
-    // value also suffixes the keychain service name, which would break sharing
-    // where the keychain, not the plaintext file, is the store.
-    hostStore: () => path.join(os.homedir(), '.claude'),
-    // CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT (ms): Claude Code aborts an HTTP MCP
-    // call after 300 s with no response or progress notification, and ONLY a
-    // progress notification bound to the call's own progressToken resets that
-    // timer — the keepalive's logging branch never does (#104, the 314 s
-    // death). The keepalive covers a client that offered a token; this floor
-    // covers one that did not. One day, the same bound as
-    // CODEX_TOOL_TIMEOUT_S below; a call whose daemon actually died is aborted
-    // by the transport-drop watchdog instead, about 120 s after the death
-    // (#341, three runs at 119.5 s, 118.9 s and 119.2 s in
-    // docs/research/tool-channel-mid-session.md — this comment said 90 s).
-    //
-    // A CONTAINER cannot have that (#156): the host store lives in the host
-    // HOME, which is the first thing the boundary denies. The variable is
-    // dropped rather than pointed somewhere else, so Claude Code falls back to
-    // CLAUDE_CONFIG_DIR — the agent's own mounted dir — and the credential
-    // arrives as an environment variable instead (sandbox.mjs). That is the
-    // frozen-credential shape #53 fixed for the bare path, accepted back by
-    // #148 as the sandbox's one remaining host-secret exposure.
-    env: (cfgDir, { sandboxed = false } = {}) => ({
-      [CONFIG_ROOT_ENV.claude]: cfgDir,
-      ...(sandboxed ? {} : { CLAUDE_SECURESTORAGE_CONFIG_DIR: path.join(os.homedir(), '.claude') }),
-      CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT: String(86_400_000),
-    }),
-
-    // Exact prototype.md §1 shape, verified live: no first-spawn dialog ever
-    // appears. The projects key MUST be the absolute worktree path (matched
-    // exactly).
-    seed: (cfgDir, wtPath, { apiKey = null } = {}) => {
-      const approvedApiKey = claudeApiKeyApproval(apiKey)
-      fs.writeFileSync(path.join(cfgDir, '.claude.json'), JSON.stringify({
-        hasCompletedOnboarding: true,
-        installMethod: 'native',
-        autoUpdates: false,
-        theme: 'dark',
-        numStartups: 1,
-        projects: {
-          [wtPath]: {
-            hasTrustDialogAccepted: true,
-            hasCompletedProjectOnboarding: true,
-            hasClaudeMdExternalIncludesApproved: true,
-            hasClaudeMdExternalIncludesWarningShown: true,
-          },
-        },
-        ...(approvedApiKey ? {
-          customApiKeyResponses: { approved: [approvedApiKey], rejected: [] },
-        } : {}),
-      }, null, 2))
-      // The MCP namespace is bounded HERE, in the two settings keys below
-      // (#180), because nothing else reaches it. `CLAUDE_CONFIG_DIR` holds the
-      // #23/#29 line for config-borne servers, but the operator's account-level
-      // claude.ai connectors — Notion, Gmail, Drive, Calendar — do not travel
-      // through the config dir. Claude Code fetches them over the wire from the
-      // account behind the credential, which #53 shares with the host on
-      // purpose. So a bare-pane agent listed 38 tools where curia configured
-      // six, and could read and write the operator's mail and documents. The
-      // container boundary does not touch it either: the fetch is an ordinary
-      // outbound HTTPS call, and #148 leaves the network open because wayfinder
-      // needs `gh` and the web.
-      //
-      // `disableClaudeAiConnectors` is the source control. Claude Code reads it
-      // from ANY settings source, and this file is the user source, so the
-      // agent's own config dir is enough — the credential does not change.
-      // Measured against the pinned CLI: the check is FIRST in its eligibility
-      // chain, ahead of every auth branch, and the debug line names the setting
-      // by name (docs/live-checks/180).
-      //
-      // `allowedMcpServers` is the second belt, and it bounds the whole
-      // namespace rather than one source: only the server curia writes is
-      // admitted, whatever route another arrives by. Its entries are OBJECTS,
-      // not strings — `['curia']` fails schema validation, and an invalid
-      // allowlist enforces an EMPTY one, which takes curia's own server down
-      // with it. That trap was measured, not reasoned about.
-      //
-      // #344 made the one-server line a DECISION and not only a setting: a
-      // read-only MCP history server was proposed here and refused. History
-      // that ever reaches an agent arrives as tools on the server below, so
-      // this list stays at one entry.
-      fs.writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify({
-        skipDangerousModePermissionPrompt: true,
-        disableClaudeAiConnectors: true,
-        allowedMcpServers: [{ serverName: MCP_SERVER_NAME }],
-        cleanupPeriodDays: 36500,
-      }, null, 2))
-    },
-
-    // .mcp.json (curia HTTP MCP side channel) + .claude/settings.json (all-project
-    // MCP on, bypass permissions, Stop hook → /agent_done) — spike #29 shapes
-    // with per-agent substitution. Both land in the worktree and are hidden from
-    // git by the base clone's info/exclude (see ensureBaseClone).
-    connectionSettings: ({ wtPath, agent, ticket, daemonPort, daemonHost, reasoningEffort, token }) => {
-      writeClaudeConnection({
-        dir: wtPath,
-        serverName: MCP_SERVER_NAME,
-        url: curiaMcpUrl(daemonPort, agent, ticket, daemonHost),
-        header: TOKEN_HEADER,
-        token,
-        env: reasoningEffort ? { CLAUDE_CODE_EFFORT_LEVEL: reasoningEffort } : null,
-        hooks: { Stop: [{ hooks: [{ type: 'command', command: stopHookCommand(daemonPort, agent, daemonHost, token) }] }] },
-      })
-    },
-  },
-
+  claude: CLAUDE_WORKSPACE,
   codex: {
     // See the claude row: this is the durable channel, and #340 measured it.
     memoryFile: 'AGENTS.md',
@@ -1145,7 +960,7 @@ const HARNESS = {
 export function untrustedProjectConfig(wtPath, harness) {
   const planted = harness === 'codex'
     ? path.join(wtPath, '.codex', 'hooks.json')
-    : path.join(wtPath, '.claude', 'settings.local.json')
+    : claudeUntrustedProjectConfig(wtPath)
   return fs.existsSync(planted) ? planted : null
 }
 
@@ -1155,7 +970,7 @@ export function untrustedProjectConfig(wtPath, harness) {
 // `.claude/skills`. Neither CLI has a config key that turns a repo root off.
 const REPO_SKILL_ROOTS = {
   codex: [['.codex', 'skills'], ['.agents', 'skills']],
-  claude: [['.claude', 'skills']],
+  claude: CLAUDE_REPO_SKILL_ROOTS,
 }
 
 // The name a SKILL.md claims in its frontmatter. Codex keys a skill on this

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -5679,6 +5679,7 @@ describe('live model switching (#717)', () => {
     const reply = await d.switchModel('42', { model: 'opus', by: 'operator-1' })
 
     assert.match(reply, /mid-turn/)
+    assert.deepEqual(steps.filter((step) => step.act === 'key').map((step) => step.key), ['C-u', 'C-y'])
     assert.equal(d.agents.get('curia-42').model, 'sonnet')
   })
 

--- a/daemon/test/harnesses.test.mjs
+++ b/daemon/test/harnesses.test.mjs
@@ -127,6 +127,52 @@ describe('Harness ports and normalized evidence', () => {
 })
 
 describe('Harness capabilities and durable identity', () => {
+  test('the Claude adapter drives native behavior through fake ports', async () => {
+    const adapter = HARNESS_REGISTRY.get('claude')
+    const steps = []
+    const panes = [
+      '❯ /model opus\nSwitch model?\n❯ 1. Yes, switch to opus',
+      '❯ /model opus\nSet model to opus\n❯',
+    ]
+    const ports = createHarnessPorts({
+      filesystem: {
+        refuseRepository: (context) => ({ refused: context.wtPath }),
+        prepare: (context) => ({ prepared: context.cfgDir }),
+      },
+      process: methods(['died', 'interrupt']),
+      pane: {
+        capture: () => panes.shift() ?? '',
+        send: (session, value) => { steps.push(['send', session, value]); return { status: 'sent' } },
+        key: (session, value) => { steps.push(['key', session, value]) },
+      },
+      transcript: {
+        discover: methods(['discover']).discover,
+        events: methods(['events']).events,
+        activity: (context) => ({ file: context.cfgDir, mtimeMs: 1 }),
+        usage: methods(['usage']).usage,
+        richMetadata: methods(['richMetadata']).richMetadata,
+      },
+      toolChannel: methods(['enforceCompletion']),
+    })
+
+    assert.equal(adapter.lifecycle.isReady({ paneText: '⏵⏵ bypass permissions' }), true)
+    assert.deepEqual(adapter.setup.prepare({ cfgDir: '/cfg' }, ports), { prepared: '/cfg' })
+    assert.deepEqual(adapter.evidence.activity({ cfgDir: '/cfg' }, ports), { file: '/cfg', mtimeMs: 1 })
+    assert.equal(adapter.control.enforceCompletion({}, ports), 'enforceCompletion')
+    assert.deepEqual(
+      await requireHarnessCapability(adapter, 'modelSwitch', {
+        session: 'curia-1', model: 'opus', readbackMs: 500,
+      }, ports),
+      { status: 'switched' },
+    )
+    assert.deepEqual(steps, [
+      ['key', 'curia-1', 'C-u'],
+      ['send', 'curia-1', '/model opus'],
+      ['key', 'curia-1', 'Enter'],
+      ['key', 'curia-1', 'C-y'],
+    ])
+  })
+
   test('unsupported controls refuse before a pane operation can run', () => {
     const adapter = createHarnessRegistry([fakeAdapter()]).get('fake')
     assert.throws(


### PR DESCRIPTION
## Summary

- move Claude identity, capability declarations, readiness, model switching, configuration files, and transcript vocabulary into Claude-owned modules
- route setup, lifecycle, evidence, and control calls through the Harness adapter with injected ports
- preserve legacy configuration layouts, daemon-owned Anthropic credentials, Stop-hook completion, and existing dispatch and resume behavior
- restore cut composer text when an in-pane model switch is refused because Claude is active

## Verification

- `npm test` in `daemon/`: 3,839 passed, 0 failed, 0 cancelled, 0 skipped
- focused Harness, workspace, transcript, sandbox, dispatch, stall, and model-switch tests pass

Closes #832
