### PR TITLE
Extract Codex into a conforming Harness adapter

### DIFF
--- a/daemon/src/claudeharness.mjs
+++ b/daemon/src/claudeharness.mjs
@@ -54,7 +54,7 @@ async function switchModel({ session, model, readbackMs = 15_000 }, ports) {
   }
 }
 
-export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeCommand }) {
+export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeCommand, classifyLimit }) {
   return {
     identity: {
       name: 'claude',
@@ -70,6 +70,7 @@ export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeComma
       freshCommand: (context) => buildFreshCommand(context),
       resumeCommand: (context) => buildResumeCommand(context),
       isReady: ({ paneText }) => ready(paneText),
+      classifyLimit: ({ paneText }) => classifyLimit(paneText),
       processDied: (context, ports) => call(ports, 'process', 'died', context),
       interrupt: (context, ports) => call(ports, 'process', 'interrupt', context),
       send: (context, ports) => call(ports, 'pane', 'send', context),

--- a/daemon/src/codexharness.mjs
+++ b/daemon/src/codexharness.mjs
@@ -1,0 +1,108 @@
+const call = (ports, port, operation, ...args) => {
+  const fn = ports?.[port]?.[operation]
+  if (typeof fn !== 'function') throw new Error(`Codex Harness needs ${port}.${operation}()`)
+  return fn(...args)
+}
+
+export const CODEX_READY_RE = /·\s[~/]/
+export const CODEX_LIMIT_RE = new RegExp(
+  "you['’]?ve (?:hit|reached) your (?:usage limit|workspace credit limit)"
+  + "|(?:you['’]?re|your workspace is) out of credits"
+  + '|(?:^|[^a-z])usage limit reached',
+  'i',
+)
+export const CODEX_CREDIT_GATE_RE = /approaching rate limits[\s\S]{0,500}switch to [^\n?]+ for lower credit usage\?/i
+
+const SAFE_SUBSTITUTION = /^[A-Za-z0-9._/-]+$/
+
+export const CODEX_CAPABILITIES = Object.freeze({
+  modelSwitch: true,
+  reasoningEffort: true,
+  transcriptUsage: true,
+  nativeSkills: true,
+  richMetadata: true,
+})
+
+function command({ routing, model, promptFile = null, resume = false }) {
+  const config = routing.harnesses?.codex
+  if (!config) {
+    throw new Error(`unknown harness "codex" - configured harnesses: ${Object.keys(routing.harnesses ?? {}).join(', ')}`)
+  }
+  const template = resume ? config.resumeTemplate ?? config.resume_template : config.template
+  if (typeof template !== 'string' || !template.includes('{model}')) {
+    throw new Error(`harness "codex" has no ${resume ? 'resume ' : ''}template with a {model} placeholder`)
+  }
+  const values = { model: routing.models?.[model]?.id ?? model, prompt_file: promptFile }
+  for (const [name, value] of Object.entries(values)) {
+    if (value === null) continue
+    if (!SAFE_SUBSTITUTION.test(value)) {
+      throw new Error(`refusing to substitute {${name}}: "${value}" is not quote-free/shell-safe`)
+    }
+  }
+  return Object.entries(values).reduce(
+    (result, [name, value]) => value === null ? result : result.replaceAll(`{${name}}`, value),
+    template,
+  )
+}
+
+const ready = (paneText) => {
+  CODEX_READY_RE.lastIndex = 0
+  return CODEX_READY_RE.test(String(paneText ?? ''))
+}
+
+export function classifyCodexLimit(paneText) {
+  if (!paneText) return null
+  if (CODEX_LIMIT_RE.test(paneText)) return { scope: 'provider', resetAt: null }
+  if (CODEX_CREDIT_GATE_RE.test(paneText)) {
+    return { scope: 'provider', resetAt: null, reason: 'rate-limit credit dialog' }
+  }
+  return null
+}
+
+async function switchModel({ session, model }, ports) {
+  await call(ports, 'pane', 'key', session, 'C-u')
+  await call(ports, 'pane', 'kill', session)
+  await call(ports, 'pane', 'resume', { session, model })
+  return { status: 'switched', resumed: true, recorded: true }
+}
+
+export function createCodexHarnessAdapter() {
+  return {
+    identity: {
+      name: 'codex',
+      provider: 'openai',
+      credentialConsumer: 'codex',
+      configLayoutVersion: 1,
+    },
+    setup: {
+      refuseRepository: (context, ports) => call(ports, 'filesystem', 'refuseRepository', context),
+      prepare: (context, ports) => call(ports, 'filesystem', 'prepare', context),
+    },
+    lifecycle: {
+      freshCommand: (context) => command({ ...context, resume: false }),
+      resumeCommand: (context) => command({ ...context, resume: true }),
+      isReady: ({ paneText }) => ready(paneText),
+      classifyLimit: ({ paneText }) => classifyCodexLimit(paneText),
+      processDied: (context, ports) => call(ports, 'process', 'died', context),
+      interrupt: (context, ports) => call(ports, 'process', 'interrupt', context),
+      send: (context, ports) => call(ports, 'pane', 'send', context),
+    },
+    evidence: {
+      discover: (context, ports) => call(ports, 'transcript', 'discover', context),
+      events: (context, ports) => call(ports, 'transcript', 'events', context),
+      activity: (context, ports) => call(ports, 'transcript', 'activity', context),
+      usage: (context, ports) => call(ports, 'transcript', 'usage', context),
+    },
+    control: {
+      capabilities: CODEX_CAPABILITIES,
+      operations: {
+        modelSwitch: switchModel,
+        reasoningEffort: (context, ports) => call(ports, 'pane', 'reasoningEffort', context),
+        transcriptUsage: (context, ports) => call(ports, 'transcript', 'usage', context),
+        nativeSkills: (context, ports) => call(ports, 'filesystem', 'nativeSkills', context),
+        richMetadata: (context, ports) => call(ports, 'transcript', 'richMetadata', context),
+      },
+      enforceCompletion: (context, ports) => call(ports, 'toolChannel', 'enforceCompletion', context),
+    },
+  }
+}

--- a/daemon/src/codextranscript.mjs
+++ b/daemon/src/codextranscript.mjs
@@ -1,0 +1,150 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  curiaSendBrief,
+  curiaToolSend,
+  curiaToolText,
+  firstTranscriptLine,
+  isCuriaSend,
+} from './transcriptformat.mjs'
+
+const TOPLEVEL_UNRENDERED = new Set([
+  'event_msg', 'session_meta', 'turn_context', 'world_state', 'compacted',
+])
+
+const ITEM_UNRENDERED = new Set(['reasoning', 'ghost_snapshot'])
+
+const readdirSafe = (dir) => {
+  try { return fs.readdirSync(dir) } catch { return [] }
+}
+
+function threadSource(file) {
+  let fd
+  try { fd = fs.openSync(file, 'r') } catch { return null }
+  try {
+    const size = Math.min(fs.fstatSync(fd).size, 16 * 1024)
+    const buf = Buffer.alloc(size)
+    fs.readSync(fd, buf, 0, size, 0)
+    const first = buf.toString('utf8').split('\n').find((line) => line.trim())
+    if (!first) return null
+    const event = JSON.parse(first)
+    return event?.type === 'session_meta' ? event.payload?.thread_source ?? null : null
+  } catch {
+    return null
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
+export function codexTranscriptFiles(cfgDir) {
+  const files = []
+  const walk = (dir, depth) => {
+    for (const entry of readdirSafe(dir)) {
+      const file = path.join(dir, entry)
+      if (depth < 3) walk(file, depth + 1)
+      else if (entry.startsWith('rollout-') && entry.endsWith('.jsonl') && threadSource(file) !== 'subagent') {
+        files.push(file)
+      }
+    }
+  }
+  walk(path.join(cfgDir, 'sessions'), 0)
+  return files
+}
+
+export const codexTranscriptForSession = (base, id) => (
+  base.startsWith('rollout-') && base.endsWith(`-${id}.jsonl`)
+)
+
+export const codexTranscriptPresent = (cfgDir) => fs.existsSync(path.join(cfgDir, 'sessions'))
+
+function displayName(name, namespace) {
+  if (namespace) return `${String(namespace).replace(/^mcp__/, '')}.${name}`
+  return name
+}
+
+function argsFrom(raw) {
+  try { return JSON.parse(raw ?? '{}') ?? {} } catch { return {} }
+}
+
+function toolBrief(name, args) {
+  if (name === 'exec_command' || name === 'shell') return firstTranscriptLine(args.cmd ?? args.command)
+  if (name === 'write_stdin') return firstTranscriptLine(args.chars)
+  if (name === 'ask_human' || name === 'notify' || name === 'report_result' || name === 'request_review') {
+    if (isCuriaSend(args)) return curiaSendBrief(args)
+    return firstTranscriptLine(args.prompt ?? args.message ?? args.summary ?? JSON.stringify(args))
+  }
+  return firstTranscriptLine(JSON.stringify(args), 160)
+}
+
+function outputText(output) {
+  if (!Array.isArray(output)) return String(output ?? '')
+  return output
+    .map((block) => (String(block?.type ?? '').includes('image') ? '[image]' : String(block?.text ?? '')))
+    .filter((text) => text.trim()).join('\n')
+}
+
+function resultText(output) {
+  const text = outputText(output)
+  const preamble = /^Output:\n?/m.exec(text)
+  return preamble ? text.slice(preamble.index + preamble[0].length) : text
+}
+
+export function parseCodexTranscriptEvent(event) {
+  const at = event.timestamp ?? null
+  if (event.type === 'response_item') {
+    const payload = event.payload ?? {}
+    if (payload.type === 'message') {
+      if (payload.role !== 'assistant' && payload.role !== 'user') return []
+      const parts = payload.content ?? []
+      const text = parts
+        .filter((part) => part?.type === 'output_text' || part?.type === 'input_text')
+        .map((part) => part.text).filter((part) => part?.trim()).join('\n')
+      const items = []
+      if (text) items.push({ kind: payload.role === 'assistant' ? 'say' : 'prompt', at, text })
+      for (const part of parts) {
+        if (String(part?.type ?? '').includes('image')) items.push({ kind: 'note', at, text: '[image]' })
+      }
+      return items
+    }
+    if (payload.type === 'function_call') {
+      const args = argsFrom(payload.arguments)
+      const item = {
+        kind: 'tool', at, id: payload.call_id ?? payload.id,
+        name: displayName(payload.name, payload.namespace),
+        brief: toolBrief(payload.name, args),
+      }
+      if (String(payload.namespace ?? '').startsWith('mcp__curia')) {
+        const text = curiaToolText(args)
+        if (text) item.text = text
+        const send = curiaToolSend(args)
+        if (send) item.send = send
+      }
+      return [item]
+    }
+    if (payload.type === 'function_call_output' || payload.type === 'custom_tool_call_output') {
+      const text = resultText(payload.output)
+      const exit = /Process exited with code (\d+)/.exec(outputText(payload.output))
+      return [{
+        kind: 'result', at, forId: payload.call_id, ok: exit ? exit[1] === '0' : true,
+        brief: firstTranscriptLine(text, 300), lines: text.split('\n').length,
+      }]
+    }
+    if (payload.type === 'custom_tool_call') {
+      return [{
+        kind: 'tool', at, id: payload.call_id ?? payload.id, name: payload.name,
+        brief: firstTranscriptLine(String(payload.input ?? ''), 160),
+      }]
+    }
+    if (payload.type === 'tool_search_call') {
+      return [{ kind: 'tool', at, id: payload.id, name: 'tool_search', brief: firstTranscriptLine(payload.query ?? '') }]
+    }
+    if (payload.type === 'tool_search_output') {
+      return [{ kind: 'result', at, forId: payload.id, ok: true, brief: '', lines: 1 }]
+    }
+    if (ITEM_UNRENDERED.has(payload.type)) return []
+    return null
+  }
+  if (TOPLEVEL_UNRENDERED.has(event.type)) return []
+  return null
+}

--- a/daemon/src/codexworkspace.mjs
+++ b/daemon/src/codexworkspace.mjs
@@ -1,0 +1,195 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { parse as parseYaml } from 'yaml'
+
+import { TOKEN_HEADER } from './agenttoken.mjs'
+import { codexAccessTokenExpiry } from './credentials.mjs'
+
+export const CODEX_CONFIG_ROOT_ENV = 'CODEX_HOME'
+export const CODEX_MEMORY_FILE = 'AGENTS.md'
+export const CODEX_REPO_SKILL_ROOTS = Object.freeze([
+  ['.codex', 'skills'],
+  ['.agents', 'skills'],
+])
+
+const MCP_SERVER_NAME = 'curia'
+const LOOPBACK_HOST = '127.0.0.1'
+const TOOL_TIMEOUT_S = 86_400
+
+const toml = (value) => `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+
+const mcpUrl = (daemonPort, agent, ticket, host = LOOPBACK_HOST) => (
+  `http://${host}:${daemonPort}/mcp?agent=${agent}&ticket=${ticket}`
+)
+
+const stopHookCommand = (daemonPort, agent, host = LOOPBACK_HOST, token) => [
+  `curl -s -X POST 'http://${host}:${daemonPort}/agent_done?agent=${agent}'`,
+  `-H 'Content-Type: application/json'`,
+  `-H '${TOKEN_HEADER}: ${token}'`,
+  '-d @-',
+].join(' ')
+
+function writeSecretFile(file, data) {
+  fs.writeFileSync(file, data, { mode: 0o600 })
+  fs.chmodSync(file, 0o600)
+}
+
+function hiddenSkillNames(cfgDir, names) {
+  return (names ?? []).filter((name) => {
+    const manifest = path.join(cfgDir, 'skills', name, 'agents', 'openai.yaml')
+    let document
+    try {
+      document = parseYaml(fs.readFileSync(manifest, 'utf8'))
+    } catch {
+      return false
+    }
+    return document?.policy?.allow_implicit_invocation === false
+  })
+}
+
+function skillDescription(cfgDir, name) {
+  let text
+  try {
+    text = fs.readFileSync(path.join(cfgDir, 'skills', name, 'SKILL.md'), 'utf8')
+  } catch {
+    return null
+  }
+  if (!text.startsWith('---')) return null
+  const end = text.indexOf('\n---', 3)
+  if (end === -1) return null
+  let frontmatter
+  try {
+    frontmatter = parseYaml(text.slice(3, end))
+  } catch {
+    return null
+  }
+  const description = frontmatter?.description
+  return typeof description === 'string' && description.trim() ? description.trim() : null
+}
+
+export function writeCodexSkillPointers(cfgDir, names) {
+  const written = []
+  for (const name of hiddenSkillNames(cfgDir, names)) {
+    const description = skillDescription(cfgDir, name)
+    if (!description) continue
+    const target = path.join(cfgDir, 'skills', name, 'SKILL.md')
+    const pointer = path.join(cfgDir, 'skills', `curia-${name}`)
+    fs.mkdirSync(pointer, { recursive: true })
+    fs.writeFileSync(path.join(pointer, 'SKILL.md'), [
+      '---',
+      `name: ${JSON.stringify(`curia-${name}`)}`,
+      `description: ${JSON.stringify(`${description} Read ${target} in full before you act on this.`)}`,
+      '---',
+      '',
+      `This is the \`${name}\` skill. Read \`${target}\` completely, then follow it.`,
+      '',
+      'Curia installed that file and it is the whole skill. This pointer exists because codex does',
+      `not list \`${name}\` in its own skill catalog, and it restates none of the skill itself.`,
+      '',
+      `Read \`${target}\` ONCE in a session. If you have already read it, you are still running it,`,
+      'and reading it again only repeats what you have. Say that you are using this skill, then act.',
+      '',
+      'The curia standing orders win wherever the two disagree.',
+      '',
+    ].join('\n'))
+    written.push(`curia-${name}`)
+  }
+  return written
+}
+
+function codexSkillDenyList(install) {
+  const installed = new Set(install ?? [])
+  let entries = []
+  try {
+    entries = fs.readdirSync(path.join(os.homedir(), '.agents', 'skills'), { withFileTypes: true })
+  } catch {
+    return []
+  }
+  return entries
+    .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+    .map((entry) => entry.name)
+    .filter((name) => !installed.has(name))
+    .sort()
+}
+
+function seedCredential(cfgDir, { sandboxed = false } = {}) {
+  const destination = path.join(cfgDir, 'auth.json')
+  const host = path.join(os.homedir(), '.codex', 'auth.json')
+  fs.rmSync(destination, { force: true })
+  if (!sandboxed) {
+    fs.symlinkSync(host, destination)
+    return
+  }
+  if (!fs.existsSync(host)) {
+    throw new Error(`no codex credential for the container: ${host} does not exist, and a sandboxed codex agent cannot reach the host store - type \`reauth\` to sign in from a browser (#642)`)
+  }
+  const raw = fs.readFileSync(host, 'utf8')
+  const expiry = codexAccessTokenExpiry(raw)
+  if (expiry !== null && expiry <= Date.now()) {
+    throw new Error(`refusing to seed the codex credential into the container: the host access token expired ${new Date(expiry).toISOString()}. A copy that starts expired refreshes at once, the server rotates the refresh token, and the read-only copy cannot store the rotation - that strands the host store too (#351) - type \`reauth\` to sign in from a browser first (#642)`)
+  }
+  fs.writeFileSync(destination, raw)
+  fs.chmodSync(destination, 0o400)
+}
+
+function writeConnectionSettings({
+  wtPath, cfgDir, agent, ticket, daemonPort, daemonHost,
+  reasoningEffort, token, skills,
+}) {
+  writeSecretFile(path.join(cfgDir, 'config.toml'), [
+    '# Written by the curia daemon per agent. Never hand-edited.',
+    '',
+    ...(reasoningEffort ? [`model_reasoning_effort = ${toml(reasoningEffort)}`, ''] : []),
+    '[features]',
+    'hooks = true',
+    'apps = false',
+    'plugins = false',
+    'multi_agent = false',
+    'browser_use = false',
+    'browser_use_external = false',
+    'browser_use_full_cdp_access = false',
+    'in_app_browser = false',
+    'computer_use = false',
+    'in_app_updates = false',
+    'skill_mcp_dependency_install = false',
+    '',
+    '[skills]',
+    'bundled = { enabled = false }',
+    ...codexSkillDenyList(skills?.install).flatMap((name) => [
+      '',
+      '[[skills.config]]',
+      `name = ${toml(name)}`,
+      'enabled = false',
+    ]),
+    '',
+    `[projects.${toml(wtPath)}]`,
+    'trust_level = "trusted"',
+    '',
+    `[mcp_servers.${MCP_SERVER_NAME}]`,
+    `url = ${toml(mcpUrl(daemonPort, agent, ticket, daemonHost))}`,
+    `tool_timeout_sec = ${TOOL_TIMEOUT_S}`,
+    `http_headers = { ${toml(TOKEN_HEADER)} = ${toml(token)} }`,
+    '',
+  ].join('\n'))
+  writeSecretFile(path.join(cfgDir, 'hooks.json'), JSON.stringify({
+    hooks: {
+      Stop: [{ hooks: [{
+        type: 'command',
+        command: stopHookCommand(daemonPort, agent, daemonHost, token),
+      }] }],
+    },
+  }, null, 2))
+}
+
+export const CODEX_WORKSPACE = Object.freeze({
+  memoryFile: CODEX_MEMORY_FILE,
+  provider: 'openai',
+  skillPointers: writeCodexSkillPointers,
+  hostStore: () => path.join(os.homedir(), '.codex'),
+  env: (cfgDir) => ({ [CODEX_CONFIG_ROOT_ENV]: cfgDir }),
+  seed: (cfgDir, _wtPath, options) => seedCredential(cfgDir, options),
+  connectionSettings: writeConnectionSettings,
+})
+
+export const codexUntrustedProjectConfig = (wtPath) => path.join(wtPath, '.codex', 'hooks.json')

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -25,7 +25,7 @@ import {
   deleteRemoteBranch, pullRequestDiff, approvePullRequest,
 } from './github.mjs'
 import {
-  resolveModel, candidates, spawnModelId, parseUsageLimit, parseCreditGate,
+  resolveModel, candidates, spawnModelId,
   carriesLimitPhrase, resolveReviewer, isActive, Cooling, SAME_PROVIDER_STAMP, namedModel,
   reasoningEffortFor, harnessReasoningEffort,
 } from './routing.mjs'
@@ -3204,7 +3204,8 @@ export class Dispatcher {
   // until the composer appears. stallSweep keeps polling after that contract
   // ends, so a later account fault reaches the same handler and cooling store.
   async #classifyPaneLimit(agent, pane, { postReady = false } = {}) {
-    const limit = parseUsageLimit(pane, agent.provider) ?? parseCreditGate(pane, agent.provider)
+    const adapter = this.harnesses.get(agent.harness)
+    const limit = adapter.lifecycle.classifyLimit({ paneText: pane })
     if (!limit) return 'none'
     if (agent.promptCarriesLimitText) {
       // The ticket's own text can produce this match. Veto readiness and every
@@ -6734,49 +6735,16 @@ export class Dispatcher {
       return `ℹ️ \`${session}\` already runs on **${spawnModelId(this.routing, model)}**.`
     }
 
-    const adapter = this.harnesses.get(agent.harness)
-    if (agent.harness === 'claude') return this.#switchInPane(adapter, agent, model, by)
-
-    try {
-      await this.deps.sendKey(session, 'C-u')
-    } catch (e) {
-      return `❌ could not clear pending composer text in \`${session}\`: ${failureProse(e.message)}`
-    }
-
-    try {
-      await this.deps.killSession(session)
-    } catch (e) {
-      return `❌ could not stop \`${session}\` for its model switch: ${failureProse(e.message)}`
-    }
-
-    const previousRequested = agent.requestedModel
-    agent.requestedModel = model
-    try {
-      await this.#respawnOn(agent, model, {
-        operator_model_switch: true,
-        switched_from: agent.model,
-        requested_model: model,
-        by: by ?? 'unknown',
-      }, { resume: true })
-    } catch (e) {
-      agent.requestedModel = previousRequested
-      const released = await this.#releaseClaim(agent, `operator model switch failed: ${e.message}`)
-      return `❌ could not switch \`${session}\` to \`${model}\`: ${failureProse(e.message)}. ${released ? 'The claim is released.' : 'The issue is still assigned.'}`
-    }
-    return this.#switchedLine(agent, model, { resumed: true })
+    return this.#switchWithAdapter(this.harnesses.get(agent.harness), agent, model, by)
   }
 
-  // The claude in-pane switch. The composer is already cut. The pane answers
-  // in one of three shapes the prototype captured: "Set model to" (done),
-  // "Switch model?" (one confirm, Enter), or an API error line (the CLI's own
-  // live validation refused the target; the old model stands). A pane that
-  // says none of them inside the budget is reported as unconfirmed and the
-  // record is left alone, because a record that names a model the pane never
-  // took is the lie the status line exists to avoid.
-  async #switchInPane(adapter, agent, model, by) {
+  // The adapter owns the native switch. Claude drives its in-pane dialog;
+  // Codex restarts through `resume`. This method owns only the shared record.
+  async #switchWithAdapter(adapter, agent, model, by) {
     const session = agent.session
     const id = spawnModelId(this.routing, model)
     const from = agent.model
+    const previousRequested = agent.requestedModel
     let verdict
     try {
       verdict = await requireHarnessCapability(adapter, 'modelSwitch', {
@@ -6786,9 +6754,29 @@ export class Dispatcher {
           capture: this.deps.capturePane,
           key: this.deps.sendKey,
           send: this.deps.sendText,
+          kill: this.deps.killSession,
+          resume: async () => {
+            agent.requestedModel = model
+            try {
+              await this.#respawnOn(agent, model, {
+                operator_model_switch: true,
+                switched_from: from,
+                requested_model: model,
+                by: by ?? 'unknown',
+              }, { resume: true })
+            } catch (error) {
+              agent.requestedModel = previousRequested
+              error.modelSwitchStopped = true
+              throw error
+            }
+          },
         },
       })
     } catch (e) {
+      if (e.modelSwitchStopped) {
+        const released = await this.#releaseClaim(agent, `operator model switch failed: ${e.message}`)
+        return `❌ could not switch \`${session}\` to \`${model}\`: ${failureProse(e.message)}. ${released ? 'The claim is released.' : 'The issue is still assigned.'}`
+      }
       return `❌ could not switch \`${session}\`: ${failureProse(e.message)}`
     }
     if (verdict.status === 'active') {
@@ -6803,6 +6791,7 @@ export class Dispatcher {
     if (verdict.status !== 'switched') {
       return `⚠️ \`${session}\` did not confirm the switch to **${id}** in time. It is recorded as still on **${spawnModelId(this.routing, from)}**; the terminal shows what the pane took.`
     }
+    if (verdict.recorded) return this.#switchedLine(agent, model, { resumed: verdict.resumed === true })
     agent.model = model
     agent.requestedModel = model
     agent.provider = this.routing.models[model].provider

--- a/daemon/src/harnesses.mjs
+++ b/daemon/src/harnesses.mjs
@@ -1,11 +1,12 @@
 // The public Harness adapter seam (ADR-0029 and ADR-0030).
 //
-// Claude now owns its native behavior behind this seam. Codex still delegates
-// to its legacy implementation until the next migration step.
+// Claude and Codex own their native behavior behind this seam. Shared services
+// select an adapter and provide the ports that retain Curia's invariants.
 
-import { buildResumeCmd, buildSpawnCmd } from './routing.mjs'
+import { buildResumeCmd, buildSpawnCmd, parseCreditGate, parseUsageLimit } from './routing.mjs'
 import { CONSUMER_NAMES, PROVIDER_CREDENTIALS } from './credentials.mjs'
 import { createClaudeHarnessAdapter } from './claudeharness.mjs'
+import { createCodexHarnessAdapter } from './codexharness.mjs'
 
 export const HARNESS_FACETS = Object.freeze([
   'identity',
@@ -104,7 +105,7 @@ export function validateHarnessAdapter(adapter, {
   }
 
   for (const method of ['refuseRepository', 'prepare']) requireFunction('setup', setup, method)
-  for (const method of ['freshCommand', 'resumeCommand', 'isReady', 'processDied', 'interrupt', 'send']) {
+  for (const method of ['freshCommand', 'resumeCommand', 'isReady', 'classifyLimit', 'processDied', 'interrupt', 'send']) {
     requireFunction('lifecycle', lifecycle, method)
   }
   for (const method of ['discover', 'events', 'activity', 'usage']) requireFunction('evidence', evidence, method)
@@ -245,71 +246,14 @@ export function spawnIdentity(event = {}) {
   })
 }
 
-const portCall = (ports, port, operation, ...args) => {
-  const fn = ports?.[port]?.[operation]
-  if (typeof fn !== 'function') contractFault(`Harness call needs ${port}.${operation}() through its ports`)
-  return fn(...args)
-}
-
-function legacyAdapter({ name, provider, capabilities }) {
-  const capabilityOperations = {
-    modelSwitch: (context, ports) => portCall(ports, 'pane', 'modelSwitch', context),
-    reasoningEffort: (context, ports) => portCall(ports, 'pane', 'reasoningEffort', context),
-    transcriptUsage: (context, ports) => portCall(ports, 'transcript', 'usage', context),
-    nativeSkills: (context, ports) => portCall(ports, 'filesystem', 'nativeSkills', context),
-    richMetadata: (context, ports) => portCall(ports, 'transcript', 'richMetadata', context),
-  }
-  return {
-    identity: {
-      name,
-      provider,
-      credentialConsumer: name,
-      configLayoutVersion: CURRENT_CONFIG_LAYOUT,
-    },
-    setup: {
-      refuseRepository: (context, ports) => portCall(ports, 'filesystem', 'refuseRepository', context),
-      prepare: (context, ports) => portCall(ports, 'filesystem', 'prepare', context),
-    },
-    lifecycle: {
-      freshCommand: ({ routing, model, promptFile }) => buildSpawnCmd(routing, name, model, promptFile),
-      resumeCommand: ({ routing, model }) => buildResumeCmd(routing, name, model),
-      isReady: ({ routing, paneText }) => Boolean(routing.harnesses?.[name]?.readyRe?.test(paneText)),
-      processDied: (context, ports) => portCall(ports, 'process', 'died', context),
-      interrupt: (context, ports) => portCall(ports, 'process', 'interrupt', context),
-      send: (context, ports) => portCall(ports, 'pane', 'send', context),
-    },
-    evidence: {
-      discover: (context, ports) => portCall(ports, 'transcript', 'discover', context),
-      events: (context, ports) => portCall(ports, 'transcript', 'events', context),
-      activity: (context, ports) => portCall(ports, 'transcript', 'activity', context),
-      usage: (context, ports) => portCall(ports, 'transcript', 'usage', context),
-    },
-    control: {
-      capabilities,
-      operations: Object.fromEntries(
-        Object.entries(capabilities)
-          .filter(([, supported]) => supported)
-          .map(([capability]) => [capability, capabilityOperations[capability]]),
-      ),
-      enforceCompletion: (context, ports) => portCall(ports, 'toolChannel', 'enforceCompletion', context),
-    },
-  }
-}
-
-const sharedCapabilities = Object.freeze({
-  modelSwitch: true,
-  reasoningEffort: true,
-  transcriptUsage: true,
-  nativeSkills: true,
-  richMetadata: true,
-})
-
 export const HARNESS_REGISTRY = createHarnessRegistry([
   createClaudeHarnessAdapter({
     buildFreshCommand: ({ routing, model, promptFile }) => buildSpawnCmd(routing, 'claude', model, promptFile),
     buildResumeCommand: ({ routing, model }) => buildResumeCmd(routing, 'claude', model),
+    classifyLimit: (paneText) => parseUsageLimit(paneText, 'anthropic')
+      ?? parseCreditGate(paneText, 'anthropic'),
   }),
-  legacyAdapter({ name: 'codex', provider: 'openai', capabilities: sharedCapabilities }),
+  createCodexHarnessAdapter(),
 ], {
   providers: Object.keys(PROVIDER_CREDENTIALS),
   credentialConsumers: CONSUMER_NAMES,

--- a/daemon/src/routing.mjs
+++ b/daemon/src/routing.mjs
@@ -1,5 +1,7 @@
 // Model routing (#13): label resolution, two-level cooling cache, transitive
 // fallback candidates, spawn-command build, usage-limit parse.
+
+import { CODEX_CREDIT_GATE_RE, CODEX_LIMIT_RE } from './codexharness.mjs'
 //
 // Two providers since #39, which is what #13 asked for and what #33 deferred.
 // The shapes that were already here for one provider now carry real weight: a
@@ -461,12 +463,7 @@ export const LIMIT_PATTERNS = {
   // instant in its transcript, and #handleLimit reads it there (#175). What
   // stays conservative is the case neither surface states: an hour.
   openai: {
-    reached: new RegExp(
-      `you${AP}ve (?:hit|reached) your (?:usage limit|workspace credit limit)`
-      + `|(?:you${AP}re|your workspace is) out of credits`
-      + '|(?:^|[^a-z])usage limit reached',
-      'i',
-    ),
+    reached: CODEX_LIMIT_RE,
     scopeOf: () => 'provider',
     reset: null,
   },
@@ -489,7 +486,7 @@ export const CREDIT_GATE_PATTERNS = {
   // Codex renders this modal over a healthy-looking composer footer. Require
   // both modal lines, so its session-opening reset notice and status footer
   // remain healthy-session text under field-notes contract 4.
-  openai: /approaching rate limits[\s\S]{0,500}switch to [^\n?]+ for lower credit usage\?/i,
+  openai: CODEX_CREDIT_GATE_RE,
 }
 
 export function parseCreditGate(paneText, provider = 'anthropic') {

--- a/daemon/src/transcript.mjs
+++ b/daemon/src/transcript.mjs
@@ -34,18 +34,13 @@ import {
   parseClaudeTranscriptEvent,
 } from './claudetranscript.mjs'
 import {
-  curiaSendBrief,
-  curiaToolSend,
-  curiaToolText,
-  firstTranscriptLine as firstLine,
-  isCuriaSend,
-} from './transcriptformat.mjs'
+  codexTranscriptFiles,
+  codexTranscriptForSession,
+  codexTranscriptPresent,
+  parseCodexTranscriptEvent,
+} from './codextranscript.mjs'
 
 export const TRANSCRIPT_HARNESSES = ['claude', 'codex']
-
-function readdirSafe(dir) {
-  try { return fs.readdirSync(dir) } catch { return [] }
-}
 
 // Which harness wrote this config dir, by positive on-disk evidence: the claude
 // harness creates `projects/`, codex's creates `sessions/`. Null when
@@ -55,7 +50,7 @@ function readdirSafe(dir) {
 // and lab sessions.
 export function detectHarness(cfgDir) {
   if (claudeTranscriptPresent(cfgDir)) return 'claude'
-  if (fs.existsSync(path.join(cfgDir, 'sessions'))) return 'codex'
+  if (codexTranscriptPresent(cfgDir)) return 'codex'
   return null
 }
 
@@ -76,41 +71,7 @@ function newestFile(files) {
 // A spawned codex subagent writes a second rollout into its parent's config
 // directory. Its first line identifies it, so it must not win the parent's
 // newest-file lookup while the parent waits (#544, #545).
-function codexThreadSource(file) {
-  let fd
-  try { fd = fs.openSync(file, 'r') } catch { return null }
-  try {
-    const size = Math.min(fs.fstatSync(fd).size, 16 * 1024)
-    const buf = Buffer.alloc(size)
-    fs.readSync(fd, buf, 0, size, 0)
-    const first = buf.toString('utf8').split('\n').find((line) => line.trim())
-    if (!first) return null
-    const event = JSON.parse(first)
-    return event?.type === 'session_meta' ? event.payload?.thread_source ?? null : null
-  } catch {
-    return null
-  } finally {
-    fs.closeSync(fd)
-  }
-}
-
-function codexFiles(cfgDir) {
-  // sessions/<year>/<month>/<day>/rollout-*.jsonl
-  const files = []
-  const walk = (dir, depth) => {
-    for (const entry of readdirSafe(dir)) {
-      const p = path.join(dir, entry)
-      if (depth < 3) walk(p, depth + 1)
-      else if (entry.startsWith('rollout-') && entry.endsWith('.jsonl') && codexThreadSource(p) !== 'subagent') {
-        files.push(p)
-      }
-    }
-  }
-  walk(path.join(cfgDir, 'sessions'), 0)
-  return files
-}
-
-const FILES = { claude: claudeTranscriptFiles, codex: codexFiles }
+const FILES = { claude: claudeTranscriptFiles, codex: codexTranscriptFiles }
 
 // What each harness NAMES a session's transcript. The claude harness names the
 // file after the session id — measured on the box (docs/live-checks/
@@ -120,7 +81,7 @@ const FILES = { claude: claudeTranscriptFiles, codex: codexFiles }
 // overseer is the one thing curia keys and it runs the claude harness.
 const NAMES_SESSION = {
   claude: claudeTranscriptForSession,
-  codex: (base, id) => base.startsWith('rollout-') && base.endsWith(`-${id}.jsonl`),
+  codex: codexTranscriptForSession,
 }
 
 // The newest root transcript in a config dir, by mtime.
@@ -218,130 +179,7 @@ export function firstPrompt(harness, file, { max = 90, bytes = LABEL_BYTES } = {
   return null
 }
 
-// ---------------------------------------------------------------------------
-// codex harness
-// ---------------------------------------------------------------------------
-
-// event_msg is codex's live-UI event stream and every payload type it carries
-// is DUPLICATED by (or derivable from) a response_item on the same file —
-// agent_message/user_message mirror `message` items, mcp_tool_call_end mirrors
-// a function_call_output, token_count/task_started/task_complete are counters.
-// Rendering from response_item alone avoids double items, so event_msg is
-// tolerated wholesale rather than allowlisted per payload type: a NEW event
-// subtype is additive UI noise, not a vocabulary break. The break signal for
-// this harness is an unknown response_item payload or an unknown top-level type.
-const CODEX_TOPLEVEL_UNRENDERED = new Set([
-  'event_msg', 'session_meta', 'turn_context', 'world_state', 'compacted',
-])
-
-// reasoning is stored encrypted with no text (same fact as claude's
-// signature-only thinking — the terminal shows it live, no timeline can).
-const CODEX_ITEM_UNRENDERED = new Set(['reasoning', 'ghost_snapshot'])
-
-function codexDisplayName(name, namespace) {
-  // namespace "mcp__curia" + name "ask_human" → "curia.ask_human", matching
-  // how the page shows the claude harness's mcp__curia__ tools.
-  if (namespace) return `${String(namespace).replace(/^mcp__/, '')}.${name}`
-  return name
-}
-
-function codexArgs(raw) {
-  try { return JSON.parse(raw ?? '{}') ?? {} } catch { return {} }
-}
-
-function codexToolBrief(name, args) {
-  if (name === 'exec_command' || name === 'shell') return firstLine(args.cmd ?? args.command)
-  if (name === 'write_stdin') return firstLine(args.chars)
-  if (name === 'ask_human' || name === 'notify' || name === 'report_result' || name === 'request_review') {
-    if (isCuriaSend(args)) return curiaSendBrief(args)
-    return firstLine(args.prompt ?? args.message ?? args.summary ?? JSON.stringify(args))
-  }
-  return firstLine(JSON.stringify(args), 160)
-}
-
-// A codex tool output is a plain string on the classic tools and an ARRAY of
-// content blocks on 0.146's exec harness — and the array is the only path an
-// image takes to the model (measured on #176: an MCP `image` block arrives as
-// `{type:"input_image", image_url:"data:…"}`). Flatten to text, with each
-// image standing in as [image] — the claude harness's own spelling — so a
-// message whose only cargo is a screenshot renders as something rather than
-// as "[object Object]".
-function codexOutputText(output) {
-  if (!Array.isArray(output)) return String(output ?? '')
-  return output
-    .map((b) => (String(b?.type ?? '').includes('image') ? '[image]' : String(b?.text ?? '')))
-    .filter((s) => s.trim()).join('\n')
-}
-
-// exec_command outputs open with a bookkeeping preamble; the human wants the
-// command's own first line.
-function codexResultText(output) {
-  const s = codexOutputText(output)
-  const m = /^Output:\n?/m.exec(s)
-  return m ? s.slice(m.index + m[0].length) : s
-}
-
-function codexItems(e) {
-  const at = e.timestamp ?? null
-  if (e.type === 'response_item') {
-    const p = e.payload ?? {}
-    if (p.type === 'message') {
-      if (p.role !== 'assistant' && p.role !== 'user') return [] // developer: injected context, not conversation
-      const parts = p.content ?? []
-      const text = parts
-        .filter((c) => c?.type === 'output_text' || c?.type === 'input_text')
-        .map((c) => c.text).filter((t) => t?.trim()).join('\n')
-      const out = []
-      if (text) out.push({ kind: p.role === 'assistant' ? 'say' : 'prompt', at, text })
-      // #176 gap 9: an image block used to render as NO item at all, where the
-      // claude harness shows [image] (its user-message image case). Same note here.
-      for (const c of parts) {
-        if (String(c?.type ?? '').includes('image')) out.push({ kind: 'note', at, text: '[image]' })
-      }
-      return out
-    }
-    if (p.type === 'function_call') {
-      const args = codexArgs(p.arguments)
-      const item = {
-        kind: 'tool', at, id: p.call_id ?? p.id,
-        name: codexDisplayName(p.name, p.namespace),
-        brief: codexToolBrief(p.name, args),
-      }
-      if (String(p.namespace ?? '').startsWith('mcp__curia')) {
-        const text = curiaToolText(args)
-        if (text) item.text = text
-        const send = curiaToolSend(args)
-        if (send) item.send = send
-      }
-      return [item]
-    }
-    if (p.type === 'function_call_output' || p.type === 'custom_tool_call_output') {
-      const text = codexResultText(p.output)
-      const exit = /Process exited with code (\d+)/.exec(codexOutputText(p.output))
-      return [{
-        kind: 'result', at, forId: p.call_id, ok: exit ? exit[1] === '0' : true,
-        brief: firstLine(text, 300), lines: text.split('\n').length,
-      }]
-    }
-    // 0.146's exec harness (measured on #176): MCP calls no longer arrive as
-    // namespaced function_calls — the model writes a custom_tool_call named
-    // `exec` whose `input` is JS driving `tools.mcp__<server>__<tool>`. The
-    // input is a raw string, not JSON arguments.
-    if (p.type === 'custom_tool_call') {
-      return [{ kind: 'tool', at, id: p.call_id ?? p.id, name: p.name, brief: firstLine(String(p.input ?? ''), 160) }]
-    }
-    if (p.type === 'tool_search_call') return [{ kind: 'tool', at, id: p.id, name: 'tool_search', brief: firstLine(p.query ?? '') }]
-    if (p.type === 'tool_search_output') return [{ kind: 'result', at, forId: p.id, ok: true, brief: '', lines: 1 }]
-    if (CODEX_ITEM_UNRENDERED.has(p.type)) return []
-    return null // unknown response_item vocabulary
-  }
-  if (CODEX_TOPLEVEL_UNRENDERED.has(e.type)) return []
-  return null
-}
-
-// ---------------------------------------------------------------------------
-
-const READERS = { claude: parseClaudeTranscriptEvent, codex: codexItems }
+const READERS = { claude: parseClaudeTranscriptEvent, codex: parseCodexTranscriptEvent }
 
 // Read the messages that the Chat surface can render from transcript lines.
 // The branch selection lives here so agent and overseer conversations don't

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -19,15 +19,9 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { parse as parseYaml } from 'yaml'
 import { execFileP } from './exec.mjs'
 import { endingProse, CHARTING_NEVER, REVIEWER_NEVER, dutyLines, ALL_AS_RECOMMENDED } from './lifecycle.mjs'
-import { TOKEN_HEADER } from './agenttoken.mjs'
 import { forgetGhCredentials } from './agentgh.mjs'
-// One expiry parser for the whole daemon (#642). The broker in credentials.mjs
-// refreshes on the same reading this seed refuses on, and a second parser here
-// would be free to disagree with it about whether a dispatch may proceed.
-import { codexAccessTokenExpiry } from './credentials.mjs'
 // the daemon's own minted credential (#390, ADR-0018) — every clone, fetch and
 // push below reaches GitHub as `curia-sh[bot]` rather than as the operator
 import { daemonGhEnv } from './daemongh.mjs'
@@ -45,8 +39,20 @@ import {
   claudeUntrustedProjectConfig,
   writeClaudeConnection,
 } from './claudeworkspace.mjs'
+import {
+  CODEX_CONFIG_ROOT_ENV,
+  CODEX_REPO_SKILL_ROOTS,
+  CODEX_WORKSPACE,
+  codexUntrustedProjectConfig,
+  writeCodexSkillPointers,
+} from './codexworkspace.mjs'
 
-export { CLAUDE_API_KEY_TAIL_LENGTH, claudeApiKeyApproval, writeClaudeConnection }
+export {
+  CLAUDE_API_KEY_TAIL_LENGTH,
+  claudeApiKeyApproval,
+  writeClaudeConnection,
+  writeCodexSkillPointers as writeSkillPointers,
+}
 
 // The mandatory communication rules (#133): a curia-owned copy of the
 // operator's STE writing standard, seeded into every config dir as the CLI's
@@ -572,7 +578,7 @@ export const HARNESS_NAMES = ['claude', 'codex']
 // once, for the agent spawn and the usage sync alike.
 export const CONFIG_ROOT_ENV = Object.freeze({
   claude: CLAUDE_CONFIG_ROOT_ENV,
-  codex: 'CODEX_HOME',
+  codex: CODEX_CONFIG_ROOT_ENV,
 })
 
 export function configRootEnvFor(harness = 'claude') {
@@ -645,293 +651,13 @@ export function agentEnv(cfgDir, harness = 'claude', { sandboxed = false } = {})
 // URL, so this is belt rather than need — but an unescaped backslash or quote
 // in a config file the daemon writes would fail at codex startup, where the
 // symptom is an agent sitting at a parse error nobody reads.
-function toml(value) {
-  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
-}
-
-// The daemon's own address, as the agent reaches it. A bare pane reaches it on
-// loopback; a container's loopback is the container, so it reaches the same
-// listener through the docker host gateway instead (#156).
 export const LOOPBACK = LOOPBACK_HOST
-
-// The name curia's own MCP server carries in the agent's `.mcp.json`, and the
-// one name the claude harness's allowlist admits (#180). One constant, because the
-// two must never drift: an allowlist that does not name the server curia writes
-// leaves the agent with no tools at all.
 export const MCP_SERVER_NAME = CURIA_MCP_SERVER_NAME
-
-function curiaMcpUrl(daemonPort, agent, ticket, host = LOOPBACK) {
-  return `http://${host}:${daemonPort}/mcp?agent=${agent}&ticket=${ticket}`
-}
-
-// How long codex may wait on one curia tool call. Its default is 300 s, and it
-// is a HARD deadline on the call, not an idle timer — so #34's MCP-stream
-// keepalive, which is what lifts Claude Code's identical 300 s abort, does
-// nothing here. That was found the way #34's was: a live agent held a
-// `request_review` open, the human took five minutes, and the call died with
-// `tool call error: timed out awaiting tools/call after 300s` — twice, because
-// the agent correctly retried it (#56's standing order) into a second deadline.
-//
-// A day, not a literal infinity: codex wants a number, and this is the one place
-// #11's "blocks for as long as the human takes" is bounded. It is ~3x the
-// longest real block on record (7 h 53 m, #56), and a block that outlives it
-// re-dispatches rather than resolving anything (#11/#12). The keepalive stays on
-// for the claude harness and costs nothing here.
-//
-// #371 then measured what else this number bounds, and it is more than the human
-// wait. Codex has NO transport-drop watchdog: when the daemon dies holding a
-// call, the client is told nothing and waits out this deadline from the moment
-// the CALL was made. Measured three ways in
-// docs/research/tool-channel-mid-session-codex.md — still waiting 595 s and
-// 295 s after the death at this value, and dying at 60.009 s and 60.007 s with
-// the value cut to 60. The claude row above is told in ~120 s instead, which is
-// why #341's retry ladder works there and cannot fire here.
-//
-// So one number serves two jobs that pull apart: generous to a slow human, and
-// a day of silence for an agent a restart stranded. Changing it is a decision
-// against #34, not a tuning.
-//
-// #426 took that decision and left the number ALONE. One value cannot be both
-// jobs, so the second job moves off it: the daemon says goodbye. Before it
-// exits, a restart, a SIGTERM and a crash each end every blocked call with a
-// tool ERROR, which is the error #341's ladder needs and the thing codex never
-// gets by itself. That reaches the agent in about a second rather than in a
-// day, and it costs the slow human nothing. What the goodbye cannot reach is a
-// SIGKILL, and this deadline is still the only bound there.
-const CODEX_TOOL_TIMEOUT_S = 86_400
-
-function writeSecretFile(file, data) {
-  fs.writeFileSync(file, data, { mode: 0o600 })
-  fs.chmodSync(file, 0o600)
-}
-
-function stopHookCommand(daemonPort, agent, host = LOOPBACK, token) {
-  return [
-    `curl -s -X POST 'http://${host}:${daemonPort}/agent_done?agent=${agent}'`,
-    `-H 'Content-Type: application/json'`,
-    `-H '${TOKEN_HEADER}: ${token}'`,
-    '-d @-',
-  ].join(' ')
-}
 
 const HARNESS = {
   claude: CLAUDE_WORKSPACE,
-  codex: {
-    // See the claude row: this is the durable channel, and #340 measured it.
-    memoryFile: 'AGENTS.md',
-    // See the claude row (#648). `openai` is the name the routing table and
-    // `Cooling` use; `codex` is the consumer that runs on it.
-    provider: 'openai',
-    // Codex hides a skill whose manifest says so, and its catalog is the only
-    // channel that re-arms a skill without pasting it (#399). See
-    // writeSkillPointers. A new harness answers this row for itself: a CLI with
-    // no catalog of its own writes no pointers and needs none.
-    skillPointers: writeSkillPointers,
-    // CODEX_HOME is the whole config dir: settings, skills, sessions, logs AND
-    // the credential file, with no second variable to split them (Claude's
-    // CLAUDE_SECURESTORAGE_CONFIG_DIR has no codex equivalent). Sharing the
-    // host's credentials therefore has to happen inside the dir.
-    hostStore: () => path.join(os.homedir(), '.codex'),
-    env: (cfgDir) => ({ [CONFIG_ROOT_ENV.codex]: cfgDir }),
-
-    // A SYMLINK to the host's auth.json, which is the same shared-store property
-    // #53 landed for Claude and — read this carefully — reached by the opposite
-    // mechanism. #53 found that a symlinked Claude credential file is REPLACED by
-    // a regular file on the agent's first refresh, because Claude writes
-    // temp-then-rename over an unresolved path, stranding the host on the
-    // rotated-away token. Codex does not: it opens the path
-    // O_WRONLY|O_CREAT|O_TRUNC, which follows the link and writes the host's own
-    // file (verified by strace, and by watching a write through the link land on
-    // the target while the link survived). So here the link is the fix, not the
-    // trap.
-    //
-    // Rebuilt on every seed, and any regular file at that path is removed first:
-    // a config dir reused from a run that somehow left a real credential behind
-    // must not keep it, because a stale copy that still parses is the silent
-    // return to the frozen-token failure.
-    //
-    // The cost is the same one #53 accepted: an agent can reach the host's real
-    // credential file, so it has a host session's blast radius there. The one
-    // difference worth stating is that codex's write is NOT atomic — a truncating
-    // in-place rewrite, where Claude's is a rename — so a refresh racing a read
-    // can be seen torn. The window is one small write and nothing in codex locks
-    // that file (its own locks live under $CODEX_HOME/tmp, which is per-agent
-    // and so shares nothing), and the failure re-dispatches (#11/#12).
-    // A CONTAINER cannot have the link, and cannot have the sharing either
-    // (#158). It mounts no host HOME, so a link into `~/.codex` resolves to
-    // nothing inside — the silent shape #156 found with skills. The credential
-    // is a FILE in `CODEX_HOME`, and `CODEX_HOME` is the config dir the
-    // container already mounts, so delivery is a copy and needs no new mount.
-    //
-    // The copy is READ-ONLY, and that is the whole decision rather than a
-    // detail. `auth.json` on this box carries a `refresh_token`, and providers
-    // rotate those: an agent that refreshed its copy would invalidate the
-    // token the HOST still holds — #53's stranding, arriving by the other harness.
-    // So the container agent is frozen on the token it started with, which is
-    // the same bound #156 accepted for the claude harness and stated.
-    //
-    // 0400 is a bound against accident, not against the agent: the container
-    // runs as uid 1000 and owns the file, so it could chmod it back. What it
-    // buys is that an ordinary in-place refresh FAILS rather than silently
-    // rotating the host away.
-    //
-    // AND THE COPY MUST NOT START EXPIRED (#351). The 0400 bit blocks the
-    // write-back, not the refresh: a refresh is a network call, and the server
-    // rotates the refresh token the moment it succeeds. A copy whose access
-    // token is already expired refreshes on first use, the rotated credential
-    // lives only in process memory, and the next re-read presents the old
-    // refresh token — which the server refuses as already used. That strands
-    // the agent AND the host store, because both hold the same spent token.
-    // So an expired host token refuses the dispatch here, loudly and before
-    // any claim work is lost. The bound this buys is one access-token
-    // lifetime: an agent that outlives a fresh token still dies on the same
-    // sequence, and only the API-key shape (ADR-0007's, for the claude lane)
-    // removes the lineage entirely.
-    seed: (cfgDir, _wtPath, { sandboxed = false } = {}) => {
-      const dest = path.join(cfgDir, 'auth.json')
-      const host = path.join(os.homedir(), '.codex', 'auth.json')
-      fs.rmSync(dest, { force: true })
-      if (!sandboxed) {
-        fs.symlinkSync(host, dest)
-        return
-      }
-      if (!fs.existsSync(host)) {
-        throw new Error(`no codex credential for the container: ${host} does not exist, and a sandboxed codex agent cannot reach the host store — type \`reauth\` to sign in from a browser (#642)`)
-      }
-      const raw = fs.readFileSync(host, 'utf8')
-      const expiry = codexAccessTokenExpiry(raw)
-      if (expiry !== null && expiry <= Date.now()) {
-        throw new Error(`refusing to seed the codex credential into the container: the host access token expired ${new Date(expiry).toISOString()}. A copy that starts expired refreshes at once, the server rotates the refresh token, and the read-only copy cannot store the rotation — that strands the host store too (#351) — type \`reauth\` to sign in from a browser first (#642)`)
-      }
-      fs.writeFileSync(dest, raw)
-      fs.chmodSync(dest, 0o400)
-    },
-
-    // Everything the codex harness needs is in the config dir, so nothing is written
-    // into the watched repo at all — no .mcp.json, no settings file, nothing to
-    // git-exclude.
-    //
-    // `[projects.<wt>] trust_level` is the codex analogue of Claude's
-    // hasTrustDialogAccepted: without it the first spawn stops at a "Do you trust
-    // the contents of this directory?" prompt and the agent never reaches its
-    // composer (observed, before this line existed).
-    connectionSettings: ({ wtPath, cfgDir, agent, ticket, daemonPort, daemonHost, reasoningEffort, token, skills }) => {
-      writeSecretFile(path.join(cfgDir, 'config.toml'), [
-        '# Written by the curia daemon per agent. Never hand-edited.',
-        '',
-        // Written whenever routing states one, because a model's OWN default is
-        // not a constant across models: gpt-5.5 defaults to medium and
-        // gpt-5.6-sol to low, so changing `models.<name>.id` alone would move
-        // the effort underneath the harness without saying so. Stating it makes the
-        // model and the depth two separate, visible decisions.
-        ...(reasoningEffort ? [`model_reasoning_effort = ${toml(reasoningEffort)}`, ''] : []),
-        '[features]',
-        'hooks = true',
-        // The tool set is bounded HERE (#172), and this table is the whole lever:
-        // every one of these is `stable` and defaults to TRUE on the pinned
-        // codex, so curia carried them without ever choosing them. A live agent
-        // held `mcp__codex_apps__plugin_management` — search, install and
-        // uninstall apps — plus `_update_app_permissions`, and none of it was
-        // named in `[mcp_servers]` or in the bounds.
-        //
-        // This is the codex half of the fault #180 fixed on claude, and the
-        // mechanism rhymes: the `codex_apps` namespace follows the ChatGPT
-        // credential rather than the config file, and ADR-0007 shares that
-        // credential with the host on purpose. The container boundary (#148)
-        // does not reach it either — a connector call is ordinary outbound
-        // HTTPS, and the network is open because wayfinder needs `gh` and the
-        // web.
-        //
-        // `apps` and `plugins` are the namespace itself, and #207's live read
-        // confirmed both bite: the mcp-resource tools and `request_plugin_install`
-        // drop out of a real agent's tool set when they are false.
-        //
-        // `multi_agent` was written against `resume_agent` and `close_agent`, and
-        // #207 measured it as a no-op on 0.146: the family moved to
-        // `collaboration.*` and off the flag, and a live agent under this very
-        // table spawned a sub-agent (`Started /root/pong`,
-        // docs/live-checks/207). The operator then ruled the collaboration
-        // tools ALLOWED (2026-08-05): they are the codex spelling of claude's
-        // own subagents, which curia has never forbidden, and the review gate
-        // reads the output either way. The key stays because it is true to its
-        // name and costs nothing.
-        //
-        // The trap is the OPPOSITE shape to #180's, and it was measured both
-        // ways. A key codex does not know is ignored in silence, so a rename
-        // upstream fails as a no-op rather than as a dead agent. A key with the
-        // wrong TYPE is a hard config error that stops the spawn at startup.
-        // So nothing here can quietly take curia's own MCP server down, and a
-        // typo buys back the whole surface with nothing to say so. That is why
-        // the guard is a live read of `codex features list` (docs/live-checks/172)
-        // rather than a unit test on the string this writes. `multi_agent` is
-        // that trap CAUGHT, one ticket later.
-        'apps = false',
-        'plugins = false',
-        'multi_agent = false',
-        // The rest of the default-on registry curia never chose (#207). All
-        // seven were measured INERT for a CLI agent on the pinned codex: with
-        // all of them false, a live agent's tool set is byte-identical, in the
-        // TUI lane and the exec lane, bare and in the container. They gate the
-        // Codex desktop app and IDE surfaces, not this one — no browser or
-        // computer-use tool ever reached a CLI agent's definitions, and
-        // `in_app_updates = false` does not even remove `codex update` from the
-        // CLI. So these lines remove no capability today. They are a pin: each
-        // is `stable` and defaults to TRUE, so the next version bump that does
-        // attach one of them to the CLI meets a stated choice instead of a
-        // default nobody made (operator ruling, 2026-08-05, docs/live-checks/207).
-        'browser_use = false',
-        'browser_use_external = false',
-        'browser_use_full_cdp_access = false',
-        'in_app_browser = false',
-        'computer_use = false',
-        'in_app_updates = false',
-        'skill_mcp_dependency_install = false',
-        '',
-        // The skill bound (#171). #57's install list is the whole skill set an
-        // agent may see, and CODEX_HOME does not enforce it: codex also reads
-        // `$HOME/.agents/skills`, with no config key to turn that root off on
-        // the pinned codex. So the bound is subtractive — one disable entry per
-        // host skill the seed did not install, exact-name match, resolved
-        // against every root at load (verified live: the model-visible prompt
-        // then lists exactly the installed nine, docs/live-checks/171).
-        //
-        // `bundled` covers gap 2 of the same inventory: codex plants six skills
-        // of its own under `<cfgDir>/skills/.system` on every start,
-        // `skill-installer` — which installs more — among them. Nothing curia
-        // chose, so it is pinned off like the feature table above; false also
-        // deletes the planted cache dir (verified live). Same silent-rename
-        // caveat as `[features]`: an unknown key is ignored without a word, so
-        // the guard is the live read, not a unit test on this string.
-        '[skills]',
-        'bundled = { enabled = false }',
-        ...codexSkillDenyList(skills?.install).flatMap((name) => [
-          '',
-          '[[skills.config]]',
-          `name = ${toml(name)}`,
-          'enabled = false',
-        ]),
-        '',
-        `[projects.${toml(wtPath)}]`,
-        'trust_level = "trusted"',
-        '',
-        `[mcp_servers.${MCP_SERVER_NAME}]`,
-        `url = ${toml(curiaMcpUrl(daemonPort, agent, ticket, daemonHost))}`,
-        `tool_timeout_sec = ${CODEX_TOOL_TIMEOUT_S}`,
-        // #159, the codex spelling of the claude harness's `headers` object. An
-        // inline table, which is what `codex mcp list --json` reads back as the
-        // transport's `http_headers`. `bearer_token_env_var` is the other option
-        // codex offers and it is the wrong one here: it names an ENVIRONMENT
-        // VARIABLE, which puts the secret back in `ps` on the bare path.
-        `http_headers = { ${toml(TOKEN_HEADER)} = ${toml(token)} }`,
-        '',
-      ].join('\n'))
-      writeSecretFile(path.join(cfgDir, 'hooks.json'), JSON.stringify({
-        hooks: { Stop: [{ hooks: [{ type: 'command', command: stopHookCommand(daemonPort, agent, daemonHost, token) }] }] },
-      }, null, 2))
-    },
-  },
+  codex: CODEX_WORKSPACE,
 }
-
 // A config file the WATCHED REPO carries, which curia does not write and cannot
 // vouch for. Returns the offending path, or null. One exposure per harness, same
 // shape on both: a file the harness loads with no prompt, whose hooks would
@@ -959,7 +685,7 @@ const HARNESS = {
 // flag (#105).
 export function untrustedProjectConfig(wtPath, harness) {
   const planted = harness === 'codex'
-    ? path.join(wtPath, '.codex', 'hooks.json')
+    ? codexUntrustedProjectConfig(wtPath)
     : claudeUntrustedProjectConfig(wtPath)
   return fs.existsSync(planted) ? planted : null
 }
@@ -969,7 +695,7 @@ export function untrustedProjectConfig(wtPath, harness) {
 // config dir plus `.agents/skills` at the spawn cwd; claude reads
 // `.claude/skills`. Neither CLI has a config key that turns a repo root off.
 const REPO_SKILL_ROOTS = {
-  codex: [['.codex', 'skills'], ['.agents', 'skills']],
+  codex: CODEX_REPO_SKILL_ROOTS,
   claude: CLAUDE_REPO_SKILL_ROOTS,
 }
 
@@ -1093,173 +819,6 @@ export function installSkills(cfgDir, skills, { copy = false } = {}) {
     else fs.symlinkSync(src, path.join(dir, name), 'dir')
   }
   return names
-}
-
-// The skills codex HIDES from its own catalog, read off upstream's manifest
-// rather than decided here (#399). A skill whose `agents/openai.yaml` carries
-// `policy.allow_implicit_invocation: false` is absent from the
-// `<skills_instructions>` developer message, so the model never learns it
-// exists. Today that is `wayfinder` and `implement`.
-//
-// The manifest IS the question, so it is the thing read. If upstream lists a
-// skill in a later release, curia writes no pointer for it and the pointer
-// simply stops existing — no list here to fall out of date, and no patched byte
-// to break in silence.
-//
-// A skill with no manifest at all is listed: `allow_implicit_invocation`
-// defaults to true. That is why a pointer needs no manifest of its own.
-function hiddenSkillNames(cfgDir, names) {
-  return (names ?? []).filter((name) => {
-    const manifest = path.join(cfgDir, 'skills', name, 'agents', 'openai.yaml')
-    let doc
-    try {
-      doc = parseYaml(fs.readFileSync(manifest, 'utf8'))
-    } catch {
-      return false // no manifest, or one codex itself could not read: codex lists it
-    }
-    return doc?.policy?.allow_implicit_invocation === false
-  })
-}
-
-// The one line a `SKILL.md` contributes to the codex catalog. Read from the
-// installed file, never held as a copy here, so a skill-tree bump carries into
-// the pointer at the next seed with nothing to synchronise.
-//
-// PARSED as YAML rather than matched with a regex, and the reason is a real bug
-// this caught: `implement` writes its description as a QUOTED scalar, so the
-// obvious `description:[ \t]*(.+)` capture returns the quotes too. Appending a
-// sentence to that produced `description: "..." Read ...`, which is invalid
-// YAML — and codex answers invalid frontmatter by dropping the skill from its
-// catalog IN SILENCE. The pointer existed on disk and reached no model.
-function skillDescription(cfgDir, name) {
-  let text
-  try {
-    text = fs.readFileSync(path.join(cfgDir, 'skills', name, 'SKILL.md'), 'utf8')
-  } catch {
-    return null
-  }
-  if (!text.startsWith('---')) return null
-  const end = text.indexOf('\n---', 3)
-  if (end === -1) return null
-  let front
-  try {
-    front = parseYaml(text.slice(3, end))
-  } catch {
-    return null
-  }
-  const description = front?.description
-  return typeof description === 'string' && description.trim() ? description.trim() : null
-}
-
-// A pointer per hidden skill, so the codex catalog names it again (#399).
-//
-// #360 closed every cheap way to re-arm a skill on codex: a second `$wayfinder`
-// adds an 11,867-character copy and keeps the first, and neither a tool result
-// nor `AGENTS.md` resolves a mention at all. What survives is the catalog — a
-// developer message, world state, restated every turn and never stale. The
-// operator rejected the obvious way in (flip `allow_implicit_invocation` in the
-// vendored manifest) on 2026-08-16: a patched vendored byte is brittle, and a
-// skill-tree update breaks it without a word.
-//
-// So curia writes a file it OWNS instead, beside the `standing.md` it already
-// writes here, and patches nothing. Measured on the pinned codex
-// (docs/live-checks/399): a listed skill costs about 270 characters per turn and
-// NEVER pastes its body. The 11,867 characters arrive only from a `$name` typed
-// by a user, which is why the codex spawn prompt no longer types one.
-//
-// Three properties make this stable rather than clever:
-//
-//   - The description is READ from the installed skill, so the trigger fires on
-//     the same tasks the real skill claims, and an upstream reword carries
-//     through at the next seed.
-//   - Hidden-ness is read from upstream's manifest, so upstream stays the
-//     authority on which skills need a pointer at all.
-//   - The name is `curia-<name>` and not `<name>`. Codex keys a skill on the
-//     name in its frontmatter, so a pointer claiming `wayfinder` would put two
-//     skills under one name — the ambiguity #224 measured, created on purpose.
-//     The prefix also says whose file it is to anyone reading the config dir.
-//
-// It is GENERATED per agent rather than committed to the tree, for the same
-// reason `standing.md` is: it names an absolute path that only exists once the
-// config dir does. And it is written from `seedConfigDir`, AFTER
-// `installSkills` — that call wipes `<cfgDir>/skills` on every re-arm, and a
-// pointer written anywhere else would vanish on the respawn a usage limit
-// forces. That is #340's `standing.md` trap, one directory over.
-export function writeSkillPointers(cfgDir, names) {
-  const written = []
-  for (const name of hiddenSkillNames(cfgDir, names)) {
-    const description = skillDescription(cfgDir, name)
-    if (!description) continue // a skill with no description contributes no catalog line to match on
-    const target = path.join(cfgDir, 'skills', name, 'SKILL.md')
-    const pointer = path.join(cfgDir, 'skills', `curia-${name}`)
-    fs.mkdirSync(pointer, { recursive: true })
-    // Both values are emitted as JSON strings, which are valid YAML
-    // double-quoted scalars. The description is upstream's prose and carries
-    // whatever upstream put in it — quotes, colons, em-dashes — and a
-    // hand-spliced line is how the `implement` pointer broke in silence.
-    fs.writeFileSync(path.join(pointer, 'SKILL.md'), [
-      '---',
-      `name: ${JSON.stringify(`curia-${name}`)}`,
-      `description: ${JSON.stringify(`${description} Read ${target} in full before you act on this.`)}`,
-      '---',
-      '',
-      `This is the \`${name}\` skill. Read \`${target}\` completely, then follow it.`,
-      '',
-      'Curia installed that file and it is the whole skill. This pointer exists because codex does',
-      'not list `' + name + '` in its own skill catalog, and it restates none of the skill itself.',
-      '',
-      // The read-once rule, and it is the whole reason this file is worth
-      // owning (#399). Codex tells the model to read a skill completely every
-      // time it uses one, and not to carry a skill across turns. A model that
-      // obeys both re-reads on every turn: measured at 12,299 characters per
-      // turn for wayfinder, which STACKS, so it is worse than the 11,867-char
-      // mention this replaced. Curia cannot edit codex's rule and it can write
-      // its own, in the one file upstream does not own.
-      `Read \`${target}\` ONCE in a session. If you have already read it, you are still running it,`,
-      'and reading it again only repeats what you have. Say that you are using this skill, then act.',
-      '',
-      'The curia standing orders win wherever the two disagree.',
-      '',
-    ].join('\n'))
-    written.push(`curia-${name}`)
-  }
-  return written
-}
-
-// The second skill root the codex harness reads, and the reason #171 exists.
-// CODEX_HOME does not bound skills: the pinned codex (0.146) reads
-// `$HOME/.agents/skills` unconditionally, beside `$CODEX_HOME/skills`
-// (source: core-skills root loader; measured with `codex debug prompt-input`
-// under a fresh CODEX_HOME — all 25 host skills appeared, the four #57
-// excludes among them, docs/live-checks/171). The claude harness has no such
-// root: the same isolated-config-dir check showed only the installed skill
-// plus Claude Code's own built-ins.
-function codexHostSkillsRoot() {
-  return path.join(os.homedir(), '.agents', 'skills')
-}
-
-// The names the host root would leak past the install list. Codex 0.146 has no
-// off switch for the root itself, so the bound is a per-name deny list in
-// config.toml, computed when the agent is armed. Canonicalisation makes the
-// name selector safe here: the installed nine are symlinks into the same host
-// tree, and a denied name is exactly a name the seed did not install.
-//
-// Computed at arm time, so a skill the operator adds to the host root DURING a
-// run leaks until the next arm. That race is accepted: the alternative is a
-// watcher on the operator's own skill tree.
-function codexSkillDenyList(install) {
-  const installed = new Set(install ?? [])
-  let entries = []
-  try {
-    entries = fs.readdirSync(codexHostSkillsRoot(), { withFileTypes: true })
-  } catch {
-    return []
-  }
-  return entries
-    .filter((e) => e.isDirectory() || e.isSymbolicLink())
-    .map((e) => e.name)
-    .filter((name) => !installed.has(name))
-    .sort()
 }
 
 // ---- the durable instruction channel (#340) ---------------------------------

--- a/daemon/test/harnesses.test.mjs
+++ b/daemon/test/harnesses.test.mjs
@@ -36,7 +36,7 @@ function fakeAdapter(name = 'fake', overrides = {}) {
       configLayoutVersion: 1,
     },
     setup: methods(['refuseRepository', 'prepare']),
-    lifecycle: methods(['freshCommand', 'resumeCommand', 'isReady', 'processDied', 'interrupt', 'send']),
+    lifecycle: methods(['freshCommand', 'resumeCommand', 'isReady', 'classifyLimit', 'processDied', 'interrupt', 'send']),
     evidence: methods(['discover', 'events', 'activity', 'usage']),
     control: {
       capabilities,
@@ -170,6 +170,65 @@ describe('Harness capabilities and durable identity', () => {
       ['send', 'curia-1', '/model opus'],
       ['key', 'curia-1', 'Enter'],
       ['key', 'curia-1', 'C-y'],
+    ])
+  })
+
+  test('the Codex adapter drives native behavior through fake ports', async () => {
+    const adapter = HARNESS_REGISTRY.get('codex')
+    const steps = []
+    const ports = createHarnessPorts({
+      filesystem: {
+        refuseRepository: (context) => ({ refused: context.wtPath }),
+        prepare: (context) => ({ prepared: context.cfgDir }),
+        nativeSkills: methods(['nativeSkills']).nativeSkills,
+      },
+      process: methods(['died', 'interrupt']),
+      pane: {
+        capture: methods(['capture']).capture,
+        send: methods(['send']).send,
+        key: (session, value) => { steps.push(['key', session, value]) },
+        kill: (session) => { steps.push(['kill', session]) },
+        resume: ({ session, model }) => { steps.push(['resume', session, model]) },
+        reasoningEffort: methods(['reasoningEffort']).reasoningEffort,
+      },
+      transcript: {
+        discover: methods(['discover']).discover,
+        events: methods(['events']).events,
+        activity: (context) => ({ file: context.cfgDir, mtimeMs: 2 }),
+        usage: methods(['usage']).usage,
+        richMetadata: methods(['richMetadata']).richMetadata,
+      },
+      toolChannel: methods(['enforceCompletion']),
+    })
+    const routing = {
+      models: { gpt: { id: 'gpt-5.6-sol' } },
+      harnesses: {
+        codex: {
+          template: 'codex --model {model} "$(cat {prompt_file})"',
+          resumeTemplate: 'codex resume --last --model {model}',
+        },
+      },
+    }
+
+    assert.equal(adapter.lifecycle.isReady({ paneText: 'gpt-5.6-sol high · ~/work' }), true)
+    assert.deepEqual(adapter.lifecycle.classifyLimit({ paneText: "You've hit your usage limit." }), {
+      scope: 'provider', resetAt: null,
+    })
+    assert.match(adapter.lifecycle.freshCommand({ routing, model: 'gpt', promptFile: '/cfg/prompt.md' }), /gpt-5\.6-sol/)
+    assert.match(adapter.lifecycle.resumeCommand({ routing, model: 'gpt' }), /resume --last/)
+    assert.deepEqual(adapter.setup.prepare({ cfgDir: '/cfg' }, ports), { prepared: '/cfg' })
+    assert.deepEqual(adapter.evidence.activity({ cfgDir: '/cfg' }, ports), { file: '/cfg', mtimeMs: 2 })
+    assert.equal(adapter.control.enforceCompletion({}, ports), 'enforceCompletion')
+    assert.deepEqual(
+      await requireHarnessCapability(adapter, 'modelSwitch', {
+        session: 'curia-2', model: 'gpt-5.5',
+      }, ports),
+      { status: 'switched', resumed: true, recorded: true },
+    )
+    assert.deepEqual(steps, [
+      ['key', 'curia-2', 'C-u'],
+      ['kill', 'curia-2'],
+      ['resume', 'curia-2', 'gpt-5.5'],
     ])
   })
 

--- a/docs/adr/0030-harness-adapters-compose-native-behavior.md
+++ b/docs/adr/0030-harness-adapters-compose-native-behavior.md
@@ -65,6 +65,18 @@ Implementation follows this order:
 4. Remove superseded private tables and central Harness branches.
 5. Add OpenCode, then Pi, only after the existing adapters pass automated and live checks.
 
+### Codex migration checks
+
+The Codex extraction moves native code without changing the pinned command-line interface or worker image. Run these recorded checks again before treating the migrated adapter as deployable:
+
+- Recheck container setup and credential delivery with [the Codex container check](../live-checks/158-codex-container.md) and [the credential replacement check](../live-checks/644-credential-swap-heals.md).
+- Recheck bounded skills and tools with [the skill-root check](../live-checks/171-codex-skill-roots.md), [the feature-table check](../live-checks/207-codex-feature-table.md), and [the skill-arming check](../live-checks/399-codex-skill-arming.md).
+- Recheck completion enforcement with [the Codex Stop-hook check](../live-checks/447-codex-stop-hook.md).
+- Recheck pane and rollout behavior with [the attach-surface check](../live-checks/176-codex-attach-surfaces.md), [the tool-channel check](../live-checks/194-tool-channel.md), and [the session-memory check](../live-checks/360-codex-session-memory.md).
+- Run the full-loop rehearsal from ADR-0029, including same-conversation resume and restart-based model switching.
+
+Automated fixtures guard the extracted byte shapes. These live checks still guard process boundaries, terminal geometry, credential reads, and conversation identity.
+
 ## Considered options
 
 - **One declarative row per Harness** was rejected because native lifecycle, completion, and recovery behavior are state machines, not configuration values.


### PR DESCRIPTION
## Summary

- move Codex identity, capability declarations, command rendering, readiness, provider-fault classification, configuration files, skill bounds, and rollout parsing into Codex-owned modules
- route restart-based model switching and provider-fault classification through the Harness adapter while shared services retain journal, cooling, claim, and worktree invariants
- preserve daemon-owned OpenAI credentials, in-place healing, Stop-hook completion, same-conversation resume, legacy configuration layouts, routed effort, and fallback behavior
- document the existing live checks that must be rerun for the migrated native surface

## Verification

- `npm test` in `daemon/`: 3,841 passed, 0 failed, 0 cancelled, 0 skipped
- focused Harness, workspace, transcript, routing, dispatch, stall, credential, and model-switch tests pass

Closes #833
