### PR TITLE
fix: proxy the terminal WebSocket through the app's served address

### DIFF
--- a/daemon/package-lock.json
+++ b/daemon/package-lock.json
@@ -14,6 +14,9 @@
         "yaml": "^2.6.0",
         "zod": "^4.4.3"
       },
+      "devDependencies": {
+        "ws": "^8.21.3"
+      },
       "engines": {
         "node": ">=24.19.0"
       }
@@ -1654,9 +1657,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -21,5 +21,8 @@
     "discord.js": "^14.16.0",
     "yaml": "^2.6.0",
     "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "ws": "^8.21.3"
   }
 }

--- a/daemon/src/dashboard.mjs
+++ b/daemon/src/dashboard.mjs
@@ -407,6 +407,20 @@ export const CHAT_PAGE = '/chat'
 const CHAT_ROUTES = new Set(['/events', '/send', '/draft', '/key', '/take-back', '/dialog-answer'])
 export const TERMINAL_PAGE = '/terminal/'
 
+// ttyd's WebSocket, under the app's terminal path. The attach page derives its
+// socket from `window.location` (`<pathname without trailing slash>/ws` plus
+// the query), so the proxied page at `/terminal/` opens `/terminal/ws?arg=`.
+export const TERMINAL_SOCKET = `${TERMINAL_PAGE}ws`
+
+// The path ttyd sees for a request under the app's terminal path: the prefix
+// comes off and the query stays, so `/terminal/ws?arg=curia-1` reaches ttyd as
+// `/ws?arg=curia-1`, `/terminal/token` as `/token`, and the page as `/`. One
+// mapping for the page and the upgrade, so the two cannot drift apart.
+export function terminalUpstreamPath(url) {
+  if (url.pathname === '/terminal') return `/${url.search}`
+  return `/${url.pathname.slice(TERMINAL_PAGE.length)}${url.search}`
+}
+
 export class DashboardSurface {
   constructor({
     port, servePort, index, allow, daemonPort: dPort = daemonPort(),
@@ -1003,14 +1017,13 @@ export class DashboardSurface {
       socket.end(`HTTP/1.1 ${status}\r\nConnection: close\r\n\r\n`)
       return
     }
-    const upstreamPath = `/${url.pathname.slice(TERMINAL_PAGE.length)}${url.search}`
     const headers = {
       ...req.headers,
       host: `127.0.0.1:${this.terminalPort}`,
       origin: `http://127.0.0.1:${this.terminalPort}`,
     }
     const up = http.request({
-      host: '127.0.0.1', port: this.terminalPort, method: 'GET', path: upstreamPath, headers,
+      host: '127.0.0.1', port: this.terminalPort, method: 'GET', path: terminalUpstreamPath(url), headers,
     })
     up.on('upgrade', (upRes, upSocket, upHead) => {
       const lines = [`HTTP/1.1 ${upRes.statusCode} ${upRes.statusMessage}`]
@@ -1054,10 +1067,19 @@ export class DashboardSurface {
     const url = new URL(req.url, `http://127.0.0.1:${this.port}`)
 
     if (req.method === 'GET' && (url.pathname === '/terminal' || url.pathname.startsWith(TERMINAL_PAGE))) {
-      const upstreamPath = url.pathname === '/terminal'
-        ? '/'
-        : `/${url.pathname.slice(TERMINAL_PAGE.length)}${url.search}`
-      return this.#terminal(req, res, upstreamPath)
+      // A request on the socket path that arrives here, and not on the
+      // server's `upgrade` event, carries no `Upgrade: websocket`. Tailscale
+      // Serve speaks HTTP/2 to its clients, and HTTP/2 has no `Connection`
+      // header: a probe over HTTP/2 loses its upgrade at that hop and lands
+      // here as a plain GET (#891). Relayed to ttyd, that answers ttyd's 404
+      // for any plain path but its index and token, which reads as a route
+      // the sidecar never had. Name the cause instead, and keep ttyd out of it.
+      // A browser opens its WebSocket over HTTP/1.1 and never lands here.
+      if (url.pathname === TERMINAL_SOCKET) {
+        res.writeHead(426, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'no-store', upgrade: 'websocket', connection: 'close' })
+        return res.end(`${TERMINAL_SOCKET} is the terminal's WebSocket: open it with an HTTP/1.1 upgrade (Connection: Upgrade, Upgrade: websocket). A request over HTTP/2 cannot carry the upgrade, and the served address drops it.\n`)
+      }
+      return this.#terminal(req, res, terminalUpstreamPath(url))
     }
 
     if (req.method === 'POST') {

--- a/daemon/test/dashboard.test.mjs
+++ b/daemon/test/dashboard.test.mjs
@@ -14,11 +14,15 @@ import http from 'node:http'
 import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
+import vm from 'node:vm'
+import { WebSocket, WebSocketServer } from 'ws'
 
 import {
   DashboardSurface, DEFAULT_DASHBOARD, DEFAULT_DASHBOARD_INDEX, DASHBOARD_PROTO,
   loadDashboardConfig, pageRefusal, readDashboard, daemonPort, ANSWER_REFUSAL, CHAT_PAGE, TERMINAL_PAGE,
+  terminalUpstreamPath,
 } from '../src/dashboard.mjs'
+import { DEFAULT_INDEX as ATTACH_INDEX } from '../src/attach.mjs'
 import { APP_VERSION } from '../src/appversion.mjs'
 import { loadCuriaConfig } from '../src/config.mjs'
 import { serveHosts, LOGIN_HEADER, FUNNEL_HEADER } from '../src/identity.mjs'
@@ -1702,6 +1706,86 @@ describe('the embedded terminal (#714)', () => {
   test('an unknown operator cannot reach the terminal or its WebSocket', async () => {
     assert.equal((await req(surface.port, TERMINAL_PAGE, { headers: { host: 'box.tail1234.ts.net:8445' } })).status, 403)
     assert.equal(seen.length, 0)
+  })
+
+  // The rehearsal of the packaged lifecycle (#891) reported the terminal page
+  // rendering empty on 0.9.1, with a probe of the WebSocket path answering 404.
+  // The three cases below pin the whole path a browser walks: the socket URL
+  // the attach page computes from its own address, the proxy carrying a real
+  // WebSocket handshake and frames both ways to ttyd's `/ws`, and the answer a
+  // request gets when it reaches the socket path without an upgrade.
+  test('the attach page computes its socket URL from the served path, and the proxy maps it onto ttyd', () => {
+    // ttyd's client builds the socket address from `window.location`. The
+    // expression is lifted out of the built bundle and evaluated against the
+    // address the app serves the page on, so a ttyd upgrade that changes how
+    // the client derives its socket fails here and not in a browser.
+    const bundle = fs.readFileSync(ATTACH_INDEX, 'utf8')
+    const match = bundle.match(/"https:"===window\.location\.protocol\?"wss:":"ws:",\w+=window\.location\.pathname\.replace\([^)]*\),\w+=\[[^\]]*"\/ws"[^\]]*\]\.join\(""\)/)
+    assert.ok(match, 'the attach index no longer derives its WebSocket address the way this test reads it; rebuild and update the test together')
+    const [, protocol, trimmed, socket] = match[0].match(/^(.*?),\w+=(.*?),\w+=(.*)$/)
+    const sandbox = { window: { location: new URL('https://box.tail1234.ts.net:8445/terminal/?arg=curia-929') } }
+    const socketUrl = vm.runInNewContext(`const n=${protocol};const o=${trimmed};${socket}`, sandbox)
+    assert.equal(socketUrl, 'wss://box.tail1234.ts.net:8445/terminal/ws?arg=curia-929')
+    assert.equal(terminalUpstreamPath(new URL(socketUrl)), '/ws?arg=curia-929')
+    assert.equal(terminalUpstreamPath(new URL('https://box.tail1234.ts.net:8445/terminal/token')), '/token')
+    assert.equal(terminalUpstreamPath(new URL('https://box.tail1234.ts.net:8445/terminal/?arg=curia-929')), '/?arg=curia-929')
+    assert.equal(terminalUpstreamPath(new URL('https://box.tail1234.ts.net:8445/terminal')), '/')
+  })
+
+  test('a real WebSocket handshake reaches ttyd through the proxy and carries frames both ways', async () => {
+    // A fake ttyd: a WebSocket server on `/ws` that echoes, the way ttyd's
+    // `tty` protocol answers what the client sends.
+    terminal.close()
+    terminal = http.createServer((req, res) => { seen.push({ type: 'http', url: req.url }); res.end() })
+    const wss = new WebSocketServer({ server: terminal, path: '/ws', handleProtocols: (set) => (set.has('tty') ? 'tty' : false) })
+    wss.on('connection', (ws, req) => {
+      seen.push({ type: 'upgrade', url: req.url, headers: req.headers })
+      ws.on('message', (data) => ws.send(`echo:${data}`))
+    })
+    await new Promise((done) => terminal.listen(0, '127.0.0.1', done))
+    surface.stop()
+    surface = new DashboardSurface({
+      port: 0, servePort: 8445, index: DEFAULT_DASHBOARD_INDEX,
+      allow: ['alp@example.com'], terminalPort: terminal.address().port,
+      pollIntervalS: 5, log: () => {},
+      deps: {
+        fetchOverview: async () => ({}), assertServe: async () => {}, serveOff: async () => {},
+        tailnetSelf: async () => ({ dnsName: 'box.tail1234.ts.net', ips: [] }),
+      },
+    })
+    await surface.start()
+    await surface.resolveHosts()
+
+    const ws = new WebSocket(`ws://127.0.0.1:${surface.port}/terminal/ws?arg=curia-929`, ['tty'], {
+      headers: served({ origin: 'https://box.tail1234.ts.net:8445' }),
+    })
+    const echoed = await new Promise((resolve, reject) => {
+      ws.on('open', () => ws.send('hello'))
+      ws.on('message', (data) => resolve(String(data)))
+      ws.on('error', reject)
+      ws.on('unexpected-response', (_, res) => reject(new Error(`the proxy answered ${res.statusCode} instead of an upgrade`)))
+    })
+    assert.equal(echoed, 'echo:hello')
+    assert.equal(ws.protocol, 'tty')
+    ws.close()
+    await new Promise((done) => wss.close(done))
+    assert.equal(seen.at(-1).type, 'upgrade')
+    assert.equal(seen.at(-1).url, '/ws?arg=curia-929')
+    assert.equal(seen.at(-1).headers.origin, `http://127.0.0.1:${terminal.address().port}`)
+    assert.equal(seen.filter((s) => s.type === 'http').length, 0)
+  })
+
+  test('a request that reaches the socket path without an upgrade is told so, instead of relaying ttyd\'s 404', async () => {
+    // Tailscale Serve speaks HTTP/2 to the browser, and an HTTP/2 request
+    // cannot carry `Connection: Upgrade`: the hop drops the header and forwards
+    // a plain GET. ttyd answers 404 to any plain path but its index and token,
+    // which reads as a missing route. The sidecar names the cause instead.
+    const response = await req(surface.port, '/terminal/ws?arg=curia-929', { headers: served() })
+    assert.equal(response.status, 426)
+    assert.equal(response.headers.upgrade, 'websocket')
+    assert.match(response.text, /HTTP\/1\.1/)
+    assert.match(response.text, /Upgrade/)
+    assert.equal(seen.length, 0, 'the plain request must not reach ttyd')
   })
 })
 


### PR DESCRIPTION
From the live rehearsal of the packaged lifecycle (#891): on the 0.9.1 host, the terminal page and `/terminal/token` answered 200, a probe of the WebSocket path `/terminal/ws?arg=curia-929` answered 404, and the page was reported empty.

## Which hop answered 404

ttyd did, reached through the sidecar's plain request path. The chain is Tailscale Serve (`:8445`) to the sidecar (`:4273`) to ttyd. Serve speaks HTTP/2 to its clients, and HTTP/2 has no `Connection` header, so a probe over HTTP/2 (curl's default over TLS) loses `Connection: Upgrade` at that hop and reaches the sidecar as a plain `GET /terminal/ws`. The sidecar relayed that to ttyd's `/ws` as an HTTP request, and ttyd 1.7.7 answers 404 to any plain path but its index and token (`src/http.c`, `HTTP_STATUS_NOT_FOUND`). The response carried `server: ttyd/1.7.7`.

A browser never walks that path. Serve advertises `enableConnectProtocol: false`, so a browser opens its WebSocket over HTTP/1.1, and the same upgrade over HTTP/1.1 through the released host answers 101 and carries frames.

## The change

- A plain request on `/terminal/ws` answers 426 with the cause (open it with an HTTP/1.1 upgrade) and never reaches ttyd, so a probe reads the hop instead of a missing route.
- One `terminalUpstreamPath` maps the app's terminal path onto ttyd for the page and the upgrade alike, so the two cannot drift apart.
- `ws` becomes a devDependency of the daemon, for the test client and the fake ttyd. It was already in the tree through `discord.js`.

## Tests

- A real WebSocket handshake with the identity header and Origin set, through the sidecar's proxy to a fake ttyd echo on `/ws`, with the `tty` subprotocol negotiated and frames both ways.
- The attach page's own socket expression, lifted out of the built bundle and evaluated against the served address, equals `wss://<app>/terminal/ws?arg=curia-929`, and `terminalUpstreamPath` maps that onto ttyd's `/ws?arg=curia-929`.
- The 426 on a plain request, with ttyd seeing nothing.

`cd cli && npm test`: 401 pass, 0 fail, 0 cancelled. `cd daemon && npm test`: 4438 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

## Verification on the host

The host runs the released 0.9.1 image, so this branch could not be deployed there. Against that host, a headless Chromium on the tailnet opened `https://curia-ubuntu.tail3b99f1.ts.net:8445/terminal/?arg=curia-929`: the page and token answered 200, the socket opened at `wss://…/terminal/ws?arg=curia-929`, the title and renderer frames arrived, and the session's screen rendered. With `?arg=keeper`, the terminal showed `refused: 'keeper' is not a curia session`, which is the `curia-attach.sh` allowlist and not the proxy. The 426 is proven by the sidecar tests on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
