### PR TITLE
feat: scaffold the packaged lifecycle interface and stable launcher

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -938,6 +938,7 @@ One box runs everything. Phones and PCs are pure clients on the tailnet.
 - **Bridge**: the Discord module inside the daemon. Thread-per-ticket rendering, buttons, attachment passthrough both directions.
 - **Router**: the deterministic command router inside the daemon. It parses the five verbs from Discord slash commands or REST.
 - **Agents**: one harness process per ticket, in tmux sessions named `curia-<n>`. A cross-check adds a reviewer beside one, in `curia-review-<n>`.
+- **Lifecycle interface** (`cli/`): the `@curia-sh/cli` package. It owns `curia install`, `reinstall`, `update`, `rollback`, `doctor`, `uninstall`, and `purge`, and it carries no service code. The stable launcher at `~/.local/bin/curia` reads the installation record and runs the lifecycle interface of the active version on that version's pinned runtime under `versions/<version>/`. The operator's view is [docs/operator/command-reference.md](docs/operator/command-reference.md).
 - **Sidecar** (`daemon/bin/curia-dashboard.mjs`): the Curia app's own Node process, in its own container. It imports the daemon's identity check, config rules and Serve helper, and reads the daemon over loopback.
 - **Surfaces**: the shared ttyd terminal, the timeline and the Curia app, all published with Tailscale Serve. Previews take their own port range.
 - **Config** (`config/`): two layers. `curia.yaml` (watch list, dispatch, attach, dashboard, skills) and `routing.yaml` (models, defaults, fallbacks, the cross-check pairing) are the base, hand-edited and tracked in git. `curia.local.yaml` and `routing.local.yaml` beside them hold this box's own answers, and git ignores them. The daemon reads a base file and the override over it: a mapping merges key by key, a list or a scalar replaces whole. The settings screen writes only the override, which is what keeps the box's checkout clean. Every file is written in the form the yaml document API prints back unchanged, so an edit rewrites the lines it changed and no others. A trailing comment takes one space before the `#`, and a comment block belongs above its key rather than after it.
@@ -960,6 +961,7 @@ Everything else is a cache that reconcile can rebuild.
 
 - `docs/adr/`: one file per standing decision, indexed at `docs/adr/README.md`.
 - `docs/research/`: research notes, one per investigation, indexed at `docs/research/README.md`.
