### PR TITLE
fix: inject the tailscale runner in every lifecycle test and run both suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+# The test workflow (#891 rehearsal follow-up).
+#
+# The 0.7.0 publication (run 33636124347) failed in the bundle job's "Prove
+# the bundle" step: `npm test --prefix cli` had 20 failures, every one
+# `spawn tailscale ENOENT`, because the lifecycle tests reached the real
+# `tailscale`, which the developers' machines have and the GitHub runner does
+# not. Nothing ran the suites on the pull request that introduced it. This
+# workflow runs both suites on every pull request and on every push to main,
+# on the same runner image and the same pinned Node the release builds
+# with, so a test that depends on the host fails here first.
+#
+# The two suites run one after the other, never concurrently: both start
+# services on fixed loopback ports.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run both test suites
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+
+      # The same reading the release workflow's pins job does, so the tests
+      # run on the Node every image and the bundle build with.
+      - name: Read the release pins from config/curia.yaml
+        id: pins
+        run: node deploy/bundle/pins.mjs | tee -a "$GITHUB_OUTPUT"
+
+      - name: Set up the pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ steps.pins.outputs.NODE_VERSION }}
+
+      - name: Install the daemon's dependencies
+        run: npm ci --prefix daemon --no-fund --no-audit
+
+      - name: Run the cli suite
+        run: npm test --prefix cli
+
+      - name: Run the daemon suite
+        run: npm test --prefix daemon

