### PR TITLE
fix: seed agent containers from the installation's secret files

### DIFF
--- a/daemon/src/codexworkspace.mjs
+++ b/daemon/src/codexworkspace.mjs
@@ -113,16 +113,23 @@ function codexSkillDenyList(install) {
     .sort()
 }
 
-function seedCredential(cfgDir, { sandboxed = false } = {}) {
+// `credentialFile` is `cfg.paths.codexAuth` (#891): `secrets/codex-auth.json`
+// under an installation root, the home's `.codex/auth.json` without one. The
+// caller that has no config (the bare-path seed in the suite) gets the home's
+// file, which is what the source deployment's config names too. The reauth lane
+// writes that same file and the model card verifies it, so a spawn that read
+// any other path would refuse a credential the operator can see is connected -
+// the rehearsal's first dispatch did exactly that, looking in `cache/home`.
+function seedCredential(cfgDir, { sandboxed = false, credentialFile = null } = {}) {
   const destination = path.join(cfgDir, 'auth.json')
-  const host = path.join(os.homedir(), '.codex', 'auth.json')
+  const host = credentialFile ?? path.join(os.homedir(), '.codex', 'auth.json')
   fs.rmSync(destination, { force: true })
   if (!sandboxed) {
     fs.symlinkSync(host, destination)
     return
   }
   if (!fs.existsSync(host)) {
-    throw new Error(`no codex credential for the container: ${host} does not exist, and a sandboxed codex agent cannot reach the host store - type \`reauth\` to sign in from a browser (#642)`)
+    throw new Error(`no codex credential for the container: ${host} does not exist, and a sandboxed codex agent cannot reach curia's store - type \`reauth\` to sign in from a browser (#642)`)
   }
   const raw = fs.readFileSync(host, 'utf8')
   const expiry = codexAccessTokenExpiry(raw)

--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -1857,9 +1857,18 @@ export class Dispatcher {
     }, {
       filesystem: {
         prepare: (context) => {
+          // The credential files come from the loaded config's paths (#891):
+          // under an installation root they are the `secrets/` files the
+          // reauth lanes write, and the home paths only without a root. The
+          // seed must never derive them from HOME, which is `cache/home` under
+          // a root and holds no credential.
+          const paths = pathsOf(this.config)
           this.deps.seedConfigDir(
             context.cfgDir, GUEST_WT, context.skills, context.harness,
-            { sandboxed: true, adapter },
+            {
+              sandboxed: true, adapter,
+              credentialFiles: { openai: paths.codexAuth, anthropic: paths.anthropicStore },
+            },
           )
           this.deps.writeConnectionSettings({
             wtPath: GUEST_WT, hostWtPath: context.wtPath, cfgDir: context.cfgDir,

--- a/daemon/src/workspace.mjs
+++ b/daemon/src/workspace.mjs
@@ -859,7 +859,14 @@ export function composeMemoryFile(cfgDir, harness) {
 // it as a `projects` key, which Claude Code matches against its own cwd — and a
 // container's cwd is the mount point, not the host path. Everything this
 // function WRITES goes to `cfgDir`, which is always the host path.
-export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude', { sandboxed = false, apiKey = null, adapter = null, sweep = true } = {}) {
+//
+// `credentialFiles` maps a provider to the long-lived credential file the seed
+// copies from, `{ openai: cfg.paths.codexAuth, anthropic: cfg.paths.anthropicStore }`
+// (#891). The dispatcher passes the loaded config's paths, so under an
+// installation root the copy comes from `secrets/`, the file the reauth lane
+// wrote. A caller that passes none gets each harness's home-directory default,
+// which is the source deployment's answer.
+export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude', { sandboxed = false, apiKey = null, adapter = null, sweep = true, credentialFiles = {} } = {}) {
   const selected = adapter ?? harness
   const h = workspaceFor(selected)
   fs.mkdirSync(cfgDir, { recursive: true })
@@ -877,7 +884,7 @@ export function seedConfigDir(cfgDir, wtPath, skills = null, harness = 'claude',
   // The seed needs the boundary too (#158): the codex harness shares the host's
   // credential file through a symlink on the bare path and cannot share it at
   // all across a mount, so it copies instead.
-  h.seed(cfgDir, wtPath, { sandboxed, apiKey })
+  h.seed(cfgDir, wtPath, { sandboxed, apiKey, credentialFile: credentialFiles[h.provider] ?? null })
   // The one deliberate narrowing of the no-host-config stance below (#133):
   // the operator's communication rules are mandatory for every agent, so a
   // curia-owned copy lands as the CLI's global-memory file. `CLAUDE.md` for

--- a/daemon/test/rootdispatch.test.mjs
+++ b/daemon/test/rootdispatch.test.mjs
@@ -1,0 +1,180 @@
+// A dispatch under an installation root seeds the agent container from the
+// root's secret files (#891, rehearsal of #863).
+//
+// The rehearsal signed in to OpenAI, the reauth lane wrote
+// `secrets/codex-auth.json`, the model card verified it, and the first
+// dispatch refused: the codex seed still read `$HOME/.codex/auth.json`, which
+// under a root is `cache/home/.codex/auth.json` and never exists. Every
+// long-lived credential a spawn consumes has to come from `cfg.paths`, the
+// same source the reauth lanes write and the setup cards verify.
+
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { Dispatcher } from '../src/dispatch.mjs'
+import { AnthropicCredentialStore, CLAUDE_CREDENTIAL_FILE } from '../src/credentials.mjs'
+import { servicePaths } from '../src/paths.mjs'
+import { cfgDirFor } from '../src/workspace.mjs'
+import { ensureLayout } from '../../cli/src/root.mjs'
+import { writeSecret } from '../../cli/src/secrets.mjs'
+import { journalDouble } from './fixtures/journal.mjs'
+import { TEST_PINS } from './fixtures/sandbox.mjs'
+import { TEST_ANTHROPIC_TOKEN } from './fixtures/credentials.mjs'
+
+const ROUTING = {
+  defaults: { untyped: 'sonnet', research: 'gpt' },
+  models: {
+    sonnet: { provider: 'anthropic', harness: 'claude' },
+    gpt: { provider: 'openai', harness: 'codex', id: 'gpt-5.5' },
+  },
+  fallbacks: {},
+  harnesses: {
+    claude: {
+      template: 'claude --model {model} "$(cat {prompt_file})"',
+      ready: '⏵⏵|bypass permissions', toolChannelGraceS: 15, readyRe: /⏵⏵|bypass permissions/,
+    },
+    codex: {
+      template: 'codex --model {model} "$(cat {prompt_file})"',
+      ready: '·\\s[~/]', toolChannelGraceS: 15, readyRe: /·\s[~/]/,
+    },
+  },
+}
+
+const ISSUE = { number: 42, title: 'a ticket', body: 'body text', state: 'open', assignees: [], labels: [] }
+
+const jwt = (payload) => `h.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.s`
+const CODEX_AUTH = JSON.stringify({
+  tokens: { access_token: jwt({ exp: Math.floor(Date.now() / 1000) + 3600 }), refresh_token: 'r' },
+})
+
+let tmp
+let root
+let paths
+let savedHome
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-rootdispatch-'))
+  root = path.join(tmp, 'install')
+  ensureLayout(root, { uid: process.getuid() })
+  paths = servicePaths({ root })
+  // HOME is the root's `cache/home`, the way the service container runs, and
+  // it holds no `.codex` and no `.claude`: a seed that falls back to the home
+  // finds nothing there.
+  savedHome = process.env.HOME
+  process.env.HOME = paths.home
+})
+afterEach(() => {
+  process.env.HOME = savedHome
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+function makeDispatcher({ labels = [], anthropic }) {
+  const double = journalDouble(path.join(tmp, 'data'))
+  const d = new Dispatcher({
+    config: {
+      watch: [{ repo: 'o/r', mode: 'auto' }],
+      dispatch: {
+        auto_dispatch: false, max_concurrent: 2, poll_interval_s: 60,
+        workspace_root: paths.workspaceRoot, ready_timeout_s: 1, stop_nudge_budget: 3, claim_login: 'me',
+      },
+      attach: { ttyd_port: 7681, serve_port: 8443 },
+      identity: { allow: ['a@b.c'], proxy_port: 7682 },
+      skills: null,
+      sandbox: TEST_PINS,
+      paths,
+    },
+    routing: ROUTING,
+    reduction: {
+      journal: (type, data) => { double.journal(type, data) },
+      questions: double.questions, openEscalations: () => [], answeredExchangeFor: () => [], cancel: () => ({ ok: true }), expireAgentNotes: () => 0,
+    },
+    notify: () => {},
+    log: () => {},
+    dataDir: paths.state,
+    daemonPort: 4271,
+    minter: {
+      tokenFor: async () => 'ghs_test',
+      botIdentity: async () => ({ name: 'curia-sh[bot]', email: '1+curia-sh[bot]@users.noreply.github.com' }),
+    },
+    anthropic,
+    deps: {
+      fetchIssue: async () => ({ ...ISSUE, labels: labels.map((name) => ({ name })) }),
+      claim: async () => {},
+      unclaim: async () => {},
+      hasSession: async () => false,
+      listSessions: async () => [],
+      newSession: async () => {},
+      capturePane: async () => '',
+      killSession: async () => {},
+      createPrivateClone: async (r, repo, n) => {
+        const wt = path.join(r, 'repos', repo.replace('/', '__'), 'wt', String(n))
+        fs.mkdirSync(path.join(wt, 'docs', 'agents'), { recursive: true })
+        fs.mkdirSync(path.join(wt, '.git'), { recursive: true })
+        fs.writeFileSync(path.join(wt, 'docs', 'agents', 'issue-tracker.md'), '# Issue tracker: GitHub\n')
+        return wt
+      },
+      removeWorkspace: async () => {},
+      removeConfigDir: () => {},
+      removeCredentials: () => {},
+      probeTtyd: async () => ({ verified: true }),
+      assertServe: async () => {},
+      serveOff: async () => {},
+      defaultBranchOf: async () => 'main',
+      hasUnpushedCommits: async () => false,
+      hasUncommittedChanges: async () => false,
+      salvageLocalOnlyWork: async () => ({ salvaged: false, branch: null, sha: null }),
+      findPullRequest: async () => null,
+      ensureAgentImage: async () => ({ ref: 'curia-agent:test', built: false }),
+      assertSideChannel: async () => '10.0.1.1',
+      stopContainer: async () => true,
+      listContainers: async () => [],
+      allocatePorts: async () => [9000, 9001, 9002],
+      containerPorts: async () => [],
+      setGitIdentity: async () => {},
+    },
+  })
+  d.identityProxy = { listening: true }
+  return { d }
+}
+
+describe('a dispatch under an installation root seeds the container from secrets/ (#891)', () => {
+  test('a codex spawn copies secrets/codex-auth.json into the config dir, with no cache/home/.codex', async () => {
+    writeSecret(root, 'codex-auth.json', CODEX_AUTH)
+    assert.equal(fs.existsSync(path.join(paths.home, '.codex')), false)
+    const { d } = makeDispatcher({ labels: ['wayfinder:research'], anthropic: null })
+
+    const said = await d.start('42', { repo: 'o/r', by: 'test' })
+
+    assert.doesNotMatch(said, /failed before the agent could run/, 'the dispatch must not refuse over a credential the root holds')
+    const copy = path.join(cfgDirFor(paths.workspaceRoot, 'curia-42', 'codex'), 'auth.json')
+    assert.equal(fs.readFileSync(copy, 'utf8'), CODEX_AUTH)
+    assert.equal(fs.lstatSync(copy).isSymbolicLink(), false)
+    assert.equal(fs.lstatSync(copy).mode & 0o777, 0o400)
+  })
+
+  test('a codex spawn with no secret names the root file it looked at', async () => {
+    const { d } = makeDispatcher({ labels: ['wayfinder:research'], anthropic: null })
+
+    const said = await d.start('42', { repo: 'o/r', by: 'test' })
+
+    assert.match(said, /failed before the agent could run/)
+    assert.ok(said.includes(`${paths.codexAuth} does not exist`), said)
+    assert.doesNotMatch(said, /cache\/home/)
+  })
+
+  test('a claude spawn writes the copy from secrets/anthropic.json, with no cache/home/.claude', async () => {
+    const anthropic = new AnthropicCredentialStore({ file: paths.anthropicStore })
+    anthropic.adopt(TEST_ANTHROPIC_TOKEN)
+    assert.equal(fs.existsSync(path.join(paths.home, '.claude')), false)
+    const { d } = makeDispatcher({ anthropic })
+
+    const said = await d.start('42', { repo: 'o/r', by: 'test' })
+
+    assert.doesNotMatch(said, /failed before the agent could run/, 'the dispatch must not refuse over a credential the root holds')
+    const copy = path.join(cfgDirFor(paths.workspaceRoot, 'curia-42', 'claude'), CLAUDE_CREDENTIAL_FILE)
+    assert.equal(JSON.parse(fs.readFileSync(copy, 'utf8')).claudeAiOauth.accessToken, TEST_ANTHROPIC_TOKEN)
+  })
+})


### PR DESCRIPTION
## The defect

The live rehearsal of the packaged lifecycle (#891, map #863) installed 0.9.0, signed in to OpenAI from the model card, and saw the daemon adopt the credential into `secrets/codex-auth.json`. Pressing **Run Full loop** then failed at dispatch:

> no codex credential for the container: /home/curia/.local/share/curia/cache/home/.codex/auth.json does not exist

The codex seed in `daemon/src/codexworkspace.mjs` read `$HOME/.codex/auth.json`. Under an installation root HOME is `cache/home`, which holds no credential. The reauth lane and the model card use `cfg.paths.codexAuth`, so the operator saw a verified credential and a dispatch that couldn't find it.

## The fix

- `seedConfigDir` takes `credentialFiles`, a provider-keyed map of long-lived credential files, and hands each harness seed the file for its provider.
- The dispatcher's arm step passes `cfg.paths` (`codexAuth`, `anthropicStore`). Under a root that is `secrets/`; without one it is the home path the source deployment has always used.
- The refusal sentence names the file the seed read.

The anthropic copy already came from the store at `cfg.paths.anthropicStore`, and the GitHub App key from `secrets/github-app.json`. Only the codex seed read from HOME.

## Tests

`daemon/test/rootdispatch.test.mjs` boots a dispatcher on a root with `secrets/codex-auth.json` and no `cache/home/.codex`, and proves a codex spawn copies the secret into the config dir at `0400`; that a missing secret names `secrets/codex-auth.json`; and that a claude spawn writes its copy from `secrets/anthropic.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