+- `docs/operator/`: the operator's reference pages for an installed Curia, subordinate to the lifecycle guide.
 - `docs/live-checks/`: first-person agent evidence.
 - `docs/agents/`: tracker, triage, and domain-doc conventions for agents.
 - `docs/full-loop.md`: the rehearsal record of the PoC map. History, not a live procedure.

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.tgz

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,40 @@
+# @curia-sh/cli
+
+Curia's lifecycle interface. It installs, updates, rolls back, diagnoses, and removes one Curia installation. It contains no Curia service code: the service, the app, and the overseer run in containers that the Compose bundle of an installed version describes.
+
+For the operator's view, read the [command reference](https://github.com/alp82/curia/blob/main/docs/operator/command-reference.md). This file is for people who work on the package.
+
+## What this version ships
+
+This version ships the stable launcher and the command vocabulary. Every lifecycle command exists and routes, and each one refuses with exit code `3` and a message that names the version and the release map. The follow-up tickets in [Ship Curia's supported installation lifecycle](https://github.com/alp82/curia/issues/863) fill the commands in.
+
+## Layout
+
+- `bin/curia.mjs`: the process entry. It hands `argv`, `env`, and the streams to `runCli` and exits with what `runCli` returns.
+- `src/cli.mjs`: `runCli`. It routes one command, prints usage, turns a thrown `Refusal` into exit `3` and any other error into exit `1`. Nothing in the package calls `process.exit`.
+- `src/commands.mjs`: the command table, in lifecycle order. One entry per command with a one-line summary and a `run(context)`.
+- `src/exit.mjs`: the four exit codes and the `Refusal` error.
+- `src/root.mjs`: the installation root, the installation record, and the two paths an installed version must have.
+- `src/launcher.mjs`: renders the stable `curia` launcher for one installation root.
+
+## The launcher
+
+The bootstrap writes `~/.local/bin/curia` once per installation. The launcher is a POSIX shell script with the installation root written into it. On each run it reads `state/installation.json`, takes `activeVersion`, and runs:
+
+```text
+<root>/versions/<activeVersion>/node/bin/node <root>/versions/<activeVersion>/cli/bin/curia.mjs "$@"
+```
+
+with `CURIA_ROOT` exported. An update changes the active version and never rewrites the launcher. When the record is missing or either file is absent, the launcher exits `3` and names the missing file.
+
+`versions/<version>/cli/` is the unpacked package: the `package/` directory of the npm tarball. `versions/<version>/node/` is the pinned Node runtime. Later versions may add sibling files under the version directory; the launcher reads only these two paths.
+
+## Tests
+
+```sh
+npm test
+```
+
+The suite has no dependencies and reads no file outside its own temporary directories. `test/package.test.mjs` runs `npm pack` and installs the tarball into an empty prefix, so it needs `npm` and `tar` on the path. The launcher tests run the rendered script with `/bin/sh` against a fake version directory whose `node` is a shell script that reports how it was called.
+
+There is no build step. `npm pack` produces the release artifact.

--- a/cli/bin/curia.mjs
+++ b/cli/bin/curia.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+// The lifecycle interface's process entry. The installed launcher runs this
+// file on the pinned runtime under versions/<active>/node with CURIA_ROOT set.
+// `npm install -g @curia-sh/cli` links it as `curia` too, which is how the
+// package is invoked before an installation exists.
+
+import { runCli } from '../src/cli.mjs'
+
+process.exitCode = await runCli({
+  argv: process.argv.slice(2),
+  env: process.env,
+  stdout: process.stdout,
+  stderr: process.stderr,
+})

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@curia-sh/cli",
+  "version": "0.4.1",
+  "description": "Curia's lifecycle interface: install, update, roll back, diagnose, and remove one Curia installation.",
+  "type": "module",
+  "bin": {
+    "curia": "bin/curia.mjs"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alp82/curia.git",
+    "directory": "cli"
+  },
+  "homepage": "https://curia.sh",
+  "//engines": "The host Node only matters while the package is invoked without an installed version, such as in this test suite. An installed Curia runs the lifecycle interface on its own pinned runtime under versions/<version>/node.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "test": "node --test 'test/*.test.mjs'"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -1,0 +1,66 @@
+import { EXIT, Refusal } from './exit.mjs'
+import { commands as lifecycleCommands, packageVersion } from './commands.mjs'
+import { installationRoot } from './root.mjs'
+
+// The lifecycle interface's one entry point. `bin/curia.mjs` calls it with the
+// process's argv, env, and streams and exits with what it returns. Tests call
+// it with their own, and can hand in a `commands` table to observe how the
+// core treats a command that throws.
+export async function runCli({ argv, env, stdout, stderr, commands = lifecycleCommands }) {
+  const [name, ...args] = argv
+
+  if (name === undefined) {
+    stderr.write(usage(commands))
+    return EXIT.usage
+  }
+  if (name === '--version' || name === '-V') {
+    stdout.write(`curia ${packageVersion}\n`)
+    return EXIT.ok
+  }
+  if (name === 'help' || name === '--help' || name === '-h') {
+    stdout.write(usage(commands))
+    return EXIT.ok
+  }
+
+  const command = commands[name]
+  if (!command) {
+    stderr.write(`curia: unknown command: ${name}\nRun 'curia help' for the command vocabulary.\n`)
+    return EXIT.usage
+  }
+
+  // No command takes an option yet. An option it does not know is a usage error
+  // before anything runs, never something a stub swallows.
+  const options = args.filter((a) => a.startsWith('-'))
+  if (options.length > 0) {
+    stderr.write(`curia ${name}: unknown option: ${options[0]}\nRun 'curia help' for the command vocabulary.\n`)
+    return EXIT.usage
+  }
+
+  try {
+    return await command.run({ env, args, stdout, stderr, root: installationRoot(env) })
+  } catch (e) {
+    stderr.write(`curia ${name}: ${e.message}\n`)
+    return e instanceof Refusal ? EXIT.refused : EXIT.failed
+  }
+}
+
+export function usage(commands = lifecycleCommands) {
+  const width = Math.max(...Object.keys(commands).map((n) => n.length))
+  const lines = Object.entries(commands).map(([n, c]) => `  ${n.padEnd(width)}  ${c.summary}`)
+  return [
+    'usage: curia <command>',
+    '',
+    'Commands:',
+    ...lines,
+    `  ${'help'.padEnd(width)}  Print this text.`,
+    '',
+    'Exit codes:',
+    `  ${EXIT.ok}  ok       The command did what it said.`,
+    `  ${EXIT.failed}  failed   The operation started and failed. The message says what to do next.`,
+    `  ${EXIT.usage}  usage    The command line was wrong. Nothing ran.`,
+    `  ${EXIT.refused}  refused  Curia refused to start. Nothing changed. The message names the condition.`,
+    '',
+    'The installation root comes from CURIA_ROOT, which the installed launcher sets.',
+    '',
+  ].join('\n')
+}

--- a/cli/src/commands.mjs
+++ b/cli/src/commands.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+
+import { EXIT, Refusal } from './exit.mjs'
+import { installationRoot, readInstallationRecord } from './root.mjs'
+
+export const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
+
+// One lifecycle command. `run(context)` gets `{ env, args, stdout, stderr, root }`
+// and returns an exit code, throws a `Refusal` to exit `refused` without a
+// change, or throws any other error to exit `failed`. Commands print on their
+// own streams and never call `process.exit`, which keeps every one of them
+// callable from a test.
+//
+// The seven lifecycle commands are seams the follow-up tickets fill in. Each
+// stub refuses with the same message so an operator who runs a released
+// package that lacks a command learns that fact instead of a stack trace.
+function notYet(name) {
+  return async () => {
+    throw new Refusal(`not available in version ${packageVersion}. This release ships the launcher and command vocabulary only. Watch https://github.com/alp82/curia/issues/863 for the release that adds ${name}.`)
+  }
+}
+
+async function version({ env, stdout }) {
+  stdout.write(`curia ${packageVersion}\n`)
+  const root = installationRoot(env)
+  const record = readInstallationRecord(root)
+  stdout.write(`active version: ${record ? record.activeVersion : 'none (no installation record)'}\n`)
+  stdout.write(`installation root: ${root}\n`)
+  return EXIT.ok
+}
+
+// Order matters: `curia help` lists the commands in lifecycle order.
+export const commands = {
+  install: { summary: 'Install Curia into the installation root and start it.', run: notYet('install') },
+  reinstall: { summary: 'Reinstall the active version over a preserved installation root.', run: notYet('reinstall') },
+  update: { summary: 'Stage, verify, and switch to the latest stable release, or to an exact version.', run: notYet('update') },
+  rollback: { summary: 'Switch back to the one retained previous release.', run: notYet('rollback') },
+  doctor: { summary: 'Check the host, configuration, integrations, and services. Read-only.', run: notYet('doctor') },
+  uninstall: { summary: 'Remove the runnable system and keep config/, secrets/, state/, and work/.', run: notYet('uninstall') },
+  purge: { summary: 'Remove the entire installation root and every Curia-labelled Docker resource, after confirmation.', run: notYet('purge') },
+  version: { summary: 'Print the lifecycle interface version and the active installed version.', run: version },
+}

--- a/cli/src/exit.mjs
+++ b/cli/src/exit.mjs
@@ -1,0 +1,23 @@
+// The four exit codes every lifecycle command and the launcher use.
+//
+//   ok       the command did what it said.
+//   failed   the command started the operation and the operation failed.
+//            The installation may have changed. The message says what to do next.
+//   usage    the command line was wrong. Nothing ran.
+//   refused  Curia refused to start the operation. Nothing changed. The message
+//            names the condition and one corrective action.
+//
+// A script can branch on these numbers. The launcher exits `refused` when the
+// active version is incomplete, so the same code means the same thing whether
+// the refusal came from the shell script or from the lifecycle interface.
+export const EXIT = Object.freeze({ ok: 0, failed: 1, usage: 2, refused: 3 })
+
+// A refusal a command raises before it changes anything. `runCli` turns it into
+// `EXIT.refused` and prints the message on stderr, so a command states the
+// condition once and never touches the exit code itself.
+export class Refusal extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'Refusal'
+  }
+}

