### PR TITLE
fix: write a real env file for the bundle proof in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,10 @@ jobs:
           npm ci --prefix daemon --no-fund --no-audit
           npm test --prefix cli
           node --test daemon/test/bundlecompose.test.mjs daemon/test/bundlerelease.test.mjs daemon/test/releaseimages.test.mjs daemon/test/releasepublish.test.mjs daemon/test/releaseworkflow.test.mjs daemon/test/bootstrap.test.mjs
-          docker compose --env-file <(printf 'CURIA_ROOT=/tmp/curia\nCURIA_UID=1001\nCURIA_GID=1001\nDOCKER_GID=998\nCURIA_INSTALLATION_ID=00000000000000000000000000000000\n') \
+          # Compose reads the env file by path and cannot read a process
+          # substitution, so the sample values go into a real file.
+          printf 'CURIA_ROOT=/tmp/curia\nCURIA_UID=1001\nCURIA_GID=1001\nDOCKER_GID=998\nCURIA_INSTALLATION_ID=00000000000000000000000000000000\n' > "$RUNNER_TEMP/bundle.env"
+          docker compose --env-file "$RUNNER_TEMP/bundle.env" \
             -f "dist/curia-bundle-${{ needs.pins.outputs.version }}/compose.yaml" config --quiet
 
       # A version whose package pins no stable-index key, or pins one the

--- a/daemon/test/releaseworkflow.test.mjs
+++ b/daemon/test/releaseworkflow.test.mjs
@@ -110,6 +110,13 @@ describe('the release workflow', () => {
     for (const file of ['bundlecompose', 'bundlerelease', 'releaseimages', 'releasepublish', 'releaseworkflow', 'bootstrap']) {
       assert.match(prove.run, new RegExp(`daemon/test/${file}\\.test\\.mjs`), `the bundle job runs ${file}`)
     }
+    // Compose reads its env file by path, so a process substitution leaves
+    // every variable unset and the proof fails on the first `:?` expansion.
+    assert.doesNotMatch(prove.run, /--env-file\s+<\(/, 'the compose proof writes a real env file')
+    assert.match(prove.run, /--env-file\s+"\$RUNNER_TEMP\/bundle\.env"/, 'the compose proof reads the env file it wrote')
+    for (const name of ['CURIA_ROOT', 'CURIA_UID', 'CURIA_GID', 'DOCKER_GID', 'CURIA_INSTALLATION_ID']) {
+      assert.match(prove.run, new RegExp(`${name}=`), `the compose proof supplies ${name}`)
+    }
   })
 
   test('the bundle job renders the bootstrap with the release version, keeps it with the bundle, and attaches it through the gate', () => {


### PR DESCRIPTION
## What changed

The first live publication of 0.5.0 (run 33612290868) built and attested all four images, then failed in the bundle job at **Prove the bundle**:

```
error while interpolating networks.default.labels.sh.curia.installation: required variable CURIA_INSTALLATION_ID is missing a value
```

Docker Compose reads its `--env-file` by path and can't read a process substitution, so every run-time variable was unset. Reproduced locally against a rendered bundle: the process-substitution form fails, a real file passes.

- The step writes the sample values to `$RUNNER_TEMP/bundle.env` and passes that path.
- `daemon/test/releaseworkflow.test.mjs` pins the form and the five variables. The new assertions fail on the old step text.

## Evidence

- `daemon`: 4324 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).
- Part of [Publish the immutable rehearsal candidates](https://github.com/alp82/curia/issues/890).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
