### PR TITLE
fix: show every setup action's progress at once and bring the Full loop run into view

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -633,6 +633,30 @@
   .setup-card.failed .setup-logo { color: var(--bad); background: color-mix(in srgb, var(--bg-raise) 60%, transparent); }
   .setup-card.failed .setup-foot { color: var(--bad); background: color-mix(in srgb, var(--bad) 8%, var(--bg-raise)); }
   .setup-card.failed .setup-secondary { color: color-mix(in srgb, var(--bad) 80%, var(--ink)); }
+  /* A card whose action is in flight (#891): the failure or the connected
+     tint gives way to what Curia is doing, a pulse in the footer and the
+     sentence, until the next read for that card lands. The red and the
+     brand color come back only from that read. */
+  .setup-card.working, .setup-card.failed.working { border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line)); }
+  .setup-card.working.on { outline-color: var(--accent); }
+  .setup-card.working .setup-head { color: var(--ink-dim); background: color-mix(in srgb, var(--brand) 22%, var(--bg-raise)); }
+  .setup-card.working .setup-logo { color: var(--ink-dim); background: color-mix(in srgb, var(--bg-raise) 70%, transparent); }
+  .setup-card.working .setup-foot { color: var(--ink); background: color-mix(in srgb, var(--accent) 7%, var(--bg-raise)); }
+  .setup-working { display: flex; gap: 9px; align-items: baseline; font-size: 13px; font-weight: 650; line-height: 1.45; }
+  .setup-pulse { flex: 0 0 8px; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 45%, transparent); animation: setup-pulse 1.8s ease-out infinite; }
+  @keyframes setup-pulse { 70%, 100% { box-shadow: 0 0 0 7px transparent; } }
+  /* The panel while the action is in flight: one sentence, one thin sweep
+     of the accent across a hairline, and nothing of what stood before. */
+  .setup-panel.working { border-color: color-mix(in srgb, var(--accent) 55%, var(--line)); }
+  .setup-working-panel { padding: 8px 0 4px; }
+  .setup-working-panel b { display: block; font-size: 15px; margin: 12px 0 4px; }
+  .setup-progress { position: relative; height: 2px; overflow: hidden; border-radius: 2px; background: color-mix(in srgb, var(--accent) 18%, var(--line)); }
+  .setup-progress::before { content: ""; position: absolute; inset: 0; width: 38%; border-radius: 2px; background: var(--accent); transform: translateX(-110%); animation: setup-sweep 1.6s ease-in-out infinite; }
+  @keyframes setup-sweep { 0% { transform: translateX(-110%); } 100% { transform: translateX(290%); } }
+  @media (prefers-reduced-motion: reduce) {
+    .setup-pulse, .setup-progress::before { animation: none; }
+    .setup-progress::before { transform: none; width: 100%; opacity: .5; }
+  }
   .setup-loop {
     display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
     margin-top: 4px; padding: 14px 15px; border: 1px dashed var(--line); border-radius: 14px;
@@ -640,8 +664,18 @@
   .setup-loop .dim-note { flex: 1 1 180px; }
   /* The run (#882): the legs, one row each, and the links to the real
      artifacts. Color marks attention only; every state is also a word. */
-  .setup-loop.run { flex-direction: column; align-items: stretch; border-style: solid; }
-  .setup-loop.run > div { display: flex; flex-direction: column; gap: 4px; }
+  .setup-loop.on { outline: 2px solid var(--accent); outline-offset: 2px; }
+  /* The rail's Full loop card once a run exists or a press is in flight
+     (#891): one selectable surface, the state as a word, and the legs in
+     the main panel where a card's panel renders, never below the fold. */
+  .setup-loop.run, .setup-loop.working { flex-direction: column; align-items: stretch; border-style: solid; color: var(--ink); text-align: left; box-shadow: var(--shadow); }
+  .setup-loop.run.running, .setup-loop.working { border-color: color-mix(in srgb, var(--accent) 55%, var(--line)); }
+  .setup-loop.run.complete { border-color: color-mix(in srgb, var(--ok) 55%, var(--line)); }
+  .setup-loop.run.failed { border-color: var(--bad); }
+  .setup-loop.run.failed .setup-badge { color: var(--bad); }
+  .setup-loop.run > div, .setup-loop.working > div { display: flex; flex-direction: column; gap: 4px; }
+  .setup-loop-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .setup-run-body { display: flex; flex-direction: column; gap: 4px; }
   .loop-legs { list-style: none; margin: 8px 0 0; padding: 0; display: grid; gap: 3px; }
   .loop-leg { display: flex; gap: 8px; align-items: baseline; font-size: 13px; }
   .loop-leg .loop-mark { width: 1.4em; text-align: center; flex: none; }
@@ -916,7 +950,7 @@ var UI = {
   /* The setup frame's own state (#874): whether a read is in flight, and the
      one sentence the last press left behind. The selected card is not here —
      it is the record's `step`, kept by the service so a reopen restores it. */
-  setup: { busy: false, note: null, loopBusy: false, loopTimer: null, githubBusy: false, discord: null, discordBusy: null, discordTimer: null, tailscale: null, tailscaleBusy: null, openai: null, openaiBusy: null, openaiTimer: null, anthropic: null, anthropicBusy: null, anthropicTimer: null },
+  setup: { busy: false, note: null, working: null, panel: null, restartTimer: null, loopBusy: false, loopTimer: null, githubBusy: false, discord: null, discordBusy: null, discordTimer: null, tailscale: null, tailscaleBusy: null, openai: null, openaiBusy: null, openaiTimer: null, anthropic: null, anthropicBusy: null, anthropicTimer: null },
   /* The drill-in frame's own state (#699), one entry per page that is a list
      of sections: which section is open, and whether the phone is on the list
      in front of it. */
@@ -5016,6 +5050,35 @@ function screenCredentials(p) {
 
 const SETUP_ORDER = ["github", "discord", "tailscale", "model"];
 
+/* WHAT CURIA IS DOING, THE ONE MECHANISM (#891). The rehearsal pressed a
+   card's action and read the pre-action content, the sign-in steps or the
+   old failure, for the seconds until the next read landed. `UI.setup.working`
+   is one record, `{ card, what }`: the card whose action is in flight and
+   the sentence for it. A press sets it before anything else and the render
+   draws it in place of the card's footer and the whole panel; nothing that
+   stood before survives. Only the next read for that card clears it
+   (`setupSettled`): the frame read clears every card, a row's own read
+   clears its card, and a write that is refused before any read clears it
+   with the refusal beside the form. The Full loop is the card `loop`. */
+function setupWorking(card, what) {
+  UI.setup.working = { card, what };
+  UI.act.said = null;
+  render();
+}
+function setupSettled(card = null) {
+  if (!UI.setup.working) return;
+  if (card === null || UI.setup.working.card === card) UI.setup.working = null;
+}
+const setupWork = (card) => (UI.setup.working?.card === card ? UI.setup.working : null);
+const sentence = (s) => s.charAt(0).toUpperCase() + s.slice(1);
+function setupProgress(work) {
+  return `<div class="setup-working-panel" role="status" aria-live="polite">
+    <div class="setup-progress" aria-hidden="true"></div>
+    <b>${esc(sentence(work.what))}…</b>
+    <div class="dim-note">The result replaces this as soon as Curia has it.</div>
+  </div>`;
+}
+
 /* The content slot, per card: the body of the configuration panel, given
    the card, its remembered progress, and the held overview reading. A stub
    says what the step will do and that it is not available in this release
@@ -5134,7 +5197,7 @@ async function doSetupGitHubWatch() {
     return null;
   }
   UI.setup.githubBusy = true;
-  render();
+  setupWorking("github", "saving the watch list and verifying the repositories");
   try {
     const res = await fetch("/api/setup/github/watch", {
       method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
@@ -5145,6 +5208,7 @@ async function doSetupGitHubWatch() {
   } catch (error) {
     UI.act.said = { key: "github-setup:watch", text: error.message, ok: false };
     UI.setup.githubBusy = false;
+    setupSettled("github");
     render();
     return null;
   }
@@ -5171,7 +5235,7 @@ function setupDiscord(card, progress) {
   if (card.state === "connected" && detail) {
     const bridge = detail.bridge === "up"
       ? `<span class="dim-note">The bridge is running.</span>`
-      : `<span class="dim-note">The bridge reads the token when the service starts. <a href="#" onclick="doRestart();return false">Restart Curia</a> to start it.</span>`;
+      : `<span class="dim-note">The bridge reads the token when the service starts. <a href="#" onclick="doSetupRestart();return false">Restart Curia</a> to start it.</span>`;
     return `<div class="rows">
       <div class="row"><span class="key grow">Channel</span><span><a href="${esc(detail.channel?.url)}" target="_blank" rel="noopener">#${esc(detail.channel?.name)}</a> in ${esc(detail.guild?.name)}${detail.channel?.created ? " · created by Curia" : ""}</span></div>
       <div class="row"><span class="key grow">Confirmation</span><span><a href="${esc(detail.confirmation?.url)}" target="_blank" rel="noopener">${detail.confirmation?.posted ? "Posted" : "Delivered"} ${esc(ago(detail.confirmation?.at))}</a></span></div>
@@ -5250,6 +5314,7 @@ async function loadDiscordSetup() {
   } catch (error) {
     UI.setup.discord = { secret: null, settings: null, bot: null, guilds: [], invite_url: null, error: error.message };
   }
+  setupSettled("discord");
   render();
   return ensureDiscordSetupWait(before);
 }
@@ -5288,8 +5353,11 @@ async function doSetupDiscordToken() {
   const userId = document.getElementById("setup-discord-user")?.value?.trim() ?? "";
   if (!token) return refuse("discord-setup:token", "Paste the bot token.");
   if (!userId) return refuse("discord-setup:token", "Enter your Discord user ID.");
+  setupWorking("discord", "verifying the bot token and reading the bot's servers");
   const out = await discordSetupWrite("discord-setup:token", "/api/setup/discord/token", { token, user_id: userId });
   if (out) UI.setup.discord = out;
+  /* The answer is the card's own read, so it settles the work either way. */
+  setupSettled("discord");
   render();
   ensureDiscordSetupWait();
   return out;
@@ -5299,9 +5367,11 @@ async function doSetupDiscordChannel() {
   const channel = document.getElementById("setup-discord-channel")?.value?.trim() ?? "";
   if (!guildId) return refuse("discord-setup:channel", "Select a server.");
   if (!channel) return refuse("discord-setup:channel", "Enter a channel name.");
+  setupWorking("discord", "registering commands and posting the confirmation");
   await rememberSetupProgress("discord", { guild_id: guildId, channel });
   const out = await discordSetupWrite("discord-setup:channel", "/api/setup/discord/channel", { guild_id: guildId, channel });
   if (out) UI.setup.discord = null;
+  else { setupSettled("discord"); render(); return null; }
   return loadSetup();
 }
 async function discordSetupWrite(key, path, body) {
@@ -5402,8 +5472,7 @@ function ensureTailscaleSetupRead() {
 }
 async function doSetupTailscaleOperator() {
   UI.setup.tailscaleBusy = "tailscale-setup:operator";
-  UI.act.said = null;
-  render();
+  setupWorking("tailscale", "verifying the operator");
   try {
     const res = await fetch("/api/setup/tailscale/operator", {
       method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
@@ -5415,6 +5484,7 @@ async function doSetupTailscaleOperator() {
   } catch (error) {
     UI.act.said = { key: "tailscale-setup:operator", text: error.message, ok: false };
     UI.setup.tailscaleBusy = null;
+    setupSettled("tailscale");
     render();
     return null;
   }
@@ -5503,8 +5573,13 @@ async function loadOpenAISetup() {
   } catch (error) {
     UI.setup.openai = { provider: "openai", secret: null, identity: null, login: null, ending: null, said: null, routing: null, error: error.message };
   }
-  render();
   const now = UI.setup.openai.login ?? null;
+  /* A login that is gone means the credential landed or the login ended:
+     the frame read says which, and until it does the row shows the
+     verification, never the steps again (#891). */
+  if (before && !now) setupWorking("model", "completing one minimal model request and applying the routing preset");
+  else setupSettled("model");
+  render();
   if (now && UI.screen === "setup") {
     UI.setup.openaiTimer = setTimeout(loadOpenAISetup, 3000);
   } else if (before && !now) {
@@ -5519,10 +5594,9 @@ function ensureOpenAISetupRead() {
   if (UI.setup.openai === null) loadOpenAISetup();
 }
 async function doSetupOpenAILogin() {
-  await rememberSetupProgress("model", { provider: "openai" });
   UI.setup.openaiBusy = "openai-setup:login";
-  UI.act.said = null;
-  render();
+  setupWorking("model", "starting the OpenAI sign-in session");
+  await rememberSetupProgress("model", { provider: "openai" });
   try {
     const res = await fetch("/api/setup/openai/login", {
       method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
@@ -5534,6 +5608,7 @@ async function doSetupOpenAILogin() {
   } catch (error) {
     UI.act.said = { key: "openai-setup:login", text: error.message, ok: false };
     UI.setup.openaiBusy = null;
+    setupSettled("model");
     render();
     return null;
   }
@@ -5599,8 +5674,10 @@ async function loadAnthropicSetup() {
   } catch (error) {
     UI.setup.anthropic = { provider: "anthropic", secret: null, credential: null, login: null, ending: null, said: null, routing: null, error: error.message };
   }
-  render();
   const now = UI.setup.anthropic.login ?? null;
+  if (before && !now) setupWorking("model", "completing one minimal model request and applying the routing preset");
+  else setupSettled("model");
+  render();
   if (now && UI.screen === "setup") {
     UI.setup.anthropicTimer = setTimeout(loadAnthropicSetup, 3000);
   } else if (before && !now) {
@@ -5615,10 +5692,9 @@ function ensureAnthropicSetupRead() {
   if (UI.setup.anthropic === null) loadAnthropicSetup();
 }
 async function doSetupAnthropicLogin() {
-  await rememberSetupProgress("model", { provider: "anthropic" });
   UI.setup.anthropicBusy = "anthropic-setup:login";
-  UI.act.said = null;
-  render();
+  setupWorking("model", "starting the Anthropic sign-in session");
+  await rememberSetupProgress("model", { provider: "anthropic" });
   try {
     const res = await fetch("/api/setup/anthropic/login", {
       method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
@@ -5630,6 +5706,7 @@ async function doSetupAnthropicLogin() {
   } catch (error) {
     UI.act.said = { key: "anthropic-setup:login", text: error.message, ok: false };
     UI.setup.anthropicBusy = null;
+    setupSettled("model");
     render();
     return null;
   }
@@ -5648,8 +5725,8 @@ async function doSetupAnthropicCode(code) {
     return null;
   }
   UI.setup.anthropicBusy = "anthropic-setup:code";
-  UI.act.said = null;
-  render();
+  if (UI.screen === "setup") setupWorking("model", "delivering the code to the login");
+  else { UI.act.said = null; render(); }
   try {
     const res = await fetch("/api/setup/anthropic/code", {
       method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
@@ -5662,6 +5739,7 @@ async function doSetupAnthropicCode(code) {
   } catch (error) {
     UI.act.said = { key: "anthropic-setup:code", text: error.message, ok: false };
     UI.setup.anthropicBusy = null;
+    setupSettled("model");
     render();
     return null;
   }
@@ -5669,6 +5747,33 @@ async function doSetupAnthropicCode(code) {
   const el = document.getElementById("setup-anthropic-code");
   if (el) el.value = "";
   return UI.screen === "setup" ? loadAnthropicSetup() : tick();
+}
+
+/* Restart Curia from the Discord card (#891): the bridge reads the token
+   only when the service starts, and the press used to change nothing on
+   this screen. The card works until the restarted service answers the
+   frame read; a refusal settles it with the sentence. */
+async function doSetupRestart() {
+  setupWorking("discord", "restarting Curia so the bridge reads the token");
+  clearTimeout(UI.setup.restartTimer);
+  await doRestart();
+  const ordered = daemonRestartAction() || UI.set.phase === "restart-unknown";
+  if (UI.set.phase === "refused" || !ordered) {
+    /* Refused, or the operator cancelled the confirmation: nothing is in
+       flight, so the card goes back to what this read said. */
+    if (UI.set.phase === "refused") UI.setup.note = UI.set.error;
+    setupSettled("discord");
+    render();
+    return;
+  }
+  const until = Date.now() + 120_000;
+  const waitForService = () => {
+    UI.setup.restartTimer = null;
+    if (UI.screen !== "setup" || !setupWork("discord")) return;
+    if (UI.set.phase === "restarted" || UI.set.phase === "refused" || Date.now() >= until) { loadSetup(); return; }
+    UI.setup.restartTimer = setTimeout(waitForService, 1000);
+  };
+  UI.setup.restartTimer = setTimeout(waitForService, 1000);
 }
 
 function setupUnavailable(card) {
@@ -5689,6 +5794,8 @@ function setupLogo(key) {
    failed verification and its one action on an error, and before either the
    name of the data that will appear. Never a decorative metric. */
 function setupFooter(card) {
+  const work = setupWork(card.key);
+  if (work) return `<div class="setup-working"><span class="setup-pulse" aria-hidden="true"></span><span>${esc(sentence(work.what))}…</span></div>`;
   if (card.state === "failed") {
     return `<div class="setup-primary"><span class="emoji" aria-hidden="true">⚠️</span><span class="fact">${esc(card.error?.failed)}</span></div>
       <div class="setup-secondary">${esc(card.error?.action)}</div>`;
@@ -5701,9 +5808,10 @@ function setupFooter(card) {
 }
 
 function setupCard(card, selected) {
-  return `<button class="setup-card ${esc(card.key)} ${esc(card.state)}${selected ? " on" : ""}" aria-pressed="${selected ? "true" : "false"}"
+  const work = setupWork(card.key);
+  return `<button class="setup-card ${esc(card.key)} ${esc(card.state)}${work ? " working" : ""}${selected ? " on" : ""}" aria-pressed="${selected ? "true" : "false"}"
       onclick="selectSetupCard('${js(card.key)}')">
-    <div class="setup-head">${setupLogo(card.key)}<span class="setup-title">${esc(card.title)}</span><span class="setup-badge">${esc(card.badge)}</span></div>
+    <div class="setup-head">${setupLogo(card.key)}<span class="setup-title">${esc(card.title)}</span><span class="setup-badge">${work ? "Working" : esc(card.badge)}</span></div>
     <div class="setup-foot">${setupFooter(card)}</div>
   </button>`;
 }
@@ -5716,16 +5824,73 @@ const setupConnected = () => setupCards().filter((c) => c.state === "connected")
 /* The one dependent step, under the rail. The button is enabled by the
    service's gate and by nothing on this page: four connected cards with no
    verified facts behind them are still not a loop to run. */
+const setupRun = () => {
+  const run = setup?.full_loop?.run;
+  return run && run.state && run.state !== "idle" ? run : null;
+};
+const LOOP_STATE_WORDS = { running: "Running", complete: "Verified", failed: "Action required" };
+/* WHICH PANEL THE MAIN AREA SHOWS (#891). The run is a panel of its own,
+   drawn where a card's panel renders: the press selects it, the rail's Full
+   loop card selects it again, and a card's own press brings the card back.
+   Arriving with a run live or ended lands on the run, which is the
+   installation's acceptance, until a card is selected. */
+function setupPanelChoice() {
+  if (UI.setup.panel) return UI.setup.panel;
+  return setupRun() || setupWork("loop") ? "run" : "card";
+}
+function selectSetupRun() {
+  UI.setup.panel = "run";
+  render();
+}
 function setupFullLoop() {
   const gate = setup?.full_loop;
-  if (gate?.run && gate.run.state && gate.run.state !== "idle") return setupLoopRun(gate.run);
+  const on = setupPanelChoice() === "run";
+  const work = setupWork("loop");
+  const run = setupRun();
+  if (work || run) {
+    const state = work ? "Working" : LOOP_STATE_WORDS[run.state] ?? run.state;
+    const where = run?.ticket ? `${esc(run.repo)}#${esc(run.ticket.number)}` : esc(run?.repo ?? "");
+    const done = (run?.legs ?? []).filter((l) => l.state === "complete").length;
+    const line = work ? `<span class="setup-pulse" aria-hidden="true"></span> ${esc(sentence(work.what))}…`
+      : `${where} · ${done} of ${(run.legs ?? []).length} legs · ${loopDur(run.elapsed_ms)}${run.state === "running" ? " so far" : ""}`;
+    return `<button class="setup-loop ${work ? "working" : `run ${esc(run.state)}`}${on ? " on" : ""}" aria-pressed="${on ? "true" : "false"}" onclick="selectSetupRun()">
+      <div><div class="setup-loop-head"><b>Full loop</b><span class="setup-badge">${esc(state)}</span></div><div class="dim-note">${line}</div></div></button>`;
+  }
   const missing = gate?.missing ?? SETUP_ORDER.filter((k) => !setupConnected().includes(k));
   const ready = Boolean(gate?.ready);
   const why = ready ? "Every integration is connected and verified."
     : missing.length ? `Waiting for ${missing.map((k) => esc(setupCardOf(k)?.title ?? k)).join(", ")}.`
       : esc(gate?.reason ?? "The Full loop isn't available yet in this release.");
-  return `<div class="setup-loop"><div><b>Full loop</b><div class="dim-note">${why}</div>${ready ? setupLoopFacts(gate?.facts) : ""}</div>
-    <button class="btn primary" ${ready ? `onclick="runFullLoop()"` : "disabled"}>Run Full loop</button></div>`;
+  return `<div class="setup-loop${on ? " on" : ""}"><div><b>Full loop</b><div class="dim-note">${why}</div>${ready ? setupLoopFacts(gate?.facts) : ""}</div>
+    <button class="btn primary" ${ready && !UI.setup.loopBusy ? `onclick="runFullLoop()"` : "disabled"}>Run Full loop</button></div>`;
+}
+
+/* The run's panel in the main area (#891): what Curia is doing from the
+   press until the service answers, then the run as the service reads it,
+   and before any run the gate's word and the one press. */
+function setupRunPanel() {
+  const gate = setup?.full_loop;
+  const work = setupWork("loop");
+  const run = setupRun();
+  const state = work ? "Working" : run ? LOOP_STATE_WORDS[run.state] ?? run.state : gate?.ready ? "Ready to run" : "Not ready";
+  let body;
+  if (work) body = setupProgress(work);
+  else if (run) body = setupLoopRun(run);
+  else {
+    const ready = Boolean(gate?.ready);
+    const missing = gate?.missing ?? SETUP_ORDER.filter((k) => !setupConnected().includes(k));
+    const why = ready ? "Every integration is connected and verified. The run takes the ticket marked <code>rehearsal</code> on the covered repository through every leg."
+      : missing.length ? `Waiting for ${missing.map((k) => esc(setupCardOf(k)?.title ?? k)).join(", ")}.`
+        : esc(gate?.reason ?? "The Full loop isn't available yet in this release.");
+    body = `<p>${why}</p>${ready ? setupLoopFacts(gate?.facts) : ""}
+      <div class="loop-actions"><button class="btn primary" ${ready && !UI.setup.loopBusy ? `onclick="runFullLoop()"` : "disabled"}>Run Full loop</button>${UI.setup.note ? `<span class="dim-note">${esc(UI.setup.note)}</span>` : ""}</div>`;
+  }
+  return `<div class="setup-panel${work ? " working" : ""}" id="setup-run">
+    <div class="eyebrow">Installation acceptance · ${esc(state)}</div>
+    <h2>Full loop</h2>
+    ${body}
+    <div class="setup-actions"><a href="#home" onclick="goto('home');return false">Close setup</a></div>
+  </div>`;
 }
 
 /* The facts the gate hands the loop, named where the action is: the
@@ -5782,13 +5947,18 @@ function setupLoopRun(run) {
     : run.state === "complete"
       ? `<a class="btn primary" href="#home" onclick="goto('home');return false">Open Curia</a>`
       : `<button class="btn primary" disabled>Running…</button>`;
-  return `<div class="setup-loop run"><div>${head}<ul class="loop-legs">${legs}</ul>${linkRow ? `<div class="loop-links">${linkRow}</div>` : ""}${problem}
-    <div class="loop-actions">${actions}${UI.setup.note ? `<span class="dim-note">${esc(UI.setup.note)}</span>` : ""}</div></div></div>`;
+  return `<div class="setup-run-body">${head}<ul class="loop-legs">${legs}</ul>${linkRow ? `<div class="loop-links">${linkRow}</div>` : ""}${problem}
+    <div class="loop-actions">${actions}${UI.setup.note ? `<span class="dim-note">${esc(UI.setup.note)}</span>` : ""}</div></div>`;
 }
-async function pressFullLoop(path) {
+/* The press (#891): the run becomes the selected panel at once, in progress,
+   and the page brings it into view, because the rail's card was below the
+   fold and the press read as nothing. The service's answer settles it. */
+async function pressFullLoop(path, what) {
   UI.setup.loopBusy = true;
   UI.setup.note = null;
-  render();
+  UI.setup.panel = "run";
+  setupWorking("loop", what);
+  document.getElementById("setup-run")?.scrollIntoView?.({ block: "start", behavior: "smooth" });
   try {
     const res = await fetch(path, {
       method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
@@ -5801,11 +5971,15 @@ async function pressFullLoop(path) {
     UI.setup.note = error.message;
   }
   UI.setup.loopBusy = false;
+  setupSettled("loop");
   render();
   ensureFullLoopRead();
 }
-function runFullLoop() { return pressFullLoop("/api/setup/full-loop"); }
-function retryFullLoop() { return pressFullLoop("/api/setup/full-loop/retry"); }
+function runFullLoop() { return pressFullLoop("/api/setup/full-loop", "starting the Full loop"); }
+function retryFullLoop() {
+  const leg = setupRun()?.failed?.title;
+  return pressFullLoop("/api/setup/full-loop/retry", leg ? `retrying ${leg}` : "retrying the Full loop");
+}
 /* While a run is live the panel follows the service's read; the timer stops
    itself when the run ends or the operator leaves the screen. */
 function ensureFullLoopRead() {
@@ -5830,6 +6004,15 @@ function ensureFullLoopRead() {
 /* The panel: the selected card's own configuration, the error treatment
    when its verification failed, and the frame's one forward action. */
 function setupPanel(card, p) {
+  const work = setupWork(card.key);
+  if (work) {
+    return `<div class="setup-panel working">
+    <div class="eyebrow">Independent connection · Working</div>
+    <h2>${esc(card.title)}</h2>
+    ${setupProgress(work)}
+    <div class="setup-actions"><a href="#home" onclick="goto('home');return false">Close setup</a></div>
+  </div>`;
+  }
   const slot = SETUP_CONTENT[card.key];
   const progress = setup?.progress?.[card.key] ?? {};
   const problem = card.state === "failed"
@@ -5879,7 +6062,7 @@ function screenSetup(p) {
       ${cards.map((c) => setupCard(c, c.key === selected)).join("")}
       ${setupFullLoop()}
     </aside>
-    <section>${setupPanel(setupCardOf(selected), p)}</section>
+    <section>${setupPanelChoice() === "run" ? setupRunPanel() : setupPanel(setupCardOf(selected), p)}</section>
   </div>`;
 }
 
@@ -5911,6 +6094,9 @@ async function loadSetup() {
     setup = { step: setup?.step ?? null, progress: setup?.progress ?? null, cards: null, full_loop: null, error: error.message };
   }
   UI.setup.busy = false;
+  /* The frame read verifies every card, so it settles whatever was in
+     flight: what it found, a failure or the connected state, is the answer. */
+  setupSettled();
   render();
   ensureDiscordSetupRead();
   ensureTailscaleSetupRead();
@@ -5922,6 +6108,10 @@ async function loadSetup() {
    verification there is. */
 function retrySetup() {
   UI.setup.note = null;
+  if (!UI.setup.working && setup?.cards) {
+    const key = setupSelected();
+    setupWorking(key, `verifying ${setupCardOf(key)?.title ?? key} again`);
+  }
   return loadSetup();
 }
 
@@ -5931,6 +6121,7 @@ function retrySetup() {
 async function selectSetupCard(key) {
   if (!SETUP_ORDER.includes(key) || !setup) return;
   setup.step = key;
+  UI.setup.panel = "card";
   UI.setup.note = null;
   render();
   ensureDiscordSetupRead();

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -4668,7 +4668,9 @@ describe('integration setup (#874)', () => {
     assert.match(body, /Escalation and answer · running/)
     assert.match(body, /Map update · pending/)
     assert.doesNotMatch(html, /onclick="runFullLoop\(\)"/, 'no second press while a run is live')
-    assert.match(html, /<button class="btn primary" disabled>Running the Full loop…<\/button>/)
+    assert.match(html, /<section><div class="setup-panel" id="setup-run">/, 'a live run is the selected panel (#891)')
+    page.UI.setup.panel = 'card'
+    assert.match(page.screenSetup(payload()), /<button class="btn primary" disabled>Running the Full loop…<\/button>/, 'the card panel names the run as the forward action')
     assert.match(html, /href="https:\/\/github\.com\/alp82\/curia\/issues\/42"[^>]*>Ticket/)
     assert.match(html, /href="https:\/\/discord\.com\/channels\/2\/777"[^>]*>Discord thread/)
     assert.doesNotMatch(html, /Pull request ↗/, 'a link the run has not produced is not drawn')
@@ -5206,7 +5208,7 @@ describe('integration setup (#874)', () => {
     assert.match(html, /href="https:\/\/discord\.com\/channels\/333333333333333333\/444444444444444444\/777"[^>]*>Posted /)
     assert.match(html, /<code>\/tickets<\/code> <code>\/next<\/code> <code>\/status<\/code>/)
     assert.match(text(html), /Alp 111111111111111111/)
-    assert.match(html, /onclick="doRestart\(\);return false">Restart Curia</)
+    assert.match(html, /onclick="doSetupRestart\(\);return false">Restart Curia</)
     assert.match(html, /<div class="setup-secondary">Confirmation delivered · 6 commands registered<\/div>/)
     assert.doesNotMatch(html, /type="password"/, 'no token form on a connected card')
     assert.match(html, /Continue setup/)
@@ -5665,5 +5667,180 @@ describe('integration setup (#874)', () => {
     assert.match(html, /<details><summary>Sign in to OpenAI again<\/summary>/)
     assert.doesNotMatch(html, /sk-ant-|acct-42/)
     assert.doesNotMatch(html, /Try again/)
+  })
+
+  // The rehearsal (#891): after a press the panel kept the pre-action content,
+  // the sign-in steps or the old failure, until the next read landed with the
+  // connected state. One mechanism for every card: the press switches the card
+  // and its panel to what Curia is doing, and only the next read for that card
+  // replaces it, with the failure or the connected state it found.
+  const deferred = () => { let resolve; const promise = new Promise((r) => { resolve = r }); return { promise, resolve } }
+  const TAILSCALE_FAILED = { state: 'failed', badge: 'Action required', error: { failed: 'Tailscale Serve is not reachable', action: 'Run tailscale serve --bg 8445 on this host, then try again.' } }
+  const TAILSCALE_READ = { requester: 'alp', operator: null, node: { installed: true, online: true, backend_state: 'Running', dns_name: 'curia.tail1234.ts.net', ips: ['100.1.2.3'] }, serve: null, app_url: null, first_operator: null, error: null }
+
+  test('a card action switches the card and its panel to in-progress at once, with none of the old content, and the next read replaces it', async () => {
+    const press = deferred()
+    const read = deferred()
+    page.setup = SETUP({ step: 'tailscale', cards: { tailscale: TAILSCALE_FAILED } })
+    page.UI.setup.tailscale = TAILSCALE_READ
+    page.fetch = async (url, init = {}) => {
+      if (url === '/api/setup/tailscale/operator') { await press.promise; return { ok: true, json: async () => ({ ok: true }) } }
+      if (url === '/api/setup') { await read.promise; return { ok: true, json: async () => SETUP({ step: 'tailscale', cards: { tailscale: ALL.tailscale } }) } }
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+    const before = page.screenSetup(payload())
+    assert.match(before, /Confirm operator and verify/)
+    assert.match(before, /Tailscale Serve is not reachable/)
+
+    const pressed = page.doSetupTailscaleOperator()
+    let html = page.screenSetup(payload())
+    assert.match(html, /class="setup-card tailscale failed working on"/, 'the rail card shows the work')
+    assert.match(text(html), /Tailscale Working Verifying the operator/)
+    assert.match(html, /class="setup-panel working"/)
+    assert.match(text(html), /Verifying the operator… /)
+    assert.match(html, /class="setup-progress"/, 'a progress indicator, not a spinner in a button')
+    assert.doesNotMatch(html, /Tailscale Serve is not reachable/, 'the previous failure is gone the moment the press lands')
+    assert.doesNotMatch(html, /Confirm operator|setup-tailscale-name|Try again/, 'none of the pre-action content stays')
+
+    press.resolve()
+    await new Promise((resolve) => setImmediate(resolve))
+    html = page.screenSetup(payload())
+    assert.match(html, /class="setup-panel working"/, 'the panel stays in progress until the read lands, not until the press answers')
+    assert.doesNotMatch(html, /Serve is not reachable|Confirm operator/)
+
+    read.resolve()
+    await pressed
+    html = page.screenSetup(payload())
+    assert.doesNotMatch(html, /working/, 'the read settles the work')
+    assert.match(html, /class="setup-card tailscale connected on"/)
+    assert.match(text(html), /Connected and verified/)
+    assert.doesNotMatch(text(html), /Verifying the operator/)
+  })
+
+  test('Try again on a failed card hides the failure while the fresh read is in flight, and a read that fails again shows the new failure', async () => {
+    const read = deferred()
+    page.setup = SETUP({ step: 'tailscale', cards: { tailscale: TAILSCALE_FAILED } })
+    page.UI.setup.tailscale = TAILSCALE_READ
+    page.fetch = async () => { await read.promise; return { ok: true, json: async () => SETUP({ step: 'tailscale', cards: { tailscale: { ...TAILSCALE_FAILED, error: { failed: 'No operator confirmed', action: 'Confirm the operator on this card.' } } } }) } }
+    const retried = page.retrySetup()
+    let html = page.screenSetup(payload())
+    assert.match(text(html), /Verifying Tailscale again/)
+    assert.doesNotMatch(html, /Serve is not reachable|Try again/)
+    read.resolve()
+    await retried
+    html = page.screenSetup(payload())
+    assert.doesNotMatch(html, /working|Serve is not reachable/)
+    assert.match(html, /setup-problem"><b>No operator confirmed<\/b>Confirm the operator on this card\./)
+    assert.match(html, /onclick="retrySetup\(\)">Try again</)
+  })
+
+  test('when a sign-in ends the model card says it is completing the model request until the verification answers, never the steps again', async () => {
+    const read = deferred()
+    page.setup = SETUP({ step: 'model', cards: { model: { state: 'unconnected', badge: 'Ready to connect', providers: providers({ state: 'unconnected' }) } } })
+    page.UI.setup.openai = OPENAI_OVERVIEW({ login: WAITING })
+    page.UI.setup.anthropic = ANTHROPIC_OVERVIEW()
+    page.fetch = async (url) => {
+      if (url === '/api/setup/openai') return { ok: true, json: async () => OPENAI_OVERVIEW({ secret: { state: 'present' } }) }
+      if (url === '/api/setup') { await read.promise; return { ok: true, json: async () => SETUP({ step: 'model', cards: { model: ALL.model } }) } }
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+    const polled = page.loadOpenAISetup()
+    await new Promise((resolve) => setImmediate(resolve))
+    let html = page.screenSetup(payload())
+    assert.match(text(html), /Completing one minimal model request and applying the routing preset…/)
+    assert.doesNotMatch(html, /Sign in to OpenAI again|setup-steps|reauth-code/, 'neither the steps nor the finished login')
+    assert.match(html, /class="setup-card model unconnected working on"/)
+    read.resolve()
+    await polled
+    html = page.screenSetup(payload())
+    assert.doesNotMatch(html, /class="setup-card model[^"]*working|setup-panel working/)
+    assert.match(text(html), /Provider verified/)
+  })
+
+  test('Run Full loop selects the run panel in the main area with the eight legs, marks the rail card running, and scrolls the run into view', async () => {
+    const press = deferred()
+    const scrolled = []
+    page.document.getElementById = (id) => (id === 'setup-run' ? { scrollIntoView: (opts) => scrolled.push(opts) } : null)
+    page.setup = SETUP({ step: 'model', cards: ALL, full_loop: { ready: true, missing: [], reason: null, facts: RUN_FACTS, run: { state: 'idle', legs: [] } } })
+    const running = RUN('running', { legs: ['complete', 'running'] })
+    page.fetch = async (url, init = {}) => {
+      if (init.method === 'POST') { await press.promise; return { ok: true, json: async () => ({ ok: true, run: running }) } }
+      return { ok: true, json: async () => running }
+    }
+    let html = page.screenSetup(payload())
+    assert.match(html, /<h2>Model provider<\/h2>/, 'the selected card is the panel before the press')
+    const pressed = page.runFullLoop()
+    html = page.screenSetup(payload())
+    assert.match(html, /id="setup-run"/, 'the run is the selected panel from the press')
+    assert.doesNotMatch(html, /<h2>Model provider<\/h2>/)
+    assert.match(text(html), /Starting the Full loop…/)
+    assert.doesNotMatch(html, /onclick="runFullLoop\(\)"/, 'no second press')
+    assert.match(html, /class="setup-loop working on"/, 'the rail card shows the press')
+    assert.equal(scrolled.length, 1, 'the page scrolls the run into view on the press')
+    press.resolve()
+    await pressed
+    html = page.screenSetup(payload())
+    const main = /<section>([\s\S]*)<\/section>/.exec(html)[1]
+    assert.match(main, /id="setup-run"/)
+    assert.match(text(main), /Running the Full loop\./)
+    for (const title of LEG_TITLES) assert.match(text(main), new RegExp(`${title} · (complete|running|pending)`))
+    assert.match(html, /class="setup-loop run running on"/, 'the rail card shows the running state')
+    assert.doesNotMatch(/<aside[\s\S]*<\/aside>/.exec(html)[0], /loop-legs/, 'the legs live in the main area, not below the fold in the rail')
+    page.clearTimeout(page.UI.setup.loopTimer)
+    page.UI.setup.loopTimer = null
+    // Selecting a card brings its panel back; the rail's Full loop card brings the run back.
+    await page.selectSetupCard('github')
+    assert.match(page.screenSetup(payload()), /<h2>GitHub<\/h2>/)
+    page.selectSetupRun()
+    assert.match(page.screenSetup(payload()), /id="setup-run"/)
+  })
+
+  test('Try again on a failed run selects the run panel and shows the retry in progress until the answer', async () => {
+    const press = deferred()
+    const failed = { leg: 'review', title: 'Review', cause: 'The agent ended before Review: the agent exited.', action: 'Fix it, then select Try again.' }
+    page.setup = SETUP({ step: 'github', cards: ALL, full_loop: { ready: true, missing: [], reason: null, facts: RUN_FACTS, run: RUN('failed', { legs: ['complete', 'complete', 'complete', 'complete', 'failed'], failed }) } })
+    page.UI.setup.panel = 'card'
+    page.fetch = async () => { await press.promise; return { ok: true, json: async () => ({ ok: true, run: RUN('running', { legs: ['complete', 'complete', 'complete', 'complete', 'running'] }) }) } }
+    const pressed = page.retryFullLoop()
+    let html = page.screenSetup(payload())
+    assert.match(html, /id="setup-run"/)
+    assert.match(text(html), /Retrying Review…/)
+    assert.doesNotMatch(html, /The agent ended before Review/, 'the old failure is gone while the retry is in flight')
+    press.resolve()
+    await pressed
+    html = page.screenSetup(payload())
+    assert.match(text(html), /Review · running/)
+    page.clearTimeout(page.UI.setup.loopTimer)
+    page.UI.setup.loopTimer = null
+  })
+
+  test('Watch these repositories and Restart Curia show their work the same way', async () => {
+    const write = deferred()
+    page.setup = SETUP({ step: 'github', cards: { github: { state: 'failed', badge: 'Action required', error: { failed: 'No watched repository is covered', action: 'Choose the repositories.' }, detail: { available: ['alp82/curia'], watched: [], owners: [] } } } })
+    page.document.getElementById = (id) => (id === 'setup-github-repo-0' ? { checked: true } : null)
+    page.fetch = async (url) => {
+      if (url === '/api/setup/github/watch') { await write.promise; return { ok: true, json: async () => ({ ok: true }) } }
+      return { ok: true, json: async () => SETUP({ step: 'github', cards: { github: ALL.github } }) }
+    }
+    const pressed = page.doSetupGitHubWatch()
+    let html = page.screenSetup(payload())
+    assert.match(text(html), /Saving the watch list and verifying the repositories…/)
+    assert.doesNotMatch(html, /No watched repository is covered|Watch these repositories/)
+    write.resolve()
+    await pressed
+    html = page.screenSetup(payload())
+    assert.doesNotMatch(html, /working/)
+    assert.match(html, /class="setup-card github connected on"/)
+
+    page.setup = SETUP({ step: 'discord', cards: { discord: { ...ALL.discord, detail: { bridge: 'down', channel: { name: 'curia', url: 'https://discord.com/channels/2/4' }, guild: { name: 'g' }, confirmation: { posted: true, at: at(5), url: 'https://discord.com/channels/2/4/9' }, operator: { id: '1', name: 'alp' }, commands: ['start'] } } } })
+    page.document.getElementById = () => null
+    page.fetch = () => new Promise(() => {})
+    assert.match(page.screenSetup(payload()), /onclick="doSetupRestart\(\);return false">Restart Curia</)
+    page.doSetupRestart()
+    html = page.screenSetup(payload())
+    assert.match(text(html), /Restarting Curia so the bridge reads the token…/)
+    assert.doesNotMatch(html, /The bridge reads the token when the service starts/)
+    assert.match(html, /class="setup-card discord connected working on"/)
+    page.clearTimeout(page.UI.setup.restartTimer)
   })
 })

--- a/docs/operator/integration-setup.md
+++ b/docs/operator/integration-setup.md
@@ -290,6 +290,10 @@ A failed card names the verification that failed and exactly one corrective acti
 
 While Curia can't reach the service at all, **Setup** says so instead of showing four unconnected cards, and offers **Try again**.
 
+## What you see while Curia works
+
+Every action on a card, **Confirm operator and verify**, **Connect bot**, **Connect channel**, **Sign in**, **Submit** for a code, **Watch these repositories**, **Restart Curia**, and **Try again**, switches the card and its panel to an in-progress state the moment you select it. The card's badge reads **Working**, its footer names what Curia is doing (`Verifying the operator`, `Registering commands and posting the confirmation`, `Completing one minimal model request and applying the routing preset`), and the panel shows the same sentence over a thin moving line. Nothing that stood before stays: not the sign-in steps and not a previous failure. The state lasts until the next read for that card lands. A read that fails shows the failure and its action. A read that connects shows the connected state. A write the service refuses shows the refusal beside the form.
+
 ## Moving through setup
 
 - After a card connects, **Continue setup** opens the next card that isn't connected, in rail order.
@@ -349,7 +353,7 @@ The run walks the eight legs of the Full loop in order. Each leg is observed thr
 | Ticket resolution | The receipt finds the resolution comment and the closed ticket. |
 | Map update | The receipt finds the pointer line on the parent map's **Decisions so far**. |
 
-While the run is live, the **Full loop** panel under the rail shows one row per leg, the elapsed time, and the links as they appear. The page follows the service's read every 5 seconds. Your part of the run happens in Discord: answer the agent's question in the ticket's thread, then approve at the review gate. Everything else is the agent's and the daemon's.
+Selecting **Run Full loop** or **Try again** makes the run the selected panel, in the main area where a card's panel renders, and scrolls it into view. The panel first says `Starting the Full loop` (or `Retrying <leg>`), then, from the service's answer on, one row per leg with its state as a word, the elapsed time, and the links as they appear. The rail's **Full loop** card shows the run's state and brings the panel back after you select a card. The page follows the service's read every 5 seconds. Your part of the run happens in Discord: answer the agent's question in the ticket's thread, then approve at the review gate. Everything else is the agent's and the daemon's.
 
 #### When the run completes
 


### PR DESCRIPTION
The live rehearsal of the packaged lifecycle (#891, map #863) found two page-wide defects on the Setup screen of 0.9.0. This pull request fixes both with one mechanism in the page's render and brings the Full loop's run into the main area.

## What the operator saw

- After confirming a card (Tailscale, Discord, the model provider), the panel kept the pre-action content, the sign-in steps or the old failure, for several seconds until the next Setup read landed with the connected state. In the operator's words: "takes a few seconds to actually show the success state; we have similar issues in other places as tailscale etc. we need an optimistic UI with proper progress state."
- Pressing **Run Full loop** or its **Try again** gave no visible reaction. The run's leg table lived lower in the rail, below the fold.

## What changed

- **One in-progress state for every action.** `UI.setup.working` is one record, `{ card, what }`. A press sets it before anything else, and the render draws it in place of the card's footer and the whole panel: the badge reads **Working**, the footer names what Curia is doing (`Verifying the operator`, `Registering commands and posting the confirmation`, `Completing one minimal model request and applying the routing preset`), and the panel shows the sentence over a thin sweeping line. Nothing that stood before survives. Only the next read for that card clears it: the frame read clears every card, a row's own read clears its card, and a refused write clears it with the refusal beside the form. A read that fails shows the failure, and a read that connects shows the connected state. Covered: confirm operator, connect bot, connect channel, sign in to OpenAI and Anthropic, submit the code, the end of a sign-in, watch repositories, Restart Curia from the Discord card, and Try again.
- **The run is a panel.** **Run Full loop** and **Try again** select the run panel in the main area, where a card's panel renders, with the eight legs and their states, and scroll it into view. The rail's Full loop card shows the run's state as a word (Working, Running, Verified, Action required) and brings the panel back after a card is selected. Arriving with a run live or ended lands on the run.
- **Restart Curia** from the Discord card shows its work until the restarted service answers the frame read. A refusal or a cancelled confirmation settles it.

## Tests and docs

- `daemon/test/dashboardpage.test.mjs` (+6): the press switches the card and its panel at once with none of the old content and the read replaces it; Try again hides the failure while the read is in flight and a failing read shows the new failure; the end of a sign-in shows the verification, never the steps; Run Full loop selects the run panel, marks the rail card, and scrolls the run into view; Try again on a failed run; the watch action and Restart Curia. Two existing tests updated for the moved panel and the renamed restart press.
- `docs/operator/integration-setup.md`: **What you see while Curia works**, and the run panel under **What the run covers**.
- `cd cli && npm test`: 395 pass. `cd daemon && npm test`: 4423 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
