### PR TITLE
fix: keep typed setup fields across refreshes and quiet the app's loopback health probe

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -6031,6 +6031,7 @@ function render() {
      out. It reads the same comparison the Maintenance section draws. */
   const stale = runningDiff(payload)?.length ? `<span class="nav-marker">stale</span>` : "";
   const field = activeField();
+  const typed = typedFields(app);
   app.innerHTML = `<div class="shell">
     ${desktopNav(n, stale)}
     <main>${SCREENS[UI.screen][1](payload)}</main>
@@ -6039,6 +6040,7 @@ function render() {
     ${handoffSheet()}
   </div>`;
   document.title = (n ? `(${n}) ` : "") + "Curia app";
+  restoreTyped(typed);
   restoreField(field);
   if (UI.screen === "chat") chatAfterRender();
   /* The hunks a card just asked for (#355). Started AFTER the page is written,
@@ -6074,9 +6076,36 @@ function mobileNav(needs, stale) {
 }
 
 /* The poll re-renders the whole page every few seconds, and the settings screen
-   has fields somebody may be halfway through typing in. The VALUE is never at
-   risk — every keystroke lands on the draft — so what has to survive a render
-   is the cursor, by id and offset. */
+   has fields somebody may be halfway through typing in. There the VALUE is
+   never at risk — every keystroke lands on the draft — so what has to survive
+   a render is the cursor, by id and offset. The setup forms (#874 to #879)
+   and the GitHub App name have no draft: a token or a machine name lives in
+   its field until the press sends it, and the rehearsal (#891) watched the
+   poll clear it. So a render also carries over each of THOSE fields whose
+   value is not the one the page drew, because that difference IS the
+   operator's typing, by id. A field nobody touched takes the fresh render's
+   value, so a read that moves a default is not undone. Only the draftless
+   forms qualify: the chat box is drawn from its draft, and a send clears the
+   draft, so carrying its element's text over would undo the send. */
+const DRAFTLESS_FIELDS = 'input[id^="setup-"], select[id^="setup-"], textarea[id^="setup-"], #github-app-name';
+function typedFields(app) {
+  if (typeof app?.querySelectorAll !== "function") return [];
+  const kept = [];
+  for (const el of app.querySelectorAll(DRAFTLESS_FIELDS)) {
+    if (el.type === "checkbox" || el.type === "radio") continue;
+    const drawn = el.tagName === "SELECT"
+      ? (Array.from(el.options ?? []).find((o) => o.defaultSelected)?.value ?? "")
+      : String(el.defaultValue ?? "");
+    if (String(el.value ?? "") !== drawn) kept.push({ id: el.id, value: el.value });
+  }
+  return kept;
+}
+function restoreTyped(kept) {
+  for (const f of kept) {
+    const el = document.getElementById(f.id);
+    if (el && "value" in el) el.value = f.value;
+  }
+}
 function activeField() {
   const el = document.activeElement;
   if (!el || !el.id) return null;

--- a/daemon/test/bundlecompose.test.mjs
+++ b/daemon/test/bundlecompose.test.mjs
@@ -169,13 +169,13 @@ describe('owned resources carry the installation ID', () => {
 })
 
 // Each check asks the process the question that means it is serving: the
-// service and the overseer answer their own `/ping`, the tmux server holds the
-// keeper session, the attach surface and the app answer HTTP on their ports.
+// service, the app, and the overseer answer their own `/ping`, the tmux server
+// holds the keeper session, the attach surface answers HTTP on its port.
 const HEALTH = {
   daemon: /127\.0\.0\.1:4271\/ping/,
   tmux: /has-session -t keeper/,
   ttyd: /127\.0\.0\.1:7681/,
-  dashboard: /127\.0\.0\.1:4273/,
+  dashboard: /127\.0\.0\.1:4273\/ping/,
   overseer: /127\.0\.0\.1:4274\/ping/,
 }
 
@@ -189,6 +189,16 @@ describe('every service declares a health check that asks the process itself', (
       for (const key of ['interval', 'timeout', 'retries', 'start_period']) assert.ok(h[key] !== undefined, `${service} sets no ${key}`)
     })
   }
+
+  // The rehearsal (#891) found the app logging a refusal every 30 s: the
+  // probe asked `/`, which sits behind the identity gate, and a loopback
+  // caller has no Serve identity. `/ping` answers before the gate (#884), so
+  // the probe passes only on the app's own 200 and logs nothing.
+  test('the app probe asks /ping before the identity gate and passes only on a 200, so a healthy app logs no refusal', () => {
+    const probe = cfg.services.dashboard.healthcheck.test.join(' ')
+    assert.match(probe, /r\.ok \? 0 : 1/)
+    assert.doesNotMatch(probe, /status < 500/)
+  })
 
   test('the service and the app wait for a healthy tmux runtime and service, so a start settles in order', () => {
     assert.deepEqual(cfg.services.daemon.depends_on, { tmux: { condition: 'service_healthy' } })

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -5072,6 +5072,75 @@ describe('integration setup (#874)', () => {
     assert.doesNotMatch(html, /Try again/)
   })
 
+  // The rehearsal (#891) found the Discord fields clearing themselves: the
+  // poll re-renders the whole page every few seconds, and the setup forms are
+  // not backed by a draft, so a value typed but not yet sent was lost with the
+  // elements that held it. What has to survive the render is what the
+  // operator typed and where the cursor was, on every setup field.
+  test('a poll render keeps what the operator typed into the setup fields, and the cursor, until the press sends it', () => {
+    page.setup = SETUP({ step: 'discord', cards: { discord: { state: 'unconnected', badge: 'Ready to connect' } } })
+    page.UI.setup.discord = { secret: 'absent', settings: null }
+    page.payload = payload()
+    const field = (id, defaultValue, value = defaultValue) => {
+      const el = { id, value, defaultValue, tagName: 'INPUT', selectionStart: value.length, focused: 0, range: null }
+      el.focus = () => { el.focused += 1 }
+      el.setSelectionRange = (a, b) => { el.range = [a, b] }
+      return el
+    }
+    // The elements before the render, with the operator's typing in them.
+    const typedToken = field('setup-discord-token', '', 'MTIz.abc.def')
+    const typedUser = field('setup-discord-user', '', '123456789')
+    typedUser.selectionStart = 4
+    // The elements the render writes, drawn from the page's own state: empty.
+    const freshToken = field('setup-discord-token', '')
+    const freshUser = field('setup-discord-user', '')
+    let drawn = null
+    let live = [typedToken, typedUser]
+    let asked = null
+    const app = {
+      set innerHTML(value) { drawn = value; live = [freshToken, freshUser] },
+      querySelectorAll: (selector) => { asked = selector; return live },
+    }
+    page.document.activeElement = typedUser
+    page.document.getElementById = (id) => (id === 'app' ? app : live.find((el) => el.id === id) ?? null)
+    page.render()
+    assert.match(drawn, /id="setup-discord-token"/)
+    assert.equal(freshToken.value, 'MTIz.abc.def', 'the token typed but not sent survives the render')
+    assert.equal(freshUser.value, '123456789', 'the user ID typed but not sent survives the render')
+    assert.equal(freshUser.focused, 1, 'focus comes back to the field the operator was in')
+    assert.deepEqual(freshUser.range, [4, 4], 'and the cursor stays where it was')
+    assert.equal(freshToken.focused, 0)
+    // The carry-over is for the draftless forms. The chat box is drawn from
+    // its draft and a send clears the draft, so it is not asked for.
+    assert.match(asked, /\[id\^="setup-"\]/)
+    assert.doesNotMatch(asked, /chat-box|textarea\[id\]/)
+  })
+
+  test('a poll render keeps a typed Tailscale machine name, and leaves a field the operator has not touched to the page', () => {
+    page.setup = SETUP({ step: 'tailscale', cards: { tailscale: { state: 'unconnected', badge: 'Ready to connect' } } })
+    page.UI.setup.tailscale = TAILSCALE_OVERVIEW()
+    page.payload = payload()
+    const field = (id, defaultValue, value = defaultValue) => ({ id, value, defaultValue, tagName: 'INPUT', focus() {} })
+    const typed = field('setup-tailscale-machine', 'curia.sh', 'alp-workstation')
+    const fresh = field('setup-tailscale-machine', 'curia.sh')
+    let live = [typed]
+    const app = { set innerHTML(_value) { live = [fresh] }, querySelectorAll: () => live }
+    page.document.activeElement = null
+    page.document.getElementById = (id) => (id === 'app' ? app : live.find((el) => el.id === id) ?? null)
+    page.render()
+    assert.equal(fresh.value, 'alp-workstation', 'the typed machine name survives without focus')
+
+    // Untouched: the value the page drew is the value that stands, so a
+    // read that changes the default (a remembered checkpoint) is not undone.
+    const untouched = field('setup-tailscale-machine', 'curia.sh')
+    const redrawn = field('setup-tailscale-machine', 'alp-workstation')
+    live = [untouched]
+    const app2 = { set innerHTML(_value) { live = [redrawn] }, querySelectorAll: () => live }
+    page.document.getElementById = (id) => (id === 'app' ? app2 : live.find((el) => el.id === id) ?? null)
+    page.render()
+    assert.equal(redrawn.value, 'alp-workstation', 'a field nobody typed in takes the page\'s value')
+  })
+
   test('selecting the model card takes the OpenAI read once, and Sign in remembers the provider, posts no field, then polls the read for the login', async () => {
     page.setup = SETUP({ cards: { model: { state: 'unconnected', badge: 'Ready to connect', providers: providers({ state: 'unconnected' }) } } })
     let reads = 0

--- a/deploy/bundle/compose.yaml
+++ b/deploy/bundle/compose.yaml
@@ -197,12 +197,14 @@ services:
     volumes:
       - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
     # The app is fail-closed at boot: it dies when it cannot bind its loopback
-    # port. So an HTTP answer on that port is the app up. A local request
-    # carries no Tailscale identity and gets a 403, which is still an answer;
-    # only a listener that is gone or broken fails this. The app image carries
-    # node and no curl.
+    # port. So its own 200 on that port is the app up. The probe asks `/ping`,
+    # which the app answers before its identity gate (#884): a local request
+    # carries no Tailscale identity, and asking any other path got a 403 and a
+    # logged refusal every 30 s (#891). Only a listener that is gone, broken,
+    # or answering something other than its own ping fails this. The app image
+    # carries node and no curl.
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4273/').then((r) => process.exit(r.status < 500 ? 0 : 1), () => process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4273/ping').then((r) => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/operator/bundle.md
+++ b/docs/operator/bundle.md
@@ -62,7 +62,7 @@ Each service's health check asks the process the one question that means it is s
 | `daemon` | `GET http://127.0.0.1:4271/ping` answers. The service answers only after the configuration loaded, the journal opened, and the listener bound. | 60 s |
 | `tmux` | `tmux has-session -t keeper` on the shared socket succeeds. | 10 s |
 | `ttyd` | `GET http://127.0.0.1:7681/` answers with the attach index. | 10 s |
-| `dashboard` | `GET http://127.0.0.1:4273/` answers. A local request carries no Tailscale identity and gets a 403, which still proves the listener; the app exits when it can't bind the port. | 30 s |
+| `dashboard` | `GET http://127.0.0.1:4273/ping` answers 200. The app answers its ping before the identity gate, so the local probe logs no refusal; the app exits when it can't bind the port. | 30 s |
 | `overseer` | `GET http://127.0.0.1:4274/ping` answers inside the container. | 30 s |
 
 To read the state of every service:


### PR DESCRIPTION
The live rehearsal of the packaged Curia lifecycle (#891) found two defects. This pull request fixes both.

## Setup fields cleared themselves

On the Setup screen's Discord card, the token and the user ID were gone by the time the operator focused the next field. The page re-reads `/api/setup` on a short interval and re-renders the selected card's panel, which replaced the input elements and the values typed into them. The setup forms have no draft, unlike Settings, so nothing held the typing.

`render()` in `daemon/assets/dashboard.html` now carries over every draftless field (the `setup-*` inputs and the GitHub App name) whose value differs from the value the page drew, and restores focus and the cursor as before. A field nobody touched keeps taking the fresh render's value, so a read that moves a default is not undone. The chat box is not carried: it is drawn from its draft, and a send clears the draft.

## The app logged a refusal every 30 seconds

A packaged installation logged `dashboard: REFUSED / — Host "127.0.0.1:4273" is not a name this box serves` on every health check. The Compose probe in `deploy/bundle/compose.yaml` asked `/`, which sits behind the identity gate, and a loopback probe carries no Tailscale Serve identity. The probe now asks `/ping`, which the app answers before the gate, and exits 0 only on a 200. A listener that is gone, broken, or answering something other than its own ping still fails the check.

## Tests

- `daemon/test/dashboardpage.test.mjs`: type into the Discord token and user ID fields and the Tailscale machine name, trigger a render, and assert the values, focus, and cursor survive, and that an untouched field takes the page's value.
- `daemon/test/bundlecompose.test.mjs`: the app probe asks `/ping` and passes only on `r.ok`.
- `docs/operator/bundle.md`: the health-check row for the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
