### PR TITLE
fix: wait for the registry to serve a published tarball before verification

### DIFF
--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -1802,7 +1802,7 @@ describe('the Discord card routes (#876)', () => {
     daemon.close()
     const down = JSON.parse((await req(surface.port, '/api/setup/full-loop', { headers: served() })).text)
     assert.equal(down.state, null)
-    assert.match(down.error, /daemon|ECONNREFUSED|socket hang up/i)
+    assert.match(down.error, /daemon|ECONNREFUSED|ECONNRESET|socket hang up/i)
   })
 
   test('the panel read comes from the daemon unedited, and a daemon that cannot be asked answers the reason', async () => {
@@ -1812,7 +1812,7 @@ describe('the Discord card routes (#876)', () => {
     daemon.close()
     const down = JSON.parse((await req(surface.port, '/api/setup/discord', { headers: served() })).text)
     assert.equal(down.secret, null)
-    assert.match(down.error, /daemon|ECONNREFUSED|socket hang up/i)
+    assert.match(down.error, /daemon|ECONNREFUSED|ECONNRESET|socket hang up/i)
   })
 
   test('the token submission crosses once, as exactly the two fields, and the token is in no answer and no log line', async () => {
@@ -2030,7 +2030,7 @@ describe('the Tailscale card routes and the first-operator window (#877)', () =>
     const down = JSON.parse((await req(surface.port, '/api/setup/tailscale', { headers: served() })).text)
     assert.equal(down.requester, 'alp@example.com')
     assert.equal(down.node, null)
-    assert.match(down.error, /daemon|ECONNREFUSED|socket hang up/i)
+    assert.match(down.error, /daemon|ECONNREFUSED|ECONNRESET|socket hang up/i)
   })
 
   test('the confirmation sends the request\'s own login and the machine name, then reads the allowlist back so the window closes at once', async () => {
@@ -2131,7 +2131,7 @@ describe('the OpenAI card routes (#878)', () => {
     const down = JSON.parse((await req(surface.port, '/api/setup/openai', { headers: served() })).text)
     assert.equal(down.secret, null)
     assert.equal(down.login, null)
-    assert.match(down.error, /daemon|ECONNREFUSED|socket hang up/i)
+    assert.match(down.error, /daemon|ECONNREFUSED|ECONNRESET|socket hang up/i)
   })
 
   test('the sign-in press crosses with no field at all, whatever the browser sent, and answers the daemon\'s read; a refusal is the sentence the page shows', async () => {
@@ -2214,7 +2214,7 @@ describe('the Anthropic card routes (#879)', () => {
     const down = JSON.parse((await req(surface.port, '/api/setup/anthropic', { headers: served() })).text)
     assert.equal(down.secret, null)
     assert.equal(down.login, null)
-    assert.match(down.error, /daemon|ECONNREFUSED|socket hang up/i)
+    assert.match(down.error, /daemon|ECONNREFUSED|ECONNRESET|socket hang up/i)
   })
 
   test('the sign-in press crosses with no field at all, whatever the browser sent, and answers the daemon\'s read; a refusal is the sentence the page shows', async () => {

--- a/daemon/test/releasepublish.test.mjs
+++ b/daemon/test/releasepublish.test.mjs
@@ -16,7 +16,7 @@ import { gzipSync } from 'node:zlib'
 
 import {
   PublicationError, PUBLICATION_ORDER,
-  planImage, attachAssets, publishRelease, publishPackage, checkSigningKey, verifyPublished,
+  planImage, attachAssets, publishRelease, publishPackage, checkSigningKey, verifyPublished, verificationFailure,
 } from '../../deploy/release/publish.mjs'
 import { createManifest, renderManifest, releaseAssets, PACKAGE_NAME } from '../../cli/src/manifest.mjs'
 import { renderBundle } from '../../cli/src/bundle.mjs'
@@ -364,7 +364,7 @@ describe('verifyPublished', () => {
   test('a release whose package the registry does not serve fails, and the report says which check', async () => {
     const d = dist()
     const out = lines()
-    const report = await verifyPublished({ version: VERSION, stdout: out }, {
+    const report = await verifyPublished({ version: VERSION, stdout: out, tarballWait: { atMost: 0 } }, {
       packageTarball: async () => null,
       downloadAsset: async (tag, name) => Buffer.from(d.files[name]),
       packument: async () => ({ error: 'HTTP 404' }),
@@ -372,6 +372,68 @@ describe('verifyPublished', () => {
     })
     assert.equal(report.ok, false)
     assert.deepEqual(report.checks.filter((c) => c.status === 'failed').map((c) => c.name), ['manifest', 'version', 'package integrity', 'bundle checksum', 'image digests', 'release manifest'])
+  })
+
+  // The registry indexes a version before it serves the tarball; 0.6.1 took
+  // about two hours (#890). The verification waits a bounded time for it.
+  function published() {
+    const d = dist()
+    const manifestText = d.files[releaseAssets(VERSION).manifest]
+    const tarball = archiveOf({
+      'package/package.json': `${JSON.stringify({ name: PACKAGE_NAME, version: VERSION })}\n`,
+      'package/manifest.json': manifestText,
+    })
+    return {
+      tarball,
+      probes: {
+        downloadAsset: async (tag, name) => Buffer.from(d.files[name]),
+        packument: async () => ({ integrity: sri(tarball), attested: true }),
+        releaseManifest: async () => manifestText,
+      },
+    }
+  }
+
+  test('a tarball the registry does not serve yet is asked for again every interval, and the report passes once it arrives', async () => {
+    const { tarball, probes } = published()
+    const slept = []
+    let asked = 0
+    const out = lines()
+    const report = await verifyPublished({ version: VERSION, stdout: out, tarballWait: { every: 20_000, atMost: 600_000 } }, {
+      ...probes,
+      packageTarball: async () => (++asked < 3 ? null : tarball),
+      sleep: async (ms) => { slept.push(ms) },
+    })
+    assert.equal(report.ok, true, out.text())
+    assert.equal(asked, 3)
+    assert.deepEqual(slept, [20_000, 20_000])
+    assert.equal(out.text().match(/the registry does not serve the package tarball yet/g).length, 2)
+    assert.match(out.text(), /waited 20s of 600s/)
+    assert.match(out.text(), /waited 40s of 600s/)
+  })
+
+  test('the wait for the tarball is bounded, and the report then fails on the missing package', async () => {
+    const { probes } = published()
+    const slept = []
+    let asked = 0
+    const out = lines()
+    const report = await verifyPublished({ version: VERSION, stdout: out, tarballWait: { every: 20_000, atMost: 60_000 } }, {
+      ...probes,
+      packageTarball: async () => { asked += 1; return null },
+      sleep: async (ms) => { slept.push(ms) },
+    })
+    assert.equal(report.ok, false)
+    assert.equal(asked, 4)
+    assert.deepEqual(slept, [20_000, 20_000, 20_000])
+    assert.match(report.refusal.message, /the package tarball is missing/)
+  })
+
+  test('the verify failure names the rerun of this workflow run, since the earlier steps keep what they published', () => {
+    const report = { ok: false, refusal: { message: 'package integrity: the package tarball is missing.' } }
+    const message = verificationFailure(report, { GITHUB_RUN_ID: '33614070854' })
+    assert.match(message, /^package integrity: the package tarball is missing\./)
+    assert.match(message, /gh run rerun 33614070854 --failed/)
+    assert.match(message, /once the registry serves the tarball/)
+    assert.match(verificationFailure(report, {}), /gh run rerun <run-id> --failed/)
   })
 })
 

--- a/deploy/release/publish.mjs
+++ b/deploy/release/publish.mjs
@@ -117,6 +117,7 @@ export const publicationProbes = Object.freeze({
       return null
     }
   },
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   // npm resolves `--pack-destination` against its working directory, which is
   // the package, so the destination is made absolute here and the error
   // carries npm's own words instead of the silenced command line.
@@ -287,10 +288,27 @@ export async function publishPackage({ version, dist: distArg, cli: cliArg, stdo
 // ---------------------------------------------------------------------------
 // After publication: is the version whole where an installation finds it?
 
-export async function verifyPublished({ version, stdout }, probes = publicationProbes) {
+// The registry indexes a new version before it serves the tarball, and the
+// lag is usually seconds but was about two hours for 0.6.1 (#890). The
+// download is asked for again every `every` ms for at most `atMost` ms, one
+// line per wait, and the report then says the tarball is missing.
+export const TARBALL_WAIT = Object.freeze({ every: 20_000, atMost: 600_000 })
+
+async function awaitTarball({ version, stdout, every, atMost }, probes) {
+  let waited = 0
+  for (;;) {
+    const tarball = await probes.packageTarball(PACKAGE_NAME, version)
+    if (tarball || waited + every > atMost) return tarball
+    await probes.sleep(every)
+    waited += every
+    stdout.write(`the registry does not serve the package tarball yet (waited ${Math.round(waited / 1000)}s of ${Math.round(atMost / 1000)}s), asking again\n`)
+  }
+}
+
+export async function verifyPublished({ version, stdout, tarballWait = TARBALL_WAIT }, probes = publicationProbes) {
   const tag = tagOf(version)
   const assets = releaseAssets(version)
-  const tarball = await probes.packageTarball(PACKAGE_NAME, version)
+  const tarball = await awaitTarball({ version, stdout, ...TARBALL_WAIT, ...tarballWait }, probes)
   const archive = await probes.downloadAsset(tag, assets.bundle).catch(() => null)
   const checksum = await probes.downloadAsset(tag, assets.checksum).catch(() => null)
   return verifyStagedRelease({
@@ -299,6 +317,14 @@ export async function verifyPublished({ version, stdout }, probes = publicationP
     archive: archive ? Buffer.from(archive) : null,
     checksum: checksum ? Buffer.from(checksum).toString('utf8') : null,
   }, { stdout }, { packument: probes.packument, releaseManifest: probes.releaseManifest, attestation: probes.attestation })
+}
+
+// The sentence `verify` fails with. Every earlier step keeps what it
+// published, so the fix for a registry that serves the tarball late is a
+// rerun of this run's failed jobs, not a new version.
+export function verificationFailure(report, env = process.env) {
+  const runId = env.GITHUB_RUN_ID || '<run-id>'
+  return `${report.refusal.message} The release and package steps keep what they published: once the registry serves the tarball, rerun the failed job with \`gh run rerun ${runId} --failed\`.`
 }
 
 // ---------------------------------------------------------------------------
@@ -354,7 +380,7 @@ async function main(argv) {
       const { version } = args(rest, ['version'])
       if (!isReleaseVersion(version)) throw new PublicationError(`${version} is not a release version`)
       const report = await verifyPublished({ version, stdout })
-      if (!report.ok) throw new PublicationError(report.refusal.message)
+      if (!report.ok) throw new PublicationError(verificationFailure(report))
       return
     }
     default:

--- a/docs/operator/releases.md
+++ b/docs/operator/releases.md
@@ -21,6 +21,8 @@ The publication is gated at each step by `deploy/release/publish.mjs`, which ask
 
 For an image, "the same bytes" means the tag already points at a digest that the release workflow attested at this commit; that digest is reused as it is. For a release asset, the published bytes are downloaded and compared. For the package, the registry's recorded integrity is compared with the tarball the workflow packed.
 
+After the package step, the workflow runs `publish.mjs verify`, which downloads the published package, bundle, and checksum and verifies them the way an installation would. The registry can index a new version before it serves the tarball, and that lag was about two hours for 0.6.1. The verification asks for the tarball again every 20 seconds for up to 10 minutes and then fails with "the package tarball is missing". A longer lag doesn't need a new version. The release and package steps keep what they published, so once the registry serves the tarball, rerun the failed job with `gh run rerun <run-id> --failed`.
+
 The version tags on images exist for browsing. The bundle and the manifest name images by digest, and nothing an installation runs reads a tag.
 
 A rehearsal of the workflow (`workflow_dispatch` on any branch) pushes images under a commit tag, renders the bundle and manifest against their real digests, and publishes nothing: no release, no package.


### PR DESCRIPTION
## What changed

On the 0.6.1 publication the registry indexed the version at once but served a 404 for the tarball for about two hours, so `publish.mjs verify` failed with "the package tarball is missing" and the job was rerun by hand.

- `verifyPublished` in `deploy/release/publish.mjs` asks for the tarball again every 20 seconds for up to 10 minutes, one line per wait. The interval and the bound are options (`tarballWait`), and the sleep is a probe, so the tests don't wait.
- When the tarball still doesn't arrive, the `verify` error names the fix: rerun the failed job with `gh run rerun <run-id> --failed` once the registry serves it. The run id comes from `GITHUB_RUN_ID`. The release and package steps keep what they published, so a rerun finishes the publication.
- The dashboard tests that close the daemon behind the socket accept `ECONNRESET` alongside `ECONNREFUSED` and `socket hang up`. A reset is the same fact and showed up as a flaky failure.
- `docs/operator/releases.md` describes the lag, the bounded wait, and the rerun.

## Tests

`daemon/test/releasepublish.test.mjs` pins the retry, the bound, and the rerun sentence. The `cli` and `daemon` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
