### PR TITLE
feat: enforce the installation root and lifecycle-operation boundary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,6 +55,9 @@ _Avoid_: workspace root, which names the current source deployment's mixed work 
 The atomic, owner-only `state/installation.json` file that identifies an installation root. It contains only a format version, a random installation ID, and the active Curia version. Lifecycle commands check ownership, permissions, and symbolic-link safety directly. Version manifests verify installed artifacts separately.
 _Avoid_: installation manifest, which can be confused with a release or version manifest.
 
+**Lifecycle-operation lock**:
+The `run/lifecycle.lock` file that serializes lifecycle commands on one installation root. A command takes it after the root boundary accepts the root and before it changes anything, and releases it on success or failure. A second command refuses while a live process holds the lock and takes over a lock whose process is gone. See [the command reference](docs/operator/command-reference.md#the-lifecycle-lock).
+
 **Secret file**:
 An owner-only file under the installation root's `secrets/` boundary that holds one long-lived credential or private key. Curia gives each container read-only access to only the secret files that container consumes, and only the credential-owning service may replace one. Long-lived secrets never travel through environment variables, command arguments, logs, diagnostics, or browser responses.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@ For the operator's view, read the [command reference](https://github.com/alp82/c
 
 ## What this version ships
 
-This version ships the stable launcher and the command vocabulary. Every lifecycle command exists and routes, and each one refuses with exit code `3` and a message that names the version and the release map. The follow-up tickets in [Ship Curia's supported installation lifecycle](https://github.com/alp82/curia/issues/863) fill the commands in.
+This version ships the stable launcher, the command vocabulary, and the installation-root boundary. Every lifecycle command exists and routes. Each one opens its root through the boundary first, so the root refusals are real, and then refuses with exit code `3` and a message that names the version and the release map. The follow-up tickets in [Ship Curia's supported installation lifecycle](https://github.com/alp82/curia/issues/863) fill the commands in.
 
 ## Layout
 
@@ -14,8 +14,16 @@ This version ships the stable launcher and the command vocabulary. Every lifecyc
 - `src/cli.mjs`: `runCli`. It routes one command, prints usage, turns a thrown `Refusal` into exit `3` and any other error into exit `1`. Nothing in the package calls `process.exit`.
 - `src/commands.mjs`: the command table, in lifecycle order. One entry per command with a one-line summary and a `run(context)`.
 - `src/exit.mjs`: the four exit codes and the `Refusal` error.
-- `src/root.mjs`: the installation root, the installation record, and the two paths an installed version must have.
+- `src/root.mjs`: the installation root. `installationRoot(env)` resolves it, `openRoot(root, { uid })` is the one safe way in and raises every boundary refusal, `ensureLayout` creates the root and its seven boundaries with mode `0700`, and the record functions read and write `state/installation.json`. It also names the two paths an installed version must have.
+- `src/atomic.mjs`: `writeAtomically(path, content, { mode })`, the temporary-file, `fsync`, and rename write that every critical file goes through.
+- `src/lock.mjs`: `withLifecycleLock(root, operation)`, the exclusive lifecycle-operation lock at `run/lifecycle.lock`.
 - `src/launcher.mjs`: renders the stable `curia` launcher for one installation root.
+
+## The root boundary
+
+A lifecycle command's `run` gets `{ env, args, stdout, stderr, uid, root }`. It calls `openRoot(root, { uid })` before it does anything else and reads the status that comes back: `absent`, `empty`, or `installed` with the record. `openRoot` throws a `Refusal` for root execution, a relative root, a symbolic link at the root, a boundary, or the record, foreign ownership, a mode that reaches past the owner, and a nonempty root without a record. A command that changes the installation then calls `ensureLayout` if it may create the root, and wraps its work in `withLifecycleLock`. The order matters: the boundary refuses before the lock exists, and the lock lives under `run/`, which `ensureLayout` creates.
+
+A command that writes a record calls `createInstallationRecord(version)` and `writeInstallationRecord(root, record)`. The writer rejects any key beyond `format`, `installationId`, and `activeVersion`. Write the record as soon as the layout exists: `openRoot` recognizes a root by its record, so a root that has a layout but no record reads as unknown on the next run.
 
 ## The launcher
 

--- a/cli/src/atomic.mjs
+++ b/cli/src/atomic.mjs
@@ -1,0 +1,38 @@
+import { closeSync, fsyncSync, openSync, renameSync, unlinkSync, writeSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+
+// The one way a lifecycle command writes a critical file: the installation
+// record, operator configuration, a secret. The content goes to a fresh
+// temporary file beside the target, is fsynced, and is renamed over the target
+// in one step. A reader sees the old file or the new one, never a partial one,
+// and a crash leaves at most a temporary file that the next write ignores.
+//
+// The mode is set on the temporary file at creation, so the target never
+// spends a moment with broader permissions than requested. Because rename
+// replaces the directory entry, a symbolic link sitting at the target is
+// replaced by the file rather than followed. The directory is fsynced after the
+// rename so the new entry is durable too.
+export function writeAtomically(path, content, { mode }) {
+  const dir = dirname(path)
+  const temp = join(dir, `.${basename(path)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`)
+  let fd
+  try {
+    fd = openSync(temp, 'wx', mode)
+    writeSync(fd, content)
+    fsyncSync(fd)
+    closeSync(fd)
+    fd = undefined
+    renameSync(temp, path)
+  } catch (e) {
+    if (fd !== undefined) closeSync(fd)
+    try { unlinkSync(temp) } catch {}
+    throw e
+  }
+  const dirFd = openSync(dir, 'r')
+  try {
+    fsyncSync(dirFd)
+  } finally {
+    closeSync(dirFd)
+  }
+}

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -4,9 +4,10 @@ import { installationRoot } from './root.mjs'
 
 // The lifecycle interface's one entry point. `bin/curia.mjs` calls it with the
 // process's argv, env, and streams and exits with what it returns. Tests call
-// it with their own, and can hand in a `commands` table to observe how the
-// core treats a command that throws.
-export async function runCli({ argv, env, stdout, stderr, commands = lifecycleCommands }) {
+// it with their own, hand in a `uid` to stand in for another operator, and can
+// hand in a `commands` table to observe how the core treats a command that
+// throws.
+export async function runCli({ argv, env, stdout, stderr, uid = process.getuid(), commands = lifecycleCommands }) {
   const [name, ...args] = argv
 
   if (name === undefined) {
@@ -37,7 +38,7 @@ export async function runCli({ argv, env, stdout, stderr, commands = lifecycleCo
   }
 
   try {
-    return await command.run({ env, args, stdout, stderr, root: installationRoot(env) })
+    return await command.run({ env, args, stdout, stderr, uid, root: installationRoot(env) })
   } catch (e) {
     stderr.write(`curia ${name}: ${e.message}\n`)
     return e instanceof Refusal ? EXIT.refused : EXIT.failed

--- a/cli/src/commands.mjs
+++ b/cli/src/commands.mjs
@@ -1,21 +1,28 @@
 import { readFileSync } from 'node:fs'
 
 import { EXIT, Refusal } from './exit.mjs'
-import { installationRoot, readInstallationRecord } from './root.mjs'
+import { installationRoot, openRoot, readInstallationRecord } from './root.mjs'
 
 export const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
-// One lifecycle command. `run(context)` gets `{ env, args, stdout, stderr, root }`
+// One lifecycle command. `run(context)` gets `{ env, args, stdout, stderr, uid, root }`
 // and returns an exit code, throws a `Refusal` to exit `refused` without a
 // change, or throws any other error to exit `failed`. Commands print on their
 // own streams and never call `process.exit`, which keeps every one of them
 // callable from a test.
 //
+// Every lifecycle command enters its root through `openRoot` first, so the
+// boundary refusals (root execution, foreign ownership, broad permissions,
+// symbolic links, an unknown nonempty root) come before anything the command
+// itself does. `version` is read-only and skips the boundary on purpose: it
+// reports the root even when a lifecycle command would refuse it.
+//
 // The seven lifecycle commands are seams the follow-up tickets fill in. Each
 // stub refuses with the same message so an operator who runs a released
 // package that lacks a command learns that fact instead of a stack trace.
 function notYet(name) {
-  return async () => {
+  return async ({ root, uid }) => {
+    openRoot(root, { uid })
     throw new Refusal(`not available in version ${packageVersion}. This release ships the launcher and command vocabulary only. Watch https://github.com/alp82/curia/issues/863 for the release that adds ${name}.`)
   }
 }

--- a/cli/src/lock.mjs
+++ b/cli/src/lock.mjs
@@ -1,0 +1,74 @@
+import { closeSync, openSync, readFileSync, renameSync, unlinkSync, writeSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { Refusal } from './exit.mjs'
+
+// The lifecycle-operation lock: `run/lifecycle.lock` inside the installation
+// root. One lifecycle operation runs at a time per installation. The lock file
+// is created exclusively and holds the owning process id, so a second `curia`
+// invocation refuses with that id instead of racing an install, update, or
+// uninstall that is half done.
+//
+// `run/` is restart-disposable, and a crash can leave the file behind. A lock
+// whose process no longer exists is taken over: the stale file is moved aside
+// first, so two takers cannot both unlink a fresh lock a third process just
+// created, and the exclusive create decides who wins.
+export function lockPath(root) {
+  return join(root, 'run', 'lifecycle.lock')
+}
+
+export async function withLifecycleLock(root, operation) {
+  const path = lockPath(root)
+  acquire(path)
+  try {
+    return await operation()
+  } finally {
+    try { unlinkSync(path) } catch {}
+  }
+}
+
+function acquire(path) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let fd
+    try {
+      fd = openSync(path, 'wx', 0o600)
+    } catch (e) {
+      if (e.code !== 'EEXIST') throw e
+      const holder = holderOf(path)
+      if (holder !== null) {
+        throw new Refusal(`another lifecycle operation is running: process ${holder} holds ${path}. Wait for it to finish, then run the command again.`)
+      }
+      // Stale: no live process owns it. Move it aside, then try the create again.
+      try { renameSync(path, `${path}.stale.${process.pid}`) } catch {}
+      try { unlinkSync(`${path}.stale.${process.pid}`) } catch {}
+      continue
+    }
+    try {
+      writeSync(fd, `${process.pid}\n`)
+    } finally {
+      closeSync(fd)
+    }
+    return
+  }
+  throw new Refusal(`another lifecycle operation is running and holds ${path}. Wait for it to finish, then run the command again.`)
+}
+
+// The live process named in the lock file, or null when the file names none.
+function holderOf(path) {
+  let text
+  try {
+    text = readFileSync(path, 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') return null
+    throw e
+  }
+  const pid = Number.parseInt(text, 10)
+  if (!Number.isInteger(pid) || pid <= 0) return null
+  try {
+    process.kill(pid, 0)
+    return pid
+  } catch (e) {
+    // EPERM means the process exists and belongs to someone else: it's alive.
+    return e.code === 'EPERM' ? pid : null
+  }
+}

--- a/cli/src/root.mjs
+++ b/cli/src/root.mjs
@@ -1,5 +1,9 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { chmodSync, lstatSync, mkdirSync, readFileSync, readdirSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import { isAbsolute, join } from 'node:path'
+
+import { Refusal } from './exit.mjs'
+import { writeAtomically } from './atomic.mjs'
 
 // The installation root the lifecycle interface acts on.
 //
@@ -12,31 +16,162 @@ export function installationRoot(env) {
   return join(env.HOME ?? '', '.local', 'share', 'curia')
 }
 
+// The seven boundaries of an installation root, in the order the operator
+// documentation lists them. Each is one directory, mode 0700, owned by the
+// operator. Lifecycle commands act on them as whole units.
+export const BOUNDARIES = Object.freeze(['config', 'secrets', 'state', 'work', 'versions', 'cache', 'run'])
+
+const OWNER_ONLY_DIR = 0o700
+const OWNER_ONLY_FILE = 0o600
+
+// The one safe way into an installation root. Every lifecycle command calls it
+// before it touches anything, and it refuses (exit 3, nothing changed) when:
+//
+//   - the command runs as root;
+//   - the root is not an absolute path;
+//   - the root, a boundary directory, or the installation record is a
+//     symbolic link;
+//   - the root or a boundary is owned by another user or is reachable by the
+//     group or by others;
+//   - the root is nonempty and holds no installation record.
+//
+// It returns the root's status so the caller decides what the operation may
+// do: `absent` (nothing there), `empty` (an empty directory), or `installed`
+// (a record is present, and it is returned). A record that is present but
+// malformed is a failure, not a refusal, so a damaged installation never reads
+// as a fresh one.
+export function openRoot(root, { uid }) {
+  if (uid === 0) {
+    throw new Refusal('this command runs as root. Curia runs unprivileged: run it as the operator that owns the installation.')
+  }
+  if (!isAbsolute(root)) {
+    throw new Refusal(`the installation root must be an absolute path, got ${root}. Set CURIA_ROOT to an absolute path or run the installed launcher.`)
+  }
+
+  const rootStat = ownerOnlyDirectory(root, { uid, what: 'the installation root' })
+  if (rootStat === null) return { root, status: 'absent', record: null }
+
+  for (const name of BOUNDARIES) {
+    ownerOnlyDirectory(join(root, name), { uid, what: `${name}/ in the installation root` })
+  }
+  const record = readInstallationRecord(root)
+  if (record) return { root, status: 'installed', record }
+
+  if (readdirSync(root).length === 0) return { root, status: 'empty', record: null }
+  throw new Refusal(`${root} is not empty and holds no installation record, so it is not a Curia installation. Choose an empty or absent directory, or move what is there out of the way.`)
+}
+
+// Creates the root and the seven boundaries with owner-only permissions. The
+// modes are set explicitly, not through the umask. It is idempotent: it adds a
+// missing boundary to an existing root and leaves the rest alone. It never
+// widens or narrows a directory that exists, so a boundary with broad
+// permissions is refused here as in `openRoot`.
+export function ensureLayout(root, { uid }) {
+  if (ownerOnlyDirectory(root, { uid, what: 'the installation root' }) === null) {
+    mkdirSync(root, { recursive: true })
+    chmodSync(root, OWNER_ONLY_DIR)
+  }
+  for (const name of BOUNDARIES) {
+    const dir = join(root, name)
+    if (ownerOnlyDirectory(dir, { uid, what: `${name}/ in the installation root` }) === null) {
+      mkdirSync(dir, { mode: OWNER_ONLY_DIR })
+      chmodSync(dir, OWNER_ONLY_DIR)
+    }
+  }
+}
+
+// The lstat of a directory that must be owned by `uid`, mode 0700, and not a
+// symbolic link. Returns null when the path does not exist. Every other
+// deviation is a refusal that names the path and the corrective action.
+function ownerOnlyDirectory(path, { uid, what }) {
+  let stat
+  try {
+    stat = lstatSync(path)
+  } catch (e) {
+    if (e.code === 'ENOENT') return null
+    throw e
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Refusal(`${what} is a symbolic link: ${path}. Curia does not follow links there. Replace the link with a real directory.`)
+  }
+  if (!stat.isDirectory()) {
+    throw new Refusal(`${what} is not a directory: ${path}. Move the file out of the way or choose another root.`)
+  }
+  if (stat.uid !== uid) {
+    throw new Refusal(`${what} is owned by user ${stat.uid}, not by you (user ${uid}): ${path}. Run the command as the owner, or choose another root.`)
+  }
+  const mode = stat.mode & 0o777
+  if ((mode & 0o077) !== 0) {
+    throw new Refusal(`${what} has mode ${octal(mode)}, which lets other users reach it: ${path}. Run 'chmod 0700 ${path}' and try again.`)
+  }
+  return stat
+}
+
+function octal(mode) {
+  return `0${mode.toString(8).padStart(3, '0')}`
+}
+
 // The installation record: `state/installation.json`, the one file that says
-// which version is active. The launcher reads the same file with `sed`, so its
-// shape stays flat: one JSON object, one key per line, `activeVersion` a string.
+// which version is active. It holds only the record format, a random
+// installation ID, and the active version. The launcher reads the same file
+// with `sed`, so its shape stays flat: one JSON object, one key per line,
+// `activeVersion` a string.
 export const RECORD_FORMAT = 1
+const RECORD_KEYS = Object.freeze(['format', 'installationId', 'activeVersion'])
 
 export function recordPath(root) {
   return join(root, 'state', 'installation.json')
 }
 
+export function createInstallationRecord(activeVersion) {
+  return { format: RECORD_FORMAT, installationId: randomBytes(16).toString('hex'), activeVersion }
+}
+
 // Returns the record, or `null` when the root holds none. A record that is
 // present but unreadable as a record is an error: a half-written or foreign
-// file must not read as "no installation".
+// file must not read as "no installation". A record that is a symbolic link
+// is refused, because the file is security-sensitive and must live in state/.
 export function readInstallationRecord(root) {
+  const path = recordPath(root)
   let text
   try {
-    text = readFileSync(recordPath(root), 'utf8')
+    if (lstatSync(path).isSymbolicLink()) {
+      throw new Refusal(`the installation record ${path} is a symbolic link. Replace the link with the real file or remove it.`)
+    }
+    text = readFileSync(path, 'utf8')
   } catch (e) {
     if (e.code === 'ENOENT') return null
     throw e
   }
-  const record = JSON.parse(text)
-  if (record.format !== RECORD_FORMAT || typeof record.activeVersion !== 'string' || typeof record.installationId !== 'string') {
-    throw new Error(`${recordPath(root)} is not a Curia installation record`)
+  let record
+  try {
+    record = JSON.parse(text)
+  } catch {
+    record = null
+  }
+  if (!isRecord(record)) {
+    throw new Error(`${path} is not a Curia installation record`)
   }
   return record
+}
+
+function isRecord(record) {
+  return record !== null
+    && typeof record === 'object'
+    && record.format === RECORD_FORMAT
+    && typeof record.activeVersion === 'string'
+    && typeof record.installationId === 'string'
+}
+
+// Writes the record atomically, owner-only. The record must hold exactly the
+// three documented keys, so nothing operator-specific or generated slips in.
+export function writeInstallationRecord(root, record) {
+  const foreign = Object.keys(record).filter((k) => !RECORD_KEYS.includes(k))
+  if (foreign.length > 0 || !isRecord(record)) {
+    throw new Error(`the installation record holds only ${RECORD_KEYS.join(', ')}; refusing to write ${JSON.stringify(record)}${foreign.length ? ` (unexpected: ${foreign.join(', ')})` : ''}`)
+  }
+  const ordered = Object.fromEntries(RECORD_KEYS.map((k) => [k, record[k]]))
+  writeAtomically(recordPath(root), JSON.stringify(ordered, null, 2) + '\n', { mode: OWNER_ONLY_FILE })
 }
 
 // The two paths the launcher needs from an installed version: the pinned Node

--- a/cli/test/atomic.test.mjs
+++ b/cli/test/atomic.test.mjs
@@ -1,0 +1,53 @@
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, symlinkSync, lstatSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { writeAtomically } from '../src/atomic.mjs'
+
+let dir
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'curia-atomic-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('writeAtomically', () => {
+  test('writes the content with the requested mode and leaves no temporary file behind', () => {
+    const path = join(dir, 'installation.json')
+    writeAtomically(path, '{"a":1}\n', { mode: 0o600 })
+    assert.equal(readFileSync(path, 'utf8'), '{"a":1}\n')
+    assert.equal(statSync(path).mode & 0o777, 0o600)
+    assert.deepEqual(readdirSync(dir), ['installation.json'])
+  })
+
+  test('replaces an existing file in one step and keeps the requested mode', () => {
+    const path = join(dir, 'installation.json')
+    writeFileSync(path, 'old', { mode: 0o644 })
+    writeAtomically(path, 'new', { mode: 0o600 })
+    assert.equal(readFileSync(path, 'utf8'), 'new')
+    assert.equal(statSync(path).mode & 0o777, 0o600)
+    assert.deepEqual(readdirSync(dir), ['installation.json'])
+  })
+
+  test('replaces a symbolic link at the target instead of writing through it', () => {
+    const elsewhere = join(dir, 'elsewhere')
+    writeFileSync(elsewhere, 'untouched')
+    const path = join(dir, 'installation.json')
+    symlinkSync(elsewhere, path)
+    writeAtomically(path, 'new', { mode: 0o600 })
+    assert.equal(lstatSync(path).isSymbolicLink(), false)
+    assert.equal(readFileSync(path, 'utf8'), 'new')
+    assert.equal(readFileSync(elsewhere, 'utf8'), 'untouched')
+  })
+
+  test('a write into a missing directory fails and leaves nothing behind', () => {
+    const path = join(dir, 'missing', 'installation.json')
+    assert.throws(() => writeAtomically(path, 'x', { mode: 0o600 }), /ENOENT/)
+    assert.deepEqual(readdirSync(dir), [])
+  })
+})

--- a/cli/test/cli.test.mjs
+++ b/cli/test/cli.test.mjs
@@ -21,15 +21,15 @@ function capture() {
   }
 }
 
-async function run(argv, env = {}) {
+async function run(argv, env = {}, { uid = process.getuid() } = {}) {
   const io = capture()
-  const exit = await runCli({ argv, env, stdout: io.stdout, stderr: io.stderr })
+  const exit = await runCli({ argv, env, uid, stdout: io.stdout, stderr: io.stderr })
   return { exit, out: io.out(), err: io.err() }
 }
 
 function tempRoot() {
   const root = mkdtempSync(join(tmpdir(), 'curia-cli-'))
-  mkdirSync(join(root, 'state'), { recursive: true })
+  mkdirSync(join(root, 'state'), { recursive: true, mode: 0o700 })
   return root
 }
 
@@ -90,12 +90,46 @@ describe('command routing', () => {
 
   for (const name of ['install', 'reinstall', 'update', 'rollback', 'doctor', 'uninstall', 'purge']) {
     test(`${name} routes to its seam and reports that the command is not available yet`, async () => {
-      const r = await run([name])
-      assert.equal(r.exit, EXIT.refused)
-      assert.match(r.err, new RegExp(`^curia ${name}: not available in version ${packageVersion.replaceAll('.', '\\.')}`))
-      assert.equal(r.out, '')
+      const root = tempRoot()
+      try {
+        const r = await run([name], { CURIA_ROOT: join(root, 'fresh') })
+        assert.equal(r.exit, EXIT.refused)
+        assert.match(r.err, new RegExp(`^curia ${name}: not available in version ${packageVersion.replaceAll('.', '\\.')}`))
+        assert.equal(r.out, '')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
     })
   }
+
+  test('a lifecycle command refuses root execution before anything else', async () => {
+    const r = await run(['install'], { CURIA_ROOT: '/nonexistent/curia' }, { uid: 0 })
+    assert.equal(r.exit, EXIT.refused)
+    assert.match(r.err, /^curia install: this command runs as root/)
+  })
+
+  test('a lifecycle command refuses an unknown nonempty root', async () => {
+    const root = tempRoot()
+    try {
+      writeFileSync(join(root, 'stray'), 'x')
+      const r = await run(['update'], { CURIA_ROOT: root })
+      assert.equal(r.exit, EXIT.refused)
+      assert.match(r.err, /^curia update: .* is not a Curia installation/)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('version stays read-only and reports even a root the boundary would refuse', async () => {
+    const root = tempRoot()
+    try {
+      writeFileSync(join(root, 'stray'), 'x')
+      const r = await run(['version'], { CURIA_ROOT: root })
+      assert.equal(r.exit, EXIT.ok)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
 
   test('a command refuses an unknown option before it runs', async () => {
     const r = await run(['doctor', '--frobnicate'])

--- a/cli/test/lock.test.mjs
+++ b/cli/test/lock.test.mjs
@@ -1,0 +1,71 @@
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { withLifecycleLock, lockPath } from '../src/lock.mjs'
+import { Refusal } from '../src/exit.mjs'
+
+let root
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'curia-lock-'))
+  mkdirSync(join(root, 'run'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+// A process id that no live process owns: a child that has already exited.
+function deadPid() {
+  const child = spawnSync('true')
+  return child.pid
+}
+
+describe('withLifecycleLock', () => {
+  test('holds run/lifecycle.lock with this process id while the operation runs and removes it after', async () => {
+    let seen
+    const result = await withLifecycleLock(root, async () => {
+      seen = readFileSync(lockPath(root), 'utf8')
+      return 'done'
+    })
+    assert.equal(result, 'done')
+    assert.equal(seen, `${process.pid}\n`)
+    assert.equal(existsSync(lockPath(root)), false)
+  })
+
+  test('releases the lock when the operation throws', async () => {
+    await assert.rejects(withLifecycleLock(root, async () => { throw new Error('boom') }), /boom/)
+    assert.equal(existsSync(lockPath(root)), false)
+  })
+
+  test('refuses while a live process holds the lock and names that process', async () => {
+    writeFileSync(lockPath(root), `${process.pid}\n`)
+    await assert.rejects(
+      withLifecycleLock(root, async () => 'ran'),
+      (e) => e instanceof Refusal && new RegExp(`process ${process.pid} `).test(e.message) && e.message.includes(lockPath(root)),
+    )
+    assert.equal(readFileSync(lockPath(root), 'utf8'), `${process.pid}\n`)
+  })
+
+  test('a second operation in the same process is refused too', async () => {
+    await withLifecycleLock(root, async () => {
+      await assert.rejects(withLifecycleLock(root, async () => 'nested'), Refusal)
+    })
+  })
+
+  test('takes over a lock whose process is gone', async () => {
+    writeFileSync(lockPath(root), `${deadPid()}\n`)
+    const result = await withLifecycleLock(root, async () => 'ran')
+    assert.equal(result, 'ran')
+    assert.equal(existsSync(lockPath(root)), false)
+  })
+
+  test('takes over a lock file that names no process', async () => {
+    writeFileSync(lockPath(root), 'garbage')
+    assert.equal(await withLifecycleLock(root, async () => 'ran'), 'ran')
+  })
+})

--- a/cli/test/root.test.mjs
+++ b/cli/test/root.test.mjs
@@ -1,0 +1,189 @@
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, statSync, readdirSync, symlinkSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  installationRoot,
+  openRoot,
+  ensureLayout,
+  BOUNDARIES,
+  createInstallationRecord,
+  writeInstallationRecord,
+  readInstallationRecord,
+  recordPath,
+} from '../src/root.mjs'
+import { Refusal } from '../src/exit.mjs'
+
+const me = process.getuid()
+
+let home
+let root
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'curia-root-'))
+  root = join(home, 'curia')
+})
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true })
+})
+
+function refuses(fn, pattern) {
+  assert.throws(fn, (e) => {
+    assert.ok(e instanceof Refusal, `expected a Refusal, got ${e.name}: ${e.message}`)
+    assert.match(e.message, pattern)
+    return true
+  })
+}
+
+describe('installationRoot', () => {
+  test('CURIA_ROOT wins, then XDG_DATA_HOME, then ~/.local/share', () => {
+    assert.equal(installationRoot({ CURIA_ROOT: '/srv/curia', XDG_DATA_HOME: '/x', HOME: '/h' }), '/srv/curia')
+    assert.equal(installationRoot({ XDG_DATA_HOME: '/x', HOME: '/h' }), '/x/curia')
+    assert.equal(installationRoot({ HOME: '/h' }), '/h/.local/share/curia')
+  })
+})
+
+describe('openRoot', () => {
+  test('an absent root is reported as absent', () => {
+    assert.deepEqual(openRoot(root, { uid: me }), { root, status: 'absent', record: null })
+  })
+
+  test('an empty directory is reported as empty', () => {
+    mkdirSync(root, { mode: 0o700 })
+    assert.deepEqual(openRoot(root, { uid: me }), { root, status: 'empty', record: null })
+  })
+
+  test('a root with an installation record is reported as installed with that record', () => {
+    ensureLayout(root, { uid: me })
+    const record = createInstallationRecord('1.2.3')
+    writeInstallationRecord(root, record)
+    assert.deepEqual(openRoot(root, { uid: me }), { root, status: 'installed', record })
+  })
+
+  test('refuses root execution before it looks at the filesystem', () => {
+    refuses(() => openRoot(root, { uid: 0 }), /runs as root/)
+    assert.equal(readdirSync(home).length, 0)
+  })
+
+  test('refuses a relative root', () => {
+    refuses(() => openRoot('curia', { uid: me }), /absolute path/)
+  })
+
+  test('refuses a root owned by another user', () => {
+    mkdirSync(root, { mode: 0o700 })
+    refuses(() => openRoot(root, { uid: me + 1 }), /owned by user \d+, not by you/)
+  })
+
+  test('refuses a root that group or other users can reach', () => {
+    mkdirSync(root, { mode: 0o750 })
+    refuses(() => openRoot(root, { uid: me }), /mode 0750/)
+  })
+
+  test('refuses a root that is a symbolic link', () => {
+    mkdirSync(join(home, 'real'), { mode: 0o700 })
+    symlinkSync(join(home, 'real'), root)
+    refuses(() => openRoot(root, { uid: me }), /symbolic link/)
+  })
+
+  test('refuses a boundary directory that is a symbolic link', () => {
+    ensureLayout(root, { uid: me })
+    writeInstallationRecord(root, createInstallationRecord('1.2.3'))
+    rmSync(join(root, 'secrets'), { recursive: true })
+    mkdirSync(join(home, 'elsewhere'), { mode: 0o700 })
+    symlinkSync(join(home, 'elsewhere'), join(root, 'secrets'))
+    refuses(() => openRoot(root, { uid: me }), /secrets.*symbolic link/)
+  })
+
+  test('refuses a boundary directory with broad permissions', () => {
+    ensureLayout(root, { uid: me })
+    writeInstallationRecord(root, createInstallationRecord('1.2.3'))
+    chmodSync(join(root, 'config'), 0o755)
+    refuses(() => openRoot(root, { uid: me }), /config.*mode 0755/)
+  })
+
+  test('refuses a record that is a symbolic link', () => {
+    ensureLayout(root, { uid: me })
+    writeFileSync(join(home, 'record.json'), '{}')
+    symlinkSync(join(home, 'record.json'), recordPath(root))
+    refuses(() => openRoot(root, { uid: me }), /installation\.json.*symbolic link/)
+  })
+
+  test('refuses an unknown nonempty root', () => {
+    mkdirSync(root, { mode: 0o700 })
+    writeFileSync(join(root, 'notes.txt'), 'hello')
+    refuses(() => openRoot(root, { uid: me }), /not a Curia installation/)
+  })
+
+  test('refuses a root that is a file', () => {
+    writeFileSync(root, 'x')
+    refuses(() => openRoot(root, { uid: me }), /not a directory/)
+  })
+
+  test('a malformed record is a failure, not a refusal and not an empty root', () => {
+    ensureLayout(root, { uid: me })
+    writeFileSync(recordPath(root), '{"format": 1}', { mode: 0o600 })
+    assert.throws(() => openRoot(root, { uid: me }), (e) => !(e instanceof Refusal) && /not a Curia installation record/.test(e.message))
+  })
+})
+
+describe('ensureLayout', () => {
+  test('creates the root and the seven boundaries with mode 0700', () => {
+    ensureLayout(root, { uid: me })
+    assert.equal(statSync(root).mode & 0o777, 0o700)
+    assert.deepEqual(BOUNDARIES, ['config', 'secrets', 'state', 'work', 'versions', 'cache', 'run'])
+    for (const name of BOUNDARIES) {
+      assert.equal(statSync(join(root, name)).mode & 0o777, 0o700, `${name} is 0700`)
+    }
+    assert.deepEqual(readdirSync(root).sort(), [...BOUNDARIES].sort())
+  })
+
+  test('creates the root under missing parents without widening them past the process umask', () => {
+    root = join(home, 'a', 'b', 'curia')
+    ensureLayout(root, { uid: me })
+    assert.equal(statSync(root).mode & 0o777, 0o700)
+    assert.ok((statSync(join(home, 'a')).mode & 0o022) === 0)
+  })
+
+  test('is idempotent and adds a missing boundary to an existing root', () => {
+    ensureLayout(root, { uid: me })
+    rmSync(join(root, 'cache'), { recursive: true })
+    ensureLayout(root, { uid: me })
+    assert.equal(statSync(join(root, 'cache')).mode & 0o777, 0o700)
+  })
+
+  test('does not repair a boundary with broad permissions', () => {
+    ensureLayout(root, { uid: me })
+    chmodSync(join(root, 'work'), 0o755)
+    refuses(() => ensureLayout(root, { uid: me }), /work.*mode 0755/)
+    assert.equal(statSync(join(root, 'work')).mode & 0o777, 0o755)
+  })
+})
+
+describe('the installation record', () => {
+  test('createInstallationRecord holds only the format, a random id, and the active version', () => {
+    const a = createInstallationRecord('1.2.3')
+    const b = createInstallationRecord('1.2.3')
+    assert.deepEqual(Object.keys(a).sort(), ['activeVersion', 'format', 'installationId'])
+    assert.equal(a.format, 1)
+    assert.equal(a.activeVersion, '1.2.3')
+    assert.match(a.installationId, /^[0-9a-f]{32}$/)
+    assert.notEqual(a.installationId, b.installationId)
+  })
+
+  test('writeInstallationRecord writes an owner-only file the launcher can parse', () => {
+    ensureLayout(root, { uid: me })
+    writeInstallationRecord(root, createInstallationRecord('1.2.3'))
+    assert.equal(statSync(recordPath(root)).mode & 0o777, 0o600)
+    const text = readFileSync(recordPath(root), 'utf8')
+    assert.match(text, /^  "activeVersion": "1\.2\.3",?$/m)
+    assert.equal(readInstallationRecord(root).activeVersion, '1.2.3')
+  })
+
+  test('writeInstallationRecord rejects a record with a foreign key', () => {
+    ensureLayout(root, { uid: me })
+    assert.throws(() => writeInstallationRecord(root, { ...createInstallationRecord('1.2.3'), operator: 'alp' }), /operator/)
+  })
+})

--- a/docs/operator/command-reference.md
+++ b/docs/operator/command-reference.md
@@ -13,9 +13,55 @@ On every run, the launcher:
 1. Reads `state/installation.json` in the installation root to find the active version.
 2. Runs that version's own Node.js runtime on that version's lifecycle interface, from `versions/<active version>/` inside the installation root.
 
-Each installed version carries its own pinned runtime, so the launcher needs no Node.js on the host. The launcher knows its installation root. The default root is `$XDG_DATA_HOME/curia`, or `~/.local/share/curia` when `XDG_DATA_HOME` is unset. A nondefault root is written into the launcher during bootstrap, so you never pass it on the command line.
+Each installed version carries its own pinned runtime, so the launcher needs no Node.js on the host. The launcher knows its installation root. A nondefault root is written into the launcher during bootstrap, so you never pass it on the command line.
 
 When the installation record is missing, or the active version lacks its runtime or entry point, the launcher stops with exit code `3` and names the missing file. Run the bootstrap again to reinstall the active version. If you purged Curia, delete the launcher.
+
+## The installation root
+
+The installation root is the one directory that holds an installed Curia. You own it, and Curia never asks for privileges to work in it. Curia resolves the root in this order:
+
+1. `CURIA_ROOT`, when set. The launcher sets it to the root it was installed for.
+2. `$XDG_DATA_HOME/curia`, when `XDG_DATA_HOME` is set.
+3. `~/.local/share/curia`.
+
+The root must be an absolute path. To install into a nondefault root, pass the root to the bootstrap. The bootstrap writes that root into the launcher, and every later command reads it from there.
+
+### Directory layout
+
+Curia creates the root and seven directories inside it. The following table lists them, with what each one holds and what the lifecycle commands do with it.
+
+| Directory | Holds | Across update, reinstall, and uninstall |
+|---|---|---|
+| `config/` | `config.yaml`, your operator configuration. | Preserved |
+| `secrets/` | Long-lived credentials and private keys, one owner-only file each. | Preserved |
+| `state/` | Durable service state and the installation record, `state/installation.json`. | Preserved |
+| `work/` | Worktrees and native agent sessions that can resume. | Preserved |
+| `versions/` | Installed versions: the pinned runtime, the lifecycle interface, and the Compose bundle of each. | Replaceable |
+| `cache/` | Rebuildable mirrors and download caches. | Removable |
+| `run/` | The lifecycle lock, sockets, and staging for one operation. | Removable |
+
+The root and all seven directories are owned by you with mode `0700`. Configuration, secret, and state files use mode `0600`. Curia sets these modes itself and doesn't depend on your `umask`. Only `curia purge` removes the preserved directories.
+
+`state/installation.json` is the installation record. It holds three fields and nothing else: `format` (the record format, `1`), `installationId` (a random ID that Curia generates once per installation), and `activeVersion` (the installed version the launcher runs). Curia writes the record atomically, so the file is always either the previous complete record or the new one.
+
+### When a lifecycle command refuses the root
+
+Every lifecycle command checks the root before it changes anything. Each check that fails stops the command with exit code `3` and a message that names the path and the corrective action. `curia version` is read-only and skips these checks. The following conditions are refused:
+
+- **Root execution.** The command runs as the `root` user. Run it as the operator that owns the installation. There is no force flag.
+- **Foreign ownership.** The root or one of its seven directories belongs to another user.
+- **Broad permissions.** The root or one of its seven directories has a mode that lets the group or other users reach it, such as `0755`. Curia doesn't repair the mode. Run `chmod 0700` on the named path and try again.
+- **Symbolic links.** The root, one of its seven directories, or `state/installation.json` is a symbolic link. Curia doesn't follow links at those paths. Replace the link with a real directory or file.
+- **An unknown nonempty root.** The root holds files but no installation record, so Curia can't tell whether the directory is a damaged installation or something else. Choose an empty or absent directory, or move the contents out of the way. Curia never deletes what it doesn't recognize.
+
+A present but unreadable installation record is a failure (exit code `1`), not a refusal: Curia treats a damaged record as a damaged installation, never as a fresh directory.
+
+### The lifecycle lock
+
+One lifecycle operation runs at a time per installation root. A lifecycle command takes `run/lifecycle.lock` before it changes anything and releases the lock when it finishes, whether it succeeds or fails. A second command that finds the lock held stops with exit code `3` and names the process that holds it. Wait for that command to finish, then run yours again.
+
+The lock file holds the process ID of its owner. When that process no longer exists, for example after a power loss during an update, the next lifecycle command takes the lock over on its own. You never delete the lock file by hand.
 
 ## Commands
 
@@ -35,7 +81,7 @@ Run `curia help` to print this list from the installed version. The commands app
 
 `curia --version` prints only the lifecycle interface version.
 
-In this release, a command marked **Later release** exits with code `3` and a message that names the installed version and the release map. Nothing changes on the host.
+In this release, a command marked **Later release** checks the installation root as described in [When a lifecycle command refuses the root](#when-a-lifecycle-command-refuses-the-root), then exits with code `3` and a message that names the installed version and the release map. Nothing changes on the host.
 
 ## Exit codes
 
@@ -52,4 +98,4 @@ A refusal is not a failure. It means Curia checked a precondition, such as a mis
 
 ## Environment
 
-`CURIA_ROOT` names the installation root. The launcher sets it for you. Set it yourself only when you run the lifecycle interface without the launcher, such as from a development checkout.
+`CURIA_ROOT` names the installation root. The launcher sets it for you. Set it yourself only when you run the lifecycle interface without the launcher, such as from a development checkout. The value must be an absolute path.


### PR DESCRIPTION
## What this changes

Ticket: [Enforce the installation root and lifecycle-operation boundary](https://github.com/alp82/curia/issues/865), on the map [Ship Curia's supported installation lifecycle](https://github.com/alp82/curia/issues/863).

Every lifecycle command now enters its installation root through one boundary before it changes anything.

- **`cli/src/root.mjs`**: `openRoot(root, { uid })` refuses root execution, a relative root, a symbolic link at the root, a boundary directory, or the installation record, a root or boundary owned by another user or reachable past the owner, and a nonempty root that holds no record. It returns `absent`, `empty`, or `installed` with the record. `ensureLayout` creates the root and `config/`, `secrets/`, `state/`, `work/`, `versions/`, `cache/`, and `run/` with mode `0700`, set explicitly, never repaired. `createInstallationRecord` and `writeInstallationRecord` keep `state/installation.json` to `format`, `installationId`, and `activeVersion`, written owner-only and atomically. The root resolver keeps its precedence: `CURIA_ROOT`, then `$XDG_DATA_HOME/curia`, then `~/.local/share/curia`.
- **`cli/src/atomic.mjs`**: `writeAtomically(path, content, { mode })`. Temporary file beside the target, `fsync`, rename, `fsync` of the directory. A symbolic link at the target is replaced, not followed.
- **`cli/src/lock.mjs`**: `withLifecycleLock(root, operation)` on `run/lifecycle.lock`. It refuses while a live process holds the lock and names that process, and takes over a lock whose process is gone.
- **Commands**: the seven stubs open their root first, so the refusals are real in this release. `curia version` stays read-only. `run(context)` now carries `uid`, and `runCli` accepts a `uid` for tests.
- **Docs**: the command reference gains the root precedence, directory layout with modes, the record fields, the refusal conditions, and the lock. `cli/README.md` describes the boundary for contributors. `CONTEXT.md` defines the lifecycle-operation lock.

## Tests

- `cd cli && npm test`: 63 pass, 0 fail, 0 cancelled. Every boundary and failure-path test runs against a temporary root.
- `cd daemon && npm test`: 3875 pass, 0 fail, 0 cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
