### PR TITLE
fix: parse styled aistack device login output

### DIFF
--- a/daemon/src/aistackreg.mjs
+++ b/daemon/src/aistackreg.mjs
@@ -39,6 +39,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
+import { stripVTControlCharacters } from 'node:util'
 
 import {
   CLI_PACKAGE, CLI_RUNNER, DEFAULT_CLI_VERSION,
@@ -104,7 +105,7 @@ const URL_RE = /\bhttps:\/\/\S*\/cli\/auth\S*/
 // but curia shows the URL the CLI printed rather than one it composed, because
 // the composed one would be a guess about a route it does not own.
 export function parseDeviceFlow(text) {
-  const s = String(text ?? '')
+  const s = stripVTControlCharacters(String(text ?? ''))
   const url = URL_RE.exec(s)?.[0] ?? null
   const code = CODE_RE.exec(s)?.[1] ?? null
   if (!url && !code) return null

--- a/daemon/test/aistackreg.test.mjs
+++ b/daemon/test/aistackreg.test.mjs
@@ -81,6 +81,16 @@ describe('the device flow curia starts (#706)', () => {
     assert.deepEqual(seen, { code: 'AB12', url: 'https://aistack.to/cli/auth?code=AB12' })
   })
 
+  test('terminal styling around the code and link does not hide the device flow', () => {
+    const styled = [
+      'CODE \x1b[1m\x1b[38;2;163;230;53mT72NNC\x1b[0m',
+      'OPEN \x1b[38;2;120;120;120mhttps://aistack.to/cli/auth?code=T72NNC\x1b[0m',
+    ].join('\n')
+    assert.deepEqual(parseDeviceFlow(styled), {
+      code: 'T72NNC', url: 'https://aistack.to/cli/auth?code=T72NNC',
+    })
+  })
+
   test('output with neither half in it is not half a flow', () => {
     assert.equal(parseDeviceFlow('npm warn exec the following package was not found'), null)
     assert.equal(parseDeviceFlow(''), null)


### PR DESCRIPTION
## Summary

- strip terminal control sequences before parsing the aistack device-login output
- cover the pinned CLI's styled `CODE` and `OPEN` lines with a regression test

## Verification

- `npm test` in `daemon/` (3,860 passed, 0 failed, 0 cancelled)