--- a/cli/src/launcher.mjs
+++ b/cli/src/launcher.mjs
@@ -1,0 +1,53 @@
+import { join } from 'node:path'
+
+// The stable host launcher: `~/.local/bin/curia`.
+//
+// The bootstrap writes it once per installation and no update rewrites it. It
+// is one POSIX shell script with the installation root written into it, so a
+// nondefault root stays explicit without the operator typing it. On every run
+// it reads `state/installation.json`, picks the version the record names, and
+// execs that version's pinned Node runtime on that version's entry point with
+// CURIA_ROOT exported. It carries no other logic: the lifecycle interface under
+// the active version owns everything else, which is what lets an update change
+// the interface without touching the launcher.
+//
+// It exits `refused` (3) when the record is missing or the active version is
+// incomplete, and says which file is missing. That is the launcher's one
+// refusal, and it matches the lifecycle interface's own refused code.
+
+export function launcherPath(env) {
+  return join(env.HOME ?? '', '.local', 'bin', 'curia')
+}
+
+export function renderLauncher({ root }) {
+  if (root.includes("'")) throw new Error(`the installation root must not contain a single quote: ${root}`)
+  return `#!/bin/sh
+# Curia launcher. Written by the Curia bootstrap; an update never rewrites it.
+# It runs the lifecycle interface of the active installed version.
+CURIA_ROOT='${root}'
+export CURIA_ROOT
+
+record="$CURIA_ROOT/state/installation.json"
+if [ ! -r "$record" ]; then
+  echo "curia: no installation record at $record. Run the bootstrap again to reinstall, or delete the launcher if Curia was purged." >&2
+  exit 3
+fi
+
+version=$(sed -n 's/^[[:space:]]*"activeVersion"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*$/\\1/p' "$record" | head -n 1)
+if [ -z "$version" ]; then
+  echo "curia: $record names no active version. Run the bootstrap again to reinstall." >&2
+  exit 3
+fi
+
+node="$CURIA_ROOT/versions/$version/node/bin/node"
+entry="$CURIA_ROOT/versions/$version/cli/bin/curia.mjs"
+for required in "$node" "$entry"; do
+  if [ ! -f "$required" ]; then
+    echo "curia: the active version $version is incomplete: $required is missing. Run the bootstrap again to reinstall the active version." >&2
+    exit 3
+  fi
+done
+
+exec "$node" "$entry" "$@"
+`
+}