--- a/cli/test/rollback.test.mjs
+++ b/cli/test/rollback.test.mjs
@@ -105,6 +105,7 @@ async function updated({ env, root, to = '1.4.0', docker = fakeDocker(), live = 
     acquireProbes: acquireProbesFor(artifacts),
     releaseProbes: releaseProbesFor(target),
     docker,
+    tailscale: fakeTailscale(),
     fetch: fakeLoopback(docker, { initial: ACTIVE, live }),
     sleep: async (ms) => { clock += ms },
     now: () => clock,

--- a/cli/test/uninstall.test.mjs
+++ b/cli/test/uninstall.test.mjs
@@ -47,7 +47,7 @@ async function installed({ home = mkdtempSync(join(scratch, 'home-')), root = jo
   const r = releaseIn(scratch, { version: VERSION })
   const io = capture()
   const env = { HOME: home, CURIA_ROOT: root, CURIA_STAGE: stageIn(scratch, r) }
-  const deps = { hostProbes: hostProbes(), releaseProbes: releaseProbesFor(r), docker: fakeDocker(), sleep: async () => {}, now: () => 0 }
+  const deps = { hostProbes: hostProbes(), releaseProbes: releaseProbesFor(r), docker: fakeDocker(), tailscale: fakeTailscale(), sleep: async () => {}, now: () => 0 }
   const exit = await runInstall({ env, stdout: io.stdout, stderr: io.stderr, uid: process.getuid(), gid: process.getgid(), root, mode: 'install' }, deps)
   assert.equal(exit, EXIT.ok, io.err())
   const record = readInstallationRecord(root)
@@ -312,7 +312,7 @@ describe('reinstall from the preserved root', () => {
       const io = capture()
       const docker = fakeDocker()
       const env = { HOME: home, CURIA_ROOT: root, CURIA_STAGE: stageIn(scratch, r) }
-      const deps = { hostProbes: hostProbes(), releaseProbes: releaseProbesFor(r), docker, sleep: async () => {}, now: () => 0 }
+      const deps = { hostProbes: hostProbes(), releaseProbes: releaseProbesFor(r), docker, tailscale: fakeTailscale(), sleep: async () => {}, now: () => 0 }
       const exit = await runInstall({ env, stdout: io.stdout, stderr: io.stderr, uid: process.getuid(), gid: process.getgid(), root, mode }, deps)
       assert.equal(exit, EXIT.ok, io.err())
       assert.match(io.out(), new RegExp(`reinstalling ${escape(VERSION)} over the installation at ${root} \\(installation ${id}\\)`))
@@ -337,7 +337,7 @@ describe('reinstall from the preserved root', () => {
     const { home, root, r, id } = await installed()
     assert.equal((await uninstall({ home, root, docker: dockerHostOf(id), tailscale: fakeTailscale() })).exit, EXIT.ok)
     const io = capture()
-    const deps = { hostProbes: hostProbes(), releaseProbes: releaseProbesFor(r), docker: fakeDocker(), sleep: async () => {}, now: () => 0 }
+    const deps = { hostProbes: hostProbes(), releaseProbes: releaseProbesFor(r), docker: fakeDocker(), tailscale: fakeTailscale(), sleep: async () => {}, now: () => 0 }
     await assert.rejects(
       runInstall({ env: { HOME: home, CURIA_ROOT: root }, stdout: io.stdout, stderr: io.stderr, uid: process.getuid(), gid: process.getgid(), root, mode: 'reinstall' }, deps),
       (e) => e instanceof Refusal && new RegExp(`^stage: no release to install: .*${escape(BOOTSTRAP_COMMAND)}`).test(e.message),

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -51,6 +51,8 @@ One boot brings up everything: the HTTP surface, ttyd, the Discord bridge, the r
 
 **No suite reads `$HOME`.** `loadCuriaConfig` checks `skills.install` against `skills.root`, and that root defaults to `~/.claude/skills`. So a fixture config that says nothing about skills asks the host a question the test cannot control. Every fixture config now names a skills root that the test seeds. See `test/fixtures/skills.mjs`. The two tests that pin the default root swap in a home directory they own. The suite gives the same answer on the operator's box, in an agent container, and on a stranger's machine.
 
+**CI runs both suites on every pull request.** The `.github/workflows/ci.yml` workflow runs `npm test --prefix cli` and then `npm test --prefix daemon` on `ubuntu-latest`, on the Node that `config/curia.yaml` pins, on every pull request and on every push to `main`. The runner has no `tailscale`, so a test that reaches a host binary instead of an injected runner fails there before it can fail a publication, the way the 0.7.0 bundle job did. `test/ciworkflow.test.mjs` pins the trigger, the order, and the action pins.
+
 **One host binary stays optional.** The tmux describes in `tmux.test.mjs` need `tmux`, and each one states why it skipped. An agent container carries no tmux, so a green run there shows three skipped describes. Nothing needs a ttyd binary since #260 — `attach.test.mjs` pins the compose command instead.
 
 ## Surfaces

--- a/daemon/test/ciworkflow.test.mjs
+++ b/daemon/test/ciworkflow.test.mjs
@@ -1,0 +1,67 @@
+// The CI workflow as text, the way releaseworkflow.test.mjs reads the
+// release workflow. The trigger, the order of the two suites, and the
+// action pins are facts the YAML states; a change that drops a suite, runs
+// the suites concurrently, or unpins an action fails here first.
+//
+// The workflow exists because the 0.7.0 publication (run 33636124347)
+// failed in the bundle job on 20 cli tests that spawned the real
+// `tailscale`, and nothing had run the suites on the pull request.
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import YAML from 'yaml'
+
+import { RELEASE_WORKFLOW } from '../../cli/src/manifest.mjs'
+
+const root = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))))
+const yaml = (file) => YAML.parse(fs.readFileSync(path.join(root, file), 'utf8'))
+const ci = yaml('.github/workflows/ci.yml')
+const release = yaml(RELEASE_WORKFLOW)
+
+const runs = (job) => job.steps.filter((s) => typeof s.run === 'string').map((s) => s.run.trim())
+const usesOf = (job) => job.steps.filter((s) => s.uses).map((s) => s.uses)
+const action = (uses) => String(uses).split('@')[0]
+
+describe('the CI workflow', () => {
+  test('runs on every pull request and on every push to main, and holds read permission only', () => {
+    assert.deepEqual(ci.on, { pull_request: null, push: { branches: ['main'] } })
+    assert.deepEqual(ci.permissions, { contents: 'read' })
+    assert.deepEqual(Object.keys(ci.jobs), ['test'])
+    assert.equal(ci.jobs.test['runs-on'], 'ubuntu-latest')
+    assert.equal(ci.jobs.test.strategy, undefined, 'one job, no matrix: the suites contend for ports')
+  })
+
+  test('sets up the pinned Node the way the release workflow reads it', () => {
+    const job = ci.jobs.test
+    const pins = job.steps.find((s) => s.id === 'pins')
+    const releasePins = release.jobs.pins.steps.find((s) => s.id === 'pins')
+    assert.equal(pins.run, releasePins.run, 'the same reading of config/curia.yaml')
+    const node = job.steps.find((s) => String(s.uses).startsWith('actions/setup-node@'))
+    assert.equal(node.with['node-version'], '${{ steps.pins.outputs.NODE_VERSION }}')
+    assert.ok(job.steps.indexOf(pins) < job.steps.indexOf(node), 'the pins are read before Node is set up')
+  })
+
+  test('installs the daemon, then runs the cli suite, then the daemon suite, one after the other', () => {
+    const steps = runs(ci.jobs.test)
+    const install = steps.findIndex((r) => /^npm ci --prefix daemon\b/.test(r))
+    const cli = steps.findIndex((r) => r === 'npm test --prefix cli')
+    const daemon = steps.findIndex((r) => r === 'npm test --prefix daemon')
+    assert.ok(install >= 0 && cli > install && daemon > cli, `install, then cli, then daemon; got ${JSON.stringify(steps)}`)
+    for (const step of ci.jobs.test.steps) {
+      assert.ok(!/&\s*$|&\s*\n/.test(step.run ?? ''), 'no step backgrounds a suite')
+    }
+  })
+
+  test('every action is pinned to the full commit the release workflow pins', () => {
+    const releasePins = new Map()
+    for (const job of Object.values(release.jobs)) for (const uses of usesOf(job)) releasePins.set(action(uses), uses)
+    for (const uses of usesOf(ci.jobs.test)) {
+      assert.match(uses, /@[0-9a-f]{40}( #|$)/, `${uses} is not pinned to a commit`)
+      assert.equal(uses, releasePins.get(action(uses)), `${action(uses)} moves together with the release workflow`)
+    }
+  })
+})

--- a/daemon/test/releaseworkflow.test.mjs
+++ b/daemon/test/releaseworkflow.test.mjs
@@ -29,7 +29,7 @@ describe('the release workflow', () => {
   test('is the one workflow the manifest names as the signer, and there is no second release workflow', () => {
     assert.equal(RELEASE_WORKFLOW, '.github/workflows/release.yml')
     const files = fs.readdirSync(path.join(root, '.github', 'workflows')).sort()
-    assert.deepEqual(files, ['pull-request-title.yml', 'release.yml', 'stable-index.yml'])
+    assert.deepEqual(files, ['ci.yml', 'pull-request-title.yml', 'release.yml', 'stable-index.yml'])
   })
 
   test('runs on pushes to main and on dispatch, never on a tag, and serializes publications', () => {


### PR DESCRIPTION
## What failed

The 0.7.0 publication ([run 33636124347](https://github.com/alp82/curia/actions/runs/33636124347)) failed in the bundle job's "Prove the bundle" step. `npm test --prefix cli` had 20 failures, all `preflight failed: tailscale status failed: spawn tailscale ENOENT`, or the same from the uninstall `routes` step, in `rollback.test.mjs`, `uninstall.test.mjs`, and the reinstall tests.

The #891 rehearsal (PR #934) made `curia update`, `curia rollback`, and `curia reinstall` run the tailnet inspection, and made `curia uninstall` withdraw the Serve routes, both through the `tailscale` runner in `cli/src/tailscale.mjs`. Four test helpers still built their deps without that runner, so they spawned the real `tailscale`. The developers' machines have one. The GitHub runner does not.

## The fix

- `updated()` in `cli/test/rollback.test.mjs`, and `installed()` plus the two reinstall helpers in `cli/test/uninstall.test.mjs`, now hand in `fakeTailscale()` the way `install.test.mjs` and `tailnet.test.mjs` do.
- Proven by running the cli suite with every `tailscale` removed from the path: 395 tests, 0 failures. On the normal path, the same.
- The rest of `cli/test` was audited for host binaries. Docker, `gh`, and the release downloads are replaced in every test. The archive and package tests use `tar` and `npm pack` on purpose, and the runner has both, which the bundle job's own run showed.

## The CI that would have caught it

Nothing ran the suites on the pull request that introduced this. `.github/workflows/ci.yml` now runs on every pull request and on every push to `main`: one job on `ubuntu-latest` that reads the pinned Node from `config/curia.yaml` the way the release workflow's `pins` job does, runs `npm ci --prefix daemon`, then `npm test --prefix cli`, then `npm test --prefix daemon`, one after the other because the suites contend for ports. Every action is pinned to the same full commit `release.yml` pins.

`daemon/test/ciworkflow.test.mjs` pins the trigger, the order, and the pins. The daemon README's test-suite section says CI runs both suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
