### PR TITLE
Make shared orchestration Harness-neutral

### DIFF
--- a/daemon/src/claudeharness.mjs
+++ b/daemon/src/claudeharness.mjs
@@ -1,4 +1,11 @@
 import { setTimeout as sleep } from 'node:timers/promises'
+import {
+  claudeTranscriptFiles,
+  claudeTranscriptForSession,
+  claudeTranscriptPresent,
+  parseClaudeTranscriptEvent,
+} from './claudetranscript.mjs'
+import { CLAUDE_WORKSPACE } from './claudeworkspace.mjs'
 
 const call = (ports, port, operation, ...args) => {
   const fn = ports?.[port]?.[operation]
@@ -14,6 +21,10 @@ export const CLAUDE_CAPABILITIES = Object.freeze({
   transcriptUsage: true,
   nativeSkills: true,
   richMetadata: true,
+})
+
+const CLAUDE_EFFORTS = Object.freeze({
+  low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max', ultra: 'ultracode',
 })
 
 const ready = (paneText) => {
@@ -54,6 +65,19 @@ async function switchModel({ session, model, readbackMs = 15_000 }, ports) {
   }
 }
 
+async function rewind({ session, target }, ports) {
+  for (const key of ['Escape', 'Escape', 'Up', 'Enter', 'Enter', 'C-c']) {
+    await call(ports, 'pane', 'key', session, key)
+  }
+  return {
+    landingId: target?.parentUuid ?? null,
+    remains: [
+      'Files restored with the conversation.',
+      'Shell side effects, Curia verbs, subagent edits, and commits stand.',
+    ],
+  }
+}
+
 export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeCommand, classifyLimit }) {
   return {
     identity: {
@@ -63,6 +87,7 @@ export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeComma
       configLayoutVersion: 1,
     },
     setup: {
+      workspace: CLAUDE_WORKSPACE,
       refuseRepository: (context, ports) => call(ports, 'filesystem', 'refuseRepository', context),
       prepare: (context, ports) => call(ports, 'filesystem', 'prepare', context),
     },
@@ -74,8 +99,20 @@ export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeComma
       processDied: (context, ports) => call(ports, 'process', 'died', context),
       interrupt: (context, ports) => call(ports, 'process', 'interrupt', context),
       send: (context, ports) => call(ports, 'pane', 'send', context),
+      strandedCallRecovery: () => false,
+      rewind,
     },
     evidence: {
+      native: Object.freeze({
+        files: claudeTranscriptFiles,
+        namesSession: claudeTranscriptForSession,
+        present: claudeTranscriptPresent,
+        parse: parseClaudeTranscriptEvent,
+        identity: (event) => event?.uuid
+          ? { id: String(event.uuid), parentId: event.parentUuid == null ? null : String(event.parentUuid) }
+          : null,
+        unknownType: (event) => String(event?.type),
+      }),
       discover: (context, ports) => call(ports, 'transcript', 'discover', context),
       events: (context, ports) => call(ports, 'transcript', 'events', context),
       activity: (context, ports) => call(ports, 'transcript', 'activity', context),
@@ -85,7 +122,7 @@ export function createClaudeHarnessAdapter({ buildFreshCommand, buildResumeComma
       capabilities: CLAUDE_CAPABILITIES,
       operations: {
         modelSwitch: switchModel,
-        reasoningEffort: (context, ports) => call(ports, 'pane', 'reasoningEffort', context),
+        reasoningEffort: (effort) => CLAUDE_EFFORTS[effort] ?? null,
         transcriptUsage: (context, ports) => call(ports, 'transcript', 'usage', context),
         nativeSkills: (context, ports) => call(ports, 'filesystem', 'nativeSkills', context),
         richMetadata: (context, ports) => call(ports, 'transcript', 'richMetadata', context),

--- a/daemon/src/claudeworkspace.mjs
+++ b/daemon/src/claudeworkspace.mjs
@@ -55,8 +55,21 @@ export function writeClaudeConnection({
 }
 
 export const CLAUDE_WORKSPACE = Object.freeze({
+  configRootEnv: CLAUDE_CONFIG_ROOT_ENV,
   memoryFile: CLAUDE_MEMORY_FILE,
   provider: 'anthropic',
+  repoSkillRoots: CLAUDE_REPO_SKILL_ROOTS,
+  untrustedProjectConfig: claudeUntrustedProjectConfig,
+  connectionWorktree: ({ hostWtPath }) => hostWtPath,
+  skillInvocation: ({ skill, skillTarget }) => (
+    skill ? `/${skill}${skillTarget ? ` ${skillTarget}` : ''}` : null
+  ),
+  wayfinderInvocation: ({ newMap, mapUrl, ticket, charting }) => {
+    if (newMap) return '/wayfinder'
+    if (!mapUrl) return null
+    return `/wayfinder ${mapUrl}${charting ? '' : ` ticket #${ticket}`}`
+  },
+  deferredToolOrders: () => [],
   hostStore: () => path.join(os.homedir(), '.claude'),
   env: (cfgDir, { sandboxed = false } = {}) => ({
     [CLAUDE_CONFIG_ROOT_ENV]: cfgDir,
@@ -107,6 +120,6 @@ export const CLAUDE_WORKSPACE = Object.freeze({
   },
 })
 
-export const claudeUntrustedProjectConfig = (wtPath) => (
-  path.join(wtPath, '.claude', 'settings.local.json')
-)
+export function claudeUntrustedProjectConfig(wtPath) {
+  return path.join(wtPath, '.claude', 'settings.local.json')
+}

--- a/daemon/src/codexharness.mjs
+++ b/daemon/src/codexharness.mjs
@@ -23,6 +23,10 @@ export const CODEX_CAPABILITIES = Object.freeze({
   richMetadata: true,
 })
 
+const CODEX_EFFORTS = Object.freeze({
+  low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max', ultra: 'ultra',
+})
+
 function command({ routing, model, promptFile = null, resume = false }) {
   const config = routing.harnesses?.codex
   if (!config) {
@@ -66,6 +70,19 @@ async function switchModel({ session, model }, ports) {
   return { status: 'switched', resumed: true, recorded: true }
 }
 
+async function rewind({ session }, ports) {
+  for (const key of ['Escape', 'Escape', 'Enter', 'C-u']) {
+    await call(ports, 'pane', 'key', session, key)
+  }
+  return {
+    landingId: null,
+    remains: [
+      'The tree stands. Only the conversation rewound.',
+      'Shell side effects, Curia verbs, subagent edits, and commits stand.',
+    ],
+  }
+}
+
 export function createCodexHarnessAdapter() {
   return {
     identity: {
@@ -75,6 +92,7 @@ export function createCodexHarnessAdapter() {
       configLayoutVersion: 1,
     },
     setup: {
+      workspace: CODEX_WORKSPACE,
       refuseRepository: (context, ports) => call(ports, 'filesystem', 'refuseRepository', context),
       prepare: (context, ports) => call(ports, 'filesystem', 'prepare', context),
     },
@@ -86,8 +104,20 @@ export function createCodexHarnessAdapter() {
       processDied: (context, ports) => call(ports, 'process', 'died', context),
       interrupt: (context, ports) => call(ports, 'process', 'interrupt', context),
       send: (context, ports) => call(ports, 'pane', 'send', context),
+      strandedCallRecovery: ({ spoken = false } = {}) => !spoken,
+      rewind,
     },
     evidence: {
+      native: Object.freeze({
+        files: codexTranscriptFiles,
+        namesSession: codexTranscriptForSession,
+        present: codexTranscriptPresent,
+        parse: parseCodexTranscriptEvent,
+        identity: () => null,
+        unknownType: (event) => event?.type === 'response_item'
+          ? `response_item/${event.payload?.type}`
+          : String(event?.type),
+      }),
       discover: (context, ports) => call(ports, 'transcript', 'discover', context),
       events: (context, ports) => call(ports, 'transcript', 'events', context),
       activity: (context, ports) => call(ports, 'transcript', 'activity', context),
@@ -97,7 +127,7 @@ export function createCodexHarnessAdapter() {
       capabilities: CODEX_CAPABILITIES,
       operations: {
         modelSwitch: switchModel,
-        reasoningEffort: (context, ports) => call(ports, 'pane', 'reasoningEffort', context),
+        reasoningEffort: (effort) => CODEX_EFFORTS[effort] ?? null,
         transcriptUsage: (context, ports) => call(ports, 'transcript', 'usage', context),
         nativeSkills: (context, ports) => call(ports, 'filesystem', 'nativeSkills', context),
         richMetadata: (context, ports) => call(ports, 'transcript', 'richMetadata', context),
@@ -106,3 +136,10 @@ export function createCodexHarnessAdapter() {
     },
   }
 }
+import {
+  codexTranscriptFiles,
+  codexTranscriptForSession,
+  codexTranscriptPresent,
+  parseCodexTranscriptEvent,
+} from './codextranscript.mjs'
+import { CODEX_WORKSPACE } from './codexworkspace.mjs'

--- a/daemon/src/codexworkspace.mjs
+++ b/daemon/src/codexworkspace.mjs
@@ -183,8 +183,22 @@ function writeConnectionSettings({
 }
 
 export const CODEX_WORKSPACE = Object.freeze({
+  configRootEnv: CODEX_CONFIG_ROOT_ENV,
   memoryFile: CODEX_MEMORY_FILE,
   provider: 'openai',
+  repoSkillRoots: CODEX_REPO_SKILL_ROOTS,
+  untrustedProjectConfig: codexUntrustedProjectConfig,
+  connectionWorktree: ({ wtPath }) => wtPath,
+  skillInvocation: ({ skill, skillTarget }) => (
+    skill ? `$${skill}${skillTarget ? ` ${skillTarget}` : ''}` : null
+  ),
+  wayfinderInvocation: () => null,
+  deferredToolOrders: () => [
+    '- **Load deferred Curia tools once.** If `ALL_TOOLS` holds Curia schemas, return every',
+    '  `mcp__curia__*` definition from one `exec` call before your first Curia call. Keep the output',
+    '  in context, and use the same definitions for every later Curia call.',
+    '',
+  ],
   skillPointers: writeCodexSkillPointers,
   hostStore: () => path.join(os.homedir(), '.codex'),
   env: (cfgDir) => ({ [CODEX_CONFIG_ROOT_ENV]: cfgDir }),
@@ -192,4 +206,6 @@ export const CODEX_WORKSPACE = Object.freeze({
   connectionSettings: writeConnectionSettings,
 })
 
-export const codexUntrustedProjectConfig = (wtPath) => path.join(wtPath, '.codex', 'hooks.json')
+export function codexUntrustedProjectConfig(wtPath) {
+  return path.join(wtPath, '.codex', 'hooks.json')
+}

--- a/daemon/src/config.mjs
+++ b/daemon/src/config.mjs
@@ -554,7 +554,7 @@ export function loadRoutingConfig(file, { localFile } = {}) {
       fail(src, `models.${name}.reasoning_effort must be one of ${REASONING_EFFORTS.join('|')} (got ${JSON.stringify(m.reasoning_effort)})`)
     }
     if (m.reasoning_effort !== undefined
-      && !harnessReasoningEffort(m.harness, m.reasoning_effort)) {
+      && !harnessReasoningEffort(m.harness, m.reasoning_effort, HARNESS_REGISTRY)) {
       fail(src, `models.${name}.reasoning_effort "${m.reasoning_effort}" is not supported by the ${m.harness} harness`)
     }
     // Optional (#146), and since #178 the LAST resort for the status line's
@@ -607,7 +607,7 @@ export function loadRoutingConfig(file, { localFile } = {}) {
       fail(src, `defaults.${type} names "${model}", which is \`active: false\` — either turn that model on or point this row at an active one`)
     }
     if (typeof route === 'object' && route.effort
-      && !harnessReasoningEffort(cfg.models[model].harness, route.effort)) {
+      && !harnessReasoningEffort(cfg.models[model].harness, route.effort, HARNESS_REGISTRY)) {
       fail(src, `defaults.${type}.effort "${route.effort}" is not supported by the ${cfg.models[model].harness} harness`)
     }
   }

--- a/daemon/src/conversationruntime.mjs
+++ b/daemon/src/conversationruntime.mjs
@@ -3,6 +3,8 @@
 
 import { readActiveTranscript } from './transcript.mjs'
 import { capturePane, paneShowsActiveTurn, sendKey, sendText } from './tmux.mjs'
+import { HARNESS_REGISTRY } from './harnesses.mjs'
+import { HarnessRuntime } from './harnessruntime.mjs'
 
 const defaultPane = {
   active: async (session) => paneShowsActiveTurn(await capturePane(session)),
@@ -42,11 +44,15 @@ function operatorTurns(read) {
 }
 
 export class ConversationRuntime {
-  constructor({ pane = defaultPane, reduction, reopenCard = null, prepare = async () => {} }) {
+  constructor({
+    pane = defaultPane, reduction, reopenCard = null, prepare = async () => {},
+    harnessRuntime = new HarnessRuntime(HARNESS_REGISTRY),
+  }) {
     this.pane = pane
     this.reduction = reduction
     this.reopenCard = reopenCard
     this.prepare = prepare
+    this.harnessRuntime = harnessRuntime
   }
 
   async takeBack({ session, role, harness, source, landing = null, target: requestedTarget = null }) {
@@ -70,12 +76,14 @@ export class ConversationRuntime {
     const previousWords = typedWords(previous.prompt.text, recorded)
     await this.prepare(session, role)
     if (await this.pane.active(session)) await this.pane.key(session, 'Escape')
-    await this.#rewind(session, harness)
+    const rewind = await this.harnessRuntime.rewind(harness, { session, target }, {
+      pane: { key: (targetSession, key) => this.pane.key(targetSession, key) },
+    })
 
-    if (harness === 'claude' && target.parentUuid) {
+    if (rewind.landingId) {
       this.reduction.journal('transcript_landed', {
         session,
-        landing_uuid: target.parentUuid,
+        landing_uuid: rewind.landingId,
         tail_uuid: read.headUuid,
       })
     }
@@ -83,15 +91,7 @@ export class ConversationRuntime {
     const receipt = {
       headline: 'Took back your last message.',
       landing: `The conversation continues after “${oneLine(previousWords)}”`,
-      remains: harness === 'claude'
-        ? [
-            'Files restored with the conversation.',
-            'Shell side effects, Curia verbs, subagent edits, and commits stand.',
-          ]
-        : [
-            'The tree stands. Only the conversation rewound.',
-            'Shell side effects, Curia verbs, subagent edits, and commits stand.',
-          ],
+      remains: [...rewind.remains],
     }
     if (requeued.length) {
       receipt.remains.push(`Returned ${requeued.length} unread note${requeued.length === 1 ? '' : 's'} to the queue.`)
@@ -101,7 +101,7 @@ export class ConversationRuntime {
       role,
       harness,
       text: targetWords,
-      landing_uuid: harness === 'claude' ? target.parentUuid : null,
+      landing_uuid: rewind.landingId,
       transcript_tail_uuid: read.headUuid ?? null,
       receipt,
     })
@@ -216,19 +216,4 @@ export class ConversationRuntime {
     return { ok: true, composer: record.answer, correction, receipt }
   }
 
-  async #rewind(session, harness) {
-    if (harness === 'claude') {
-      for (const key of ['Escape', 'Escape', 'Up', 'Enter', 'Enter', 'C-c']) {
-        await this.pane.key(session, key)
-      }
-      return
-    }
-    if (harness === 'codex') {
-      for (const key of ['Escape', 'Escape', 'Enter', 'C-u']) {
-        await this.pane.key(session, key)
-      }
-      return
-    }
-    throw new Error(`the ${harness} harness has no checked rewind flow`)
-  }
 }

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -29,7 +29,8 @@ import {
   carriesLimitPhrase, resolveReviewer, isActive, Cooling, SAME_PROVIDER_STAMP, namedModel,
   reasoningEffortFor, harnessReasoningEffort,
 } from './routing.mjs'
-import { HARNESS_REGISTRY, requireHarnessCapability, spawnIdentity } from './harnesses.mjs'
+import { HARNESS_REGISTRY, spawnIdentity } from './harnesses.mjs'
+import { HarnessRuntime } from './harnessruntime.mjs'
 import { hasSession, listSessions, newSession, capturePane, killSession, sendText, sendKey, paneShowsActiveTurn } from './tmux.mjs'
 import {
   createPrivateClone, removeWorkspace,
@@ -422,6 +423,7 @@ export class Dispatcher {
     this.config = config
     this.routing = routing
     this.harnesses = harnessRegistry ?? HARNESS_REGISTRY
+    this.harnessRuntime = new HarnessRuntime(this.harnesses)
     this.reduction = reduction
     this.notify = notify
     // The plain channel line, injected by index.mjs the way the backup's
@@ -1580,7 +1582,7 @@ export class Dispatcher {
     // always the model typed. `review` reads its harness the same way.
     const useModel = cands[0]
     const harnessName = this.routing.models[useModel].harness
-    const reasoningEffort = reasoningEffortFor(this.routing, labels, useModel)
+    const reasoningEffort = reasoningEffortFor(this.routing, labels, useModel, this.harnesses)
     if (!this.routing.harnesses[harnessName] || !this.harnesses.has(harnessName)) {
       return `❌ unknown harness \`${harnessName}\` — registered harnesses: ${this.harnesses.names.join(', ')}`
     }
@@ -1627,7 +1629,8 @@ export class Dispatcher {
     })
     action?.progress('Preparing the agent workspace')
 
-    const cfgDir = cfgDirFor(this.root, session, harnessName)
+    const adapter = this.harnesses.get(harnessName)
+    const cfgDir = cfgDirFor(this.root, session, adapter)
     // Declared outside the try so the finally can release the pending
     // reservation (#allocatePorts) on BOTH endings — after `agents.set` the
     // ports are covered by the live-agent scan, and on a failed dispatch
@@ -1669,6 +1672,7 @@ export class Dispatcher {
         // #173: the wayfinder invocation is spelled per harness, so the prompt
         // is no longer harness-blind.
         harness: harnessName,
+        adapter,
         // #374: every question a human has already answered on this session.
         // The session name is the key and it does not change across dispatches,
         // so a resumed agent reads the exchange its predecessor paid for. On a
@@ -1803,22 +1807,23 @@ export class Dispatcher {
     // stops being able to speak for this name the moment its successor is armed.
     const token = this.deps.mintAgentToken(this.dataDir, session)
     const adapter = this.harnesses.get(harness)
-    adapter.setup.prepare({
+    this.harnessRuntime.prepare(harness, {
       session, ticket, harness, model, wtPath, cfgDir, token,
       reasoningEffort: harnessReasoningEffort(harness,
-        reasoningEffort ?? this.routing.models[model].reasoning_effort ?? null),
+        reasoningEffort ?? this.routing.models[model].reasoning_effort ?? null, this.harnesses),
       skills: this.config.skills,
     }, {
       filesystem: {
         prepare: (context) => {
           this.deps.seedConfigDir(
-            context.cfgDir, GUEST_WT, context.skills, context.harness, { sandboxed: true },
+            context.cfgDir, GUEST_WT, context.skills, context.harness,
+            { sandboxed: true, adapter },
           )
           this.deps.writeConnectionSettings({
             wtPath: GUEST_WT, hostWtPath: context.wtPath, cfgDir: context.cfgDir,
             agent: context.session, ticket: context.ticket,
             daemonPort: this.daemonPort, daemonHost: GUEST_DAEMON_HOST, token: context.token,
-            harness: context.harness, reasoningEffort: context.reasoningEffort,
+            harness: context.harness, adapter, reasoningEffort: context.reasoningEffort,
             skills: context.skills,
           })
         },
@@ -1831,12 +1836,10 @@ export class Dispatcher {
   // `--env-file`, and a pane env would put every value of it in `ps` — the cost
   // #155 measured and asked #156 not to repeat.
   async #spawnPlan({ session, ticket, repo, harness, model, wtPath, cfgDir, promptFile, ports, reviewer = false, resume = false }) {
-    const adapter = this.harnesses.get(harness)
-    const harnessCmd = resume
-      ? adapter.lifecycle.resumeCommand({ routing: this.routing, model })
-      : adapter.lifecycle.freshCommand({
-          routing: this.routing, model, promptFile: path.join(GUEST_CFG, path.basename(promptFile)),
-        })
+    const harnessCmd = this.harnessRuntime.command(harness, {
+      routing: this.routing, model,
+      promptFile: path.join(GUEST_CFG, path.basename(promptFile)),
+    }, { resume })
     const container = await this.#prepareContainer({
       session, ticket, repo, harness, model, wtPath, cfgDir, spawnCmd: harnessCmd,
       sandbox: this.config.sandbox, ports, reviewer,
@@ -2091,11 +2094,12 @@ export class Dispatcher {
   // The CODEX lane is not here: `seedConfigDir` writes that copy, because it is
   // the same act as seeding `CODEX_HOME` and it carries the #351 expired-at-seed
   // refusal with it. One consumer, one delivery, and the contract says which.
-  #writeModelCredential(harness, cfgDir, ticket) {
-    if (CONSUMER_CREDENTIALS[harness]?.provider !== ANTHROPIC_PROVIDER) return null
+  #writeModelCredential(adapter, cfgDir, ticket) {
+    const consumer = adapter.identity.credentialConsumer
+    if (CONSUMER_CREDENTIALS[consumer]?.provider !== ANTHROPIC_PROVIDER) return null
     const record = this.anthropic?.read()
     if (!record) {
-      throw new Error(`refusing to start a claude agent for #${ticket}: curia owns no anthropic credential. ${this.anthropic
+      throw new Error(`refusing to start the ${adapter.identity.name} Harness for #${ticket}: curia owns no anthropic credential. ${this.anthropic
         ? 'Run reauth anthropic to sign in'
         : 'This daemon brokers no model credential'}. An agent handed no credential dies at its first turn with a claim already taken`)
     }
@@ -2559,9 +2563,9 @@ export class Dispatcher {
     // place of a silent death somewhere in the middle of a ticket. It also
     // refuses rather than falling back to `~/.claude` or to an API key — both
     // rungs left this ladder with the map's subscription-only decision.
-    this.#writeModelCredential(harness, cfgDir, ticket)
+    this.#writeModelCredential(this.harnesses.get(harness), cfgDir, ticket)
     const envFile = writeEnvFile(path.join(cfgDir, ENV_FILE), {
-      ...agentEnv(GUEST_CFG, harness, { sandboxed: true }),
+      ...agentEnv(GUEST_CFG, this.harnesses.get(harness), { sandboxed: true }),
       // The PATH to the credential above, and no credential in it (#389). It is
       // set here rather than inside `agentEnv`, because this is where the file
       // it names gets written.
@@ -2626,16 +2630,16 @@ export class Dispatcher {
     const wayOut = where === 'respawn'
       ? 'The harness this agent was dispatched on does not load it, and the fallback harness does. Remove the file from the repo, or dispatch the ticket again once a harness that does not load it is warm'
       : 'Remove the file from the repo, or dispatch on another harness if only one harness loads it (`/start <ticket> <model>`)'
-    const adapter = this.harnesses.get(harnessName)
-    const { planted, plants } = adapter.setup.refuseRepository({
+    const { planted, plants } = this.harnessRuntime.refuseRepository(harnessName, {
       wtPath, harness: harnessName, skills: this.config.skills?.install,
     }, {
       filesystem: {
         refuseRepository: ({ wtPath: target, harness, skills }) => {
-          const planted = untrustedProjectConfig(target, harness)
+          const targetAdapter = this.harnesses.get(harness)
+          const planted = untrustedProjectConfig(target, targetAdapter)
           return {
             planted,
-            plants: planted ? [] : plantedSkills(target, harness, skills),
+            plants: planted ? [] : plantedSkills(target, targetAdapter, skills),
           }
         },
       },
@@ -2942,13 +2946,14 @@ export class Dispatcher {
   // made and leaves the builder untouched, because the cross-check owns nothing
   // the ticket depends on.
   async #spawnReviewer({ session, ticket, repo, issue, model, builderModel, harnessName, sameProvider, by, tellBuilder = true }) {
-    const cfgDir = cfgDirFor(this.root, session, harnessName)
+    const adapter = this.harnesses.get(harnessName)
+    const cfgDir = cfgDirFor(this.root, session, adapter)
     let checkout = null
     try {
       checkout = await this.deps.createReviewCheckout(this.root, repo, ticket)
       this.#assertNoPlantedConfig(checkout.path, harnessName)
       const labels = (issue.labels ?? []).map((label) => typeof label === 'string' ? label : label.name)
-      const reasoningEffort = reasoningEffortFor(this.routing, labels, model)
+      const reasoningEffort = reasoningEffortFor(this.routing, labels, model, this.harnesses)
       this.#armAgent({ session, ticket, harness: harnessName, model, reasoningEffort, wtPath: checkout.path, cfgDir })
       // No published ports: a reviewer starts no dev server, and
       // `publish_preview` is one of the four tools curia refuses it. Three
@@ -2958,6 +2963,7 @@ export class Dispatcher {
         sha: checkout.sha, model: spawnModelId(this.routing, model),
         builderModel: spawnModelId(this.routing, builderModel),
         harness: harnessName,
+        adapter,
       })
       fs.rmSync(path.join(this.dataDir, 'results', `${session}.json`), { force: true })
 
@@ -3204,8 +3210,7 @@ export class Dispatcher {
   // until the composer appears. stallSweep keeps polling after that contract
   // ends, so a later account fault reaches the same handler and cooling store.
   async #classifyPaneLimit(agent, pane, { postReady = false } = {}) {
-    const adapter = this.harnesses.get(agent.harness)
-    const limit = adapter.lifecycle.classifyLimit({ paneText: pane })
+    const limit = this.harnessRuntime.classifyLimit(agent.harness, { paneText: pane })
     if (!limit) return 'none'
     if (agent.promptCarriesLimitText) {
       // The ticket's own text can produce this match. Veto readiness and every
@@ -3240,8 +3245,7 @@ export class Dispatcher {
   async #watchdog(agent) {
     // Resolved once, and loudly: readiness that silently never matches is #33's
     // live-only defect, and its whole symptom was silence.
-    const adapter = this.harnesses.get(agent.harness)
-    const isReady = (paneText) => adapter.lifecycle.isReady({ paneText, routing: this.routing })
+    const isReady = (paneText) => this.harnessRuntime.isReady(agent.harness, { paneText, routing: this.routing })
     const deadline = Date.now() + this.config.dispatch.ready_timeout_s * 1000
     while (Date.now() < deadline) {
       await sleep(2000)
@@ -3605,6 +3609,7 @@ export class Dispatcher {
   // about when it matters.
   async #respawnOn(agent, next, journalData = {}, { freshPorts = false, resume = false } = {}) {
     const nextHarness = this.routing.models[next].harness
+    this.harnessRuntime.fallback({ from: agent.harness, to: nextHarness, resume })
     // A provider change cannot resume the old harness conversation. The cold
     // successor gets the warm private clone and an explicit statement of what
     // handoff preserves. This loss of reasoning context is the accepted cost.
@@ -3650,8 +3655,9 @@ export class Dispatcher {
     const allocated = !agent.reviewer && (freshPorts || !agent.ports)
     const ports = agent.reviewer ? [] : (allocated ? await this.#allocatePorts() : agent.ports)
     try {
-      const reasoningEffort = reasoningEffortFor(this.routing, agent.labels ?? [], next)
-      agent.cfgDir = cfgDirFor(this.root, agent.session, nextHarness)
+      const nextAdapter = this.harnesses.get(nextHarness)
+      const reasoningEffort = reasoningEffortFor(this.routing, agent.labels ?? [], next, this.harnesses)
+      agent.cfgDir = cfgDirFor(this.root, agent.session, nextAdapter)
       this.#armAgent({
         session: agent.session, ticket: agent.ticket, harness: nextHarness,
         model: next, reasoningEffort, wtPath: agent.wtPath, cfgDir: agent.cfgDir,
@@ -3768,6 +3774,8 @@ export class Dispatcher {
         sha: agent.sha,
         model: spawnModelId(this.routing, agent.model),
         builderModel: spawnModelId(this.routing, agent.builderModel),
+        harness: nextHarness,
+        adapter: this.harnesses.get(nextHarness),
       })
       agent.promptHarness = nextHarness
       return
@@ -3785,6 +3793,7 @@ export class Dispatcher {
       prototypeVariations: this.config.dispatch.prototype_variations,
       ports,
       harness: nextHarness,
+      adapter: this.harnesses.get(nextHarness),
       handoff,
       // #374: a fallback respawn rewrites the prompt, so it rewrites the
       // exchange with it. Without this the agent that crossed harnesses would
@@ -5109,6 +5118,20 @@ export class Dispatcher {
   }
 
   async onStopHook(agentName, { stopHookActive = false } = {}) {
+    const agent = this.agents.get(agentName)
+    if (!agent?.harness) return this.#enforceCompletion(agentName, { stopHookActive })
+    return this.harnessRuntime.enforceCompletion(agent.harness, {
+      agentName, stopHookActive,
+    }, {
+      toolChannel: {
+        enforceCompletion: ({ agentName: name, stopHookActive: active }) => (
+          this.#enforceCompletion(name, { stopHookActive: active })
+        ),
+      },
+    })
+  }
+
+  async #enforceCompletion(agentName, { stopHookActive = false } = {}) {
     // #194's backstop, FIRST and before the nudge. An agent that got here having
     // never sent an `/mcp` request has no way to satisfy any item of the ending
     // — `open_pull_request`, `request_review` and `report_result` are all curia
@@ -6426,10 +6449,10 @@ export class Dispatcher {
       if (seen.has(record.agent)) continue
       if (record.awaited !== true || hasResolver(record.id)) continue
       const w = this.agents.get(record.agent)
-      if (!w || w.harness !== 'codex' || w.mcpLastAt) continue
+      if (!w || !this.harnessRuntime.needsStrandedCallRecovery(w.harness, { spoken: Boolean(w.mcpLastAt) })) continue
       seen.add(record.agent)
       stranded.push({
-        agent: record.agent, ticket: w.ticket ?? String(record.ticket), id: record.id,
+        agent: record.agent, ticket: w.ticket ?? String(record.ticket), id: record.id, harness: w.harness,
         text: paneGoodbye({ id: record.id }),
       })
     }
@@ -6442,10 +6465,10 @@ export class Dispatcher {
       // are cheap.
       if (this.reviewWaits.has(String(park.ticket))) continue
       const w = this.agents.get(park.agent)
-      if (!w || w.harness !== 'codex' || w.mcpLastAt) continue
+      if (!w || !this.harnessRuntime.needsStrandedCallRecovery(w.harness, { spoken: Boolean(w.mcpLastAt) })) continue
       seen.add(park.agent)
       stranded.push({
-        agent: park.agent, ticket: w.ticket ?? park.ticket, on: park.on,
+        agent: park.agent, ticket: w.ticket ?? park.ticket, on: park.on, harness: w.harness,
         text: parkPaneGoodbye(park),
       })
     }
@@ -6454,10 +6477,10 @@ export class Dispatcher {
       parked: stranded.filter((s) => s.on).map((s) => s.agent),
     })
     if (!stranded.length) {
-      this.log('boot sweep: the last daemon died with no last word, and no codex agent was left parked')
+      this.log('boot sweep: the last daemon died with no last word, and no Harness needed parked-call recovery')
       return { swept: [] }
     }
-    this.log(`boot sweep: ${stranded.length} parked codex agent(s) — ${stranded.map((s) => s.agent).join(', ')}`)
+    this.log(`boot sweep: ${stranded.length} parked agent(s) need Harness recovery - ${stranded.map((s) => s.agent).join(', ')}`)
     // Concurrent because the panes are independent, and `sendText` queues per
     // pane (#223) — so the two writes of one agent stay in order whatever else
     // is being written elsewhere.
@@ -6485,7 +6508,7 @@ export class Dispatcher {
   // `on` is set for a builder parked on a verdict and null for an open record,
   // and the two say different things: one question is still open and unanswered,
   // and the other has no question at all — a verdict waits instead.
-  async #wakeStrandedPane({ id = null, on = null, agent, ticket, text }) {
+  async #wakeStrandedPane({ id = null, on = null, agent, ticket, text, harness }) {
     const held = on === 'ending' ? '`report_result`' : '`request_review`'
     try {
       await this.deps.sendKey(agent, 'Escape')
@@ -6507,8 +6530,8 @@ export class Dispatcher {
     }
     this.reduction.journal('pane_sweep_delivered', { agent, ticket, id, on })
     this.notify(ticket, on
-      ? `⚠️ curia died with no last word, and \`${agent}\` was left parked on a cross-check verdict with no way to be told. Curia pressed Escape in its pane and typed the news, so that codex agent calls ${held} again by itself. Nothing was approved and nothing was rejected, and curia still holds the verdict.`
-      : `⚠️ curia died with no last word, and \`${agent}\` was left parked inside **${id}** with no way to be told. Curia pressed Escape in its pane and typed the news, so that codex agent asks the same question again by itself. Nothing was answered, and the card stands.`)
+      ? `⚠️ curia died with no last word, and \`${agent}\` was left parked on a cross-check verdict with no way to be told. Curia pressed Escape in its pane and typed the news, so that ${harness} agent calls ${held} again by itself. Nothing was approved and nothing was rejected, and curia still holds the verdict.`
+      : `⚠️ curia died with no last word, and \`${agent}\` was left parked inside **${id}** with no way to be told. Curia pressed Escape in its pane and typed the news, so that ${harness} agent asks the same question again by itself. Nothing was answered, and the card stands.`)
     return true
   }
 
@@ -6747,7 +6770,7 @@ export class Dispatcher {
     const previousRequested = agent.requestedModel
     let verdict
     try {
-      verdict = await requireHarnessCapability(adapter, 'modelSwitch', {
+      verdict = await this.harnessRuntime.control(adapter.identity.name, 'modelSwitch', {
         session, model: id, readbackMs: this.switchReadbackMs,
       }, {
         pane: {
@@ -7108,8 +7131,7 @@ export class Dispatcher {
 
       let activity
       try {
-        const adapter = this.harnesses.get(w.harness)
-        activity = adapter.evidence.activity({ harness: w.harness, cfgDir: w.cfgDir }, {
+        activity = this.harnessRuntime.activity(w.harness, { harness: w.harness, cfgDir: w.cfgDir }, {
           transcript: {
             activity: ({ harness, cfgDir }) => this.deps.transcriptActivity(harness, cfgDir),
           },
@@ -7121,8 +7143,7 @@ export class Dispatcher {
       const lastGrowth = Math.max(activity.mtimeMs, w.readyAt ?? 0, w.spawnedAt ?? 0)
       if (Date.now() - lastGrowth < this.stallTimeoutMs) continue
 
-      const adapter = this.harnesses.get(w.harness)
-      const isReady = (paneText) => adapter.lifecycle.isReady({ paneText, routing: this.routing })
+      const isReady = (paneText) => this.harnessRuntime.isReady(w.harness, { paneText, routing: this.routing })
       if (!paneConfirmsStall(pane, isReady)) continue
       if (this.agents.get(w.session) !== w || w.state !== 'ready') continue
 

--- a/daemon/src/harnesses.mjs
+++ b/daemon/src/harnesses.mjs
@@ -3,10 +3,13 @@
 // Claude and Codex own their native behavior behind this seam. Shared services
 // select an adapter and provide the ports that retain Curia's invariants.
 
-import { buildResumeCmd, buildSpawnCmd, parseCreditGate, parseUsageLimit } from './routing.mjs'
+import {
+  buildResumeCmd, buildSpawnCmd, parseCreditGate, parseUsageLimit, setRoutingHarnessRegistry,
+} from './routing.mjs'
 import { CONSUMER_NAMES, PROVIDER_CREDENTIALS } from './credentials.mjs'
 import { createClaudeHarnessAdapter } from './claudeharness.mjs'
 import { createCodexHarnessAdapter } from './codexharness.mjs'
+import { setTranscriptHarnessRegistry } from './transcript.mjs'
 
 export const HARNESS_FACETS = Object.freeze([
   'identity',
@@ -105,10 +108,27 @@ export function validateHarnessAdapter(adapter, {
   }
 
   for (const method of ['refuseRepository', 'prepare']) requireFunction('setup', setup, method)
-  for (const method of ['freshCommand', 'resumeCommand', 'isReady', 'classifyLimit', 'processDied', 'interrupt', 'send']) {
+  if (!plainObject(setup.workspace)) contractFault(`Harness ${identity.name} setup needs a workspace implementation`)
+  for (const method of [
+    'hostStore', 'env', 'seed', 'connectionSettings', 'connectionWorktree',
+    'untrustedProjectConfig', 'skillInvocation', 'wayfinderInvocation', 'deferredToolOrders',
+  ]) requireFunction('setup.workspace', setup.workspace, method)
+  for (const field of ['configRootEnv', 'memoryFile']) {
+    if (typeof setup.workspace[field] !== 'string' || !setup.workspace[field]) {
+      contractFault(`Harness ${identity.name} workspace needs a non-empty ${field}`)
+    }
+  }
+  if (!Array.isArray(setup.workspace.repoSkillRoots)) {
+    contractFault(`Harness ${identity.name} workspace needs repoSkillRoots`)
+  }
+  for (const method of ['freshCommand', 'resumeCommand', 'isReady', 'classifyLimit', 'processDied', 'interrupt', 'send', 'strandedCallRecovery', 'rewind']) {
     requireFunction('lifecycle', lifecycle, method)
   }
   for (const method of ['discover', 'events', 'activity', 'usage']) requireFunction('evidence', evidence, method)
+  if (!plainObject(evidence.native)) contractFault(`Harness ${identity.name} evidence needs a native transcript implementation`)
+  for (const method of ['files', 'namesSession', 'present', 'parse', 'identity', 'unknownType']) {
+    requireFunction('evidence.native', evidence.native, method)
+  }
   requireFunction('control', control, 'enforceCompletion')
 
   if (!plainObject(control.capabilities)) contractFault(`Harness ${identity.name} control needs capabilities`)
@@ -258,3 +278,6 @@ export const HARNESS_REGISTRY = createHarnessRegistry([
   providers: Object.keys(PROVIDER_CREDENTIALS),
   credentialConsumers: CONSUMER_NAMES,
 })
+
+setTranscriptHarnessRegistry(HARNESS_REGISTRY)
+setRoutingHarnessRegistry(HARNESS_REGISTRY)

--- a/daemon/src/harnessruntime.mjs
+++ b/daemon/src/harnessruntime.mjs
@@ -1,0 +1,75 @@
+import { requireHarnessCapability } from './harnesses.mjs'
+
+// Shared orchestration crosses this interface. Native commands, evidence, and
+// controls remain inside the selected adapter. Durable state and worktrees stay
+// with the caller.
+export class HarnessRuntime {
+  constructor(registry) {
+    this.registry = registry
+  }
+
+  adapter(name) {
+    return this.registry.get(name)
+  }
+
+  identity(name) {
+    return this.adapter(name).identity
+  }
+
+  prepare(name, context, ports) {
+    return this.adapter(name).setup.prepare(context, ports)
+  }
+
+  refuseRepository(name, context, ports) {
+    return this.adapter(name).setup.refuseRepository(context, ports)
+  }
+
+  command(name, context, { resume = false } = {}) {
+    const lifecycle = this.adapter(name).lifecycle
+    return resume ? lifecycle.resumeCommand(context) : lifecycle.freshCommand(context)
+  }
+
+  isReady(name, context) {
+    return this.adapter(name).lifecycle.isReady(context)
+  }
+
+  classifyLimit(name, context) {
+    return this.adapter(name).lifecycle.classifyLimit(context)
+  }
+
+  needsStrandedCallRecovery(name, context = {}) {
+    return this.adapter(name).lifecycle.strandedCallRecovery(context)
+  }
+
+  rewind(name, context, ports) {
+    return this.adapter(name).lifecycle.rewind(context, ports)
+  }
+
+  activity(name, context, ports) {
+    return this.adapter(name).evidence.activity(context, ports)
+  }
+
+  events(name, context, ports) {
+    return this.adapter(name).evidence.events(context, ports)
+  }
+
+  control(name, capability, ...args) {
+    return requireHarnessCapability(this.adapter(name), capability, ...args)
+  }
+
+  enforceCompletion(name, context, ports) {
+    return this.adapter(name).control.enforceCompletion(context, ports)
+  }
+
+  fallback({ from, to, resume = false }) {
+    const crossHarness = from !== to
+    if (crossHarness && resume) {
+      throw new Error(`refusing to resume native ${from} conversation state on the ${to} Harness`)
+    }
+    return Object.freeze({
+      crossHarness,
+      preserveWorktree: true,
+      reuseNativeConversation: !crossHarness && resume,
+    })
+  }
+}

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -809,9 +809,12 @@ function handOffAnswer(record) {
   // agent having reached this daemon process. The composer and the whole reason
   // live in messaging.mjs.
   const w = dispatcher.agents.get(record.agent)
+  const strandedCall = Boolean(w) && dispatcher.harnessRuntime.needsStrandedCallRecovery(
+    w.harness, { spoken: Boolean(w.mcpLastAt) },
+  )
   notifyThread(record.ticket, handOffLine({
     agent: record.agent, ticket: record.ticket, harness: w?.harness ?? null,
-    live: Boolean(w), spoken: Boolean(w?.mcpLastAt),
+    live: Boolean(w), spoken: Boolean(w?.mcpLastAt), strandedCall,
   }))
   log(`escalation ${record.id} answered with no live receiver — hand-off note queued for ${record.agent}`)
 }

--- a/daemon/src/messaging.mjs
+++ b/daemon/src/messaging.mjs
@@ -330,11 +330,14 @@ export function failureProse(raw) {
 //
 // An unknown harness takes the working line. That is the default lane, and a
 // session adopted from before the harness was recorded is a claude one.
-export function handOffLine({ agent, ticket, harness = null, live = false, spoken = false }) {
+export function handOffLine({
+  agent, ticket, harness = null, live = false, spoken = false, strandedCall = false,
+}) {
   if (!live) return `${SIGNALS.ok} recorded — \`${agent}\` is not running; \`resume ${ticket}\` hands it over`
-  if (harness === 'codex' && !spoken) {
+  if (strandedCall) {
+    const harnessName = harness ?? 'Harness'
     return `${SIGNALS.warn} recorded, and \`${agent}\` did not get it.`
-      + ' That codex agent has not spoken since this daemon started, so its own call died with no last word.'
+      + ` That ${harnessName} agent has not spoken since this daemon started, so its own call died with no last word.`
       + ' It is parked, and it reads nothing until that call times out, a day out.'
       + ` To hand this answer over: \`cancel ${ticket}\`, then \`resume ${ticket}\`.`
   }

--- a/daemon/src/routing.mjs
+++ b/daemon/src/routing.mjs
@@ -2,6 +2,12 @@
 // fallback candidates, spawn-command build, usage-limit parse.
 
 import { CODEX_CREDIT_GATE_RE, CODEX_LIMIT_RE } from './codexharness.mjs'
+
+let defaultHarnessRegistry = null
+
+export function setRoutingHarnessRegistry(registry) {
+  defaultHarnessRegistry = registry
+}
 //
 // Two providers since #39, which is what #13 asked for and what #33 deferred.
 // The shapes that were already here for one provider now carry real weight: a
@@ -11,18 +17,16 @@ import { CODEX_CREDIT_GATE_RE, CODEX_LIMIT_RE } from './codexharness.mjs'
 
 export const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
 
-const HARNESS_EFFORTS = {
-  claude: { low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max', ultra: 'ultracode' },
-  codex: { low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max', ultra: 'ultra' },
-  opencode: { low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max', ultra: 'ultra' },
-  pi: { low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max' },
-}
-
 // The CLI-facing spelling, or null when this harness cannot state the effort.
 // Claude's ultracode mode is the measured spelling of the shared ultra tier.
-export function harnessReasoningEffort(harness, effort) {
+export function harnessReasoningEffort(harness, effort, registry = defaultHarnessRegistry) {
   if (!effort) return null
-  return HARNESS_EFFORTS[harness]?.[effort] ?? null
+  let adapter = harness?.identity ? harness : null
+  if (!adapter && registry) {
+    try { adapter = registry.get(harness) } catch { return null }
+  }
+  if (adapter?.control?.capabilities?.reasoningEffort !== true) return null
+  return adapter.control.operations.reasoningEffort(effort)
 }
 
 const defaultRoute = (routing, type) => {
@@ -47,7 +51,7 @@ export function resolveModel(routing, labels, override) {
 // The effort belongs to the ticket type, not to its default model. A model
 // label changes the model without erasing the type's cost and depth choice.
 // The model default remains the answer when the type states no override.
-export function reasoningEffortFor(routing, labels, model) {
+export function reasoningEffortFor(routing, labels, model, registry = defaultHarnessRegistry) {
   let route = null
   for (const label of labels ?? []) {
     if (!label.startsWith('wayfinder:')) continue
@@ -58,8 +62,8 @@ export function reasoningEffortFor(routing, labels, model) {
   const harness = routing.models?.[model]?.harness
   const modelDefault = routing.models?.[model]?.reasoning_effort ?? null
   const wanted = route?.effort ?? modelDefault
-  if (harnessReasoningEffort(harness, wanted)) return wanted
-  return harnessReasoningEffort(harness, modelDefault) ? modelDefault : null
+  if (harnessReasoningEffort(harness, wanted, registry)) return wanted
+  return harnessReasoningEffort(harness, modelDefault, registry) ? modelDefault : null
 }
 
 // The model a HUMAN named, or null when routing picked it from the type table

--- a/daemon/src/transcript.mjs
+++ b/daemon/src/transcript.mjs
@@ -27,20 +27,23 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import {
-  claudeTranscriptFiles,
-  claudeTranscriptForSession,
-  claudeTranscriptPresent,
-  parseClaudeTranscriptEvent,
-} from './claudetranscript.mjs'
-import {
-  codexTranscriptFiles,
-  codexTranscriptForSession,
-  codexTranscriptPresent,
-  parseCodexTranscriptEvent,
-} from './codextranscript.mjs'
+let defaultRegistry = null
 
-export const TRANSCRIPT_HARNESSES = ['claude', 'codex']
+export function setTranscriptHarnessRegistry(registry) {
+  defaultRegistry = registry
+}
+
+function adapterFor(candidate, registry = defaultRegistry) {
+  if (!registry) throw new Error('the Harness transcript registry is not initialized')
+  return candidate?.identity ? candidate : registry.get(candidate)
+}
+
+function nativeFor(candidate, registry = defaultRegistry) {
+  const adapter = adapterFor(candidate, registry)
+  const native = adapter.evidence.native
+  if (!native) throw new Error(`Harness "${adapter.identity.name}" has no transcript implementation`)
+  return native
+}
 
 // Which harness wrote this config dir, by positive on-disk evidence: the claude
 // harness creates `projects/`, codex's creates `sessions/`. Null when
@@ -48,9 +51,10 @@ export const TRANSCRIPT_HARNESSES = ['claude', 'codex']
 // never a guess. The dispatcher's own agent record wins over this probe when
 // it has one (it knows what it spawned); this is the fallback for re-adopted
 // and lab sessions.
-export function detectHarness(cfgDir) {
-  if (claudeTranscriptPresent(cfgDir)) return 'claude'
-  if (codexTranscriptPresent(cfgDir)) return 'codex'
+export function detectHarness(cfgDir, registry = defaultRegistry) {
+  for (const adapter of registry.values()) {
+    if (nativeFor(adapter, registry).present(cfgDir)) return adapter.identity.name
+  }
   return null
 }
 
@@ -71,19 +75,12 @@ function newestFile(files) {
 // A spawned codex subagent writes a second rollout into its parent's config
 // directory. Its first line identifies it, so it must not win the parent's
 // newest-file lookup while the parent waits (#544, #545).
-const FILES = { claude: claudeTranscriptFiles, codex: codexTranscriptFiles }
-
 // What each harness NAMES a session's transcript. The claude harness names the
 // file after the session id — measured on the box (docs/live-checks/
 // 332-transcript-by-key.md). The codex harness puts the rollout's start time in
 // front of it, which is read off the name shape this module already walks
 // rather than measured: no codex conversation is keyed today, because the
 // overseer is the one thing curia keys and it runs the claude harness.
-const NAMES_SESSION = {
-  claude: claudeTranscriptForSession,
-  codex: codexTranscriptForSession,
-}
-
 // The newest root transcript in a config dir, by mtime.
 //
 // This answers for a PANE. Curia gives every root agent its own config dir, so
@@ -93,7 +90,7 @@ const NAMES_SESSION = {
 // A dir that holds many CONVERSATIONS breaks that precondition — use
 // transcriptForSession there.
 export function findTranscript(harness, cfgDir) {
-  return newestFile(FILES[harness]?.(cfgDir) ?? [])
+  return newestFile(nativeFor(harness).files(cfgDir))
 }
 
 // The newest root transcript's last filesystem change. The stall watchdog
@@ -124,9 +121,11 @@ export function transcriptActivity(harness, cfgDir) {
 // An empty screen is the honest answer to both. The last conversation's words
 // are not a fallback, they are the defect.
 export function transcriptForSession(harness, cfgDir, sessionId) {
-  const names = NAMES_SESSION[harness]
+  let native
+  try { native = nativeFor(harness) } catch { return null }
+  const names = native.namesSession
   if (!names || !sessionId) return null
-  for (const p of FILES[harness](cfgDir)) {
+  for (const p of native.files(cfgDir)) {
     if (names(path.basename(p), sessionId)) return p
   }
   return null
@@ -150,7 +149,8 @@ export function transcriptForSession(harness, cfgDir, sessionId) {
 // bounded read is the expected case, not evidence of anything.
 const LABEL_BYTES = 128 * 1024
 export function firstPrompt(harness, file, { max = 90, bytes = LABEL_BYTES } = {}) {
-  if (!harness || !file || !READERS[harness]) return null
+  if (!harness || !file) return null
+  try { nativeFor(harness) } catch { return null }
   let head
   try {
     const fd = fs.openSync(file, 'r')
@@ -179,13 +179,12 @@ export function firstPrompt(harness, file, { max = 90, bytes = LABEL_BYTES } = {
   return null
 }
 
-const READERS = { claude: parseClaudeTranscriptEvent, codex: parseCodexTranscriptEvent }
-
 // Read the messages that the Chat surface can render from transcript lines.
 // The branch selection lives here so agent and overseer conversations don't
 // grow separate transcript rules. The caller keeps filesystem and journal
 // access: this module receives the journaled landing identity as plain data.
 export function readActiveMessages(harness, lines, { landingUuid = null } = {}) {
+  const native = nativeFor(harness)
   const items = []
   const failures = []
   const byUuid = new Map()
@@ -211,8 +210,10 @@ export function readActiveMessages(harness, lines, { landingUuid = null } = {}) 
     }
     const record = { event, parsed }
     records.push(record)
-    if (!event?.uuid) continue
-    byUuid.set(event.uuid, record)
+    const identity = native.identity(event)
+    if (!identity) continue
+    record.identity = identity
+    byUuid.set(identity.id, record)
     tail = record
   }
 
@@ -231,15 +232,15 @@ export function readActiveMessages(harness, lines, { landingUuid = null } = {}) 
   if (tail) {
     activeRecords = []
     const seen = new Set()
-    for (let record = tail; record; record = record.event.parentUuid ? byUuid.get(record.event.parentUuid) : null) {
-      if (seen.has(record.event.uuid)) {
+    for (let record = tail; record; record = record.identity.parentId ? byUuid.get(record.identity.parentId) : null) {
+      if (seen.has(record.identity.id)) {
         failures.push({
-          key: `cycle:${record.event.uuid}`,
-          reason: `transcript parent cycle at "${record.event.uuid}"`,
+          key: `cycle:${record.identity.id}`,
+          reason: `transcript parent cycle at "${record.identity.id}"`,
         })
         return { items, failures }
       }
-      seen.add(record.event.uuid)
+      seen.add(record.identity.id)
       activeRecords.push(record)
     }
     activeRecords.reverse()
@@ -252,12 +253,11 @@ export function readActiveMessages(harness, lines, { landingUuid = null } = {}) 
 }
 
 function parseEvent(harness, event) {
-  const reader = READERS[harness]
-  if (!reader) throw new Error(`no transcript reader for harness "${harness}"`)
+  const native = nativeFor(harness)
   if (!event || typeof event !== 'object') return { malformed: true }
-  const items = reader(event)
+  const items = native.parse(event)
   if (items === null) {
-    return { unknown: harness === 'codex' && event.type === 'response_item' ? `response_item/${event.payload?.type}` : String(event.type) }
+    return { unknown: native.unknownType(event) }
   }
   return { items }
 }
@@ -272,14 +272,13 @@ function parseEvent(harness, event) {
 // the abandoned branch, so the journaled landing is the temporary head.
 // Harnesses without parent identity retain their linear transcript behavior.
 export function readActiveTranscript(harness, source, { landingUuid = null, landingTailUuid = null } = {}) {
+  const native = nativeFor(harness)
   const lines = Array.isArray(source)
     ? source.map(String)
     : String(source ?? '').split('\n')
   const records = lines
     .map((line, index) => ({ line, index }))
     .filter((record) => record.line.trim())
-
-  if (harness !== 'claude') return parseActiveRecords(harness, records, null)
 
   const byUuid = new Map()
   let tailUuid = null
@@ -289,12 +288,15 @@ export function readActiveTranscript(harness, source, { landingUuid = null, land
     } catch {
       continue
     }
-    if (!record.event?.uuid) continue
-    record.uuid = String(record.event.uuid)
-    record.parentUuid = record.event.parentUuid == null ? null : String(record.event.parentUuid)
+    const identity = native.identity(record.event)
+    if (!identity) continue
+    record.uuid = identity.id
+    record.parentUuid = identity.parentId
     byUuid.set(record.uuid, record)
     tailUuid = record.uuid
   }
+
+  if (!tailUuid) return parseActiveRecords(harness, records, null)
 
   const landingStillCurrent = landingUuid
     && (!landingTailUuid || String(landingTailUuid) === tailUuid)

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -10,10 +10,8 @@
 // and the worktrees cut from it were the bare tmux path, and they are gone —
 // from the code here, and by hand from the one box that carried leftovers.
 //
-// The config dir is per HARNESS since #39: `CLAUDE_CONFIG_DIR` for the claude
-// harness, `CODEX_HOME` for the codex one. See the HARNESS table below — it is the
-// one place the two harnesses differ on disk, and everything above it (worktrees,
-// branches, landing) is harness-blind.
+// The config dir is per Harness. The selected adapter owns its native root;
+// everything above that root (worktrees, branches, and landing) is Harness-neutral.
 
 import fs from 'node:fs'
 import os from 'node:os'
@@ -28,22 +26,15 @@ import { daemonGhEnv } from './daemongh.mjs'
 // the salvage branch's stamp (#649). One stamp shape for the whole daemon: UTC,
 // colons folded to hyphens, sorting in write order.
 import { stampFor } from './backup.mjs'
+import { HARNESS_REGISTRY } from './harnesses.mjs'
 import {
   CLAUDE_API_KEY_TAIL_LENGTH,
-  CLAUDE_CONFIG_ROOT_ENV,
-  CLAUDE_REPO_SKILL_ROOTS,
-  CLAUDE_WORKSPACE,
   CURIA_MCP_SERVER_NAME,
   LOOPBACK_HOST,
   claudeApiKeyApproval,
-  claudeUntrustedProjectConfig,
   writeClaudeConnection,
 } from './claudeworkspace.mjs'
 import {
-  CODEX_CONFIG_ROOT_ENV,
-  CODEX_REPO_SKILL_ROOTS,
-  CODEX_WORKSPACE,
-  codexUntrustedProjectConfig,
   writeCodexSkillPointers,
 } from './codexworkspace.mjs'
 
@@ -88,13 +79,28 @@ export function worktreePathFor(root, repo, n) {
 // roots a usage sync scans.
 export const CFG_DIR = 'cfg'
 
+function adapterFor(candidate = null) {
+  if (candidate?.identity && candidate?.setup) return candidate
+  const name = candidate ?? 'claude'
+  try {
+    return HARNESS_REGISTRY.get(name)
+  } catch {
+    throw new Error(`no agent harness for harness "${name}" - registered Harnesses: ${HARNESS_REGISTRY.names.join(', ')}`)
+  }
+}
+
+function workspaceFor(candidate = null) {
+  const adapter = adapterFor(candidate)
+  const workspace = adapter.setup.workspace
+  if (!workspace) throw new Error(`Harness "${adapter.identity.name}" has no workspace implementation`)
+  return workspace
+}
+
 export function cfgDirFor(root, session, harness = null) {
   const sessionRoot = path.join(root, CFG_DIR, session)
   if (harness === null) return sessionRoot
-  if (!HARNESS_NAMES.includes(harness)) {
-    throw new Error(`no configuration root for Harness "${harness}" - known Harnesses: ${HARNESS_NAMES.join(', ')}`)
-  }
-  return path.join(sessionRoot, harness)
+  const adapter = adapterFor(harness)
+  return path.join(sessionRoot, adapter.identity.name)
 }
 
 export function branchFor(n) {
@@ -569,35 +575,28 @@ export function removeCredentials(cfgDir) {
 // without it the spawn stalls at a "Hooks need review" menu before the first
 // turn, and no hook runs at all.
 
-export const HARNESS_NAMES = ['claude', 'codex']
+export const HARNESS_NAMES = HARNESS_REGISTRY.names
 
 // WHICH ENVIRONMENT VARIABLE CARRIES A HARNESS'S CONFIG ROOT. The HARNESS rows
 // below build their env from this map rather than spelling the name inline, and
 // `aistack.mjs` reads it rather than naming the same two variables a second
 // time — a harness whose CLI reads a different variable is then answered here,
 // once, for the agent spawn and the usage sync alike.
-export const CONFIG_ROOT_ENV = Object.freeze({
-  claude: CLAUDE_CONFIG_ROOT_ENV,
-  codex: CODEX_CONFIG_ROOT_ENV,
-})
+export const CONFIG_ROOT_ENV = Object.freeze(Object.fromEntries(
+  HARNESS_REGISTRY.values().map((adapter) => [
+    adapter.identity.name,
+    workspaceFor(adapter).configRootEnv,
+  ]),
+))
 
 export function configRootEnvFor(harness = 'claude') {
-  harnessDef(harness)
-  return CONFIG_ROOT_ENV[harness]
-}
-
-function harnessDef(harness) {
-  const h = HARNESS[harness]
-  if (!h) {
-    throw new Error(`no agent harness for harness "${harness}" — known harnesses: ${HARNESS_NAMES.join(', ')}`)
-  }
-  return h
+  return workspaceFor(harness).configRootEnv
 }
 
 // Where the host's own credential store lives for a harness — the single file
 // every agent of that harness shares (#53).
 export function hostStorageDir(harness = 'claude') {
-  return harnessDef(harness).hostStore()
+  return workspaceFor(harness).hostStore()
 }
 
 // The provider whose credential a harness runs on (#648). One reader, because
@@ -605,7 +604,7 @@ export function hostStorageDir(harness = 'claude') {
 // agree — two answers here would be the claude row and the overseer row drifting
 // apart by another road.
 export function harnessProvider(harness) {
-  return harnessDef(harness).provider
+  return adapterFor(harness).identity.provider
 }
 
 // ---- the agent's GitHub authority (#155, retired by #466) -------------------
@@ -644,7 +643,7 @@ export function retiredAgentTokenKeys(env = process.env) {
 // The overseer's own turn takes this same env and no GitHub value at all
 // (overseerturn.mjs), which is what that arm always wanted.
 export function agentEnv(cfgDir, harness = 'claude', { sandboxed = false } = {}) {
-  return harnessDef(harness).env(cfgDir, { sandboxed })
+  return workspaceFor(harness).env(cfgDir, { sandboxed })
 }
 
 // TOML basic string. The values here are daemon-generated paths and a loopback
@@ -654,10 +653,6 @@ export function agentEnv(cfgDir, harness = 'claude', { sandboxed = false } = {})
 export const LOOPBACK = LOOPBACK_HOST
 export const MCP_SERVER_NAME = CURIA_MCP_SERVER_NAME
 
-const HARNESS = {
-  claude: CLAUDE_WORKSPACE,
-  codex: CODEX_WORKSPACE,
-}
 // A config file the WATCHED REPO carries, which curia does not write and cannot
 // vouch for. Returns the offending path, or null. One exposure per harness, same
 // shape on both: a file the harness loads with no prompt, whose hooks would
@@ -684,9 +679,7 @@ const HARNESS = {
 // conventionally git-ignored, so a tracked copy in a watched repo is already a
 // flag (#105).
 export function untrustedProjectConfig(wtPath, harness) {
-  const planted = harness === 'codex'
-    ? codexUntrustedProjectConfig(wtPath)
-    : claudeUntrustedProjectConfig(wtPath)
+  const planted = workspaceFor(harness).untrustedProjectConfig(wtPath)
   return fs.existsSync(planted) ? planted : null
 }
 
@@ -694,11 +687,6 @@ export function untrustedProjectConfig(wtPath, harness) {
 // against the pinned CLIs (#224, docs/live-checks/224). Codex reads the project
 // config dir plus `.agents/skills` at the spawn cwd; claude reads
 // `.claude/skills`. Neither CLI has a config key that turns a repo root off.
-const REPO_SKILL_ROOTS = {
-  codex: CODEX_REPO_SKILL_ROOTS,
-  claude: CLAUDE_REPO_SKILL_ROOTS,
-}
-
 // The name a SKILL.md claims in its frontmatter. Codex keys a skill on this
 // name and ignores the directory, so a plant can sit in an innocently named
 // directory (measured, #224). Claude keys on the directory name instead.
@@ -727,7 +715,7 @@ export function plantedSkills(wtPath, harness, install) {
   const installed = new Set(install ?? [])
   if (!installed.size) return []
   const found = []
-  for (const root of REPO_SKILL_ROOTS[harness] ?? []) {
+  for (const root of workspaceFor(harness).repoSkillRoots ?? []) {
     const dir = path.join(wtPath, ...root)
     let entries = []
     try {
@@ -846,7 +834,7 @@ export function installSkills(cfgDir, skills, { copy = false } = {}) {
 export const STANDING_FILE = 'standing.md'
 
 export function memoryFileFor(harness) {
-  return harnessDef(harness).memoryFile
+  return workspaceFor(harness).memoryFile
 }
 
 // voice.md + standing.md -> the CLI's global-memory file. Idempotent, and safe
@@ -871,8 +859,9 @@ export function composeMemoryFile(cfgDir, harness) {
 // it as a `projects` key, which Claude Code matches against its own cwd — and a
 // container's cwd is the mount point, not the host path. Everything this
 // function WRITES goes to `cfgDir`, which is always the host path.
-export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude', { sandboxed = false, apiKey = null } = {}) {
-  const h = harnessDef(harness)
+export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude', { sandboxed = false, apiKey = null, adapter = null } = {}) {
+  const selected = adapter ?? harness
+  const h = workspaceFor(selected)
   fs.mkdirSync(cfgDir, { recursive: true })
   // No credential is COPIED here — every harness shares the host's own store
   // instead (#53). Sweep first: a cfg dir reused across dispatches, or from
@@ -891,7 +880,7 @@ export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude',
   //
   // Composed rather than copied since #340: the same file also carries the
   // standing orders, and a re-arm must not drop them. See composeMemoryFile.
-  composeMemoryFile(cfgDir, harness)
+  composeMemoryFile(cfgDir, selected)
   // One read-only directory, and nothing else from the host: no allowlist, no
   // MCP connectors, no saved permission mode (#23/#29). Both CLIs read
   // `<config dir>/skills/<name>/SKILL.md`, so #57's install is harness-blind —
@@ -914,7 +903,7 @@ export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude',
 // pane, the docker host gateway from a container.
 export function writeConnectionSettings({
   wtPath, cfgDir, agent, ticket, daemonPort, harness = 'claude', reasoningEffort = null,
-  hostWtPath = wtPath, daemonHost = LOOPBACK, token, skills = null,
+  hostWtPath = wtPath, daemonHost = LOOPBACK, token, skills = null, adapter = null,
 }) {
   // The connection settings are the ONLY way an agent learns its token (#159), so a caller
   // that forgot one would write connection settings whose every call the daemon then
@@ -922,8 +911,9 @@ export function writeConnectionSettings({
   if (!/^[0-9a-f]{64}$/.test(String(token ?? ''))) {
     throw new Error(`refusing to write the connection settings for ${agent} without a minted agent token — every call it makes would be refused`)
   }
-  harnessDef(harness).connectionSettings({
-    wtPath: harness === 'claude' ? hostWtPath : wtPath,
+  const h = workspaceFor(adapter ?? harness)
+  h.connectionSettings({
+    wtPath: h.connectionWorktree({ wtPath, hostWtPath }),
     cfgDir, agent, ticket, daemonPort, daemonHost, reasoningEffort, token, skills,
   })
 }
@@ -1085,14 +1075,8 @@ export function exchangeBlock(exchange = []) {
 // complex Curia call made one to three ALL_TOOLS lookups. Each returned lookup
 // cost another model request. Load the Curia catalog once so later calls reuse
 // conversation state. Claude receives its schemas directly and needs no order.
-const DEFERRED_CURIA_ORDER = [
-  '- **Load deferred Curia tools once.** If `ALL_TOOLS` holds Curia schemas, return every',
-  '  `mcp__curia__*` definition from one `exec` call before your first Curia call. Keep the output',
-  '  in context, and use the same definitions for every later Curia call.',
-]
-
 function deferredCuriaOrder(harness) {
-  return harness === 'codex' ? [...DEFERRED_CURIA_ORDER, ''] : []
+  return workspaceFor(harness).deferredToolOrders()
 }
 
 // Prompt file lives in the config dir, not the worktree.
@@ -1170,16 +1154,14 @@ function deferredCuriaOrder(harness) {
 export function writePrompt(cfgDir, issue, {
   repo, wtPath, mapNumber = null, type = null, charting = false, newMap = false,
   instruction = null, ports = null, harness = 'claude', exchange = [], handoff = false,
-  prototypeVariations, skill = null, skillTarget = null,
+  prototypeVariations, skill = null, skillTarget = null, adapter = null,
 }) {
   if (type === 'wayfinder:prototype' && (!Number.isInteger(prototypeVariations) || prototypeVariations <= 0)) {
     throw new Error('prototypeVariations must be a positive integer for a prototype dispatch')
   }
   const promptFile = path.join(cfgDir, 'prompt.md')
-  // An unknown harness would take the claude spelling of the invocation in
-  // silence, which is the failure #173 exists to end. harnessDef throws on a
-  // name no harness owns.
-  harnessDef(harness)
+  const selected = adapter ?? harness
+  const workspace = workspaceFor(selected)
   const n = issue.number
   const branch = branchFor(n)
   const ticketUrl = `https://github.com/${repo}/issues/${n}`
@@ -1226,14 +1208,10 @@ export function writePrompt(cfgDir, issue, {
   // loose idea. The operator's sentence IS that idea, and it rides the params
   // below rather than the invocation line — the line is one line, and this one
   // is a paragraph the operator wrote.
-  const sigil = harness === 'codex' ? null : '/wayfinder'
-  const invocation = skill
-    ? [`${harness === 'codex' ? '$' : '/'}${skill}${skillTarget ? ` ${skillTarget}` : ''}`, '']
-    : !sigil || !(newMap || mapNumber)
-      ? []
-      : newMap
-        ? [sigil, '']
-        : [`${sigil} ${mapUrl}${charting ? '' : ` ticket #${n}`}`, '']
+  const invocationLine = skill
+    ? workspace.skillInvocation({ skill, skillTarget })
+    : workspace.wayfinderInvocation({ newMap, mapUrl, ticket: n, charting })
+  const invocation = invocationLine ? [invocationLine, ''] : []
 
   // The params of a NEW-map dispatch (#241). The difference from a map dispatch
   // is one fact with consequences everywhere: the map does not exist. So this
@@ -1646,7 +1624,7 @@ export function writePrompt(cfgDir, issue, {
     '',
     ...allParams,
     '',
-    `Your bounds, your tools and the ending are in \`${memoryFileFor(harness)}\`, which this harness`,
+    `Your bounds, your tools and the ending are in \`${memoryFileFor(selected)}\`, which this harness`,
     'loads as standing instructions rather than as one message. They hold for every turn of this',
     'ticket, and they beat any skill they disagree with.',
     '',
@@ -1667,7 +1645,7 @@ export function writePrompt(cfgDir, issue, {
     '',
     '## Your tools (the `curia` MCP server)',
     '',
-    ...deferredCuriaOrder(harness),
+    ...deferredCuriaOrder(selected),
     ...tools,
     '',
     '## How this ends',
@@ -1695,7 +1673,7 @@ export function writePrompt(cfgDir, issue, {
 
   fs.writeFileSync(promptFile, promptBody)
   fs.writeFileSync(path.join(cfgDir, STANDING_FILE), standingBody)
-  composeMemoryFile(cfgDir, harness)
+  composeMemoryFile(cfgDir, selected)
   return promptFile
 }
 
@@ -1714,9 +1692,10 @@ export function writePrompt(cfgDir, issue, {
 // `wtPath` is the checkout AS THE AGENT SEES IT (#156), like everywhere else:
 // the mount point inside a container, the host path outside one.
 export function writeReviewPrompt(cfgDir, issue, {
-  repo, wtPath, branch, baseBranch, sha, model, builderModel, ticketUrl = null, harness = 'claude',
+  repo, wtPath, branch, baseBranch, sha, model, builderModel, ticketUrl = null, harness = 'claude', adapter = null,
 }) {
-  harnessDef(harness)
+  const selected = adapter ?? harness
+  adapterFor(selected)
   const promptFile = path.join(cfgDir, 'prompt.md')
   const n = issue.number
   const url = ticketUrl ?? `https://github.com/${repo}/issues/${n}`
@@ -1800,7 +1779,7 @@ export function writeReviewPrompt(cfgDir, issue, {
     '',
     '## Your tools (the `curia` MCP server)',
     '',
-    ...deferredCuriaOrder(harness),
+    ...deferredCuriaOrder(selected),
     '- `notify` — a status line for the human. Returns at once. Use it to say what you are reading.',
     '  `kind` says what they must DO: `progress` (nothing), `look` (open a file or a page now),',
     '  `ask` (reply when they can). A reviewer reads, so its lines are `progress`.',

--- a/daemon/test/dispatch.test.mjs
+++ b/daemon/test/dispatch.test.mjs
@@ -27,6 +27,7 @@ import { CodexCredentialBroker } from '../src/credentials.mjs'
 import { CLEAR_MAP_FOG, KEEP_MAP_OPEN, MAP_FOG_VERB } from '../src/mapfog.mjs'
 import { OPENAI_CREDIT_GATE_PANE } from './fixtures/panes.mjs'
 import { workingAnthropicStore, TEST_ANTHROPIC_TOKEN } from './fixtures/credentials.mjs'
+import { HARNESS_REGISTRY, createHarnessRegistry } from '../src/harnesses.mjs'
 
 const ROUTING = {
   defaults: { untyped: 'sonnet' },
@@ -159,6 +160,7 @@ function makeDispatcher(deps = {}, {
   // one spawns `npx`, and a test that forgot to pass one must run nothing rather
   // than reach the network.
   aistack = null,
+  harnessRegistry = null,
   // Discarded by default. A test that asserts on a boot line passes a collector,
   // because the lines it wants are written inside the constructor (#377).
   log = () => {},
@@ -312,6 +314,7 @@ function makeDispatcher(deps = {}, {
   const d = new Dispatcher({
     config,
     routing,
+    harnessRegistry,
     reduction,
     notify: (ticket, message) => notifies.push({ ticket, message }),
     // the #94 confirm seams: records land in `escalations` so the dispatcher's
@@ -5848,6 +5851,76 @@ describe('live model switching (#717)', () => {
 })
 
 describe('dispatching across two harnesses (#39)', () => {
+  test('a registry-only fixture adapter dispatches without a shared Harness branch', async () => {
+    const noCapabilities = {
+      modelSwitch: false, reasoningEffort: true, transcriptUsage: false,
+      nativeSkills: false, richMetadata: false,
+    }
+    const fixture = {
+      identity: {
+        name: 'fixture', provider: 'anthropic', credentialConsumer: 'claude', configLayoutVersion: 1,
+      },
+      setup: {
+        workspace: {
+          configRootEnv: 'FIXTURE_HOME', memoryFile: 'FIXTURE.md', repoSkillRoots: [],
+          hostStore: () => '/fixture',
+          env: (cfgDir) => ({ FIXTURE_HOME: cfgDir }),
+          seed: () => {}, connectionSettings: () => {},
+          connectionWorktree: ({ wtPath }) => wtPath,
+          untrustedProjectConfig: (wtPath) => path.join(wtPath, '.fixture-untrusted'),
+          skillInvocation: () => null, wayfinderInvocation: () => null,
+          deferredToolOrders: () => [],
+        },
+        refuseRepository: () => ({ planted: null, plants: [] }),
+        prepare: (context, ports) => ports.filesystem.prepare(context),
+      },
+      lifecycle: {
+        freshCommand: ({ model }) => `fixture fresh ${model}`,
+        resumeCommand: ({ model }) => `fixture resume ${model}`,
+        isReady: ({ paneText }) => paneText.includes('fixture ready'),
+        classifyLimit: () => null,
+        processDied: () => null, interrupt: () => null, send: () => null,
+        strandedCallRecovery: () => false,
+        rewind: () => ({ landingId: null, remains: [] }),
+      },
+      evidence: {
+        discover: () => null, events: () => [], activity: () => null, usage: () => null,
+        native: {
+          files: () => [], namesSession: () => false, present: () => false,
+          parse: () => [], identity: () => null, unknownType: () => 'unknown',
+        },
+      },
+      control: {
+        capabilities: noCapabilities,
+        operations: { reasoningEffort: (effort) => effort },
+        enforceCompletion: (context, ports) => ports.toolChannel.enforceCompletion(context),
+      },
+    }
+    const registry = createHarnessRegistry([...HARNESS_REGISTRY.values(), fixture])
+    const routing = {
+      defaults: { untyped: { model: 'fixture-model', effort: 'high' } },
+      models: { 'fixture-model': { provider: 'anthropic', harness: 'fixture' } },
+      fallbacks: {},
+      harnesses: { fixture: {
+        template: 'unused', resumeTemplate: 'unused', readyRe: /fixture ready/,
+        toolChannelGraceS: 15,
+      } },
+    }
+    let spawn = null
+    const d = makeDispatcher({
+      newSession: async (options) => { spawn = options },
+    }, { routing, harnessRegistry: registry })
+
+    const reply = await d.start('42', { repo: 'o/r', by: 'test' })
+
+    assert.match(reply, /dispatched/)
+    assert.match(spawn.shellCmd, /fixture fresh fixture-model/)
+    assert.match(fs.readFileSync(
+      path.join(tmp, 'work', 'cfg', 'curia-42', 'fixture', ENV_FILE), 'utf8',
+    ), /^FIXTURE_HOME=/m)
+    assert.equal(d.agents.get('curia-42').adapter, 'fixture')
+  })
+
   test('a research ticket seeds and spawns the codex harness end to end', async () => {
     const seeded = []
     const harnessed = []

--- a/daemon/test/harnesses.test.mjs
+++ b/daemon/test/harnesses.test.mjs
@@ -17,6 +17,7 @@ import {
   unknownNativeEvidence,
 } from '../src/harnesses.mjs'
 import { Reduction } from '../src/reduction.mjs'
+import { HarnessRuntime } from '../src/harnessruntime.mjs'
 
 const methods = (names) => Object.fromEntries(names.map((name) => [name, () => name]))
 
@@ -35,9 +36,21 @@ function fakeAdapter(name = 'fake', overrides = {}) {
       credentialConsumer: 'test-consumer',
       configLayoutVersion: 1,
     },
-    setup: methods(['refuseRepository', 'prepare']),
-    lifecycle: methods(['freshCommand', 'resumeCommand', 'isReady', 'classifyLimit', 'processDied', 'interrupt', 'send']),
-    evidence: methods(['discover', 'events', 'activity', 'usage']),
+    setup: {
+      ...methods(['refuseRepository', 'prepare']),
+      workspace: {
+        configRootEnv: 'FAKE_HOME', memoryFile: 'FAKE.md', repoSkillRoots: [],
+        ...methods([
+          'hostStore', 'env', 'seed', 'connectionSettings', 'connectionWorktree',
+          'untrustedProjectConfig', 'skillInvocation', 'wayfinderInvocation', 'deferredToolOrders',
+        ]),
+      },
+    },
+    lifecycle: methods(['freshCommand', 'resumeCommand', 'isReady', 'classifyLimit', 'processDied', 'interrupt', 'send', 'strandedCallRecovery', 'rewind']),
+    evidence: {
+      ...methods(['discover', 'events', 'activity', 'usage']),
+      native: methods(['files', 'namesSession', 'present', 'parse', 'identity', 'unknownType']),
+    },
     control: {
       capabilities,
       operations: {},
@@ -123,6 +136,41 @@ describe('Harness ports and normalized evidence', () => {
       type: 'unknown_native_evidence', nativeType: 'future_item', source: 'fixture',
     })
     assert.throws(() => normalizedEvent('made_up'), /unknown normalized Harness event/)
+  })
+})
+
+describe('registry-supplied shared orchestration', () => {
+  test('a fixture-only adapter exercises launch, resume, evidence, refusal, and fallback', () => {
+    const fixture = fakeAdapter('fixture', {
+      lifecycle: {
+        ...methods(['isReady', 'classifyLimit', 'processDied', 'interrupt', 'send', 'strandedCallRecovery', 'rewind']),
+        freshCommand: ({ model }) => `fixture start ${model}`,
+        resumeCommand: ({ model }) => `fixture resume ${model}`,
+      },
+      evidence: {
+        ...methods(['discover', 'activity', 'usage']),
+        events: () => [normalizedEvent('assistant_message', { text: 'fixture evidence' })],
+        native: methods(['files', 'namesSession', 'present', 'parse', 'identity', 'unknownType']),
+      },
+    })
+    const runtime = new HarnessRuntime(createHarnessRegistry([fixture]))
+
+    assert.equal(runtime.command('fixture', { model: 'one' }), 'fixture start one')
+    assert.equal(runtime.command('fixture', { model: 'one' }, { resume: true }), 'fixture resume one')
+    assert.deepEqual(runtime.events('fixture', {}), [{
+      type: 'assistant_message', text: 'fixture evidence',
+    }])
+    assert.throws(
+      () => runtime.control('fixture', 'modelSwitch'),
+      (error) => error instanceof HarnessCapabilityError,
+    )
+    assert.deepEqual(runtime.fallback({ from: 'claude', to: 'fixture' }), {
+      crossHarness: true, preserveWorktree: true, reuseNativeConversation: false,
+    })
+    assert.throws(
+      () => runtime.fallback({ from: 'claude', to: 'fixture', resume: true }),
+      /refusing to resume native claude conversation state on the fixture Harness/,
+    )
   })
 })
 

--- a/daemon/test/messaging.test.mjs
+++ b/daemon/test/messaging.test.mjs
@@ -287,7 +287,9 @@ describe('elapsedLabel', () => {
 // parked. `spoken` is what separates the two, and a SIGKILL is the death that
 // leaves it false.
 describe('handOffLine (#139, corrected by #457)', () => {
-  const parked = { agent: 'curia-7', ticket: '7', harness: 'codex', live: true, spoken: false }
+  const parked = {
+    agent: 'curia-7', ticket: '7', harness: 'codex', live: true, spoken: false, strandedCall: true,
+  }
 
   test('an agent that is not running gets the resume verb, whatever its harness', () => {
     for (const harness of ['claude', 'codex', null]) {
@@ -329,7 +331,7 @@ describe('handOffLine (#139, corrected by #457)', () => {
   // that reached this daemon is therefore working, not parked, and the warning
   // would send the operator to cancel it for nothing.
   test('a codex agent that has spoken to this daemon is working, not parked', () => {
-    const line = handOffLine({ ...parked, spoken: true })
+    const line = handOffLine({ ...parked, spoken: true, strandedCall: false })
     assert.match(line, /gets this answer with its next tool result/)
     assert.ok(!line.includes('cancel 7'), 'a working agent was offered the cancel verb')
   })

--- a/daemon/test/reasoningrouting.test.mjs
+++ b/daemon/test/reasoningrouting.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path'
 import {
   harnessReasoningEffort, resolveModel, reasoningEffortFor,
 } from '../src/routing.mjs'
+import { HARNESS_REGISTRY } from '../src/harnesses.mjs'
 import { loadRoutingConfig } from '../src/config.mjs'
 
 const routing = {
@@ -18,6 +19,17 @@ const routing = {
     opus: { provider: 'anthropic', harness: 'claude', reasoning_effort: 'high' },
     gpt: { provider: 'openai', harness: 'codex', reasoning_effort: 'medium' },
   },
+}
+
+const fixtureAdapter = {
+  identity: { name: 'fixture' },
+  control: {
+    capabilities: { reasoningEffort: true },
+    operations: { reasoningEffort: (effort) => effort === 'ultra' ? null : effort },
+  },
+}
+const fixtureRegistry = {
+  get: (name) => name === 'fixture' ? fixtureAdapter : HARNESS_REGISTRY.get(name),
 }
 
 describe('ticket-type reasoning effort', () => {
@@ -35,24 +47,24 @@ describe('ticket-type reasoning effort', () => {
     assert.equal(reasoningEffortFor(routing, ['wayfinder:prototype'], 'gpt'), 'ultra')
     assert.equal(harnessReasoningEffort('codex', 'ultra'), 'ultra')
 
-    const withPiFallback = {
+    const withFixtureFallback = {
       ...routing,
       models: {
         ...routing.models,
-        pi: { provider: 'openai', harness: 'pi', reasoning_effort: 'medium' },
+        fixture: { provider: 'openai', harness: 'fixture', reasoning_effort: 'medium' },
       },
     }
-    assert.equal(reasoningEffortFor(withPiFallback, ['wayfinder:prototype'], 'pi'), 'medium')
-    assert.equal(harnessReasoningEffort('pi', 'medium'), 'medium')
+    assert.equal(reasoningEffortFor(withFixtureFallback, ['wayfinder:prototype'], 'fixture', fixtureRegistry), 'medium')
+    assert.equal(harnessReasoningEffort('fixture', 'medium', fixtureRegistry), 'medium')
 
-    withPiFallback.models.pi.reasoning_effort = 'ultra'
-    assert.equal(reasoningEffortFor(withPiFallback, ['wayfinder:prototype'], 'pi'), null)
+    withFixtureFallback.models.fixture.reasoning_effort = 'ultra'
+    assert.equal(reasoningEffortFor(withFixtureFallback, ['wayfinder:prototype'], 'fixture', fixtureRegistry), null)
   })
 
   test('harness spelling maps the shared effort vocabulary onto each CLI', () => {
     assert.equal(harnessReasoningEffort('claude', 'ultra'), 'ultracode')
-    assert.equal(harnessReasoningEffort('opencode', 'ultra'), 'ultra')
-    assert.equal(harnessReasoningEffort('pi', 'ultra'), null)
+    assert.equal(harnessReasoningEffort('fixture', 'high', fixtureRegistry), 'high')
+    assert.equal(harnessReasoningEffort('fixture', 'ultra', fixtureRegistry), null)
   })
 })
 


### PR DESCRIPTION
## Summary

- Route shared workspace, transcript, lifecycle, completion, effort, and model-switch behavior through registered Harness adapters.
- Keep routing, credentials, fallback safety, pane evidence, and normalized activity under shared Curia invariants.
- Prove the boundary with a registry-only third adapter that covers dispatch, resume, evidence, capability refusal, and fallback.

## Verification

- `npm test` in `daemon/`

Resolves #834.