### PR TITLE
fix: boot with a pending GitHub App setup and withdraw Serve routes idempotently

### DIFF
--- a/cli/src/purge.mjs
+++ b/cli/src/purge.mjs
@@ -116,7 +116,7 @@ export async function runPurge(
       steps.begin('routes')
       const routes = await withdrawServeRoutes({ stateDir: join(root, 'state'), stdout }, { tailscale })
       if (routes.recorded.length === 0) say('no Serve route is recorded for this installation')
-      else if (routes.withdrawn.length === 0 && routes.absent.length > 0 && !routes.unreachable) say('no recorded Serve route is standing; nothing to withdraw')
+      else if (routes.withdrawn.length === 0 && routes.stale.length === 0 && routes.absent.length > 0 && !routes.unreachable) say('no recorded Serve route is standing; nothing to withdraw')
 
       // 5. images
       steps.begin('images')
@@ -144,7 +144,8 @@ export async function runPurge(
       for (const route of recordedRoutes) {
         const withdrawn = routes.withdrawn.some((r) => r.https === route.https && r.target === route.target)
         const absent = routes.absent.some((r) => r.https === route.https && r.target === route.target) && !routes.unreachable
-        say(`  Serve route https://:${route.https} -> ${route.target}: ${withdrawn ? 'withdrawn' : absent ? 'was not standing' : `still recorded when the root was removed; run 'tailscale serve --https=${route.https} off' on the node`}`)
+        const stale = routes.stale.some((r) => r.https === route.https && r.target === route.target)
+        say(`  Serve route https://:${route.https} -> ${route.target}: ${withdrawn ? 'withdrawn' : absent ? 'was not standing' : stale ? 'still standing under a name this node no longer has; \'tailscale serve reset\' on the node clears it with every other rule' : `still recorded when the root was removed; run 'tailscale serve --https=${route.https} off' on the node`}`)
       }
       say('  Model-provider logins (Anthropic, OpenAI): revoke them in each provider\'s account settings if you won\'t reinstall; only the local copies were deleted.')
       return EXIT.ok

--- a/cli/src/tailscale.mjs
+++ b/cli/src/tailscale.mjs
@@ -18,7 +18,18 @@ import { writeAtomically } from './atomic.mjs'
 // CURIA DETECTS TAILSCALE AND NEVER CHANGES IT, except for its own routes.
 // `withdrawServeRoutes` reads what the node serves, turns off only a recorded
 // route that is standing, and leaves every other route alone. A route that
-// is no longer standing is nothing to do, so a rerun is quiet.
+// is no longer standing is nothing to do, so a rerun is quiet, and so is a
+// route that went away between the read and the off: Tailscale's "handler
+// does not exist" is the answer of a rule that is already off, which the
+// #891 rehearsal saw fail a purge.
+//
+// A rule stands under a MagicDNS name, and `serve --https=<port> off`
+// addresses the node's current name only. A node renamed by hand keeps
+// Curia's rule under the old name, where the port off cannot reach it and
+// only `serve reset`, which clears the whole Serve config, can. The reset
+// runs when every rule the node serves is Curia's, because then it is
+// Curia's own routes and no other. Otherwise the stale rule is left and
+// named, with the reset the operator can decide on.
 
 export const TAILSCALE_FILE = 'tailscale.json'
 export const tailscalePath = (stateDir) => join(stateDir, TAILSCALE_FILE)
@@ -85,12 +96,15 @@ export function writeTailscaleRecord(stateDir, data) {
 // The routes in a `tailscale serve status --json` answer, which is the
 // node's whole serve config: `{ Web: { "<host>:<port>": { Handlers: { "/":
 // { Proxy } } } } }`.
+// Each route names the MagicDNS host the rule stands under.
 export function serveRoutes(config) {
   const out = []
   for (const [hostPort, site] of Object.entries(config?.Web ?? {})) {
-    const port = Number(hostPort.split(':').pop())
+    const at = hostPort.lastIndexOf(':')
+    const host = at > 0 ? hostPort.slice(0, at) : ''
+    const port = Number(hostPort.slice(at + 1))
     for (const [mount, handler] of Object.entries(site?.Handlers ?? {})) {
-      if (handler?.Proxy) out.push({ https: port, mount, target: String(handler.Proxy) })
+      if (handler?.Proxy) out.push({ https: port, host, mount, target: String(handler.Proxy) })
     }
   }
   return out
@@ -142,44 +156,93 @@ export class TailscaleError extends Error {
 }
 
 // Withdraws the Serve routes the record under `stateDir` names, and no
-// other. Returns `{ recorded, withdrawn, absent, unreachable }`: the
+// other. Returns `{ recorded, withdrawn, absent, stale, unreachable }`: the
 // recorded routes, the ones turned off on this call, the ones that were not
-// standing, and whether the node could be asked at all. The `tailscale`
+// standing, the ones that stand under a name the node no longer has and
+// were left, and whether the node could be asked at all. The `tailscale`
 // command missing from the path counts every route as absent and the node
 // as unreachable: with no CLI there is no node this operator can reach, and
 // the record is kept for the next run that can. A node that answers with an
 // error fails, because a route may still stand.
 export async function withdrawServeRoutes({ stateDir, stdout }, { tailscale = tailscaleRunner } = {}) {
   const recorded = readTailscaleRecord(stateDir).serve
-  if (recorded.length === 0) return { recorded, withdrawn: [], absent: [], unreachable: false }
+  if (recorded.length === 0) return { recorded, withdrawn: [], absent: [], stale: [], unreachable: false }
 
   const status = await tailscale(['serve', 'status', '--json'])
   if (!status.ok && status.missing) {
     stdout?.write(`the tailscale command is not on the path, so no Serve route is withdrawn; the record keeps ${recorded.length === 1 ? 'the route' : 'the routes'} for a host that runs Tailscale\n`)
-    return { recorded, withdrawn: [], absent: recorded, unreachable: true }
+    return { recorded, withdrawn: [], absent: recorded, stale: [], unreachable: true }
   }
   if (!status.ok) throw new TailscaleError(`tailscale serve status failed: ${firstLine(status.stderr || status.stdout) || `exit ${status.code}`}`)
-  let standing
-  try {
-    standing = serveRoutes(JSON.parse(status.stdout.trim() || '{}'))
-  } catch {
-    throw new TailscaleError('tailscale serve status --json did not answer JSON')
-  }
+  const standing = parseServeStatus(status)
 
+  const same = (a, b) => a.https === b.https && a.target === b.target
   const withdrawn = []
   const absent = []
+  // Rules of a recorded route that the port off left standing.
+  const left = []
   for (const route of recorded) {
-    const stands = standing.some((s) => s.https === route.https && s.target === route.target)
-    if (!stands) {
+    const rules = standing.filter((s) => same(s, route))
+    if (rules.length === 0) {
       absent.push(route)
       continue
     }
     const off = await tailscale(['serve', `--https=${route.https}`, 'off'])
-    if (!off.ok) throw new TailscaleError(`tailscale serve --https=${route.https} off failed: ${firstLine(off.stderr || off.stdout) || `exit ${off.code}`}`)
-    stdout?.write(`withdrew the Serve route https://:${route.https} -> ${route.target}\n`)
-    withdrawn.push(route)
+    if (off.ok) {
+      stdout?.write(`withdrew the Serve route ${describe(route)}\n`)
+      withdrawn.push(route)
+      // One rule was the one the off reached. More than one stand under
+      // different names, and the node says which remain.
+      if (rules.length > 1) left.push(...parseServeStatus(await tailscale(['serve', 'status', '--json'])).filter((s) => same(s, route)))
+      continue
+    }
+    if (!handlerMissing(off)) throw new TailscaleError(`tailscale serve --https=${route.https} off failed: ${firstLine(off.stderr || off.stdout) || `exit ${off.code}`}`)
+    // The off addressed the node's current name and found nothing there:
+    // the rule went away since the read, or stands under another name.
+    // The node says which.
+    left.push(...parseServeStatus(await tailscale(['serve', 'status', '--json'])).filter((s) => same(s, route)))
   }
-  return { recorded, withdrawn, absent, unreachable: false }
+
+  const stale = []
+  if (left.length > 0) {
+    const others = standing.filter((s) => !recorded.some((r) => same(s, r)))
+    if (others.length === 0) {
+      const reset = await tailscale(['serve', 'reset'])
+      if (!reset.ok) throw new TailscaleError(`tailscale serve reset failed: ${firstLine(reset.stderr || reset.stdout) || `exit ${reset.code}`}`)
+      for (const route of recorded) {
+        const rules = left.filter((s) => same(s, route))
+        if (rules.length === 0) continue
+        stdout?.write(`withdrew the Serve route ${describe(route)}, which stood under ${rules.map(at).join(' and ')}, a name this node no longer has; the node served nothing else, so 'tailscale serve reset' cleared it\n`)
+        if (!withdrawn.includes(route)) withdrawn.push(route)
+      }
+    } else {
+      for (const route of recorded) {
+        const rules = left.filter((s) => same(s, route))
+        if (rules.length === 0) continue
+        stdout?.write(`the Serve route ${describe(route)} stands under ${rules.map(at).join(' and ')}, a name this node no longer has; 'tailscale serve --https=${route.https} off' cannot reach it, and 'tailscale serve reset' would also remove ${others.map((s) => `${at(s)} -> ${s.target}`).join(' and ')}\n`)
+        stale.push(route)
+      }
+    }
+  }
+  for (const route of recorded) {
+    if (!withdrawn.includes(route) && !absent.includes(route) && !stale.includes(route)) absent.push(route)
+  }
+  return { recorded, withdrawn, absent, stale, unreachable: false }
 }
+
+function parseServeStatus(status) {
+  if (!status.ok) throw new TailscaleError(`tailscale serve status failed: ${firstLine(status.stderr || status.stdout) || `exit ${status.code}`}`)
+  try {
+    return serveRoutes(JSON.parse(status.stdout.trim() || '{}'))
+  } catch {
+    throw new TailscaleError('tailscale serve status --json did not answer JSON')
+  }
+}
+
+// Tailscale's answer to an off on a hostport it does not serve: the rule
+// is already off, whether it never stood or stands under another name.
+const handlerMissing = (off) => /handler does not exist/.test(`${off.stderr}\n${off.stdout}`)
+const describe = (route) => `https://:${route.https} -> ${route.target}`
+const at = (rule) => `https://${rule.host}:${rule.https}`
 
 const firstLine = (text) => String(text ?? '').trim().split('\n')[0]

--- a/cli/src/uninstall.mjs
+++ b/cli/src/uninstall.mjs
@@ -90,7 +90,7 @@ export async function runUninstall(
       steps.begin('routes')
       const routes = await withdrawServeRoutes({ stateDir: join(root, 'state'), stdout }, { tailscale })
       if (routes.recorded.length === 0) say('no Serve route is recorded for this installation')
-      else if (routes.withdrawn.length === 0) say(`no recorded Serve route is standing; nothing to withdraw`)
+      else if (routes.withdrawn.length === 0 && routes.stale.length === 0) say(`no recorded Serve route is standing; nothing to withdraw`)
 
       // 4. files
       steps.begin('files')

--- a/cli/test/fixtures/install.mjs
+++ b/cli/test/fixtures/install.mjs
@@ -366,9 +366,15 @@ export const nodeStatus = (label = 'host') => ({
 })
 export const loggedOutStatus = () => ({ BackendState: 'NeedsLogin', CertDomains: [], Self: { DNSName: '', Online: false } })
 
-export function fakeTailscale({ serving = [], status = nodeStatus(), up = {}, servePermitted = true, missing = false, broken = false } = {}) {
+// `serving` routes may carry a `host`, the MagicDNS name the rule stands
+// under (the node's own name by default). The real `serve --https=<port>
+// off` addresses only the node's current name, so a rule under another
+// name answers "handler does not exist", and `serve reset` clears every
+// rule; `vanishing` models the race of a rule that went away between the
+// status read and the off: the off answers that way and the rule is gone.
+export function fakeTailscale({ serving = [], status = nodeStatus(), up = {}, servePermitted = true, missing = false, broken = false, vanishing = false } = {}) {
   const calls = []
-  let routes = serving.map((r) => ({ ...r }))
+  let routes = serving.map((r) => ({ host: NODE_ADDRESS, ...r }))
   const state = { status, reads: 0 }
   const run = async (args, { onLine } = {}) => {
     calls.push(args)
@@ -391,18 +397,25 @@ export function fakeTailscale({ serving = [], status = nodeStatus(), up = {}, se
     }
     if (line === 'serve status --json') {
       const web = {}
-      for (const r of routes) web[`${NODE_ADDRESS}:${r.https}`] = { Handlers: { '/': { Proxy: r.target } } }
+      for (const r of routes) web[`${r.host}:${r.https}`] = { Handlers: { '/': { Proxy: r.target } } }
       return { ok: true, stdout: JSON.stringify(routes.length ? { Web: web } : {}), stderr: '' }
     }
     const off = /^serve --https=(\d+) off$/.exec(line)
     if (off) {
-      routes = routes.filter((r) => r.https !== Number(off[1]))
+      const mine = routes.filter((r) => r.host === NODE_ADDRESS && r.https === Number(off[1]))
+      if (vanishing) routes = routes.filter((r) => !mine.includes(r))
+      if (vanishing || mine.length === 0) return { ok: false, stdout: '', stderr: 'error: failed to remove web serve: handler does not exist\n', code: 1 }
+      routes = routes.filter((r) => !mine.includes(r))
+      return { ok: true, stdout: '', stderr: '' }
+    }
+    if (line === 'serve reset') {
+      routes = []
       return { ok: true, stdout: '', stderr: '' }
     }
     return { ok: false, stdout: '', stderr: `fake: no such tailscale command: ${line}`, code: 1 }
   }
   run.calls = calls
-  run.serving = () => routes
+  run.serving = () => routes.map(({ host, ...r }) => (host === NODE_ADDRESS ? r : { host, ...r }))
   run.state = state
   return run
 }

--- a/cli/test/purge.test.mjs
+++ b/cli/test/purge.test.mjs
@@ -351,6 +351,45 @@ describe('repeating after a partial failure', () => {
     assert.ok(!existsSync(root))
   })
 
+  // The #891 rehearsal: the node was renamed by hand, so Curia's rule stood
+  // under the old MagicDNS name. `serve status --json` listed it, the port
+  // off addressed the new name, and Tailscale answered "handler does not
+  // exist", which failed the routes step.
+  test('a Curia rule under another MagicDNS name is withdrawn with a reset when the node serves nothing else, and purge says so', async () => {
+    const { home, root, id } = await installed()
+    const tailscale = fakeTailscale({ serving: [{ ...APP_ROUTE, host: 'old-name.tail1234.ts.net' }] })
+    const r = await purge({ home, root, docker: dockerHostOf(id), tailscale, prompt: answering(root) })
+    assert.equal(r.exit, EXIT.ok, r.error?.stack)
+    assert.deepEqual(tailscale.calls, [['serve', 'status', '--json'], ['serve', '--https=8445', 'off'], ['serve', 'status', '--json'], ['serve', 'reset']])
+    assert.deepEqual(tailscale.serving(), [])
+    assert.match(r.out, /withdrew the Serve route https:\/\/:8445 -> http:\/\/127\.0\.0\.1:4273, which stood under https:\/\/old-name\.tail1234\.ts\.net:8445, a name this node no longer has/)
+    assert.match(r.out, /Serve route https:\/\/:8445 -> http:\/\/127\.0\.0\.1:4273: withdrawn/)
+    assert.ok(!existsSync(root))
+  })
+
+  test('a Curia rule under another MagicDNS name is left and named in the report when the node serves something else', async () => {
+    const { home, root, id } = await installed()
+    const tailscale = fakeTailscale({ serving: [{ ...APP_ROUTE, host: 'old-name.tail1234.ts.net' }, OTHER_ROUTE] })
+    const r = await purge({ home, root, docker: dockerHostOf(id), tailscale, prompt: answering(root) })
+    assert.equal(r.exit, EXIT.ok, r.error?.stack)
+    assert.ok(!tailscale.calls.some((c) => c.includes('reset')), 'no reset beside a rule that is not Curia\'s')
+    assert.deepEqual(tailscale.serving(), [{ host: 'old-name.tail1234.ts.net', ...APP_ROUTE }, OTHER_ROUTE])
+    assert.doesNotMatch(r.out, /nothing to withdraw/)
+    assert.match(r.out, /Serve route https:\/\/:8445 -> http:\/\/127\.0\.0\.1:4273: still standing under a name this node no longer has; 'tailscale serve reset' on the node clears it with every other rule/)
+    assert.ok(!existsSync(root))
+  })
+
+  test('a rule Tailscale says is already gone at the off is already off, not a failure', async () => {
+    const { home, root, id } = await installed()
+    const tailscale = fakeTailscale({ serving: [APP_ROUTE], vanishing: true })
+    const r = await purge({ home, root, docker: dockerHostOf(id), tailscale, prompt: answering(root) })
+    assert.equal(r.exit, EXIT.ok, r.error?.stack)
+    assert.deepEqual(tailscale.calls, [['serve', 'status', '--json'], ['serve', '--https=8445', 'off'], ['serve', 'status', '--json']], 'the node is asked again, and nothing is reset')
+    assert.match(r.out, /no recorded Serve route is standing; nothing to withdraw/)
+    assert.match(r.out, /Serve route https:\/\/:8445 -> http:\/\/127\.0\.0\.1:4273: was not standing/)
+    assert.ok(!existsSync(root))
+  })
+
   test('an image Docker refuses to remove is kept with the reason, not a failure', async () => {
     const { home, root, id } = await installed()
     const docker = dockerHostOf(id, { fail: { 'image rm': 1 } })

--- a/cli/test/uninstall.test.mjs
+++ b/cli/test/uninstall.test.mjs
@@ -251,6 +251,29 @@ describe('an uninstall over an installed root', () => {
     assert.ok(existsSync(other.launcher), 'the files step did not run')
   })
 
+  // A Curia rule under the old MagicDNS name of a renamed node, beside a
+  // rule that is not Curia's: the port off cannot reach the old name and a
+  // reset would take the other rule too, so the rule is left and named.
+  test('a Curia rule under another MagicDNS name is left and named when the node serves something else', async () => {
+    const { home, root, id } = await installed()
+    const tailscale = fakeTailscale({ serving: [{ ...APP_ROUTE, host: 'old-name.tail1234.ts.net' }, OTHER_ROUTE] })
+    const r = await uninstall({ home, root, docker: dockerHostOf(id), tailscale })
+    assert.equal(r.exit, EXIT.ok, r.error?.stack)
+    assert.deepEqual(tailscale.calls, [['serve', 'status', '--json'], ['serve', '--https=8445', 'off'], ['serve', 'status', '--json']], 'no reset')
+    assert.deepEqual(tailscale.serving(), [{ host: 'old-name.tail1234.ts.net', ...APP_ROUTE }, OTHER_ROUTE], 'the other rule is not touched')
+    assert.match(r.out, /the Serve route https:\/\/:8445 -> http:\/\/127\.0\.0\.1:4273 stands under https:\/\/old-name\.tail1234\.ts\.net:8445, a name this node no longer has; 'tailscale serve --https=8445 off' cannot reach it, and 'tailscale serve reset' would also remove https:\/\/host\.tail1234\.ts\.net:443 -> http:\/\/127\.0\.0\.1:3000/)
+    assertPreserved(root, id)
+
+    // The same node with nothing else served: the reset is Curia's own rule and no other.
+    const alone = await installed()
+    const only = fakeTailscale({ serving: [{ ...APP_ROUTE, host: 'old-name.tail1234.ts.net' }] })
+    const again = await uninstall({ home: alone.home, root: alone.root, docker: dockerHostOf(alone.id), tailscale: only })
+    assert.equal(again.exit, EXIT.ok, again.error?.stack)
+    assert.deepEqual(only.calls, [['serve', 'status', '--json'], ['serve', '--https=8445', 'off'], ['serve', 'status', '--json'], ['serve', 'reset']])
+    assert.deepEqual(only.serving(), [])
+    assert.match(again.out, /withdrew the Serve route https:\/\/:8445 -> http:\/\/127\.0\.0\.1:4273, which stood under https:\/\/old-name\.tail1234\.ts\.net:8445/)
+  })
+
   test('a launcher that names another root is kept', async () => {
     const { home, root, id, launcher } = await installed()
     const elsewhere = join(home, 'elsewhere')

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -442,18 +442,6 @@ const githubAppSetup = new GitHubAppSetup({
   },
 })
 
-// A setup spans the trip through github.com, so its Action can outlive this
-// process. The setup record carries only the Action identity. The journal
-// still owns the evidence and the setup record still contains no credential.
-{
-  const setup = githubAppSetup.status()
-  const evidence = setup.action_id ? actions.get(setup.action_id) : null
-  if (evidence && !['confirmed', 'refused', 'failed'].includes(evidence.status)) {
-    if (setup.status === 'complete') reduction.recordAction({ ...evidence, status: 'confirmed' })
-    if (setup.status === 'expired') reduction.recordAction({ ...evidence, status: 'failed', reason: 'GitHub App setup expired after one hour' })
-  }
-}
-
 // #390: the DAEMON cuts over. Every `gh` child it spawns for a named repo now
 // carries that owner's minted write token, so the frontier reads, the claims,
 // the pull requests and the branch pushes all run as `curia-sh[bot]`.
@@ -483,6 +471,22 @@ log(`claims assign ${curiaConfig.dispatch.claim_login} (dispatch.claim_login) â€
 // so the conversion line reaches journalctl even from here.
 const reduction = new Reduction(DATA, { log })
 const actions = new ActionCoordinator(reduction, { log })
+
+// A GitHub App setup spans the trip through github.com, so its Action can
+// outlive this process. The setup record carries only the Action identity.
+// The journal still owns the evidence and the setup record still contains
+// no credential. This read runs here, after the coordinator exists: the
+// #891 rehearsal restarted the service in the middle of the GitHub card and
+// found the block above the `actions` declaration, which crashed every boot
+// on `state/github-app-setup.json` in a loop.
+{
+  const setup = githubAppSetup.status()
+  const evidence = setup.action_id ? actions.get(setup.action_id) : null
+  if (evidence && !['confirmed', 'refused', 'failed'].includes(evidence.status)) {
+    if (setup.status === 'complete') reduction.recordAction({ ...evidence, status: 'confirmed' })
+    if (setup.status === 'expired') reduction.recordAction({ ...evidence, status: 'failed', reason: 'GitHub App setup expired after one hour' })
+  }
+}
 
 // The boot line (#436). The journal is `node:sqlite`, which Node marks Stability
 // 1.2, so a patch update can change the API, the defaults and the bundled SQLite

--- a/daemon/test/rootboot.test.mjs
+++ b/daemon/test/rootboot.test.mjs
@@ -309,4 +309,24 @@ describe('the daemon under an installation root (#867)', () => {
       if (child.exitCode === null) child.kill('SIGKILL')
     }
   })
+
+  // The #891 rehearsal: a restart in the middle of the GitHub card found
+  // `state/github-app-setup.json` with an Action identity and crashed on
+  // the resume before the Action coordinator existed, in a loop.
+  test('a pending GitHub App setup with an Action identity in state/ boots', async () => {
+    const setupFile = path.join(root, 'state', 'github-app-setup.json')
+    fs.writeFileSync(setupFile, `${JSON.stringify({ state: 'a'.repeat(64), expires_at: Date.now() + 3_600_000, status: 'pending', screen: 'setup', action_id: 'act-891' })}\n`, { mode: 0o600 })
+    const child = boot({})
+    const watch = watchDaemon(child)
+    try {
+      await waitForBoot(watch, () => /curia daemon listening/.test(watch.log()), 'its listening line')
+      assert.deepEqual(await (await fetch(`http://127.0.0.1:${ports[0]}/ping`)).json(), { curia: 'curia-side-channel', port: ports[0], version: APP_VERSION })
+      const overview = await (await fetch(`http://127.0.0.1:${ports[0]}/overview`)).json()
+      assert.equal(overview.github_app.status, 'pending', 'the setup in flight is still in flight')
+      assert.equal(overview.github_app.action_id, 'act-891')
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL')
+      fs.rmSync(setupFile, { force: true })
+    }
+  })
 })

--- a/daemon/test/tailscalesetup.test.mjs
+++ b/daemon/test/tailscalesetup.test.mjs
@@ -384,7 +384,7 @@ describe('the Tailscale card (#877)', () => {
 
   describe('the pieces', () => {
     test('the served routes are read out of the serve config, and an empty config is no route', () => {
-      assert.deepEqual(serveRoutes(serveConfig()), [{ https: SERVE_PORT, mount: '/', target: `http://127.0.0.1:${APP_PORT}` }])
+      assert.deepEqual(serveRoutes(serveConfig()), [{ https: SERVE_PORT, host: DNS, mount: '/', target: `http://127.0.0.1:${APP_PORT}` }])
       assert.deepEqual(serveRoutes({}), [])
       assert.deepEqual(serveRoutes(null), [])
     })


### PR DESCRIPTION
Two defects from the packaged lifecycle rehearsal (#891).

## The service crashed at boot with a pending GitHub App setup

On a root that still held `state/github-app-setup.json`, the 0.9.1 service restarted in a loop with `ReferenceError: Cannot access 'actions' before initialization`. The block in `daemon/src/index.mjs` that resumes a pending setup ran before the `actions` declaration. Any operator who restarts Curia in the middle of the GitHub card hit this.

The resume now runs after the Action coordinator exists. A test in `daemon/test/rootboot.test.mjs` boots the real service under a root with a pending setup that carries an `action_id`, and proves the service answers `/ping` and still reports the setup as pending. No other top-level statement before the coordinator reads a later declaration.

## `curia purge` failed when Tailscale could not remove the Serve rule by port

The routes step failed with `tailscale serve --https=8445 off failed: error: failed to remove web serve: handler does not exist`. `withdrawServeRoutes` in `cli/src/tailscale.mjs` already read `serve status --json` first, but the off addresses the node's current MagicDNS name only, and a node renamed by hand keeps Curia's rule under the old name.

Now:

- "handler does not exist" means the rule is already off. The node is read again, and a rule that went away is reported as not standing.
- A Curia rule that stands under another name for the same port and target is cleared with `tailscale serve reset` when every rule the node serves is Curia's, and purge or uninstall says which name it stood under.
- When the node serves something else, the rule is left and named, with the reset the operator can decide on, and the purge report says so.

Tests in `cli/test/purge.test.mjs` and `cli/test/uninstall.test.mjs` pin all three through the injected runner. The fake node models rules under another name, the race of a rule that vanishes between the read and the off, and `serve reset`.

Both suites are green: cli 399 tests, daemon 4436 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