--- a/cli/src/root.mjs
+++ b/cli/src/root.mjs
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// The installation root the lifecycle interface acts on.
+//
+// The launcher exports `CURIA_ROOT` for the root it was installed for, so a
+// nondefault root stays explicit in the launcher and never has to be typed.
+// Without it, the default root follows the XDG base directory rules.
+export function installationRoot(env) {
+  if (env.CURIA_ROOT) return env.CURIA_ROOT
+  if (env.XDG_DATA_HOME) return join(env.XDG_DATA_HOME, 'curia')
+  return join(env.HOME ?? '', '.local', 'share', 'curia')
+}
+
+// The installation record: `state/installation.json`, the one file that says
+// which version is active. The launcher reads the same file with `sed`, so its
+// shape stays flat: one JSON object, one key per line, `activeVersion` a string.
+export const RECORD_FORMAT = 1
+
+export function recordPath(root) {
+  return join(root, 'state', 'installation.json')
+}
+
+// Returns the record, or `null` when the root holds none. A record that is
+// present but unreadable as a record is an error: a half-written or foreign
+// file must not read as "no installation".
+export function readInstallationRecord(root) {
+  let text
+  try {
+    text = readFileSync(recordPath(root), 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') return null
+    throw e
+  }
+  const record = JSON.parse(text)
+  if (record.format !== RECORD_FORMAT || typeof record.activeVersion !== 'string' || typeof record.installationId !== 'string') {
+    throw new Error(`${recordPath(root)} is not a Curia installation record`)
+  }
+  return record
+}
+
+// The two paths the launcher needs from an installed version: the pinned Node
+// runtime and the lifecycle interface's entry point. `versions/<version>/cli/`
+// holds the unpacked `@curia-sh/cli` package (the tarball's `package/` directory).
+export function versionPaths(root, version) {
+  const dir = join(root, 'versions', version)
+  return {
+    dir,
+    node: join(dir, 'node', 'bin', 'node'),
+    cli: join(dir, 'cli', 'bin', 'curia.mjs'),
+  }
+}

--- a/cli/test/cli.test.mjs
+++ b/cli/test/cli.test.mjs
@@ -1,0 +1,124 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+
+import { runCli } from '../src/cli.mjs'
+import { EXIT } from '../src/exit.mjs'
+
+const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
+
+function capture() {
+  const out = []
+  const err = []
+  return {
+    stdout: { write: (s) => { out.push(s); return true } },
+    stderr: { write: (s) => { err.push(s); return true } },
+    out: () => out.join(''),
+    err: () => err.join(''),
+  }
+}
+
+async function run(argv, env = {}) {
+  const io = capture()
+  const exit = await runCli({ argv, env, stdout: io.stdout, stderr: io.stderr })
+  return { exit, out: io.out(), err: io.err() }
+}
+
+function tempRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'curia-cli-'))
+  mkdirSync(join(root, 'state'), { recursive: true })
+  return root
+}
+
+describe('version reporting', () => {
+  test('--version prints the package version and exits ok', async () => {
+    const r = await run(['--version'])
+    assert.equal(r.exit, EXIT.ok)
+    assert.equal(r.out, `curia ${packageVersion}\n`)
+  })
+
+  test('version names the active installed version from the installation record', async () => {
+    const root = tempRoot()
+    try {
+      writeFileSync(join(root, 'state', 'installation.json'), JSON.stringify({ format: 1, installationId: 'abc', activeVersion: '1.2.3' }))
+      const r = await run(['version'], { CURIA_ROOT: root })
+      assert.equal(r.exit, EXIT.ok)
+      assert.equal(r.out, `curia ${packageVersion}\nactive version: 1.2.3\ninstallation root: ${root}\n`)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('version reports when the root holds no installation record', async () => {
+    const root = tempRoot()
+    try {
+      const r = await run(['version'], { CURIA_ROOT: root })
+      assert.equal(r.exit, EXIT.ok)
+      assert.equal(r.out, `curia ${packageVersion}\nactive version: none (no installation record)\ninstallation root: ${root}\n`)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('command routing', () => {
+  test('no command prints usage on stderr and exits with the usage code', async () => {
+    const r = await run([])
+    assert.equal(r.exit, EXIT.usage)
+    assert.match(r.err, /^usage: curia <command>/)
+    assert.equal(r.out, '')
+  })
+
+  test('help prints the command vocabulary on stdout and exits ok', async () => {
+    const r = await run(['help'])
+    assert.equal(r.exit, EXIT.ok)
+    for (const name of ['install', 'reinstall', 'update', 'rollback', 'doctor', 'uninstall', 'purge', 'version']) {
+      assert.match(r.out, new RegExp(`^  ${name}\\b`, 'm'), `help lists ${name}`)
+    }
+    assert.match(r.out, /exit codes/i)
+  })
+
+  test('an unknown command is a usage error that names the command', async () => {
+    const r = await run(['dance'])
+    assert.equal(r.exit, EXIT.usage)
+    assert.match(r.err, /unknown command: dance/)
+    assert.match(r.err, /curia help/)
+  })
+
+  for (const name of ['install', 'reinstall', 'update', 'rollback', 'doctor', 'uninstall', 'purge']) {
+    test(`${name} routes to its seam and reports that the command is not available yet`, async () => {
+      const r = await run([name])
+      assert.equal(r.exit, EXIT.refused)
+      assert.match(r.err, new RegExp(`^curia ${name}: not available in version ${packageVersion.replaceAll('.', '\\.')}`))
+      assert.equal(r.out, '')
+    })
+  }
+
+  test('a command refuses an unknown option before it runs', async () => {
+    const r = await run(['doctor', '--frobnicate'])
+    assert.equal(r.exit, EXIT.usage)
+    assert.match(r.err, /unknown option: --frobnicate/)
+  })
+})
+
+describe('exit behavior', () => {
+  test('the exit codes are the four documented ones', () => {
+    assert.deepEqual(EXIT, { ok: 0, failed: 1, usage: 2, refused: 3 })
+  })
+
+  test('a command that throws reports the failure and exits with the failed code', async () => {
+    const io = capture()
+    const exit = await runCli({
+      argv: ['doctor'],
+      env: {},
+      stdout: io.stdout,
+      stderr: io.stderr,
+      commands: { doctor: { summary: 'x', run: async () => { throw new Error('the socket vanished') } } },
+    })
+    assert.equal(exit, EXIT.failed)
+    assert.match(io.err(), /^curia doctor: the socket vanished\n$/)
+  })
+})

--- a/cli/test/launcher.test.mjs
+++ b/cli/test/launcher.test.mjs
@@ -1,0 +1,118 @@
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { renderLauncher, launcherPath } from '../src/launcher.mjs'
+import { EXIT } from '../src/exit.mjs'
+
+// A fake installed version: a `node` that prints how it was called, and an
+// entry point file. The launcher must pick both from under the active version.
+function installVersion(root, version, { withNode = true, withCli = true } = {}) {
+  const dir = join(root, 'versions', version)
+  if (withNode) {
+    mkdirSync(join(dir, 'node', 'bin'), { recursive: true })
+    const node = join(dir, 'node', 'bin', 'node')
+    writeFileSync(node, `#!/bin/sh\necho "node=$0"\necho "root=$CURIA_ROOT"\nfor a in "$@"; do echo "arg=$a"; done\nexit 42\n`)
+    chmodSync(node, 0o700)
+  }
+  if (withCli) {
+    mkdirSync(join(dir, 'cli', 'bin'), { recursive: true })
+    writeFileSync(join(dir, 'cli', 'bin', 'curia.mjs'), '// entry\n')
+  }
+  return dir
+}
+
+function activate(root, version) {
+  mkdirSync(join(root, 'state'), { recursive: true })
+  writeFileSync(join(root, 'state', 'installation.json'), JSON.stringify({ format: 1, installationId: 'abc', activeVersion: version }, null, 2) + '\n')
+}
+
+let home
+let root
+let launcher
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'curia-launcher-'))
+  root = join(home, 'the root with spaces', 'curia')
+  mkdirSync(root, { recursive: true })
+  launcher = join(home, 'bin', 'curia')
+  mkdirSync(join(home, 'bin'))
+  writeFileSync(launcher, renderLauncher({ root }))
+  chmodSync(launcher, 0o700)
+})
+
+afterEach(() => rmSync(home, { recursive: true, force: true }))
+
+function invoke(...args) {
+  const r = spawnSync(launcher, args, { encoding: 'utf8', env: { PATH: process.env.PATH } })
+  return { exit: r.status, out: r.stdout, err: r.stderr }
+}
+
+describe('the stable launcher', () => {
+  test('lives at ~/.local/bin/curia', () => {
+    assert.equal(launcherPath({ HOME: '/home/op' }), '/home/op/.local/bin/curia')
+  })
+
+  test('runs the entry point on the pinned runtime under the active version with CURIA_ROOT set', () => {
+    installVersion(root, '1.0.0')
+    installVersion(root, '1.1.0')
+    activate(root, '1.1.0')
+    const r = invoke('doctor', '--verbose', 'two words')
+    assert.equal(r.exit, 42, r.err)
+    assert.equal(r.out, [
+      `node=${join(root, 'versions', '1.1.0', 'node', 'bin', 'node')}`,
+      `root=${root}`,
+      `arg=${join(root, 'versions', '1.1.0', 'cli', 'bin', 'curia.mjs')}`,
+      'arg=doctor',
+      'arg=--verbose',
+      'arg=two words',
+      '',
+    ].join('\n'))
+  })
+
+  test('refuses an active version whose runtime is missing', () => {
+    installVersion(root, '1.1.0', { withNode: false })
+    activate(root, '1.1.0')
+    const r = invoke('doctor')
+    assert.equal(r.exit, EXIT.refused)
+    assert.equal(r.out, '')
+    assert.match(r.err, /^curia: the active version 1\.1\.0 is incomplete: /)
+    assert.match(r.err, new RegExp(join(root, 'versions', '1.1.0', 'node', 'bin', 'node').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(r.err, /Run the bootstrap again to reinstall/)
+  })
+
+  test('refuses an active version whose entry point is missing', () => {
+    installVersion(root, '1.1.0', { withCli: false })
+    activate(root, '1.1.0')
+    const r = invoke('doctor')
+    assert.equal(r.exit, EXIT.refused)
+    assert.match(r.err, /^curia: the active version 1\.1\.0 is incomplete: /)
+  })
+
+  test('refuses a root without an installation record', () => {
+    installVersion(root, '1.1.0')
+    const r = invoke('version')
+    assert.equal(r.exit, EXIT.refused)
+    assert.match(r.err, /^curia: no installation record at /)
+    assert.match(r.err, /state\/installation\.json/)
+  })
+
+  test('refuses a record that names no active version', () => {
+    installVersion(root, '1.1.0')
+    mkdirSync(join(root, 'state'), { recursive: true })
+    writeFileSync(join(root, 'state', 'installation.json'), '{ "format": 1 }\n')
+    const r = invoke('version')
+    assert.equal(r.exit, EXIT.refused)
+    assert.match(r.err, /^curia: .*installation\.json names no active version/)
+  })
+
+  test('is a POSIX shell script that pins its root', () => {
+    const text = renderLauncher({ root: '/srv/curia' })
+    assert.match(text, /^#!\/bin\/sh\n/)
+    assert.match(text, /CURIA_ROOT='\/srv\/curia'/)
+    assert.throws(() => renderLauncher({ root: "/it's" }), /single quote/)
+  })
+})

--- a/cli/test/package.test.mjs
+++ b/cli/test/package.test.mjs
@@ -1,0 +1,73 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { EXIT } from '../src/exit.mjs'
+
+// The package must work with no source checkout: pack it, install the tarball
+// into an empty prefix, and invoke the linked `curia` from there.
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const packageVersion = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8')).version
+
+function npm(args, cwd) {
+  const r = spawnSync('npm', args, { cwd, encoding: 'utf8', env: { ...process.env, npm_config_update_notifier: 'false' } })
+  assert.equal(r.status, 0, `npm ${args.join(' ')} failed:\n${r.stdout}\n${r.stderr}`)
+  return r.stdout
+}
+
+let scratch
+let tarball
+let curia
+
+before(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'curia-pack-'))
+  npm(['pack', '--pack-destination', scratch, '--silent'], packageDir)
+  tarball = join(scratch, readdirSync(scratch).find((f) => f.endsWith('.tgz')))
+  const prefix = join(scratch, 'prefix')
+  npm(['install', '--prefix', prefix, '--no-audit', '--no-fund', '--silent', tarball], scratch)
+  curia = join(prefix, 'node_modules', '.bin', 'curia')
+})
+
+after(() => rmSync(scratch, { recursive: true, force: true }))
+
+function invoke(...args) {
+  const r = spawnSync(curia, args, { encoding: 'utf8', env: { PATH: process.env.PATH, HOME: join(scratch, 'home') } })
+  return { exit: r.status, out: r.stdout, err: r.stderr }
+}
+
+describe('the packed package', () => {
+  test('is named for the release version', () => {
+    assert.equal(tarball, join(scratch, `curia-sh-cli-${packageVersion}.tgz`))
+  })
+
+  test('carries the entry point and sources and no tests', () => {
+    const list = spawnSync('tar', ['tzf', tarball], { encoding: 'utf8' }).stdout.split('\n').filter(Boolean).sort()
+    assert.ok(list.includes('package/bin/curia.mjs'), list.join('\n'))
+    assert.ok(list.includes('package/src/launcher.mjs'), list.join('\n'))
+    assert.ok(list.includes('package/README.md'), list.join('\n'))
+    assert.equal(list.filter((f) => f.startsWith('package/test/')).length, 0, list.join('\n'))
+  })
+
+  test('installs a curia that reports its version', () => {
+    const r = invoke('--version')
+    assert.equal(r.exit, EXIT.ok, r.err)
+    assert.equal(r.out, `curia ${packageVersion}\n`)
+  })
+
+  test('installs a curia that routes a lifecycle command', () => {
+    const r = invoke('doctor')
+    assert.equal(r.exit, EXIT.refused)
+    assert.match(r.err, /^curia doctor: not available in version/)
+  })
+
+  test('installs a curia that resolves the default root from HOME', () => {
+    const r = invoke('version')
+    assert.equal(r.exit, EXIT.ok, r.err)
+    assert.match(r.out, new RegExp(`^installation root: ${join(scratch, 'home', '.local', 'share', 'curia')}$`, 'm'))
+  })
+})

--- a/docs/operator/command-reference.md
+++ b/docs/operator/command-reference.md
@@ -1,0 +1,55 @@
+# Command reference
+
+The `curia` command is the lifecycle interface of an installed Curia. This page lists the launcher, the commands, and the exit codes. It's a reference: the lifecycle topics in the operator guide tell you when to run each command and what to check afterwards. Follow those topics and open this page from them.
+
+This page describes the vocabulary that the first packaged release ships. Commands that a later release adds say so on their own line.
+
+## The launcher
+
+The bootstrap installs one file, `~/.local/bin/curia`, and puts nothing else on your path. That file is the stable launcher. It runs as you, never as root, and it doesn't change across updates.
+
+On every run, the launcher:
+
+1. Reads `state/installation.json` in the installation root to find the active version.
+2. Runs that version's own Node.js runtime on that version's lifecycle interface, from `versions/<active version>/` inside the installation root.
+
+Each installed version carries its own pinned runtime, so the launcher needs no Node.js on the host. The launcher knows its installation root. The default root is `$XDG_DATA_HOME/curia`, or `~/.local/share/curia` when `XDG_DATA_HOME` is unset. A nondefault root is written into the launcher during bootstrap, so you never pass it on the command line.
+
+When the installation record is missing, or the active version lacks its runtime or entry point, the launcher stops with exit code `3` and names the missing file. Run the bootstrap again to reinstall the active version. If you purged Curia, delete the launcher.
+
+## Commands
+
+Run `curia help` to print this list from the installed version. The commands appear in lifecycle order.
+
+| Command | What it does | Available |
+|---|---|---|
+| `curia install` | Installs Curia into the installation root and starts it. | Later release |
+| `curia reinstall` | Reinstalls the active version over a preserved installation root. It keeps `config/`, `secrets/`, `state/`, and `work/`. | Later release |
+| `curia update` | Stages, verifies, and switches to the latest stable release. It accepts an exact version. It keeps the previous release for rollback. | Later release |
+| `curia rollback` | Switches back to the one retained previous release. | Later release |
+| `curia doctor` | Checks the host, operator configuration, integrations, containers, and service reachability. It's read-only and repairs nothing. | Later release |
+| `curia uninstall` | Removes the runnable system and keeps `config/`, `secrets/`, `state/`, and `work/`. | Later release |
+| `curia purge` | Removes the entire installation root and every Curia-labelled Docker resource, after one confirmation. | Later release |
+| `curia version` | Prints the lifecycle interface version, the active installed version, and the installation root. | Now |
+| `curia help` | Prints the command list and exit codes. | Now |
+
+`curia --version` prints only the lifecycle interface version.
+
+In this release, a command marked **Later release** exits with code `3` and a message that names the installed version and the release map. Nothing changes on the host.
+
+## Exit codes
+
+Every command and the launcher use the same four exit codes, so a script can branch on them. The following table lists them.
+
+| Code | Name | Meaning |
+|---|---|---|
+| `0` | ok | The command did what it said. |
+| `1` | failed | The operation started and failed. The installation may have changed. The message says what to do next. |
+| `2` | usage | The command line was wrong. Nothing ran. Run `curia help`. |
+| `3` | refused | Curia refused to start the operation. Nothing changed. The message names the condition and one corrective action. |
+
+A refusal is not a failure. It means Curia checked a precondition, such as a missing runtime file or an unsupported host, and stopped before touching anything.
+
+## Environment
+
+`CURIA_ROOT` names the installation root. The launcher sets it for you. Set it yourself only when you run the lifecycle interface without the launcher, such as from a development checkout.


### PR DESCRIPTION
## What this is

The first piece of [Ship Curia's supported installation lifecycle](https://github.com/alp82/curia/issues/863): ticket #864. It adds the publishable `@curia-sh/cli` package and the stable host `curia` launcher. The package owns the lifecycle commands and contains no service code.

## What's in it

- `cli/`: the `@curia-sh/cli` package. No dependencies, no build step. `npm pack` produces the release artifact.
- `runCli` (`cli/src/cli.mjs`) routes `install`, `reinstall`, `update`, `rollback`, `doctor`, `uninstall`, `purge`, `version`, and `help`. Every command uses one of four exit codes: `0` ok, `1` failed, `2` usage, `3` refused. The seven lifecycle commands are seams for the follow-up tickets. Each one refuses with exit `3` and a message that names the version and the release map.
- `renderLauncher` (`cli/src/launcher.mjs`) produces `~/.local/bin/curia`: a POSIX shell script with the installation root written in. It reads `state/installation.json`, takes `activeVersion`, and runs `versions/<active>/node/bin/node versions/<active>/cli/bin/curia.mjs "$@"` with `CURIA_ROOT` exported. A missing record or an incomplete active version exits `3` and names the missing file.
- `docs/operator/command-reference.md`: the operator's reference for the launcher, the command vocabulary, and the exit codes.
- `CONTEXT.md`: the lifecycle interface joins the component list.

## Seams under test

- `runCli({ argv, env, stdout, stderr })`: routing, usage errors, version reporting with and without an installation record, and how a thrown `Refusal` or error maps to an exit code.
- The rendered launcher, run with `/bin/sh` against a fake version directory: it selects the active version's runtime and entry point, exports the root, passes arguments through, and refuses a missing record, a missing runtime, and a missing entry point.
- The packed tarball: `npm pack`, install into an empty prefix, and invoke the linked `curia` without a source checkout.

## Tests

- `cd cli && npm test`: 28 pass.
- `cd daemon && npm test`: 3875 pass, 0 fail, 0 cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
