### PR TITLE
fix: send the served origin as the GitHub App manifest url from setup

### DIFF
--- a/daemon/src/githubapp.mjs
+++ b/daemon/src/githubapp.mjs
@@ -202,6 +202,21 @@ export const APP_SETUP_STATE_RE = /^[0-9a-f]{64}$/
 // Setup), and so the two places the redirect may land.
 export const APP_SETUP_SCREENS = Object.freeze(['settings', 'setup'])
 
+// The URLs GitHub's manifest parser demands (#891): `url`, the App's homepage,
+// always; and `hook_attributes.url` whenever a `hook_attributes` object is
+// present, whether or not the hook is active. GitHub answers a manifest that
+// misses one with `"url" wasn't supplied` on its consent page, after the
+// operator has already left curia. This names the missing field on curia's
+// side, before the handoff starts.
+export function assertManifest(manifest) {
+  if (typeof manifest?.url !== 'string' || !manifest.url) {
+    throw new Error('the GitHub App manifest carries no "url": curia could not compose its own served origin for the App homepage')
+  }
+  if (manifest.hook_attributes !== undefined && !manifest.hook_attributes?.url) {
+    throw new Error('the GitHub App manifest carries "hook_attributes" without "hook_attributes.url", which GitHub requires even for an inactive webhook')
+  }
+}
+
 function atomicWrite(file, text, mode = 0o600) {
   fs.mkdirSync(path.dirname(file), { recursive: true })
   const temporary = `${file}.tmp-${process.pid}-${crypto.randomBytes(6).toString('hex')}`
@@ -319,6 +334,23 @@ export class GitHubAppSetup {
     if (redirect.protocol !== 'https:') throw new Error('the GitHub App redirect URL must use HTTPS')
     if (redirect.username || redirect.password) throw new Error('the GitHub App redirect URL must carry no credentials')
     if (redirect.search || redirect.hash) throw new Error('the GitHub App redirect URL must carry no query or fragment')
+    // What GitHub receives (#891). `url` is the App's homepage, and the only
+    // address curia has for itself is the served origin the redirect was
+    // composed from. No `hook_attributes`: GitHub requires a `url` inside that
+    // object whenever it is present, `active: false` or not, and the packaged
+    // rehearsal (#891) found GitHub refusing the manifest with
+    // `"url" wasn't supplied` for exactly that. Curia polls and listens for no
+    // webhook, so the block is absent rather than half-filled.
+    const manifest = {
+      name: appName,
+      url: redirect.origin,
+      redirect_url: redirect.toString(),
+      public: true,
+      default_permissions: { ...MANIFEST_PERMISSIONS },
+      default_events: [],
+    }
+    // Refuse here, by name, rather than let GitHub's consent page say it.
+    assertManifest(manifest)
     const state = Buffer.from(this.randomBytes(32)).toString('hex')
     const expires = this.now() + APP_SETUP_TTL_MS
     this.#writeState({ state, expires_at: expires, status: 'pending', screen, ...(actionId ? { action_id: String(actionId) } : {}) })
@@ -329,15 +361,7 @@ export class GitHubAppSetup {
       state,
       expires_at: new Date(expires).toISOString(),
       action: `https://github.com${ownerPath}?state=${state}`,
-      manifest: {
-        name: appName,
-        url: redirect.origin,
-        redirect_url: redirect.toString(),
-        public: true,
-        default_permissions: { ...MANIFEST_PERMISSIONS },
-        default_events: [],
-        hook_attributes: { active: false },
-      },
+      manifest,
     }
   }
 

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -15,8 +15,11 @@
 import { test, describe, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import vm from 'node:vm'
 import { DEFAULT_DASHBOARD_INDEX, DASHBOARD_PROTO } from '../src/dashboard.mjs'
+import { GitHubAppSetup } from '../src/githubapp.mjs'
 
 // The page boots itself only when a real document holds `#app`, so this fake
 // one keeps the load inert: no render, no poll, no timer. `fetch` never settles
@@ -4773,6 +4776,56 @@ describe('integration setup (#874)', () => {
     assert.equal(started.body.name, 'curia-alp')
     assert.equal(started.body.screen, 'setup')
     assert.equal(page.setup.progress.github.app_name, 'curia-alp')
+  })
+
+  // The rehearsal of the packaged lifecycle (#891) pressed Create GitHub App
+  // on a root installation and GitHub answered that "url" wasn't supplied.
+  // This is the whole trip in one place: the daemon's real manifest for the
+  // served address, the page's form, and what GitHub receives.
+  test('the manifest the Setup screen posts to GitHub carries the served origin as url, the redirect under it, and every URL GitHub requires', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-page-manifest-'))
+    const daemon = new GitHubAppSetup({
+      daemonRoot: dir, stateFile: path.join(dir, 'setup.json'), envFile: path.join(dir, '.env.daemon'), keyFile: path.join(dir, 'key.pem'),
+    })
+    const origin = 'https://curia-ubuntu.tail3b99f1.ts.net:8445'
+    const submitted = []
+    page = loadPage({
+      fetchImpl: async (url, init = {}) => {
+        const body = init.body ? JSON.parse(init.body) : null
+        if (url === '/api/github-app/start') {
+          const setup = daemon.start({ name: body.name, redirectUrl: `${origin}/api/github-app/complete`, actionId: body.action_id, screen: body.screen })
+          return { ok: true, json: async () => ({ action: { action_id: body.action_id, status: 'accepted' }, setup }) }
+        }
+        return { ok: true, json: async () => (init.method === 'POST' ? { ok: true } : SETUP()) }
+      },
+    })
+    page.UI.screen = 'setup'
+    page.setup = SETUP({ cards: { github: { state: 'unconnected', badge: 'Ready to connect' } } })
+    page.payload = payload()
+    page.document.getElementById = (id) => (id === 'setup-github-app-name' ? { value: 'curia-alp' } : null)
+    page.document.createElement = (tag) => {
+      const element = { tag, children: [], appendChild(child) { this.children.push(child) } }
+      if (tag === 'form') element.submit = () => submitted.push(element)
+      return element
+    }
+    page.document.body = { appendChild() {} }
+    vm.runInContext('doSetupGitHubApp()', page)
+    await new Promise((resolve) => setImmediate(resolve))
+    fs.rmSync(dir, { recursive: true, force: true })
+
+    assert.equal(submitted.length, 1, 'one form reached GitHub')
+    const [form] = submitted
+    assert.equal(form.method, 'POST')
+    assert.match(form.action, /^https:\/\/github\.com\/settings\/apps\/new\?state=[0-9a-f]{64}$/)
+    const field = form.children.find((c) => c.name === 'manifest')
+    assert.ok(field, 'the manifest rides the one form field GitHub reads')
+    const manifest = JSON.parse(field.value)
+    assert.equal(manifest.url, origin, 'the served origin, non-empty')
+    assert.equal(manifest.redirect_url, `${origin}/api/github-app/complete`)
+    assert.equal(manifest.name, 'curia-alp')
+    // GitHub demands `hook_attributes.url` whenever the object is present,
+    // active or not. Curia listens for no webhook, so the block is absent.
+    assert.equal('hook_attributes' in manifest, false)
   })
 
   test('a failed GitHub card names the failed verification and draws the install link per watched owner', () => {

--- a/daemon/test/githubappsetup.test.mjs
+++ b/daemon/test/githubappsetup.test.mjs
@@ -22,6 +22,7 @@ import {
   GitHubAppSetup,
   MANIFEST_PERMISSIONS,
   ROLES,
+  assertManifest,
   minterFrom,
 } from '../src/githubapp.mjs'
 import { ensureLayout } from '../../cli/src/root.mjs'
@@ -94,10 +95,24 @@ describe('the manifest (#694)', () => {
     assert.match(started.state, APP_SETUP_STATE_RE)
     assert.deepEqual(started.manifest.default_permissions, permissions)
     assert.deepEqual(started.manifest.default_events, [])
-    assert.deepEqual(started.manifest.hook_attributes, { active: false })
+    // GitHub requires `hook_attributes.url` whenever the object is present,
+    // even with `active: false` (#891). Curia listens for no webhook, so the
+    // manifest carries no `hook_attributes` at all.
+    assert.equal('hook_attributes' in started.manifest, false, 'no webhook block, because GitHub would demand a URL inside it')
+    assert.equal(started.manifest.url, 'https://box.example')
+    assert.equal(started.manifest.redirect_url, 'https://box.example/github-app/complete')
     assert.equal(started.manifest.public, true, 'one owner is an organization')
     assert.equal(started.expires_at, '2026-08-25T11:00:00.000Z')
     assert.deepEqual(setup.status(), { status: 'pending', expires_at: started.expires_at })
+  })
+
+  test('a manifest missing a URL GitHub requires is refused by name before any handoff (#891)', () => {
+    const good = { name: 'curia-alp', url: 'https://box.example', redirect_url: 'https://box.example/complete' }
+    assert.doesNotThrow(() => assertManifest(good))
+    assert.throws(() => assertManifest({ ...good, url: '' }), /manifest carries no "url"/)
+    assert.throws(() => assertManifest({ ...good, url: undefined }), /manifest carries no "url"/)
+    assert.throws(() => assertManifest({ ...good, hook_attributes: { active: false } }), /"hook_attributes\.url"/)
+    assert.doesNotThrow(() => assertManifest({ ...good, hook_attributes: { url: 'https://box.example/events', active: false } }))
   })
 
   test('the setup action identity survives the GitHub redirect and daemon restart', () => {

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -28,7 +28,7 @@ None of this is secret. The app id travels in every JWT the daemon signs. The pr
 
 In an installed Curia ([#867](https://github.com/alp82/curia/issues/867)) the converted app lands in one owner-only file instead, `secrets/github-app.json` in the installation root, holding `{ "id": "<app id>", "pem": "<private key>" }`. No env file is written. See [Secrets, mounts, and what survives](operator/secrets.md). The **GitHub** card of the Setup screen ([#875](https://github.com/alp82/curia/issues/875)) runs this same flow on a fresh installation, then verifies the installation and the minted credential. See [Connect GitHub](operator/integration-setup.md#connect-github).
 
-The manifest states the five permissions of step 2 and no events, so nothing on the **Permissions & events** page has to be set by hand. Neither the browser nor the dashboard sidecar ever sees the conversion response: the browser carries `code` and `state` back and gets the app id, the slug, the bot login and the install link.
+The manifest states the five permissions of step 2 and no events, so nothing on the **Permissions & events** page has to be set by hand. It carries no `hook_attributes` block at all: GitHub requires a webhook URL inside that block whenever it is present, even for an inactive webhook, and Curia listens for no webhook ([#891](https://github.com/alp82/curia/issues/891)). Neither the browser nor the dashboard sidecar ever sees the conversion response: the browser carries `code` and `state` back and gets the app id, the slug, the bot login and the install link.
 
 Steps 4 and 5 stay yours. An installation is granted per owner, and only a human can grant it.
 

--- a/docs/research/github-app-manifest.md
+++ b/docs/research/github-app-manifest.md
@@ -92,9 +92,9 @@ curia's [current app setup](../github-app.md#2-grant-the-permissions) requires t
 
 GitHub grants Metadata read access automatically. The manifest must not request Workflows, organization, or account permissions.
 
-Set `default_events` to an empty list. Set the webhook as inactive because curia polls GitHub.
+Set `default_events` to an empty list. Leave `hook_attributes` out of the manifest because curia polls GitHub and listens for no webhook.
 
-If the manifest supplies `hook_attributes`, set `active` to `false`. GitHub defaults this value to `true` inside that object.
+Don't send `hook_attributes` with only `active: false`. GitHub requires `hook_attributes.url` whenever the object is present, active or not, and refuses the manifest on its consent page with `"url" wasn't supplied`. The packaged rehearsal ([#891](https://github.com/alp82/curia/issues/891)) hit that with a manifest that carried the object without a URL. When the object is absent, GitHub creates the App with no webhook.
 
 GitHub defines these fields in the [manifest parameters](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest#github-app-manifest-parameters). GitHub also recommends the [minimum required permissions](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app#about-github-app-permissions).
 


### PR DESCRIPTION
## The defect

The rehearsal of the packaged lifecycle (#891) opened `https://curia-ubuntu.tail3b99f1.ts.net:8445/#setup` and pressed **Create GitHub App** on the GitHub card. GitHub answered on its consent page:

> Invalid GitHub App configuration. The configuration does not appear to be a valid GitHub App manifest. Error: "url" wasn't supplied.

## The cause

The top-level `url` was present and correct: the sidecar composes the redirect from `link()`, the served Tailscale address, and the daemon sets `url` to that origin. The missing field was `hook_attributes.url`. The manifest carried `hook_attributes: { active: false }` to say Curia listens for no webhook, and GitHub requires a URL inside that object whenever it is present, active or not. GitHub's error names the field without its parent.

## The fix

- `GitHubAppSetup.start` sends no `hook_attributes` block. GitHub creates the App with no webhook when the block is absent.
- `assertManifest` in `daemon/src/githubapp.mjs` refuses a manifest without `url`, or with a webhook block without a URL, by name. The daemon stops the handoff before the operator leaves Curia instead of letting GitHub say it.
- `docs/github-app.md` and `docs/research/github-app-manifest.md` say why the block is absent. The research note previously advised sending `hook_attributes` with `active: false`, which is what produced the defect.

## Tests

- `githubappsetup.test.mjs`: the manifest test pins `url` to the served origin, `redirect_url` under it, and no `hook_attributes`; a new test names both refusals of `assertManifest`.
- `dashboardpage.test.mjs`: the Setup screen's press runs against the real `GitHubAppSetup.start` for `https://curia-ubuntu.tail3b99f1.ts.net:8445`, and the test reads the form the browser posts to GitHub: `url` equals the served origin, `redirect_url` is under it, and no webhook block rides along.

`cd daemon && npm test`: 4341 tests, 4340 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
