### PR TITLE
feat: build immutable service images and the versioned Compose bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# The build context of every service image is the repository root, and the
+# release stages COPY named paths out of it (#869). This file keeps what a
+# release must never carry out of the context altogether, so a COPY that
+# named a tree by mistake could still not pick these up: secrets, the box's
+# own state and overrides, dependency trees, and git.
+.git
+.github
+.claude
+**/node_modules
+daemon/data
+daemon/.env*
+daemon/*.pem
+*.pem
+*.key
+secrets/
+config/config.yaml
+config/*.local.yaml
+config/.*.candidate
+config/.config.yaml.*.tmp
+prototypes
+docs
+spikes
+tmp
+**/*.log

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,212 @@
+# The release images and the versioned Compose bundle (#869, implementing #849
+# and #854).
+#
+# On a release tag, which Release Please creates when the release pull request
+# merges, this workflow:
+#
+#   1. builds the four service images from the `release` stage of their
+#      Dockerfiles, with the Node and Claude Code pins read from
+#      config/curia.yaml, and pushes each to GHCR under its version tag;
+#   2. records the digest the registry returned for each image and attests
+#      the build provenance of that digest;
+#   3. renders deploy/bundle/compose.yaml against those digests, proves the
+#      result with the same tests the suite runs, and attaches the bundle, its
+#      checksum, and the digest set to the GitHub release of the tag.
+#
+# The version tag on an image is for discovery only. The bundle and the
+# release manifest (#870) name images by digest, never by tag. Publication
+# order and the stable-release index are #871's; this workflow leaves the
+# release as it found it, with three more assets.
+#
+# `workflow_dispatch` is a rehearsal of the same path on any branch: it pushes
+# the images under a commit tag, renders the bundle against their real
+# digests, and attaches nothing anywhere.
+#
+# Every action is pinned to a commit SHA, and each job holds only the
+# permissions it needs.
+
+name: Release images and bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pins:
+    name: Read the release pins
+    runs-on: ubuntu-latest
+    outputs:
+      node: ${{ steps.pins.outputs.NODE_VERSION }}
+      claude: ${{ steps.pins.outputs.CLAUDE_VERSION }}
+      version: ${{ steps.version.outputs.version }}
+      release: ${{ steps.version.outputs.release }}
+    steps:
+      - name: Check out the tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+
+      - name: Read the Node and Claude Code pins from config/curia.yaml
+        id: pins
+        run: node deploy/bundle/pins.mjs | tee -a "$GITHUB_OUTPUT"
+
+      - name: Name the version
+        id: version
+        env:
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [[ "$REF" == refs/tags/v* ]]; then
+            echo "version=${REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            base=$(node -p "require('./daemon/package.json').version")
+            echo "version=${base}-rehearsal.${SHA:0:7}" >> "$GITHUB_OUTPUT"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  images:
+    name: Build and push ${{ matrix.service }}
+    needs: pins
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: true
+      matrix:
+        service: [daemon, tmux, dashboard, overseer]
+    steps:
+      - name: Check out the tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The image manifest itself is the subject: no provenance or SBOM
+      # manifest list from the builder, so the digest the bundle names is the
+      # digest of the image and `docker pull <name>@<digest>` gets exactly it.
+      - name: Build the release stage and push it
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12cc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: deploy/${{ matrix.service }}/Dockerfile
+          target: release
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          sbom: false
+          tags: ghcr.io/alp82/curia-${{ matrix.service }}:${{ needs.pins.outputs.release == 'true' && needs.pins.outputs.version || format('sha-{0}', github.sha) }}
+          build-args: |
+            NODE_VERSION=${{ needs.pins.outputs.node }}
+            CLAUDE_VERSION=${{ needs.pins.outputs.claude }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.pins.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Attest the build provenance of the pushed digest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ghcr.io/alp82/curia-${{ matrix.service }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Record the digest
+        env:
+          SERVICE: ${{ matrix.service }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p digests
+          printf '%s\n' "$DIGEST" > "digests/$SERVICE"
+          echo "$SERVICE $DIGEST"
+
+      - name: Hand the digest to the bundle job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-${{ matrix.service }}
+          path: digests/${{ matrix.service }}
+          if-no-files-found: error
+
+  bundle:
+    name: Render and attach the bundle
+    needs: [pins, images]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out the tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+
+      - name: Set up the pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ needs.pins.outputs.node }}
+
+      - name: Collect the digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digest-*
+          path: digests
+          merge-multiple: true
+
+      - name: Write the digest set
+        run: |
+          node -e '
+            const fs = require("node:fs")
+            const out = {}
+            for (const s of ["daemon", "tmux", "dashboard", "overseer"]) out[s] = fs.readFileSync(`digests/${s}`, "utf8").trim()
+            fs.writeFileSync("digests.json", JSON.stringify(out, null, 2))
+            console.log(JSON.stringify(out, null, 2))
+          '
+
+      - name: Render the bundle
+        env:
+          VERSION: ${{ needs.pins.outputs.version }}
+        run: node deploy/bundle/render.mjs --version "$VERSION" --digests digests.json --out dist
+
+      # The same tests the suite runs on every change, against the file that is
+      # about to be published: the mount contract, the labels, the health
+      # checks, the digest references, and Compose's own reading of it.
+      - name: Prove the bundle
+        run: |
+          npm ci --prefix daemon --no-fund --no-audit
+          npm test --prefix cli
+          node --test daemon/test/bundlecompose.test.mjs daemon/test/bundlerelease.test.mjs daemon/test/releaseimages.test.mjs
+          docker compose --env-file <(printf 'CURIA_ROOT=/tmp/curia\nCURIA_UID=1001\nCURIA_GID=1001\nDOCKER_GID=998\nCURIA_INSTALLATION_ID=00000000000000000000000000000000\n') \
+            -f "dist/curia-bundle-${{ needs.pins.outputs.version }}/compose.yaml" config --quiet
+
+      - name: Keep the rendered bundle as a run artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: curia-bundle-${{ needs.pins.outputs.version }}
+          path: |
+            dist/curia-bundle-*.tar.gz
+            dist/curia-bundle-*.tar.gz.sha256
+            dist/curia-images-*.json
+          if-no-files-found: error
+
+      - name: Attach the bundle, its checksum, and the digest set to the release
+        if: needs.pins.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.pins.outputs.version }}
+        run: |
+          gh release upload "$TAG" \
+            "dist/curia-bundle-$VERSION.tar.gz" \
+            "dist/curia-bundle-$VERSION.tar.gz.sha256" \
+            "dist/curia-images-$VERSION.json" \
+            --clobber

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,13 @@ _Avoid_: installation manifest, which can be confused with a release or version 
 **Lifecycle-operation lock**:
 The `run/lifecycle.lock` file that serializes lifecycle commands on one installation root. A command takes it after the root boundary accepts the root and before it changes anything, and releases it on success or failure. A second command refuses while a live process holds the lock and takes over a lock whose process is gone. See [the command reference](docs/operator/command-reference.md#the-lifecycle-lock).
 
+**Release image**:
+One of the four container images a release builds and publishes by digest: `curia-daemon`, `curia-tmux` (the tmux runtime and the attach surface), `curia-dashboard`, and `curia-overseer`, under `ghcr.io/alp82`. Each is the `release` stage of its Dockerfile, which carries the checkout at `/opt/curia` read-only and assumes no uid and no host path. The agent image is not one: the service builds it on the host from its pins.
+_Avoid_: tag as identity; a version tag exists for browsing only.
+
+**Compose bundle**:
+The one Compose file of a release, `deploy/bundle/compose.yaml` rendered with every image as an exact digest, unpacked to `versions/<version>/bundle/` and started by the lifecycle interface under the fixed project name `curia`. It labels every container, the network, and the volume with the installation ID under `sh.curia.installation`, declares a health check per service, runs every container as the operator's numeric uid and gid, and interpolates five run-time values that are paths and numbers, never a secret. `cli/src/bundle.mjs` is its contract.
+
 **Host preflight**:
 The direct host checks that `curia install` and `curia update` run before they change anything, and that `curia doctor` reruns. `cli/src/preflight.mjs` reads the host through injectable probes into one facts object and evaluates it into one report, one result per check: `passed`, `warning`, or `refused` with what was observed and one corrective action ([#868](https://github.com/alp82/curia/issues/868), implementing [#850](https://github.com/alp82/curia/issues/850) and [#857](https://github.com/alp82/curia/issues/857)). A refused condition is a demonstrated incompatibility, such as another operating-system release, root execution, a busy required port, or a Docker daemon the operator can't reach. It stops the operation and there is no force flag. A warning is a nonblocking fact, such as a host below the recommended profile. Temporary probe resources are removed before the command continues. Curia supports Ubuntu 24.04 LTS and Debian 13 on x86-64 only. See [Supported hosts and preflight checks](docs/operator/supported-hosts.md).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,6 +20,7 @@ This version ships the stable launcher, the command vocabulary, the installation
 - `src/lock.mjs`: `withLifecycleLock(root, operation)`, the exclusive lifecycle-operation lock at `run/lifecycle.lock`.
 - `src/layout.mjs`: `serviceLayout(root)`, where the service data lives inside the seven boundaries, and `SERVICE_MOUNTS`, what each container may mount. See [The service layout and the secret files](#the-service-layout-and-the-secret-files).
 - `src/secrets.mjs`: the catalogue of long-lived secret files under `secrets/`, their reader, writer, and status, shared with the Curia service.
+- `src/bundle.mjs`: the Compose bundle contract: the project name, the installation label, the four release images, the run-time variables, and the render, inspect, and env-file functions. See [The Compose bundle](#the-compose-bundle).
 - `src/preflight.mjs`: the supported-host preflight. `gatherHostFacts` reads the host through injectable probes, `evaluateHostFacts` turns the facts into one report, and `preflight` does both and prints it. See [The host preflight](#the-host-preflight).
 - `src/launcher.mjs`: renders the stable `curia` launcher for one installation root.
 
@@ -72,6 +73,18 @@ The interface:
 - The constants are the contract: `SUPPORTED_SYSTEMS`, `MINIMUM_PROFILE`, `RECOMMENDED_PROFILE`, `TESTED_VERSIONS`, `REQUIRED_PORTS`, `SANDBOX_PORTS`, `RELEASE_ORIGINS`, and `CLOCK_SKEW_LIMIT_SECONDS`. `daemon/test/preflightports.test.mjs` keeps the ports in step with `config/curia.yaml`.
 
 Three probes create temporary resources, and each removes its own before it returns: the port probe listens on every port it tests and closes the listener; the Docker probe writes one temporary directory, opens one loopback HTTP listener, and runs one `--rm` container named `curia-preflight-<id>` that reads the directory through a bind mount and fetches the listener over the host network, then removes the container by force when the run failed or timed out, closes the listener, and deletes the directory. Nothing in the module installs or reconfigures the host.
+
+## The Compose bundle
+
+`src/bundle.mjs` is the one place that says what a release's Compose bundle is, shared by the release workflow that renders it, the tests that inspect it, and the lifecycle commands that start it. The operator's view is [Release images and the Compose bundle](https://github.com/alp82/curia/blob/main/docs/operator/bundle.md).
+
+- The constants are the contract: `COMPOSE_PROJECT` (`curia`), `INSTALLATION_LABEL` (`sh.curia.installation`), `IMAGE_REGISTRY` (`ghcr.io/alp82`), `RELEASE_IMAGES` (the four images by service), and `BUNDLE_VARIABLES` (the five run-time variables, in env-file order).
+- `imageReference(service, digest)` is `ghcr.io/alp82/<image>@sha256:<digest>` and refuses anything but a full digest.
+- `renderBundle(template, digests)` replaces each `${CURIA_<SERVICE>_IMAGE...}` in `deploy/bundle/compose.yaml` with the digest reference and leaves every other variable alone. It is deterministic.
+- `inspectBundle(text)` returns the problems a rendered bundle has, one line each: a project name other than `curia`, an image that is not a digest reference under the registry, a variable outside the run-time set, a build stanza, an env file, or an operator path. Empty means fit to publish.
+- `bundleEnvironment({ root, uid, gid, dockerGid, installationId })` renders the env file `curia install` writes under `run/` and passes with `--env-file`. Paths and numbers only.
+
+The module reads text by line and never a YAML tree, because the package has no dependencies and every question is answerable that way. The release script that uses it is `deploy/bundle/render.mjs`, which writes the bundle directory, a deterministic `.tar.gz`, its `.sha256`, and the digest set for one version. `deploy/bundle/pins.mjs` reads the Node and Claude Code pins the images build with from `config/curia.yaml`.
 
 ## The launcher
 

--- a/cli/src/bundle.mjs
+++ b/cli/src/bundle.mjs
@@ -1,0 +1,119 @@
+import { isAbsolute } from 'node:path'
+
+// The versioned Compose bundle (#869, implementing #849, #851, and #854).
+//
+// A release is one immutable set of container images plus one Compose file
+// that names them by digest. This module is the contract between the three
+// parties that touch that file: the release workflow that renders it from
+// `deploy/bundle/compose.yaml`, the tests that inspect what was rendered, and
+// the lifecycle interface that starts it under an installation root. It is
+// text in and text out, with no YAML reader, because the package has no
+// dependencies and the questions are answerable by line.
+//
+// Three facts every party shares:
+//
+//   - the Compose project is always `curia`, so `docker compose -p curia` and
+//     the labels Compose adds name one installation's containers, network, and
+//     volume on a host;
+//   - every container, the network, and the volume carry the installation ID
+//     under `sh.curia.installation`, which is what `curia purge` (#855) removes
+//     by and never a name prefix;
+//   - the bundle interpolates paths and numbers only, the five variables in
+//     `BUNDLE_VARIABLES`, which `curia install` (#873) writes into an env file
+//     under `run/` from facts it holds. Never a secret.
+//
+// The release manifest (#870) binds the bundle's checksum and the same
+// digests; the publication order and the stable index are #871's.
+
+export class BundleError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'BundleError'
+  }
+}
+
+export const COMPOSE_PROJECT = 'curia'
+export const INSTALLATION_LABEL = 'sh.curia.installation'
+export const IMAGE_REGISTRY = 'ghcr.io/alp82'
+
+// The four images a release builds, keyed by the service that runs them. The
+// attach surface (`ttyd`) runs the tmux image, so it has no image of its own.
+// The agent image is not here: the service builds it on the host from the
+// recipe the service image carries, content-addressed by its pins.
+export const RELEASE_IMAGES = Object.freeze({
+  daemon: 'curia-daemon',
+  tmux: 'curia-tmux',
+  dashboard: 'curia-dashboard',
+  overseer: 'curia-overseer',
+})
+
+// What a started bundle interpolates, in the order the env file lists them.
+export const BUNDLE_VARIABLES = Object.freeze(['CURIA_ROOT', 'CURIA_UID', 'CURIA_GID', 'DOCKER_GID', 'CURIA_INSTALLATION_ID'])
+
+const DIGEST = /^sha256:[0-9a-f]{64}$/
+const INSTALLATION_ID = /^[0-9a-f]{32}$/
+const IMAGE_VARIABLE = /\$\{CURIA_([A-Z]+)_IMAGE(?::\?[^}]*)?\}/g
+const ANY_VARIABLE = /\$\{([A-Za-z_][A-Za-z0-9_]*)/g
+const IMAGE_LINE = /^\s*image:\s*(\S+)\s*$/
+const OPERATOR_PATH = /\/home\/[A-Za-z0-9_-]+/
+
+export function imageReference(service, digest) {
+  const name = RELEASE_IMAGES[service]
+  if (!name) throw new BundleError(`no release image is built for ${service}`)
+  if (typeof digest !== 'string' || !DIGEST.test(digest)) {
+    throw new BundleError(`the ${service} image needs a sha256 digest, got ${JSON.stringify(digest)}`)
+  }
+  return `${IMAGE_REGISTRY}/${name}@${digest}`
+}
+
+// The template with each `${CURIA_<SERVICE>_IMAGE...}` replaced by that
+// service's digest reference. Every other variable is left as it is.
+export function renderBundle(template, digests) {
+  return template.replace(IMAGE_VARIABLE, (whole, upper) => {
+    const service = upper.toLowerCase()
+    if (!RELEASE_IMAGES[service]) throw new BundleError(`the template names ${whole.slice(2, whole.indexOf('_IMAGE') + 6)}, which no release builds`)
+    return imageReference(service, digests?.[service])
+  })
+}
+
+const referencePattern = new RegExp(`^${IMAGE_REGISTRY.replace(/[.]/g, '\\.')}/(${Object.values(RELEASE_IMAGES).join('|')})@sha256:[0-9a-f]{64}$`)
+
+// The problems a rendered bundle has, as one line each. Empty means it is fit
+// to publish: one fixed project name, every image an exact digest under the
+// registry, only the run-time variables, no build, no env file, no path of
+// anyone's home.
+export function inspectBundle(text) {
+  const problems = []
+  const lines = text.split('\n')
+  if (!lines.some((l) => l === `name: ${COMPOSE_PROJECT}`)) {
+    problems.push(`the project name must be \`name: ${COMPOSE_PROJECT}\` at the top level`)
+  }
+  lines.forEach((line, i) => {
+    const n = i + 1
+    const image = IMAGE_LINE.exec(line)
+    if (image && !referencePattern.test(image[1])) {
+      problems.push(`line ${n}: image ${image[1]} is not a digest reference under ${IMAGE_REGISTRY}`)
+    }
+    for (const m of line.matchAll(ANY_VARIABLE)) {
+      if (!BUNDLE_VARIABLES.includes(m[1])) problems.push(`line ${n}: variable ${m[1]} is not one the lifecycle interface writes`)
+    }
+    if (/^\s*build:/.test(line)) problems.push(`line ${n}: a build stanza; the bundle runs published images only`)
+    if (/^\s*env_file:/.test(line)) problems.push(`line ${n}: env_file; the bundle loads no env file`)
+    if (OPERATOR_PATH.test(line)) problems.push(`line ${n}: an operator path, ${OPERATOR_PATH.exec(line)[0]}`)
+  })
+  return problems
+}
+
+// The env file `curia install` writes under `run/` and passes with
+// `--env-file`. Paths and numbers, one per line, never a secret.
+export function bundleEnvironment({ root, uid, gid, dockerGid, installationId }) {
+  if (typeof root !== 'string' || !isAbsolute(root)) throw new BundleError(`CURIA_ROOT must be an absolute path, got ${JSON.stringify(root)}`)
+  for (const [name, value] of [['CURIA_UID', uid], ['CURIA_GID', gid], ['DOCKER_GID', dockerGid]]) {
+    if (!(Number.isInteger(value) && value >= 0)) throw new BundleError(`${name} must be a non-negative whole number, got ${JSON.stringify(value)}`)
+  }
+  if (typeof installationId !== 'string' || !INSTALLATION_ID.test(installationId)) {
+    throw new BundleError(`CURIA_INSTALLATION_ID must be the 32-hex installation ID, got ${JSON.stringify(installationId)}`)
+  }
+  const values = { CURIA_ROOT: root, CURIA_UID: uid, CURIA_GID: gid, DOCKER_GID: dockerGid, CURIA_INSTALLATION_ID: installationId }
+  return BUNDLE_VARIABLES.map((name) => `${name}=${values[name]}\n`).join('')
+}

--- a/cli/test/bundle.test.mjs
+++ b/cli/test/bundle.test.mjs
@@ -1,0 +1,129 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  COMPOSE_PROJECT, INSTALLATION_LABEL, IMAGE_REGISTRY, RELEASE_IMAGES, BUNDLE_VARIABLES,
+  imageReference, renderBundle, inspectBundle, bundleEnvironment, BundleError,
+} from '../src/bundle.mjs'
+
+const D = 'a'.repeat(64)
+const DIGESTS = { daemon: `sha256:${D}`, tmux: `sha256:${'b'.repeat(64)}`, dashboard: `sha256:${'c'.repeat(64)}`, overseer: `sha256:${'d'.repeat(64)}` }
+
+// A template in the shape of deploy/bundle/compose.yaml: one image variable
+// per service and the run-time variables beside them.
+const TEMPLATE = [
+  'name: curia',
+  'services:',
+  '  daemon:',
+  '    image: ${CURIA_DAEMON_IMAGE:?the digest-pinned service image}',
+  '    user: "${CURIA_UID:?}:${CURIA_GID:?}"',
+  '    labels:',
+  '      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}',
+  '  tmux:',
+  '    image: ${CURIA_TMUX_IMAGE:?}',
+  '  ttyd:',
+  '    image: ${CURIA_TMUX_IMAGE:?}',
+  '  dashboard:',
+  '    image: ${CURIA_DASHBOARD_IMAGE:?}',
+  '  overseer:',
+  '    image: ${CURIA_OVERSEER_IMAGE:?}',
+  '    volumes:',
+  '      - ${CURIA_ROOT:?}/run:${CURIA_ROOT:?}/run',
+  '',
+].join('\n')
+
+describe('the contract', () => {
+  test('one fixed project name, one label key, four release images under one registry', () => {
+    assert.equal(COMPOSE_PROJECT, 'curia')
+    assert.equal(INSTALLATION_LABEL, 'sh.curia.installation')
+    assert.equal(IMAGE_REGISTRY, 'ghcr.io/alp82')
+    assert.deepEqual(RELEASE_IMAGES, { daemon: 'curia-daemon', tmux: 'curia-tmux', dashboard: 'curia-dashboard', overseer: 'curia-overseer' })
+    assert.deepEqual(BUNDLE_VARIABLES, ['CURIA_ROOT', 'CURIA_UID', 'CURIA_GID', 'DOCKER_GID', 'CURIA_INSTALLATION_ID'])
+  })
+
+  test('an image reference is registry, name, and digest, and nothing mutable', () => {
+    assert.equal(imageReference('daemon', `sha256:${D}`), `ghcr.io/alp82/curia-daemon@sha256:${D}`)
+    assert.throws(() => imageReference('daemon', '1.2.3'), BundleError)
+    assert.throws(() => imageReference('daemon', `sha256:${D.slice(1)}`), BundleError)
+    assert.throws(() => imageReference('agent', `sha256:${D}`), BundleError)
+  })
+})
+
+describe('rendering the bundle', () => {
+  test('replaces every image variable with the digest reference and leaves the run-time variables', () => {
+    const out = renderBundle(TEMPLATE, DIGESTS)
+    assert.match(out, new RegExp(`^    image: ghcr.io/alp82/curia-daemon@sha256:${D}$`, 'm'))
+    assert.equal((out.match(/curia-tmux@sha256:b{64}/g) ?? []).length, 2, 'tmux and ttyd share the image')
+    assert.ok(!out.includes('_IMAGE'), 'no image variable survives')
+    assert.ok(out.includes('${CURIA_ROOT:?}/run'), 'the root is a run-time variable')
+    assert.ok(out.includes('${CURIA_INSTALLATION_ID:?}'), 'the installation ID is a run-time variable')
+  })
+
+  test('is deterministic', () => {
+    assert.equal(renderBundle(TEMPLATE, DIGESTS), renderBundle(TEMPLATE, DIGESTS))
+  })
+
+  test('refuses a missing image, a tag, or a template that names an image the release does not build', () => {
+    assert.throws(() => renderBundle(TEMPLATE, { ...DIGESTS, overseer: undefined }), /overseer/)
+    assert.throws(() => renderBundle(TEMPLATE, { ...DIGESTS, tmux: '1.2.3' }), /tmux/)
+    assert.throws(() => renderBundle(`${TEMPLATE}  agent:\n    image: \${CURIA_AGENT_IMAGE:?}\n`, DIGESTS), /CURIA_AGENT_IMAGE/)
+  })
+})
+
+describe('inspecting a rendered bundle', () => {
+  test('a rendered bundle passes', () => {
+    assert.deepEqual(inspectBundle(renderBundle(TEMPLATE, DIGESTS)), [])
+  })
+
+  test('names every image that is not a digest reference under the registry', () => {
+    const tagged = renderBundle(TEMPLATE, DIGESTS).replace(`curia-tmux@${DIGESTS.tmux}`, 'curia-tmux:latest')
+    const foreign = renderBundle(TEMPLATE, DIGESTS).replace(`ghcr.io/alp82/curia-daemon@${DIGESTS.daemon}`, `docker.io/alp82/curia-daemon@${DIGESTS.daemon}`)
+    assert.match(inspectBundle(tagged).join('\n'), /curia-tmux:latest/)
+    assert.match(inspectBundle(foreign).join('\n'), /docker\.io/)
+  })
+
+  test('names a variable outside the run-time set, a build stanza, an env file, and an operator path', () => {
+    const problems = inspectBundle([
+      'name: curia',
+      'services:',
+      '  daemon:',
+      '    build: .',
+      `    image: ghcr.io/alp82/curia-daemon@sha256:${D}`,
+      '    env_file: ../daemon/.env.daemon',
+      '    environment:',
+      '      HOME: ${CURIA_HOME:-/home/alp/curia-work/home}',
+      '',
+    ].join('\n')).join('\n')
+    assert.match(problems, /CURIA_HOME/)
+    assert.match(problems, /build/)
+    assert.match(problems, /env_file/)
+    assert.match(problems, /\/home\/alp/)
+  })
+
+  test('names a project name that is not the fixed one', () => {
+    assert.match(inspectBundle(renderBundle(TEMPLATE, DIGESTS).replace('name: curia', 'name: curia-two')).join('\n'), /project name/)
+    assert.match(inspectBundle(renderBundle(TEMPLATE, DIGESTS).replace('name: curia\n', '')).join('\n'), /project name/)
+  })
+})
+
+describe('the run-time environment', () => {
+  const facts = { root: '/home/operator/.local/share/curia', uid: 1001, gid: 1001, dockerGid: 998, installationId: 'f'.repeat(32) }
+
+  test('is the five variables, one per line, in contract order', () => {
+    assert.equal(bundleEnvironment(facts), [
+      'CURIA_ROOT=/home/operator/.local/share/curia',
+      'CURIA_UID=1001',
+      'CURIA_GID=1001',
+      'DOCKER_GID=998',
+      `CURIA_INSTALLATION_ID=${'f'.repeat(32)}`,
+      '',
+    ].join('\n'))
+  })
+
+  test('refuses a relative root, a non-numeric id, and a malformed installation ID', () => {
+    assert.throws(() => bundleEnvironment({ ...facts, root: 'curia' }), /CURIA_ROOT/)
+    assert.throws(() => bundleEnvironment({ ...facts, uid: '1001' }), /CURIA_UID/)
+    assert.throws(() => bundleEnvironment({ ...facts, dockerGid: -1 }), /DOCKER_GID/)
+    assert.throws(() => bundleEnvironment({ ...facts, installationId: 'nope' }), /CURIA_INSTALLATION_ID/)
+  })
+})

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -330,6 +330,14 @@ The daemon measures the credential the WATCH LIST stands on, every six hours, an
 
 The Compose shape of an installed Curia is `deploy/bundle/compose.yaml`, inspected against `SERVICE_MOUNTS` by `test/bundlecompose.test.mjs`. The operator's page is [Secrets, mounts, and what survives](../docs/operator/secrets.md).
 
+## The release images and the bundle (#869)
+
+Each of the four service Dockerfiles under `deploy/` ends in a `release` stage, and `.github/workflows/release-images.yml` builds that stage once per release tag, pushes it to `ghcr.io/alp82/curia-<service>`, attests the digest, and renders `deploy/bundle/compose.yaml` against the four digests with `deploy/bundle/render.mjs`. The rendered bundle, its checksum, and `curia-images-<version>.json` land on the GitHub release. `workflow_dispatch` rehearses the same path on any branch under a commit tag and attaches nothing.
+
+The release stage carries the checkout at `/opt/curia`: `daemon/src`, `daemon/bin`, `daemon/assets`, the pinned `node_modules`, `cli/src` (the daemon imports the operator configuration and the layout from there), `config/curia.yaml` and `routing.yaml`, and in the daemon image `skills/` and `deploy/agent/`. Named paths, never a tree: `daemon/` as a whole would carry the box's env file and journal. `.dockerignore` at the repository root keeps those out of every build context too. The files are root-owned and read-only to the uid that runs the container, and nothing in the stage names a uid or a host path: the bundle sets `user`, `HOME`, and every mount at run time. Under `CURIA_ROOT` the loader also takes `sandbox.agent_uid` from the process's own uid rather than the file, because the file's `1000` is the source box's fact.
+
+The source deployment keeps building the `box` stage (`target: box` in `deploy/compose.yaml`), which is the image it always had. The Node and Claude Code pins reach a release build through `deploy/bundle/pins.mjs`, which reads `sandbox.node_version` and `sandbox.claude_version` from `config/curia.yaml`; `test/releaseimages.test.mjs` keeps them equal to the anchors in `deploy/compose.yaml`, inspects every release stage as text, and, with `CURIA_BUILD_IMAGES=1` and Docker present, builds the tmux image and runs it as uid 4242. The operator's page is [Release images and the Compose bundle](../docs/operator/bundle.md).
+
 ## What an agent knows (#57)
 
 `seedConfigDir` symlinks the configured skills into `<CLAUDE_CONFIG_DIR>/skills/`, so an agent resolves in the same idiom a hand session does instead of being told about skills in its prompt (#49). Config is `skills.root` + `skills.install` in `curia.yaml`; the default list is `wayfinder`, `grilling`, `domain-modeling`, `research`, `prototype`, `implement`, `tdd`, `code-review`, `diagnosing-bugs`. The charting-and-PM skills (`to-tickets`, `triage`, `to-spec`, `handoff`) are withheld — `to-tickets` is mass ticket creation in the hands of an agent that carries charting authority.
@@ -538,7 +546,7 @@ One Node patch version runs every curia image. It is committed in two places, an
 
 - `deploy/compose.yaml` passes `NODE_VERSION` to the daemon, the dashboard and the overseer from the `x-node-version` anchor. It is an anchor and not an interpolated variable, because the pin is committed and the `.env` file beside it is not.
 - `config/curia.yaml` holds `sandbox.node_version` for the agent image, beside the other pins. It rides the image content address, so a bump names a tag the box does not have and the daemon rebuilds.
-- The four Dockerfiles take `ARG NODE_VERSION` with no default. A build that forgets the arg then fails. This is the rule the agent Dockerfile already states for every other version it carries.
+- The four Dockerfiles take `ARG NODE_VERSION` with no default. A build that forgets the arg then fails. This is the rule the agent Dockerfile already states for every other version it carries. A release build reads the value from `config/curia.yaml` through `deploy/bundle/pins.mjs`, so the two committed places stay two and the workflow adds no third.
 - Every image names its distro too, as `node:${NODE_VERSION}-bookworm-slim`. A new Debian then arrives by a commit and never by a rebuild.
 - `daemon/package.json` states `engines.node`. It is a warning and not a wall, because a daemon that refuses to install is worse than the stack trace it prevents.
 - `image.test.mjs` holds the two rules that silence would break: the two committed places name one version, and no Dockerfile carries a default.

--- a/daemon/src/config.mjs
+++ b/daemon/src/config.mjs
@@ -540,6 +540,10 @@ export function loadCuriaConfig(file, { checkPaths = true, localFile, env = proc
     // its first write. Defaulted to the daemon's own uid, which is the only
     // value that can be right by construction.
     sb.agent_uid = sb.agent_uid ?? process.getuid?.()
+    // Under an installation root the file's answer is the source box's (#869).
+    // Every container of the bundle runs as the operator's uid, this process
+    // included, so the uid it runs as is the one that owns the worktrees.
+    if (installRoot) sb.agent_uid = process.getuid?.() ?? sb.agent_uid
     if (!(Number.isInteger(sb.agent_uid) && sb.agent_uid >= 0 && sb.agent_uid < 2 ** 31)) {
       fail(src, `sandbox.agent_uid must be a uid (got ${JSON.stringify(sb.agent_uid)})`)
     }

--- a/daemon/test/bundlecompose.test.mjs
+++ b/daemon/test/bundlecompose.test.mjs
@@ -9,16 +9,23 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { BUNDLE_COMPOSE_FILE, composeConfigOf } from './fixtures/compose.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { BUNDLE_COMPOSE_FILE, composeConfigOf, composeConfigOfText } from './fixtures/compose.mjs'
 import { serviceLayout, SERVICE_MOUNTS, DOCKER_SOCKET_SERVICES, SERVICES } from '../../cli/src/layout.mjs'
 import { CREDENTIAL_ENV_KEYS } from '../../cli/src/secrets.mjs'
+import { COMPOSE_PROJECT, INSTALLATION_LABEL, renderBundle, inspectBundle, bundleEnvironment } from '../../cli/src/bundle.mjs'
 
 const ROOT = '/home/operator/.local/share/curia'
+const INSTALLATION_ID = '0123456789abcdef0123456789abcdef'
 const ENV = {
   CURIA_ROOT: ROOT,
   CURIA_UID: '1001',
   CURIA_GID: '1001',
   DOCKER_GID: '998',
+  CURIA_INSTALLATION_ID: INSTALLATION_ID,
   CURIA_DAEMON_IMAGE: 'ghcr.io/alp82/curia-daemon@sha256:d',
   CURIA_TMUX_IMAGE: 'ghcr.io/alp82/curia-tmux@sha256:t',
   CURIA_DASHBOARD_IMAGE: 'ghcr.io/alp82/curia-dashboard@sha256:a',
@@ -40,6 +47,10 @@ const SOCKETS = ['/var/run/docker.sock', '/var/run/tailscale/tailscaled.sock']
 describe('the bundle names the five services and interpolates nothing but paths and numbers', () => {
   test('the five services, and no others', () => {
     assert.deepEqual(Object.keys(cfg.services), [...SERVICES])
+  })
+
+  test('one fixed project name, so one host runs one Curia under one name', () => {
+    assert.equal(cfg.name, COMPOSE_PROJECT)
   })
 
   test('every variable is required, so a bundle started without one refuses', () => {
@@ -137,6 +148,106 @@ describe('sockets and volumes', () => {
   test('the service, the app, and the overseer are told the root, so one loader yields one set of paths', () => {
     for (const name of ['daemon', 'dashboard', 'overseer']) {
       assert.equal(cfg.services[name].environment.CURIA_ROOT, ROOT)
+    }
+  })
+})
+
+describe('owned resources carry the installation ID', () => {
+  test('every container, the network, and the volume are labelled with it', () => {
+    for (const [name, s] of Object.entries(cfg.services)) {
+      assert.equal(s.labels?.[INSTALLATION_LABEL], INSTALLATION_ID, `${name} is not labelled`)
+    }
+    assert.equal(cfg.volumes['tmux-sock'].labels?.[INSTALLATION_LABEL], INSTALLATION_ID, 'the volume is not labelled')
+    assert.equal(cfg.networks.default.labels?.[INSTALLATION_LABEL], INSTALLATION_ID, 'the network is not labelled')
+  })
+
+  test('a bundle started without the installation ID refuses', () => {
+    assert.throws(() => composeConfigOf(BUNDLE_COMPOSE_FILE, { ...ENV, CURIA_INSTALLATION_ID: '' }), /CURIA_INSTALLATION_ID/)
+  })
+})
+
+// Each check asks the process the question that means it is serving: the
+// service and the overseer answer their own `/ping`, the tmux server holds the
+// keeper session, the attach surface and the app answer HTTP on their ports.
+const HEALTH = {
+  daemon: /127\.0\.0\.1:4271\/ping/,
+  tmux: /has-session -t keeper/,
+  ttyd: /127\.0\.0\.1:7681/,
+  dashboard: /127\.0\.0\.1:4273/,
+  overseer: /127\.0\.0\.1:4274\/ping/,
+}
+
+describe('every service declares a health check that asks the process itself', () => {
+  for (const service of SERVICES) {
+    test(`${service}`, () => {
+      const h = cfg.services[service].healthcheck
+      assert.ok(h, `${service} has no health check`)
+      assert.equal(h.test[0], 'CMD', 'exec form, so no shell interprets it')
+      assert.match(h.test.join(' '), HEALTH[service])
+      for (const key of ['interval', 'timeout', 'retries', 'start_period']) assert.ok(h[key] !== undefined, `${service} sets no ${key}`)
+    })
+  }
+
+  test('the service and the app wait for a healthy tmux runtime and service, so a start settles in order', () => {
+    assert.deepEqual(cfg.services.daemon.depends_on, { tmux: { condition: 'service_healthy' } })
+    assert.deepEqual(cfg.services.ttyd.depends_on, { tmux: { condition: 'service_healthy' } })
+  })
+})
+
+describe('the rendered bundle', () => {
+  const template = fs.readFileSync(BUNDLE_COMPOSE_FILE, 'utf8')
+  const digests = {
+    daemon: `sha256:${'1'.repeat(64)}`,
+    tmux: `sha256:${'2'.repeat(64)}`,
+    dashboard: `sha256:${'3'.repeat(64)}`,
+    overseer: `sha256:${'4'.repeat(64)}`,
+  }
+  const rendered = renderBundle(template, digests)
+  const environment = bundleEnvironment({ root: ROOT, uid: 1001, gid: 1001, dockerGid: 998, installationId: INSTALLATION_ID })
+
+  test('passes the static inspection: digests only, the five variables only, no build, no env file, no operator path', () => {
+    assert.deepEqual(inspectBundle(rendered), [])
+  })
+
+  test('the template itself fails it only for the image variables, which is what rendering resolves', () => {
+    const problems = inspectBundle(template)
+    assert.ok(problems.length > 0)
+    for (const p of problems) assert.match(p, /_IMAGE|image \$\{CURIA_/)
+  })
+
+  test('names each service\'s image by digest and the attach surface by the tmux image', () => {
+    const r = composeConfigOfText(rendered, Object.fromEntries(environment.trim().split('\n').map((l) => l.split('='))))
+    assert.equal(r.services.daemon.image, `ghcr.io/alp82/curia-daemon@${digests.daemon}`)
+    assert.equal(r.services.tmux.image, `ghcr.io/alp82/curia-tmux@${digests.tmux}`)
+    assert.equal(r.services.ttyd.image, r.services.tmux.image)
+    assert.equal(r.services.dashboard.image, `ghcr.io/alp82/curia-dashboard@${digests.dashboard}`)
+    assert.equal(r.services.overseer.image, `ghcr.io/alp82/curia-overseer@${digests.overseer}`)
+  })
+
+  test('renders the same bytes twice', () => {
+    assert.equal(renderBundle(template, digests), rendered)
+  })
+
+  // Compose's own reader, where Docker is on the machine. `config` validates
+  // the schema and the interpolation without touching an image or a socket.
+  const compose = spawnSync('docker', ['compose', 'version'], { encoding: 'utf8' })
+  test('docker compose config accepts it', { skip: compose.status === 0 ? false : 'docker compose is not available here' }, () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-bundle-'))
+    try {
+      fs.writeFileSync(path.join(dir, 'compose.yaml'), rendered)
+      fs.writeFileSync(path.join(dir, 'bundle.env'), environment)
+      const r = spawnSync('docker', ['compose', '--env-file', 'bundle.env', '-f', 'compose.yaml', 'config', '--format', 'json'], { cwd: dir, encoding: 'utf8' })
+      assert.equal(r.status, 0, r.stderr)
+      const out = JSON.parse(r.stdout)
+      assert.equal(out.name, COMPOSE_PROJECT)
+      assert.deepEqual(Object.keys(out.services).sort(), [...SERVICES].sort())
+      for (const [name, s] of Object.entries(out.services)) {
+        assert.equal(s.user, '1001:1001', name)
+        assert.equal(s.labels[INSTALLATION_LABEL], INSTALLATION_ID, name)
+        assert.ok(s.healthcheck?.test, `${name} lost its health check`)
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
     }
   })
 })

--- a/daemon/test/bundlerelease.test.mjs
+++ b/daemon/test/bundlerelease.test.mjs
@@ -1,0 +1,86 @@
+// The rendered release bundle (#869): what `deploy/bundle/render.mjs` writes
+// for one version from the digests the image builds produced. The output is
+// what #870 binds into the release manifest and #871 publishes, so its shape
+// and its determinism are pinned here.
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { inspectBundle, RELEASE_IMAGES, IMAGE_REGISTRY } from '../../cli/src/bundle.mjs'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const RENDER = path.join(REPO, 'deploy', 'bundle', 'render.mjs')
+const VERSION = '1.2.3'
+const DIGESTS = {
+  daemon: `sha256:${'1'.repeat(64)}`,
+  tmux: `sha256:${'2'.repeat(64)}`,
+  dashboard: `sha256:${'3'.repeat(64)}`,
+  overseer: `sha256:${'4'.repeat(64)}`,
+}
+
+const gnuTar = /GNU tar/.test(spawnSync('tar', ['--version'], { encoding: 'utf8' }).stdout ?? '')
+
+let dir
+before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-release-')) })
+after(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+function render(out, digests = DIGESTS, version = VERSION) {
+  const file = path.join(dir, `digests-${crypto.randomUUID()}.json`)
+  fs.writeFileSync(file, JSON.stringify(digests))
+  return spawnSync(process.execPath, [RENDER, '--version', version, '--digests', file, '--out', out], { encoding: 'utf8' })
+}
+
+describe('deploy/bundle/render.mjs', { skip: gnuTar ? false : 'the bundle archive needs GNU tar' }, () => {
+  test('writes the bundle directory, its archive, the checksum, and the image set for one version', () => {
+    const out = path.join(dir, 'one')
+    const r = render(out)
+    assert.equal(r.status, 0, r.stderr)
+
+    const compose = fs.readFileSync(path.join(out, `curia-bundle-${VERSION}`, 'compose.yaml'), 'utf8')
+    assert.deepEqual(inspectBundle(compose), [])
+    assert.match(compose, new RegExp(`image: ${IMAGE_REGISTRY}/curia-daemon@${DIGESTS.daemon}$`, 'm'))
+
+    const archive = path.join(out, `curia-bundle-${VERSION}.tar.gz`)
+    const listing = spawnSync('tar', ['tzf', archive], { encoding: 'utf8' }).stdout.trim().split('\n')
+    assert.deepEqual(listing, [`curia-bundle-${VERSION}/`, `curia-bundle-${VERSION}/compose.yaml`])
+
+    const sum = crypto.createHash('sha256').update(fs.readFileSync(archive)).digest('hex')
+    assert.equal(fs.readFileSync(`${archive}.sha256`, 'utf8'), `${sum}  curia-bundle-${VERSION}.tar.gz\n`)
+
+    const images = JSON.parse(fs.readFileSync(path.join(out, `curia-images-${VERSION}.json`), 'utf8'))
+    assert.equal(images.version, VERSION)
+    assert.deepEqual(Object.keys(images.images), Object.keys(RELEASE_IMAGES))
+    assert.deepEqual(images.images.tmux, { name: `${IMAGE_REGISTRY}/curia-tmux`, digest: DIGESTS.tmux, reference: `${IMAGE_REGISTRY}/curia-tmux@${DIGESTS.tmux}` })
+
+    assert.match(r.stdout, new RegExp(`curia-bundle-${VERSION}.tar.gz\\s+sha256:${sum}`))
+  })
+
+  test('renders the same bytes on every run, so the checksum the manifest binds is stable', () => {
+    const a = path.join(dir, 'a')
+    const b = path.join(dir, 'b')
+    assert.equal(render(a).status, 0)
+    assert.equal(render(b).status, 0)
+    const archive = `curia-bundle-${VERSION}.tar.gz`
+    assert.ok(fs.readFileSync(path.join(a, archive)).equals(fs.readFileSync(path.join(b, archive))))
+    assert.equal(fs.readFileSync(path.join(a, `${archive}.sha256`), 'utf8'), fs.readFileSync(path.join(b, `${archive}.sha256`), 'utf8'))
+  })
+
+  test('refuses a missing digest, a tag, or a version that is not a plain release version', () => {
+    const missing = render(path.join(dir, 'missing'), { ...DIGESTS, overseer: undefined })
+    assert.equal(missing.status, 1)
+    assert.match(missing.stderr, /overseer/)
+    const tagged = render(path.join(dir, 'tagged'), { ...DIGESTS, daemon: 'v1.2.3' })
+    assert.equal(tagged.status, 1)
+    assert.match(tagged.stderr, /daemon/)
+    const version = render(path.join(dir, 'version'), DIGESTS, 'v1.2.3')
+    assert.equal(version.status, 1)
+    assert.match(version.stderr, /version/)
+    assert.ok(!fs.existsSync(path.join(dir, 'version', 'curia-bundle-v1.2.3.tar.gz')))
+  })
+})

--- a/daemon/test/config.test.mjs
+++ b/daemon/test/config.test.mjs
@@ -996,4 +996,14 @@ describe('the installation root and the service paths (#867)', () => {
   test('a relative root is refused', () => {
     assert.throws(() => loadCuriaConfig(writeConfig(noSkills()), { env: { CURIA_ROOT: 'relative' } }), /absolute/)
   })
+
+  // The shipped file says `agent_uid: 1000`, which is the source box's fact.
+  // Under a root the containers run as the operator (#869), and the service
+  // is one of them, so the uid it runs as is the uid the agents get.
+  test('under a root the agent uid is the service\'s own uid, whatever the shipped file says', () => {
+    const installRoot = path.join(tmp, 'install-uid')
+    const withUid = `${noSkills()}\n${sandboxYaml().join('\n').replace(/agent_uid: \d+/, 'agent_uid: 4242')}`
+    assert.equal(loadCuriaConfig(writeConfig(withUid), { env: {} }).sandbox.agent_uid, 4242)
+    assert.equal(loadCuriaConfig(writeConfig(withUid), { env: { CURIA_ROOT: installRoot } }).sandbox.agent_uid, process.getuid())
+  })
 })

--- a/daemon/test/fixtures/compose.mjs
+++ b/daemon/test/fixtures/compose.mjs
@@ -69,3 +69,8 @@ export function composeConfigOf(file, env = {}) {
 export const DEFAULT_REPO_ROOT = '/home/alp/curia'
 export const DEFAULT_WORKSPACE_ROOT = '/home/alp/curia-work'
 export const DEFAULT_HOME = `${DEFAULT_WORKSPACE_ROOT}/home`
+
+// The same resolution over text that is not on disk: the rendered bundle.
+export function composeConfigOfText(text, env = {}) {
+  return resolve(YAML.parse(text), env)
+}

--- a/daemon/test/image.test.mjs
+++ b/daemon/test/image.test.mjs
@@ -505,7 +505,7 @@ describe('the Node pin (#357, applied by #409)', () => {
     for (const name of [...Object.values(BUILT), 'agent']) {
       assert.match(
         dockerfile(name),
-        /^FROM node:\$\{NODE_VERSION\}-bookworm-slim$/m,
+        /^FROM node:\$\{NODE_VERSION\}-bookworm-slim( AS \w+)?$/m,
         `${name} does not build on the pinned node base image`,
       )
     }

--- a/daemon/test/releaseimages.test.mjs
+++ b/daemon/test/releaseimages.test.mjs
@@ -1,0 +1,179 @@
+// The release images (#869, implementing #849, #851, and #854).
+//
+// Each service Dockerfile ends in a `release` stage that carries the checkout
+// at /opt/curia with its dependency tree installed, so the bundle mounts no
+// source. These tests inspect the Dockerfiles as text, which needs no Docker:
+// the stage exists, it copies only named checkout paths and never a secret or
+// a whole tree, it assumes no uid and no operator path, every base image is
+// pinned, and the pins come from the one place that holds them. One opt-in
+// test builds the tmux image and runs it as an arbitrary uid, where Docker is
+// on the machine and `CURIA_BUILD_IMAGES=1` asks for it.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import YAML from 'yaml'
+
+import { RELEASE_IMAGES } from '../../cli/src/bundle.mjs'
+import { composeConfig } from './fixtures/compose.mjs'
+import { releasePins, PINS_FILE } from '../../deploy/bundle/pins.mjs'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const dockerfileOf = (service) => path.join(REPO, 'deploy', service, 'Dockerfile')
+
+// The instructions of one stage, comment lines dropped and continuation
+// lines joined, so a regex reads one instruction per line.
+function stages(text) {
+  const out = {}
+  let current = null
+  for (const raw of text.replace(/\\\n/g, ' ').split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const from = /^FROM\s+(\S+)(?:\s+AS\s+(\S+))?/i.exec(line)
+    if (from) {
+      current = from[2] ?? from[1]
+      out[current] = { base: from[1], lines: [] }
+      continue
+    }
+    if (current) out[current].lines.push(line)
+  }
+  return out
+}
+
+// What a release stage may copy out of the checkout: the paths a service
+// reads at run time, and nothing beside them.
+const CHECKOUT_PATHS = [
+  'daemon/package.json', 'daemon/package-lock.json', 'daemon/src', 'daemon/bin', 'daemon/assets',
+  'daemon/bin/curia-attach.sh', 'daemon/assets/attach-index.html',
+  'cli/src', 'config/curia.yaml', 'config/routing.yaml', 'skills', 'deploy/agent', 'deploy/overseer/gh-shim.sh',
+]
+
+describe('every service Dockerfile ends in a release stage', () => {
+  for (const service of Object.keys(RELEASE_IMAGES)) {
+    const text = fs.readFileSync(dockerfileOf(service), 'utf8')
+    const all = stages(text)
+    const release = all.release
+
+    test(`${service}: the release stage is the last one, so a build with no target is the release`, () => {
+      assert.ok(release, `deploy/${service}/Dockerfile has no release stage`)
+      assert.equal(Object.keys(all).at(-1), 'release')
+    })
+
+    test(`${service}: it assumes no uid, no operator path, and no source-deployment argument`, () => {
+      const body = release.lines.join('\n')
+      assert.ok(!/\b1000\b/.test(body), 'a uid is assumed')
+      assert.ok(!/\/home\//.test(body), 'an operator path')
+      assert.ok(!/CURIA_HOME|CURIA_REPO_ROOT|CURIA_WORKSPACE_ROOT/.test(body), 'a source-deployment argument')
+      assert.ok(!/\buseradd\b|\bchown\b/.test(body), 'a user is created or a path is given to one')
+    })
+
+    test(`${service}: it copies named checkout paths under /opt/curia, never a tree or a secret`, () => {
+      const copies = release.lines.filter((l) => /^COPY\b/.test(l) && !/--from=/.test(l))
+      assert.ok(copies.length > 0, 'nothing is copied')
+      for (const copy of copies) {
+        const words = copy.split(/\s+/).slice(1).filter((w) => !w.startsWith('--'))
+        const destination = words.at(-1)
+        assert.ok(destination.startsWith('/opt/curia/') || destination.startsWith('./'), `${copy}: lands outside /opt/curia`)
+        for (const source of words.slice(0, -1)) {
+          assert.ok(CHECKOUT_PATHS.includes(source), `${copy}: ${source} is not a named checkout path`)
+        }
+      }
+      const workdir = release.lines.find((l) => /^WORKDIR\b/.test(l))
+      if (workdir) assert.match(workdir, /^WORKDIR \/opt\/curia\//)
+    })
+
+    test(`${service}: it is labelled with its source, so GHCR links the package to the repository`, () => {
+      assert.match(release.lines.join('\n'), /org\.opencontainers\.image\.source="https:\/\/github\.com\/alp82\/curia"/)
+    })
+
+    test(`${service}: every base image is a pinned version, never a floating tag`, () => {
+      // The ARG defaults declared before the first FROM, plus the two pins the
+      // release passes in, are what the base images resolve against.
+      const defaults = { ...releasePins() }
+      for (const m of text.matchAll(/^ARG ([A-Z_]+)=(\S+)/gm)) defaults[m[1]] = m[2]
+      for (const [name, { base }] of Object.entries(all)) {
+        if (Object.hasOwn(all, base)) continue
+        const resolved = base.replace(/\$\{([A-Z_]+)\}/g, (_, arg) => {
+          assert.ok(defaults[arg], `${name} builds on ${base}, and ${arg} has no pinned value`)
+          return defaults[arg]
+        })
+        assert.ok(!/:latest$|^[^:@]+$/.test(resolved), `${name} builds on ${resolved}, which floats`)
+        assert.match(resolved, /:\S*\d\S*$/, `${name} builds on ${resolved}, which names no version`)
+      }
+    })
+  }
+
+  test('the two images that share the tmux socket volume seed it for any uid', () => {
+    for (const service of ['daemon', 'tmux']) {
+      const body = stages(fs.readFileSync(dockerfileOf(service), 'utf8')).release.lines.join('\n')
+      assert.match(body, /mkdir -p \/run\/curia-tmux && chmod 1777 \/run\/curia-tmux/, `${service} seeds the socket directory for uid 1000 only`)
+    }
+  })
+
+  test('the node images install the dependency tree from the lock file, with no scripts', () => {
+    for (const service of ['daemon', 'dashboard', 'overseer']) {
+      const body = stages(fs.readFileSync(dockerfileOf(service), 'utf8')).release.lines.join('\n')
+      assert.match(body, /COPY daemon\/package\.json daemon\/package-lock\.json/)
+      assert.match(body, /npm ci --omit=dev --no-fund --no-audit --ignore-scripts/)
+    }
+  })
+
+  test('the source deployment builds the box stage, so its images are unchanged by the release stage', () => {
+    const compose = composeConfig()
+    for (const service of Object.keys(RELEASE_IMAGES)) {
+      assert.equal(compose.services[service].build.target, 'box', `${service} builds the wrong stage on the box`)
+    }
+  })
+})
+
+describe('the release pins', () => {
+  const pins = releasePins()
+  const compose = YAML.parse(fs.readFileSync(path.join(REPO, 'deploy', 'compose.yaml'), 'utf8'))
+
+  test('come from config/curia.yaml, and match the anchors the source deployment builds with', () => {
+    assert.equal(PINS_FILE, path.join(REPO, 'config', 'curia.yaml'))
+    assert.deepEqual(Object.keys(pins), ['NODE_VERSION', 'CLAUDE_VERSION'])
+    assert.equal(pins.NODE_VERSION, compose['x-node-version'])
+    assert.equal(pins.CLAUDE_VERSION, compose['x-claude-version'])
+  })
+
+  test('print as build arguments, one per line', () => {
+    const r = spawnSync(process.execPath, [path.join(REPO, 'deploy', 'bundle', 'pins.mjs')], { encoding: 'utf8' })
+    assert.equal(r.status, 0, r.stderr)
+    assert.equal(r.stdout, `NODE_VERSION=${pins.NODE_VERSION}\nCLAUDE_VERSION=${pins.CLAUDE_VERSION}\n`)
+  })
+})
+
+// The one test that runs Docker. The tmux image is the smallest and the one
+// whose process looks its user up, so it is the one to prove for a uid the
+// image has never heard of.
+const docker = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], { encoding: 'utf8' })
+const wantsBuild = process.env.CURIA_BUILD_IMAGES === '1'
+const skip = !wantsBuild ? 'set CURIA_BUILD_IMAGES=1 to build the tmux image' : docker.status !== 0 ? 'Docker is not available here' : false
+
+describe('the tmux release image', () => {
+  test('builds, and runs tmux and ttyd as an arbitrary uid', { skip, timeout: 10 * 60_000 }, () => {
+    const tag = `curia-tmux-test:${Date.now()}`
+    const build = spawnSync('docker', ['build', '--target', 'release', '-t', tag, '-f', dockerfileOf('tmux'), REPO], { encoding: 'utf8' })
+    assert.equal(build.status, 0, build.stderr.slice(-4000))
+    try {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-tmux-home-'))
+      fs.chmodSync(home, 0o777)
+      const run = (...argv) => spawnSync('docker', ['run', '--rm', '--user', '4242:4242', '-e', `HOME=${home}`, '-v', `${home}:${home}`, tag, ...argv], { encoding: 'utf8' })
+      const tmux = run('sh', '-c', 'tmux -S /run/curia-tmux/default new-session -d -s keeper && tmux -S /run/curia-tmux/default has-session -t keeper && echo held')
+      assert.equal(tmux.status, 0, tmux.stderr)
+      assert.match(tmux.stdout, /held/)
+      const ttyd = run('ttyd', '--version')
+      assert.equal(ttyd.status, 0, ttyd.stderr)
+      const attach = run('/opt/curia/daemon/bin/curia-attach.sh', 'not-a-session')
+      assert.match(attach.stdout, /refused/)
+      fs.rmSync(home, { recursive: true, force: true })
+    } finally {
+      spawnSync('docker', ['rmi', '-f', tag])
+    }
+  })
+})

--- a/deploy/bundle/compose.yaml
+++ b/deploy/bundle/compose.yaml
@@ -1,9 +1,14 @@
-# The Compose shape of an installed Curia (#867, implementing #851).
+# The Compose shape of an installed Curia (#867 and #869, implementing #851
+# and #854).
 #
-# This is the file the versioned Compose bundle (#869) packages under
-# `versions/<version>/` and `curia install` (#873) starts. It differs from
-# `deploy/compose.yaml`, which is the source deployment on one box, in three
-# ways that the tests in daemon/test/bundlecompose.test.mjs pin:
+# This is the TEMPLATE of the versioned Compose bundle. The release workflow
+# (.github/workflows/release-images.yml) renders it once per release by
+# replacing each `CURIA_*_IMAGE` variable with that image's digest reference
+# (`cli/src/bundle.mjs`, `renderBundle`), and the rendered file is what
+# `versions/<version>/bundle/compose.yaml` holds and `curia install` (#873)
+# starts. It differs from `deploy/compose.yaml`, which is the source
+# deployment on one box, in these ways, and daemon/test/bundlecompose.test.mjs
+# pins every one of them:
 #
 #   1. EVERY MOUNT IS A BOUNDARY OF THE INSTALLATION ROOT, or a path inside
 #      one, and each service gets only what `SERVICE_MOUNTS` in
@@ -12,36 +17,56 @@
 #      credentials are files under `secrets/`, which only the service mounts.
 #      The service refuses to boot if one of the credential keys is set anyway.
 #   3. ONLY THE SERVICE AND THE TMUX RUNTIME REACH THE DOCKER SOCKET.
+#   4. EVERY IMAGE IS AN EXACT DIGEST, once rendered. No build stanza, no tag.
+#   5. ONE FIXED PROJECT NAME, `curia`, and every container, the network, and
+#      the volume carry the installation ID under `sh.curia.installation`.
+#      `curia purge` removes by that label and never by a name.
+#   6. EVERY SERVICE DECLARES A HEALTH CHECK that asks the process itself, and
+#      a start settles in order: the service and the attach surface wait for a
+#      healthy tmux runtime.
+#   7. CONTAINERS RUN AS THE OPERATOR'S NUMERIC UID AND GID. Nothing here or
+#      in the images assumes uid 1000.
 #
 # The interpolated variables are paths and numbers, never secrets. The
 # lifecycle interface writes them into an env file under `run/` when it starts
-# the project:
+# the project (`bundleEnvironment` in cli/src/bundle.mjs):
 #
-#   CURIA_ROOT      the installation root, absolute
-#   CURIA_UID       the operator's numeric user id
-#   CURIA_GID       the operator's numeric group id
-#   DOCKER_GID      the host's docker group id
-#   CURIA_*_IMAGE   the digest-pinned images, from the release manifest (#870)
+#   CURIA_ROOT             the installation root, absolute
+#   CURIA_UID              the operator's numeric user id
+#   CURIA_GID              the operator's numeric group id
+#   DOCKER_GID             the host's docker group id
+#   CURIA_INSTALLATION_ID  the installation ID from state/installation.json
 #
 # Host paths mount at their identical paths inside, as the source deployment
 # does: the service composes `docker run -v` lines from its own paths, and the
 # Chat screen reads the overseer's transcript off the config directory.
 #
 # The images carry the checkout at /opt/curia (daemon/, cli/, config/,
-# skills/) with the dependency tree installed, so nothing here mounts source.
+# skills/, and the agent image recipe under deploy/agent/) with the dependency
+# tree installed, root-owned and read-only to the operator, so nothing here
+# mounts source.
 #
-# The two named volumes are runtime and disposable: the tmux socket, and
-# nothing else. The agent image's npm and browser caches are volumes the
-# service creates by name (daemon/src/sandbox.mjs). No volume holds
-# installation identity, durable state, or resumable work, so every volume can
-# be recreated without losing the installation.
+# The one named volume is runtime and disposable: the tmux socket. The agent
+# image's npm and browser caches are volumes the service creates by name
+# (daemon/src/sandbox.mjs). No volume holds installation identity, durable
+# state, or resumable work, so every volume can be recreated without losing
+# the installation.
 
 name: curia
+
+networks:
+  # The bridge network the overseer sits on. Compose creates it as
+  # `curia_default`; the label is what makes it this installation's.
+  default:
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?the installation ID from state/installation.json}
 
 volumes:
   # The tmux server socket, shared by the service, the tmux runtime, and the
   # attach surface: /run/curia-tmux/default in every container.
   tmux-sock:
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}
 
 services:
   daemon:
@@ -51,6 +76,8 @@ services:
     user: "${CURIA_UID:?the operator's user id}:${CURIA_GID:?the operator's group id}"
     group_add:
       - "${DOCKER_GID:?host docker group id — getent group docker | cut -d: -f3}"
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}
     working_dir: /opt/curia/daemon
     command: ["node", "src/index.mjs"]
     environment:
@@ -70,8 +97,18 @@ services:
       - ${CURIA_ROOT:?}/cache:${CURIA_ROOT:?}/cache
       - ${CURIA_ROOT:?}/run:${CURIA_ROOT:?}/run
       - tmux-sock:/run/curia-tmux
+    # The service's own probe route on host loopback, the one the self-deploy
+    # sibling and every agent container already read. It answers only once the
+    # config loaded, the journal opened, and the listener bound.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-m", "3", "-o", "/dev/null", "http://127.0.0.1:4271/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     depends_on:
-      - tmux
+      tmux:
+        condition: service_healthy
 
   # The tmux server that holds the agent panes, outside the service's
   # lifecycle. Its panes run `docker run` against host paths under work/, so it
@@ -84,6 +121,8 @@ services:
     user: "${CURIA_UID:?}:${CURIA_GID:?}"
     group_add:
       - "${DOCKER_GID:?}"
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}
     tty: true
     command: ["tmux", "-S", "/run/curia-tmux/default", "new-session", "-A", "-s", "keeper"]
     environment:
@@ -93,6 +132,14 @@ services:
       - ${CURIA_ROOT:?}/work:${CURIA_ROOT:?}/work
       - ${CURIA_ROOT:?}/cache/home:${CURIA_ROOT:?}/cache/home
       - tmux-sock:/run/curia-tmux
+    # The server is healthy while the keeper session exists on the shared
+    # socket: that is what the service and the attach surface connect to.
+    healthcheck:
+      test: ["CMD", "tmux", "-S", "/run/curia-tmux/default", "has-session", "-t", "keeper"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   # The attach surface: `tmux attach` over the shared socket, behind the
   # identity proxy. It needs nothing of the root and no Docker socket.
@@ -102,6 +149,8 @@ services:
     stop_grace_period: 30s
     network_mode: host
     user: "${CURIA_UID:?}:${CURIA_GID:?}"
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}
     command:
       [
         "ttyd", "-W", "-a", "-O", "-p", "7681", "-i", "127.0.0.1",
@@ -114,8 +163,17 @@ services:
       CURIA_TMUX_SOCKET: /run/curia-tmux/default
     volumes:
       - tmux-sock:/run/curia-tmux
+    # ttyd serves the attach index on loopback. An answer means the listener
+    # is bound and the surface can hand out the page.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-m", "3", "-o", "/dev/null", "http://127.0.0.1:7681/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
-      - tmux
+      tmux:
+        condition: service_healthy
 
   # The Curia app. It receives no installation-root mount: it reads and updates
   # configuration through the service, and it holds no secret and no socket
@@ -125,6 +183,8 @@ services:
     restart: unless-stopped
     network_mode: host
     user: "${CURIA_UID:?}:${CURIA_GID:?}"
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}
     working_dir: /opt/curia/daemon
     command: ["node", "/opt/curia/daemon/bin/curia-dashboard.mjs"]
     environment:
@@ -132,6 +192,17 @@ services:
       HOME: ${CURIA_ROOT:?}/cache/home
     volumes:
       - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+    # The app is fail-closed at boot: it dies when it cannot bind its loopback
+    # port. So an HTTP answer on that port is the app up. A local request
+    # carries no Tailscale identity and gets a 403, which is still an answer;
+    # only a listener that is gone or broken fails this. The app image carries
+    # node and no curl.
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4273/').then((r) => process.exit(r.status < 500 ? 0 : 1), () => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # The overseer, off the host network because it holds a shell. It receives
   # its own config directory and native sessions read-write, its mirrors of
@@ -142,6 +213,8 @@ services:
     image: ${CURIA_OVERSEER_IMAGE:?the digest-pinned overseer image, from the release manifest}
     restart: unless-stopped
     user: "${CURIA_UID:?}:${CURIA_GID:?}"
+    labels:
+      sh.curia.installation: ${CURIA_INSTALLATION_ID:?}
     working_dir: /opt/curia/daemon
     command: ["node", "/opt/curia/daemon/bin/curia-overseer.mjs"]
     ports:
@@ -158,3 +231,12 @@ services:
       - ${CURIA_ROOT:?}/work/cfg/curia-overseer:${CURIA_ROOT:?}/work/cfg/curia-overseer
       - ${CURIA_ROOT:?}/cache/overseer-repos:${CURIA_ROOT:?}/cache/overseer-repos
       - ${CURIA_ROOT:?}/run/overseer-tokens:${CURIA_ROOT:?}/run/overseer-tokens:ro
+    # The overseer's own `/ping`, the route the service reads before it sends
+    # a turn. Inside the container, because the port is published on the
+    # host's loopback and not on the bridge.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-m", "3", "-o", "/dev/null", "http://127.0.0.1:4274/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s

--- a/deploy/bundle/pins.mjs
+++ b/deploy/bundle/pins.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// The build arguments of a release (#869).
+//
+// One Node patch version runs every Curia image, and one Claude Code version
+// runs the overseer and every claude agent. Both are pinned in
+// config/curia.yaml under `sandbox:`, beside the agent image's other pins, and
+// the release workflow reads them from here so the images it publishes run
+// the versions the suite ran on. The source deployment's anchors in
+// deploy/compose.yaml name the same two values, and
+// daemon/test/releaseimages.test.mjs keeps them equal.
+//
+//     node deploy/bundle/pins.mjs        NODE_VERSION=... CLAUDE_VERSION=...
+//
+// Read by line rather than through a YAML reader, so the script needs no
+// dependency tree on the runner before the images are built.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const PINS_FILE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'config', 'curia.yaml')
+
+const PINS = { NODE_VERSION: 'node_version', CLAUDE_VERSION: 'claude_version' }
+
+export function releasePins(file = PINS_FILE) {
+  const text = fs.readFileSync(file, 'utf8')
+  const out = {}
+  for (const [arg, key] of Object.entries(PINS)) {
+    const m = new RegExp(`^  ${key}:\\s*([0-9]+\\.[0-9]+\\.[0-9]+)\\s*(?:#.*)?$`, 'm').exec(text)
+    if (!m) throw new Error(`${file} pins no sandbox.${key}`)
+    out[arg] = m[1]
+  }
+  return out
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  for (const [arg, value] of Object.entries(releasePins())) process.stdout.write(`${arg}=${value}\n`)
+}

--- a/deploy/bundle/render.mjs
+++ b/deploy/bundle/render.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Render the versioned Compose bundle of one release (#869).
+//
+//     node deploy/bundle/render.mjs --version 1.2.3 --digests digests.json --out dist
+//
+// `digests.json` maps each release image's service name to the sha256 digest
+// the registry returned when the release workflow pushed it:
+//
+//     { "daemon": "sha256:…", "tmux": "sha256:…", "dashboard": "sha256:…", "overseer": "sha256:…" }
+//
+// The script renders deploy/bundle/compose.yaml with those digests, refuses
+// anything the static inspection in cli/src/bundle.mjs objects to, and writes
+// into `--out`:
+//
+//     curia-bundle-<version>/compose.yaml     the bundle, what versions/<version>/bundle/ holds
+//     curia-bundle-<version>.tar.gz           the same, as one deterministic archive
+//     curia-bundle-<version>.tar.gz.sha256    its checksum, `sha256sum -c` shape
+//     curia-images-<version>.json             the digest set, for the release manifest (#870)
+//
+// The archive is byte-for-byte the same for the same inputs: a sorted ustar
+// with epoch timestamps and numeric zero ownership, gzipped with no name and
+// no time. That is what lets the manifest bind one checksum and an operator
+// verify a download against it.
+//
+// No dependency beyond node and GNU tar, so the runner needs no install
+// before the images are built.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import zlib from 'node:zlib'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { renderBundle, inspectBundle, imageReference, RELEASE_IMAGES, IMAGE_REGISTRY, BundleError } from '../../cli/src/bundle.mjs'
+
+const DIR = path.dirname(fileURLToPath(import.meta.url))
+export const TEMPLATE = path.join(DIR, 'compose.yaml')
+
+const RELEASE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+
+function args(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]
+    if (!/^--(version|digests|out)$/.test(key) || argv[i + 1] === undefined) {
+      throw new BundleError('usage: render.mjs --version <version> --digests <file.json> --out <dir>')
+    }
+    out[key.slice(2)] = argv[i + 1]
+  }
+  for (const key of ['version', 'digests', 'out']) if (!out[key]) throw new BundleError(`--${key} is required`)
+  return out
+}
+
+// The archive bytes for one bundle directory, deterministic.
+function archive(outDir, name) {
+  const tar = spawnSync('tar', [
+    '--format=ustar', '--sort=name', '--owner=0', '--group=0', '--numeric-owner', '--mtime=@0',
+    '-C', outDir, '-cf', '-', name,
+  ], { maxBuffer: 64 * 1024 * 1024 })
+  if (tar.status !== 0) throw new BundleError(`tar failed: ${tar.stderr}`)
+  return zlib.gzipSync(tar.stdout, { level: 9 })
+}
+
+export function renderRelease({ version, digests, out }) {
+  if (!RELEASE_VERSION.test(version)) throw new BundleError(`--version must be a plain release version like 1.2.3, got ${version}`)
+  const template = fs.readFileSync(TEMPLATE, 'utf8')
+  const compose = renderBundle(template, digests)
+  const problems = inspectBundle(compose)
+  if (problems.length) throw new BundleError(`the rendered bundle is not fit to publish:\n  ${problems.join('\n  ')}`)
+
+  const name = `curia-bundle-${version}`
+  const bundleDir = path.join(out, name)
+  fs.mkdirSync(bundleDir, { recursive: true })
+  fs.writeFileSync(path.join(bundleDir, 'compose.yaml'), compose)
+
+  const bytes = archive(out, name)
+  const sum = crypto.createHash('sha256').update(bytes).digest('hex')
+  fs.writeFileSync(path.join(out, `${name}.tar.gz`), bytes)
+  fs.writeFileSync(path.join(out, `${name}.tar.gz.sha256`), `${sum}  ${name}.tar.gz\n`)
+
+  const images = Object.fromEntries(Object.entries(RELEASE_IMAGES).map(([service, image]) => [service, {
+    name: `${IMAGE_REGISTRY}/${image}`,
+    digest: digests[service],
+    reference: imageReference(service, digests[service]),
+  }]))
+  fs.writeFileSync(path.join(out, `curia-images-${version}.json`), `${JSON.stringify({ version, images }, null, 2)}\n`)
+
+  return { name, archive: `${name}.tar.gz`, sha256: sum, images }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const { version, digests, out } = args(process.argv.slice(2))
+    const result = renderRelease({ version, digests: JSON.parse(fs.readFileSync(digests, 'utf8')), out })
+    process.stdout.write(`${result.archive}  sha256:${result.sha256}\n`)
+    for (const [service, { reference }] of Object.entries(result.images)) process.stdout.write(`${service}  ${reference}\n`)
+  } catch (e) {
+    process.stderr.write(`render.mjs: ${e.message}\n`)
+    process.exit(1)
+  }
+}

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -37,7 +37,14 @@ name: curia
 # THE NODE PIN (ruled by #357, first value applied by #409). One patch version
 # runs every curia image, and this anchor is that version for the three images
 # built here. The fourth is the agent image, pinned by `sandbox.node_version` in
-# config/curia.yaml. Move both in one commit.
+# config/curia.yaml. Move both in one commit. A release reads the same value
+# from config/curia.yaml through deploy/bundle/pins.mjs, and
+# daemon/test/releaseimages.test.mjs keeps the anchor and the pin equal.
+#
+# EVERY BUILD NAMES `target: box` (#869). The Dockerfiles end in a `release`
+# stage that bakes the checkout at /opt/curia for the published images, and a
+# build that named no target would build that one. This box runs its code
+# from the repo mount, so it builds the stage before it.
 #
 # It is an anchor and not an interpolated variable on purpose: the pin is
 # committed, and `.env` beside this file is not. No Dockerfile carries a default
@@ -60,6 +67,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/daemon/Dockerfile
+      target: box
       args:
         NODE_VERSION: *node-version
         CURIA_HOME: ${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/home
@@ -119,6 +127,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/tmux/Dockerfile
+      target: box
       args:
         CURIA_HOME: ${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/home
     image: curia-tmux
@@ -197,6 +206,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/dashboard/Dockerfile
+      target: box
       args:
         NODE_VERSION: *node-version
         CURIA_HOME: ${CURIA_WORKSPACE_ROOT:-/home/alp/curia-work}/home
@@ -252,6 +262,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/overseer/Dockerfile
+      target: box
       args:
         NODE_VERSION: *node-version
         CLAUDE_VERSION: *claude-version

--- a/deploy/daemon/Dockerfile
+++ b/deploy/daemon/Dockerfile
@@ -1,19 +1,29 @@
-# The daemon image (#260). The code is NOT baked in — it runs from the repo
-# mount at /home/alp/curia — so this image is only the toolchain: node (the one
-# pin every curia image shares, #357), git, gh, the docker CLI (agent containers
-# are siblings on host dockerd), the tailscale CLI (Serve over the host
-# tailscaled socket), tmux as a CLIENT of the tmux service's server, and the
-# sqlite3 shell for the journal.
+# The daemon image (#260, release stage by #869). Three stages:
+#
+#   toolchain  node (the one pin every curia image shares, #357), git, gh, the
+#              docker CLI (agent containers are siblings on host dockerd), the
+#              tailscale CLI (Serve over the host tailscaled socket), tmux as a
+#              CLIENT of the tmux service's server, and the sqlite3 shell for
+#              the journal.
+#   box        the source deployment's image (deploy/compose.yaml, `target:
+#              box`). The code is NOT baked in — it runs from the repo mount —
+#              so this stage adds only what uid 1000 on that box needs.
+#   release    the published image. The checkout sits at /opt/curia with its
+#              dependency tree installed, root-owned and read-only to whoever
+#              runs it, and nothing in it assumes a uid or a host path. The
+#              release workflow builds this stage and the Compose bundle names
+#              it by digest.
 #
 # Every version is a pin, same rule as config/curia.yaml `sandbox:`.
 
 # NODE_VERSION carries NO default (#357, applied by #409). One patch version
-# runs every curia image, and it is committed in deploy/compose.yaml for this
-# image and in config/curia.yaml for the agent one. A build that forgets the arg
+# runs every curia image, and it is committed in config/curia.yaml as
+# `sandbox.node_version`, which deploy/compose.yaml anchors for this box and
+# deploy/bundle/pins.mjs reads for a release. A build that forgets the arg
 # fails here rather than picking a Node of its own.
 ARG NODE_VERSION
 ARG NPM_VERSION=11.12.1
-ARG DOCKER_CLI_VERSION=28
+ARG DOCKER_CLI_VERSION=28.5.2
 ARG COMPOSE_VERSION=v2.39.2
 ARG TAILSCALE_VERSION=v1.98.10
 
@@ -21,7 +31,7 @@ FROM docker:${DOCKER_CLI_VERSION}-cli AS docker-cli
 FROM docker/compose-bin:${COMPOSE_VERSION} AS compose-bin
 FROM tailscale/tailscale:${TAILSCALE_VERSION} AS tailscale
 
-FROM node:${NODE_VERSION}-bookworm-slim
+FROM node:${NODE_VERSION}-bookworm-slim AS toolchain
 ARG GH_VERSION=2.97.0
 ARG NPM_VERSION
 
@@ -58,6 +68,10 @@ COPY --from=tailscale /usr/local/bin/tailscale /usr/local/bin/tailscale
 # `docker compose`. Pinned to the version proven on the box (#260).
 COPY --from=compose-bin /docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
 
+# ---------------------------------------------------------------------------
+# The source deployment's image. deploy/compose.yaml builds this stage.
+FROM toolchain AS box
+
 # Seed the tmux socket volume dir with the right owner: a named volume copies
 # ownership from the image on first use, and a root-owned dir would stop
 # uid 1000 from creating the socket.
@@ -75,3 +89,42 @@ RUN mkdir -p /run/curia-tmux && chown 1000:1000 /run/curia-tmux
 # home at a path nobody named.
 ARG CURIA_HOME
 RUN mkdir -p "$CURIA_HOME" && chown 1000:1000 "$CURIA_HOME"
+
+# ---------------------------------------------------------------------------
+# The release image (#869). Last, so a build that names no target builds it.
+#
+# What it carries is what the service reads at run time and nothing beside it:
+# the daemon's code, its assets, and its pinned dependency tree; the lifecycle
+# interface's source, which the daemon imports by relative path (#866); the
+# shipped configuration; the vendored skills; and the agent image recipe, which
+# the service builds on the host from its pins (daemon/src/image.mjs). Named
+# paths, never a tree: `daemon/` as a whole would carry the box's env file and
+# journal, and the repository root would carry the secrets directory.
+#
+# Every file is root-owned and world-readable, which is what makes an installed
+# version read-only to the operator that runs it (#851). The process writes
+# only under the installation root's mounts and under HOME, which the bundle
+# sets to `cache/home` inside the root.
+FROM toolchain AS release
+
+# The socket directory the tmux volume copies on first use, writable by any uid
+# with the sticky bit, because the operator's uid is a run-time fact (#851).
+RUN mkdir -p /run/curia-tmux && chmod 1777 /run/curia-tmux
+
+WORKDIR /opt/curia/daemon
+# Its own layer, keyed on the two pin files, so a code-only change reuses it.
+COPY daemon/package.json daemon/package-lock.json ./
+RUN npm ci --omit=dev --no-fund --no-audit --ignore-scripts \
+  && npm cache clean --force
+COPY daemon/src ./src
+COPY daemon/bin ./bin
+COPY daemon/assets ./assets
+COPY cli/src /opt/curia/cli/src
+COPY config/curia.yaml config/routing.yaml /opt/curia/config/
+COPY skills /opt/curia/skills
+COPY deploy/agent /opt/curia/deploy/agent
+
+LABEL org.opencontainers.image.title="curia daemon" \
+      org.opencontainers.image.source="https://github.com/alp82/curia" \
+      org.opencontainers.image.description="The Curia service: the agent-facing surface, the Discord bridge, and the durable journal." \
+      curia.gh-version="${GH_VERSION}"

--- a/deploy/dashboard/Dockerfile
+++ b/deploy/dashboard/Dockerfile
@@ -1,30 +1,39 @@
-# The dashboard sidecar image (#249, #260, stood up by #263). Secret-free: node
-# plus the tailscale CLI — the sidecar asserts its own Serve rule over the host
-# tailscaled socket. No credentials on disk or in env.
+# The dashboard sidecar image (#249, #260, stood up by #263, release stage by
+# #869). Secret-free: node plus the tailscale CLI — the sidecar asserts its own
+# Serve rule over the host tailscaled socket. No credentials on disk or in env.
 #
-# The CODE is not baked in. It runs from the repo mount, exactly as the daemon's
-# does, so a deploy is a pull plus a restart. What IS baked in is the dependency
-# tree, and that is deliberate: compose mounts `daemon/src`, `daemon/bin` and
-# `daemon/assets` and nothing else under `daemon/`, because the two things it
-# must NOT mount live beside them — `.env` holds the Discord token, and `data/`
-# holds the journal the where-it-lives decision keeps daemon-private. So
-# `node_modules` cannot come from the mount, and it comes from here.
+# Three stages, the same shape as the daemon image:
 #
-# It installs the DAEMON's own pinned tree rather than a hand-listed subset. The
-# sidecar imports daemon modules, so a second pin here would be a second version
-# of a module the two processes share. Today that tree is needed for one package
-# (`yaml`, to read curia.yaml); the pin is what matters, not the count.
+#   toolchain  node and the tailscale CLI.
+#   box        the source deployment's image. The CODE is not baked in. It
+#              runs from the repo mount, exactly as the daemon's does, so a
+#              deploy is a pull plus a restart. What IS baked in is the
+#              dependency tree, and that is deliberate: compose mounts
+#              `daemon/src`, `daemon/bin` and `daemon/assets` and nothing else
+#              under `daemon/`, because the two things it must NOT mount live
+#              beside them — `.env` holds the Discord token, and `data/` holds
+#              the journal the where-it-lives decision keeps daemon-private.
+#   release    the published image, the code and the tree at /opt/curia.
+#
+# Both install the DAEMON's own pinned tree rather than a hand-listed subset.
+# The sidecar imports daemon modules, so a second pin here would be a second
+# version of a module the two processes share.
 
-# No default: the pin is one version across every curia image, and it comes from
-# the anchor in deploy/compose.yaml (#357, applied by #409).
+# No default: the pin is one version across every curia image, and it comes
+# from config/curia.yaml through the anchor in deploy/compose.yaml on the box
+# and deploy/bundle/pins.mjs in a release (#357, applied by #409).
 ARG NODE_VERSION
 ARG TAILSCALE_VERSION=v1.98.10
 
 FROM tailscale/tailscale:${TAILSCALE_VERSION} AS tailscale
 
-FROM node:${NODE_VERSION}-bookworm-slim
+FROM node:${NODE_VERSION}-bookworm-slim AS toolchain
 
 COPY --from=tailscale /usr/local/bin/tailscale /usr/local/bin/tailscale
+
+# ---------------------------------------------------------------------------
+# The source deployment's image. deploy/compose.yaml builds this stage.
+FROM toolchain AS box
 
 # HOME for uid 1000 (see daemon Dockerfile). This container mounts no
 # workspace, so the directory this line makes is the one the process runs on.
@@ -43,3 +52,26 @@ WORKDIR $CURIA_REPO_ROOT/daemon
 COPY daemon/package.json daemon/package-lock.json ./
 RUN npm ci --omit=dev --no-fund --no-audit --ignore-scripts \
   && chown -R 1000:1000 "$CURIA_REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# The release image (#869). Last, so a build that names no target builds it.
+#
+# The app reads the daemon's modules, the shipped configuration, and the
+# lifecycle interface's source (#866). It reads no skill and no agent recipe,
+# so neither is here. Root-owned and world-readable, read-only to the operator
+# that runs it; the process writes under HOME only.
+FROM toolchain AS release
+
+WORKDIR /opt/curia/daemon
+COPY daemon/package.json daemon/package-lock.json ./
+RUN npm ci --omit=dev --no-fund --no-audit --ignore-scripts \
+  && npm cache clean --force
+COPY daemon/src ./src
+COPY daemon/bin ./bin
+COPY daemon/assets ./assets
+COPY cli/src /opt/curia/cli/src
+COPY config/curia.yaml config/routing.yaml /opt/curia/config/
+
+LABEL org.opencontainers.image.title="curia dashboard" \
+      org.opencontainers.image.source="https://github.com/alp82/curia" \
+      org.opencontainers.image.description="The Curia app: the console beside the service."

--- a/deploy/overseer/Dockerfile
+++ b/deploy/overseer/Dockerfile
@@ -1,6 +1,6 @@
 # The overseer image (#327, building the service [ADR-0015](../../docs/adr/0015-the-overseer-is-a-service.md)
-# decided). One long-lived container beside the dashboard, and many
-# conversations pass through it.
+# decided; release stage by #869). One long-lived container beside the
+# dashboard, and many conversations pass through it.
 #
 # ITS OWN IMAGE, NOT THE AGENT IMAGE. The agent image already carries git, gh
 # and both harnesses, so reuse was the obvious move. Its tag is a CONTENT
@@ -25,18 +25,19 @@
 # stays an agent's job, and the overseer dispatches one. What it can do is read
 # every watched repo at every ref, which is what ADR-0014 asked for.
 #
-# The CODE is not baked in. It runs from the repo mount, exactly as the daemon's
-# and the dashboard's do, so a deploy is a pull plus a restart. What IS baked in
-# is the dependency tree, for the reason the dashboard states: `daemon/` as a
-# whole must not be mounted, because `.env.daemon` and `data/` live in it.
+# Three stages, the same shape as the daemon image: `toolchain` is the shell
+# and the harness, `box` is the source deployment's image (the code runs from
+# the repo mount, the dependency tree is baked in for the reason the dashboard
+# states), and `release` is the published image with the code at /opt/curia.
 
-# No default: the pin is one version across every curia image, and it comes from
-# the anchor in deploy/compose.yaml (#357, applied by #409).
+# No default: the pin is one version across every curia image, and it comes
+# from config/curia.yaml through the anchor in deploy/compose.yaml on the box
+# and deploy/bundle/pins.mjs in a release (#357, applied by #409).
 ARG NODE_VERSION
 ARG GH_VERSION=2.97.0
 ARG CLAUDE_VERSION
 
-FROM node:${NODE_VERSION}-bookworm-slim
+FROM node:${NODE_VERSION}-bookworm-slim AS toolchain
 ARG GH_VERSION
 ARG CLAUDE_VERSION
 
@@ -81,6 +82,14 @@ RUN npm install -g --no-fund --no-audit \
 COPY deploy/overseer/gh-shim.sh /usr/local/bin/gh
 RUN chmod 0755 /usr/local/bin/gh
 
+# The SDK checks for a newer self on start. The image is the pin, and this
+# container is recreated by a deploy, never by an update it decided itself.
+ENV DISABLE_AUTOUPDATER=1
+
+# ---------------------------------------------------------------------------
+# The source deployment's image. deploy/compose.yaml builds this stage.
+FROM toolchain AS box
+
 # THE BAKED DEPENDENCY TREE HAS TO SIT WHERE THE REPO MOUNTS (#473), the same
 # reason the dashboard image states. So this path is the variable the mounts
 # take, and it carries no default: an empty arg fails the chown below rather
@@ -104,10 +113,31 @@ RUN npm ci --omit=dev --no-fund --no-audit --ignore-scripts \
 ARG CURIA_HOME
 RUN mkdir -p "$CURIA_HOME" && chown 1000:1000 "$CURIA_HOME"
 
-# The SDK checks for a newer self on start. The image is the pin, and this
-# container is recreated by a deploy, never by an update it decided itself.
-ENV DISABLE_AUTOUPDATER=1
+LABEL org.opencontainers.image.title="curia overseer" \
+      org.opencontainers.image.source="https://github.com/alp82/curia" \
+      curia.gh-version="${GH_VERSION}"
+
+# ---------------------------------------------------------------------------
+# The release image (#869). Last, so a build that names no target builds it.
+#
+# The overseer reads the daemon's modules, the seed's assets (`voice.md`, #314),
+# the shipped configuration, and the lifecycle interface's source (#866). The
+# per-owner git config lands under HOME, which the bundle sets to `cache/home`
+# inside the installation root. Root-owned and world-readable, read-only to the
+# operator that runs it.
+FROM toolchain AS release
+
+WORKDIR /opt/curia/daemon
+COPY daemon/package.json daemon/package-lock.json ./
+RUN npm ci --omit=dev --no-fund --no-audit --ignore-scripts \
+  && npm cache clean --force
+COPY daemon/src ./src
+COPY daemon/bin ./bin
+COPY daemon/assets ./assets
+COPY cli/src /opt/curia/cli/src
+COPY config/curia.yaml config/routing.yaml /opt/curia/config/
 
 LABEL org.opencontainers.image.title="curia overseer" \
       org.opencontainers.image.source="https://github.com/alp82/curia" \
+      org.opencontainers.image.description="The Curia overseer: one shell-holding container that every conversation passes through." \
       curia.gh-version="${GH_VERSION}"

--- a/deploy/tmux/Dockerfile
+++ b/deploy/tmux/Dockerfile
@@ -1,20 +1,28 @@
-# The shared tmux/ttyd image (#260). Two services run it:
+# The shared tmux/ttyd image (#260, release stage by #869). Two services run it:
 #
 #   tmux — the server that holds the agent panes, parked on a `keeper`
 #          session. It replaces the systemd unit's KillMode=process: a daemon
 #          restart never touches it.
 #   ttyd — the attach surface, `tmux attach` as a client over the shared
-#          socket volume via daemon/bin/curia-attach.sh (from the repo mount).
+#          socket volume via daemon/bin/curia-attach.sh.
+#
+# Three stages, the same shape as the daemon image: `toolchain` is the two
+# binaries and their libraries, `box` is the source deployment's image with the
+# uid 1000 facts of that box, and `release` is the published image, which
+# carries the attach script and the attach index at /opt/curia and assumes no
+# uid.
 #
 # ttyd is pinned to the version the committed attach index was built from
 # (daemon/assets/attach-index.html embeds that ttyd's whole client bundle —
 # see daemon/bin/build-attach-index.mjs). Bump both together.
 
-ARG DOCKER_CLI_VERSION=28
+ARG DOCKER_CLI_VERSION=28.5.2
+# A dated tag, so the distro moves by a commit and never by a rebuild.
+ARG DEBIAN_TAG=bookworm-20260824-slim
 
 FROM docker:${DOCKER_CLI_VERSION}-cli AS docker-cli
 
-FROM debian:bookworm-slim
+FROM debian:${DEBIAN_TAG} AS toolchain
 ARG TTYD_VERSION=1.7.7
 
 RUN apt-get update \
@@ -28,6 +36,10 @@ RUN curl -fsSL -o /usr/local/bin/ttyd \
 # Panes run `docker run` for sandboxed agents, against host dockerd.
 COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
 
+# ---------------------------------------------------------------------------
+# The source deployment's image. deploy/compose.yaml builds this stage.
+FROM toolchain AS box
+
 # Seed the tmux socket volume dir with the right owner (see daemon Dockerfile).
 RUN mkdir -p /run/curia-tmux && chown 1000:1000 /run/curia-tmux
 
@@ -40,3 +52,26 @@ RUN mkdir -p /run/curia-tmux && chown 1000:1000 /run/curia-tmux
 ARG CURIA_HOME
 RUN useradd -u 1000 -d "$CURIA_HOME" -M -s /bin/bash curia \
   && mkdir -p "$CURIA_HOME" && chown 1000:1000 "$CURIA_HOME"
+
+# ---------------------------------------------------------------------------
+# The release image (#869). Last, so a build that names no target builds it.
+#
+# No user entry: the operator's uid is a run-time fact, and tmux with no passwd
+# entry falls back to /bin/sh for its default shell, which the panes never use
+# (every pane runs the command the service hands it). HOME comes from the
+# bundle, at `cache/home` inside the installation root.
+FROM toolchain AS release
+
+# The socket directory the tmux volume copies on first use, writable by any uid
+# with the sticky bit (#851).
+RUN mkdir -p /run/curia-tmux && chmod 1777 /run/curia-tmux
+
+# What the attach surface runs and serves: the whitelist wrapper and the built
+# attach index. The same paths the bundle's ttyd command names.
+COPY daemon/bin/curia-attach.sh /opt/curia/daemon/bin/curia-attach.sh
+COPY daemon/assets/attach-index.html /opt/curia/daemon/assets/attach-index.html
+
+LABEL org.opencontainers.image.title="curia tmux" \
+      org.opencontainers.image.source="https://github.com/alp82/curia" \
+      org.opencontainers.image.description="The Curia tmux runtime and attach surface." \
+      curia.ttyd-version="${TTYD_VERSION}"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,7 +7,7 @@ Curia runs under docker compose on `coinmatica.net`, a Hetzner Cloud box (Ubuntu
 
 ## The compose stack
 
-`deploy/compose.yaml` defines five services, all built locally. Four run on the host network:
+`deploy/compose.yaml` defines five services, all built locally from the `box` stage of their Dockerfiles (the `release` stage after it is the published image, see [Release images and the Compose bundle](operator/bundle.md)). Four run on the host network:
 
 | Service | Restart | Role |
 | --- | --- | --- |
@@ -176,6 +176,8 @@ Curia also deploys itself, with no dev box in the loop ([#270](https://github.co
 - `fix:` selects a patch release.
 - `feat:` selects a minor release.
 - `feat!:` selects a major release.
+
+When Release Please creates the release tag, the release-images workflow (`.github/workflows/release-images.yml`) builds and pushes the four service images, renders the Compose bundle against their digests, and attaches the bundle, its checksum, and the digest set to the release. The tag is created with the Curia GitHub App's token, which is what lets it trigger a workflow. This box doesn't consume those artifacts until its cutover.
 
 The `open_pull_request` tool produces these titles from its `release_level` argument. The pull-request title workflow rejects titles that don't select a release. Release Please then opens or updates one release pull request with the version files and `daemon/CHANGELOG.md`. Merge that release pull request before you deploy. Until it merges, `main` still has the old version and the deploy gate refuses it.
 

--- a/docs/operator/bundle.md
+++ b/docs/operator/bundle.md
@@ -1,0 +1,82 @@
+# Release images and the Compose bundle
+
+Every long-running Curia process runs in a container from a published image, and one Compose bundle per release names those images by digest. This page is the reference for what a release ships, what each service is, how each one reports health, and how the containers run as you. The lifecycle topics in the operator guide tell you when to install, update, or roll back; this page tells you what those commands put on the host.
+
+## What a release ships
+
+A Curia release is one version, such as `1.2.3`, made of three kinds of artifact that name each other:
+
+| Artifact | Where it lives | What it is |
+|---|---|---|
+| Four service images | `ghcr.io/alp82/curia-daemon`, `curia-tmux`, `curia-dashboard`, `curia-overseer` | The Curia service, the tmux runtime (which also serves the attach surface), the Curia app, and the overseer. Each is built once per release from the `release` stage of its Dockerfile and identified by its digest. |
+| The Compose bundle | `curia-bundle-<version>.tar.gz` on the GitHub release, unpacked to `versions/<version>/bundle/` in the installation root | One `compose.yaml` that names the four images by exact digest. |
+| The digest set | `curia-images-<version>.json` on the GitHub release | The image names and digests the bundle was rendered against, for the release manifest. |
+
+The release workflow (`.github/workflows/release-images.yml`) runs when the release tag is created. It pushes each image, records the digest the registry returned, attests the build provenance of that digest, renders the bundle against the four digests, runs the bundle tests against the rendered file, and attaches the bundle, its SHA-256 checksum (`curia-bundle-<version>.tar.gz.sha256`), and the digest set to the release.
+
+The version tag on an image, such as `curia-daemon:1.2.3`, is for browsing the registry. Nothing Curia installs reads a tag: the bundle and the release manifest name images by digest, so `docker pull` gets exactly the bytes the release tested.
+
+Each image carries the checkout at `/opt/curia`: the daemon's code and pinned dependency tree, the lifecycle interface's source, the shipped `curia.yaml` and `routing.yaml`, and, in the service image, the vendored skills and the agent image recipe. The files are root-owned and read-only to the user that runs the container, so an installed version can't drift. The images contain no operator path, no credential, and no state. What a container may see of the installation root is in [Secrets, mounts, and what survives](secrets.md).
+
+The agent image is not a release image. The service builds it on the host from the recipe in the service image and the pins in `curia.yaml`, once per set of pins, and agents start from that content-addressed image.
+
+## The bundle
+
+The bundle is one Compose file and nothing else. It has these properties, and the test suite checks each one on every change:
+
+- **One fixed project name.** The Compose project is `curia`. One host runs one Curia, and `docker compose -p curia ps` lists it.
+- **Exact digests.** Every `image:` is `ghcr.io/alp82/<name>@sha256:<digest>`. There is no build stanza and no tag.
+- **Labelled resources.** Every container, the Compose network, and the tmux socket volume carry the label `sh.curia.installation=<installation ID>`, the ID from `state/installation.json`. `curia purge` removes Docker resources by that label and never by a name.
+- **Health checks.** Every service declares one. See [Health checks](#health-checks).
+- **Your numeric user and group.** Every container runs as `<your uid>:<your gid>`, and the two that reach the Docker socket also join the host's `docker` group. Nothing in the bundle or the images assumes user ID 1000.
+- **No secret, no env file, no operator path.** The bundle interpolates five values, all paths or numbers, that the lifecycle interface writes into an env file under `run/` when it starts the project: `CURIA_ROOT`, `CURIA_UID`, `CURIA_GID`, `DOCKER_GID`, and `CURIA_INSTALLATION_ID`. Credentials are files under `secrets/`, mounted into the service only.
+
+To read the bundle of the active version:
+
+```sh
+cat "$(curia version | sed -n 's/^installation root: //p')/versions/$(curia version | sed -n 's/^active version: //p')/bundle/compose.yaml"
+```
+
+## The services
+
+The following table lists the five services, in the order the bundle declares them.
+
+| Service | Image | Network | Role |
+|---|---|---|---|
+| `daemon` | `curia-daemon` | host | The Curia service: the agent-facing surface on `127.0.0.1:4271`, the timeline on `4272`, the Discord bridge, the journal, and the dispatch loop. It restarts on failure, which is how `POST /restart` works. |
+| `tmux` | `curia-tmux` | host | The tmux server that holds every agent pane, parked on a `keeper` session. It lives outside the service's lifecycle, so a service restart never touches a running agent. Stopping it is a deliberate act at zero live agents. |
+| `ttyd` | `curia-tmux` | host | The attach surface on `127.0.0.1:7681`, behind the identity proxy. It runs `tmux attach` over the shared socket and holds nothing else. |
+| `dashboard` | `curia-dashboard` | host | The Curia app on `127.0.0.1:4273`, published to your tailnet through Tailscale Serve. It reads the service and holds no secret. |
+| `overseer` | `curia-overseer` | bridge | The overseer, the one container that holds a shell. It stays off the host network and reaches the service at `host.docker.internal`. The service reaches it on `127.0.0.1:4274`. |
+
+The service and the attach surface wait for a healthy tmux runtime before they start, so a start settles in order.
+
+## Health checks
+
+Each service's health check asks the process the one question that means it is serving. Docker runs the check every 30 seconds with a 5-second timeout, and marks the container unhealthy after three failures in a row. The following table lists them.
+
+| Service | Check | Start period |
+|---|---|---|
+| `daemon` | `GET http://127.0.0.1:4271/ping` answers. The service answers only after the configuration loaded, the journal opened, and the listener bound. | 60 s |
+| `tmux` | `tmux has-session -t keeper` on the shared socket succeeds. | 10 s |
+| `ttyd` | `GET http://127.0.0.1:7681/` answers with the attach index. | 10 s |
+| `dashboard` | `GET http://127.0.0.1:4273/` answers. A local request carries no Tailscale identity and gets a 403, which still proves the listener; the app exits when it can't bind the port. | 30 s |
+| `overseer` | `GET http://127.0.0.1:4274/ping` answers inside the container. | 30 s |
+
+To read the state of every service:
+
+```sh
+docker compose -p curia ps
+```
+
+A container that shows `unhealthy` is one whose process answers nothing. Read its log with `docker compose -p curia logs <service>`, then run `curia doctor`, which reruns the reachability checks and names the corrective action.
+
+## User and group
+
+The lifecycle interface records your numeric user ID and group ID when it starts the project and passes them to every container as `user: <uid>:<gid>`. Files the containers write under the installation root are yours, and the containers can read what you own. The `daemon` and `tmux` containers also join the host's `docker` group by its numeric ID, because their processes run agent containers through the Docker socket.
+
+The images create no user of their own. A process that looks its user up, such as `tmux`, runs with `HOME` set to `cache/home/` inside the installation root and a default shell of `/bin/sh`, which no pane uses.
+
+## The source deployment
+
+The current source deployment on one box runs `deploy/compose.yaml`, which builds the same Dockerfiles at their `box` stage and mounts the checkout. It doesn't use the bundle. The cutover runbook moves that box onto an installed version.

--- a/docs/operator/command-reference.md
+++ b/docs/operator/command-reference.md
@@ -37,7 +37,7 @@ Curia creates the root and seven directories inside it. The following table list
 | `secrets/` | Long-lived credentials, one owner-only file each. See [Secrets, mounts, and what survives](secrets.md). | Preserved |
 | `state/` | The installation record `state/installation.json`, the journal, attachments, results, and the service's own token records. | Preserved |
 | `work/` | Worktrees, per-session config directories, and the overseer's native sessions, all of which can resume. | Preserved |
-| `versions/` | Installed versions: the pinned runtime, the lifecycle interface, and the Compose bundle of each. | Replaceable |
+| `versions/` | Installed versions: the pinned runtime, the lifecycle interface, and the Compose bundle of each. See [Release images and the Compose bundle](bundle.md). | Replaceable |
 | `cache/` | The overseer's mirrors of origin and the containers' home directory with its tool caches. | Removable |
 | `run/` | The lifecycle lock, renewable tokens, sockets, and staging for one operation. | Removable |
 

--- a/docs/operator/secrets.md
+++ b/docs/operator/secrets.md
@@ -55,6 +55,8 @@ Every process runs with `HOME` at `cache/home/` inside the root. That directory 
 
 Curia uses named volumes for the tmux socket and for the agents' npm and browser caches. No volume holds installation identity, durable state, or resumable work. Curia can recreate every volume without losing the installation.
 
+Every container, the Compose network, and the tmux socket volume carry the label `sh.curia.installation=<installation ID>`, so `curia purge` can find what belongs to this installation. The images, the project name, and the health checks are in [Release images and the Compose bundle](bundle.md).
+
 ## What survives
 
 The seven directories of the root fall into two groups. `config/`, `secrets/`, `state/`, and `work/` are preserved. `versions/`, `cache/`, and `run/` are replaceable. The following table says what each operation keeps.


### PR DESCRIPTION
Resolves the execution ticket #869 of the map #863: every long-running Curia process gets a pinned release image, and one versioned Compose bundle names those images by digest.

## What changes

- **Release images.** Each of `deploy/{daemon,tmux,dashboard,overseer}/Dockerfile` ends in a `release` stage that carries the checkout at `/opt/curia`, root-owned and read-only, with the dependency tree installed from the lock file. The stage copies named checkout paths only (`daemon/src`, `daemon/bin`, `daemon/assets`, `cli/src`, `config/curia.yaml`, `config/routing.yaml`, and for the service `skills/` and `deploy/agent/`), so no env file, journal, or secret can ride along. A root `.dockerignore` keeps those out of every build context. No release stage names a uid or a host path. The source deployment keeps building the `box` stage (`target: box` in `deploy/compose.yaml`), which is the image it always had.
- **The bundle template.** `deploy/bundle/compose.yaml` now uses the fixed project name `curia`, labels every container, the network, and the volume with `sh.curia.installation=<installation ID>`, declares a health check per service (the service's and the overseer's `/ping`, `tmux has-session -t keeper`, the attach index on 7681, the app's listener on 4273), orders the start on a healthy tmux runtime, and runs every container as `${CURIA_UID}:${CURIA_GID}`.
- **The contract.** `cli/src/bundle.mjs` holds `COMPOSE_PROJECT`, `INSTALLATION_LABEL`, `IMAGE_REGISTRY`, `RELEASE_IMAGES`, `BUNDLE_VARIABLES`, `renderBundle`, `inspectBundle`, and `bundleEnvironment`. `deploy/bundle/render.mjs` renders one version into `curia-bundle-<version>/compose.yaml`, a deterministic `.tar.gz`, its `.sha256`, and `curia-images-<version>.json`. `deploy/bundle/pins.mjs` reads the Node and Claude Code pins from `config/curia.yaml`.
- **The workflow.** `.github/workflows/release-images.yml` runs on a `v*` tag: it builds the four images, pushes them to `ghcr.io/alp82/curia-<service>`, attests each digest, renders the bundle against the digests, runs the bundle tests on the rendered file, and attaches the bundle, its checksum, and the digest set to the GitHub release. `workflow_dispatch` rehearses the path under a commit tag and attaches nothing. Every action is pinned to a commit SHA.
- **The daemon.** Under `CURIA_ROOT`, `sandbox.agent_uid` is the process's own uid, not the file's `1000`.

## Tests

- `cli/test/bundle.test.mjs`: the contract, rendering, inspection, and the env file.
- `daemon/test/bundlecompose.test.mjs`: project name, labels, health checks, start order, the rendered bundle's inspection, and `docker compose config` on the rendered file where Docker is present (skipped otherwise).
- `daemon/test/bundlerelease.test.mjs`: the render script's outputs and byte-for-byte determinism.
- `daemon/test/releaseimages.test.mjs`: every Dockerfile's release stage as text (last stage, named copies only, no uid, no operator path, pinned bases, labels), the pins, and, with `CURIA_BUILD_IMAGES=1` and Docker, a build of the tmux image run as uid 4242.
- `cd cli && npm test`: 170 pass. `cd daemon && npm test`: 3969 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in build).
- All four release images were built locally and run as uid 4242: the checkout is read-only, no env file or secrets directory exists, the config module loads, and every pinned tool answers.

## Docs

`docs/operator/bundle.md` (new), `docs/operator/command-reference.md`, `docs/operator/secrets.md`, `docs/deploy.md`, `cli/README.md`, `daemon/README.md`, `CONTEXT.md`.

## Seams left for later tickets

- #870 binds `curia-images-<version>.json` and `curia-bundle-<version>.tar.gz.sha256` into the release manifest.
- #871 owns the publication order and the stable index. Today Release Please publishes the release before this workflow attaches assets, which immutable releases would refuse.
- The first push creates the GHCR packages as private; a human makes them public once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
