### PR TITLE
feat: guide GitHub setup in three steps and verify Discord and Tailscale implicitly

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -698,6 +698,22 @@
   .setup-provider.failed { border-color: color-mix(in srgb, var(--bad) 60%, var(--line)); }
   .setup-provider-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 8px; }
   .setup-steps li { margin-bottom: 6px; }
+  /* The guide's three steps (#891): a rule per step, the current one in the
+     accent, the done ones settled. The numerals are the order the operator
+     meets them in, which is the one thing the row has to say. */
+  .setup-stepper { list-style: none; margin: 2px 0 18px; padding: 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+  .setup-stepper li { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 9px 0 0; border-top: 2px solid var(--line); color: var(--ink-faint); font-size: 12.5px; line-height: 1.3; }
+  .setup-stepper li.done { color: var(--ink-dim); border-top-color: color-mix(in srgb, var(--ok) 65%, var(--line)); }
+  .setup-stepper li.current { color: var(--ink); font-weight: 650; border-top-color: var(--accent); }
+  .setup-step-mark { flex: 0 0 20px; width: 20px; height: 20px; border-radius: 50%; display: grid; place-items: center; font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums; background: color-mix(in srgb, currentColor 14%, transparent); }
+  .setup-stepper li.current .setup-step-mark { background: var(--accent); color: var(--accent-ink); }
+  .setup-stepper li.done .setup-step-mark { background: var(--ok); color: #fff; }
+  @media (max-width: 480px) {
+    .setup-stepper { grid-template-columns: 1fr; gap: 6px; }
+    .setup-stepper li { border-top: 0; border-left: 2px solid var(--line); padding: 2px 0 2px 10px; }
+    .setup-stepper li.done { border-left-color: color-mix(in srgb, var(--ok) 65%, var(--line)); }
+    .setup-stepper li.current { border-left-color: var(--accent); }
+  }
   .setup-panel details { margin-top: 12px; }
   .setup-panel summary { cursor: pointer; color: var(--ink-dim); font-size: 13px; }
   .setup-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 18px; }
@@ -950,7 +966,7 @@ var UI = {
   /* The setup frame's own state (#874): whether a read is in flight, and the
      one sentence the last press left behind. The selected card is not here —
      it is the record's `step`, kept by the service so a reopen restores it. */
-  setup: { busy: false, note: null, working: null, panel: null, restartTimer: null, loopBusy: false, loopTimer: null, githubBusy: false, discord: null, discordBusy: null, discordTimer: null, tailscale: null, tailscaleBusy: null, openai: null, openaiBusy: null, openaiTimer: null, anthropic: null, anthropicBusy: null, anthropicTimer: null },
+  setup: { busy: false, note: null, working: null, panel: null, restartTimer: null, loopBusy: false, loopTimer: null, githubBusy: false, githubTimer: null, discord: null, discordBusy: null, discordTimer: null, tailscale: null, tailscaleBusy: null, openai: null, openaiBusy: null, openaiTimer: null, anthropic: null, anthropicBusy: null, anthropicTimer: null },
   /* The drill-in frame's own state (#699), one entry per page that is a list
      of sections: which section is open, and whether the phone is on the list
      in front of it. */
@@ -5079,6 +5095,53 @@ function setupProgress(work) {
   </div>`;
 }
 
+/* THE GUIDED STEPS (#891). The rehearsal read the GitHub card's expected
+   states, no App yet, no installation yet, nothing watched yet, as a red
+   failure with a Try again that never helped, and pressed the Discord card
+   more than once where one press was due. A card that has steps names the
+   one the operator is at, from the verifier's own detail (`detail.step` on
+   GitHub, `detail.stage` on Discord), and while the card is plain the rail
+   badge counts the step and the footer names what the step waits for.
+   Nothing here turns a card: the state is still the read's. */
+var SETUP_GUIDES = {
+  github: {
+    labels: ["Create the App", "Install the App", "Choose repositories and continue"],
+    pending: [null, "Waiting for an installation that covers a repository", "Choose the repositories to watch, then continue"],
+    at: (card) => ({ create: 1, install: 2, watch: 3 })[card.detail?.step] ?? (card.state === "failed" ? 2 : 1),
+  },
+  discord: {
+    labels: ["Connect the bot", "Add the bot to a server", "Choose the channel"],
+    pending: [null, "Waiting for the bot to join a server", "Choose the server and the channel, then connect"],
+    at: (card) => {
+      const stage = card.detail?.stage ?? null;
+      if (!stage || DISCORD_STAGES_WITH_TOKEN_FORM.includes(stage)) return 1;
+      return stage === "server" && !(card.detail?.guilds?.length) ? 2 : 3;
+    },
+  },
+};
+function setupStepAt(card) {
+  const guide = SETUP_GUIDES[card?.key];
+  if (!guide || card.state === "connected" || card.state === "unavailable") return null;
+  return { n: guide.at(card), total: guide.labels.length, labels: guide.labels, pending: guide.pending };
+}
+function setupStepper(card) {
+  const step = setupStepAt(card);
+  if (!step) return "";
+  return `<ol class="setup-stepper" aria-label="Steps">${step.labels.map((label, i) => {
+    const n = i + 1;
+    const cls = n < step.n ? "done" : n === step.n ? "current" : "todo";
+    return `<li class="${cls}"${cls === "current" ? ` aria-current="step"` : ""}><span class="setup-step-mark" aria-hidden="true">${cls === "done" ? "✓" : n}</span><span>${esc(label)}</span></li>`;
+  }).join("")}</ol>`;
+}
+function setupCardBadge(card) {
+  const step = card.state === "unconnected" ? setupStepAt(card) : null;
+  return step && step.n > 1 ? `Step ${step.n} of ${step.total}` : card.badge;
+}
+function setupCardPending(card) {
+  const step = card.state === "unconnected" ? setupStepAt(card) : null;
+  return step?.pending[step.n - 1] || card.pending;
+}
+
 /* The content slot, per card: the body of the configuration panel, given
    the card, its remembered progress, and the held overview reading. A stub
    says what the step will do and that it is not available in this release
@@ -5107,12 +5170,17 @@ var SETUP_CONTENT = {
   },
 };
 
-/* The GitHub card's own panel (#875), in the three states the verifier
-   reports. Unconnected: the App does not exist yet, so the one press is
-   Create GitHub App, with the name as the only input. Failed or connected:
-   the App exists, so the panel draws it, the owner rows, the repositories
-   the operator may watch, and, once connected, the real ticket the service
-   discovered or the honest zero.
+/* The GitHub card's own panel (#875), a guide of three steps since the
+   rehearsal (#891). Step 1, no App yet: Create GitHub App, with the name as
+   the only input. Step 2, the App exists and no installation covers a
+   repository: the install link per watched owner or the App's own, and a
+   wait that re-reads the frame on the page's refresh interval until one
+   does. Step 3, installations cover repositories: the list with every
+   repository ticked and the one press that writes the watch list, verifies,
+   and continues setup. Connected: the App, the real ticket the service
+   discovered or the honest zero, and the choice behind a fold. A failed
+   card draws the step the detail names beside the failure, so the action is
+   at hand, and the frame's Try again.
 
    EVERYTHING HERE IS THIS READ'S (#891). The owner rows are the verifier's
    own reading of the installations (`card.detail.owners`), never the held
@@ -5124,36 +5192,69 @@ var SETUP_CONTENT = {
    the ticked ones as the watch list through the settings save. */
 function setupGitHub(card, progress, p) {
   const app = p?.overview?.github_app ?? null;
-  if (card.state === "unconnected") {
-    const action = actionFor({ conflict_key: "github-app:setup" });
-    const pending = app?.status === "pending"
-      ? `<p class="qhint">A GitHub App setup is pending until ${esc(ago(app.expires_at))}. Finish it on GitHub, or start again with a new name.</p>` : "";
-    return `<p><input id="setup-github-app-name" value="${esc(progress?.app_name || "curia-box")}" aria-label="GitHub App name">
-      <button class="btn primary" ${action ? "disabled" : ""} onclick="doSetupGitHubApp()">Create GitHub App</button></p>
-      ${action ? `<p class="qhint">${esc(action.progress || "Starting GitHub App setup")}</p>` : ""}
-      ${pending}${said("github-app")}
-      <p class="qhint">GitHub slugifies the name, and Curia posts as <code>&lt;slug&gt;[bot]</code>. The name must be free across GitHub.</p>`;
-  }
+  const detail = card.detail ?? null;
   const facts = app?.app ?? null;
   const identity = facts
     ? `<div class="rows"><div class="row"><span class="key grow">GitHub App</span><span>${facts.settings_url
       ? `<a href="${esc(facts.settings_url)}" target="_blank" rel="noopener">${esc(facts.slug || facts.id)}</a>`
       : esc(facts.slug || facts.id)}</span></div></div>` : "";
-  const detail = card.detail ?? null;
+  if (card.state === "connected") {
+    const found = !detail ? "" : detail.ticket
+      ? `<div class="setup-note">Ready for an agent: <a href="${esc(detail.ticket.url)}" target="_blank" rel="noopener">#${esc(detail.ticket.number)} · ${esc(detail.ticket.title)}</a>
+        <span class="dim-note">${esc(detail.open_tickets)} open ticket${detail.open_tickets === 1 ? "" : "s"} in ${esc((detail.covered ?? []).join(", "))}.</span></div>`
+      : `<div class="setup-note">No open ticket is ready for an agent in ${esc((detail.covered ?? []).join(", "))}. Curia starts work when one carries <code>ready-for-agent</code>.</div>`;
+    const owners = setupGitHubOwners(detail, app);
+    return `${identity}${owners ? `<div class="rows">${owners}</div>` : ""}${found}${setupGitHubRepos(card, detail)}`;
+  }
+  const guide = setupStepper(card);
+  const step = setupStepAt(card)?.n ?? 1;
+  if (step === 1) {
+    const action = actionFor({ conflict_key: "github-app:setup" });
+    const pending = app?.status === "pending"
+      ? `<p class="qhint">A GitHub App setup is pending until ${esc(ago(app.expires_at))}. Finish it on GitHub, or start again with a new name.</p>` : "";
+    return `${guide}<p><input id="setup-github-app-name" value="${esc(progress?.app_name || "curia-box")}" aria-label="GitHub App name">
+      <button class="btn primary" ${action ? "disabled" : ""} onclick="doSetupGitHubApp()">Create GitHub App</button></p>
+      ${action ? `<p class="qhint">${esc(action.progress || "Starting GitHub App setup")}</p>` : ""}
+      ${pending}${said("github-app")}
+      <p class="qhint">GitHub slugifies the name, and Curia posts as <code>&lt;slug&gt;[bot]</code>. The name must be free across GitHub.</p>`;
+  }
+  if (step === 2) return `${guide}${identity}${setupGitHubInstall(card, detail, app)}`;
+  return `${guide}${identity}${setupGitHubRepos(card, detail)}`;
+}
+
+/* Step 2: the installation. The owner rows are this read's fact; the
+   overview lends the install link per owner. While the card is plain the
+   panel waits and the frame re-reads on the refresh interval, so the
+   repositories appear on their own once an installation covers one. On a
+   failed card the operator has Try again. */
+function setupGitHubOwners(detail, app) {
   const installUrl = detail?.install_url || "https://github.com/settings/installations";
   const links = new Map((app?.owners ?? []).map((owner) => [owner.owner, owner.install_url]));
-  const owners = (detail?.owners ?? []).map((owner) => `<div class="row">
+  return (detail?.owners ?? []).map((owner) => `<div class="row">
     <span class="key grow">${esc(owner.owner)}</span>
     <span>${owner.installed ? "installed" : "missing access"}</span>
     <span><a href="${esc(links.get(owner.owner) || installUrl)}" target="_blank" rel="noopener">${owner.installed ? "Manage installation" : `Install on ${esc(owner.owner)}`}</a></span></div>`).join("");
-  const install = owners
-    ? `<p>Install the App for each owner you watch, and grant it the watched repositories. Then select <b>Try again</b>.</p><div class="rows">${owners}</div>`
-    : `<p>Install the App on the account that owns your repositories: <a href="${esc(installUrl)}" target="_blank" rel="noopener">Install the App on GitHub</a>. Then select <b>Try again</b>, and choose the repositories to watch here.</p>`;
-  const found = card.state !== "connected" || !detail ? "" : detail.ticket
-    ? `<div class="setup-note">Ready for an agent: <a href="${esc(detail.ticket.url)}" target="_blank" rel="noopener">#${esc(detail.ticket.number)} · ${esc(detail.ticket.title)}</a>
-      <span class="dim-note">${esc(detail.open_tickets)} open ticket${detail.open_tickets === 1 ? "" : "s"} in ${esc((detail.covered ?? []).join(", "))}.</span></div>`
-    : `<div class="setup-note">No open ticket is ready for an agent in ${esc((detail.covered ?? []).join(", "))}. Curia starts work when one carries <code>ready-for-agent</code>.</div>`;
-  return `${identity}${install}${setupGitHubRepos(card, detail)}${found}`;
+}
+function setupGitHubInstall(card, detail, app) {
+  const installUrl = detail?.install_url || "https://github.com/settings/installations";
+  const owners = setupGitHubOwners(detail, app);
+  const every = payload?.poll_interval_s ?? 5;
+  const wait = card.state === "unconnected"
+    ? `<p class="qhint">Waiting for an installation that covers a repository. Curia checks again every ${esc(every)} seconds while this panel is open, and the repositories appear here on their own.</p>`
+    : "";
+  const then = card.state === "failed" ? " Then select <b>Try again</b>." : "";
+  if (owners) return `<p>Install the App for each owner you watch, and grant it the watched repositories.${then}</p><div class="rows">${owners}</div>${wait}`;
+  return `<p>Install the App on the account that owns your repositories: <a href="${esc(installUrl)}" target="_blank" rel="noopener">Install the App on GitHub</a>. On GitHub, <b>Only select repositories</b> is enough.${then}</p>${wait}`;
+}
+function githubSetupWaiting() {
+  const card = setupCardOf("github");
+  return card?.state === "unconnected" && setupStepAt(card)?.n === 2;
+}
+function ensureGitHubSetupWait() {
+  clearTimeout(UI.setup.githubTimer);
+  UI.setup.githubTimer = null;
+  const onCard = UI.screen === "setup" && setupSelected() === "github";
+  if (onCard && githubSetupWaiting()) UI.setup.githubTimer = setTimeout(loadSetup, (payload?.poll_interval_s ?? 5) * 1000);
 }
 
 /* The repositories the card offers to watch (#891): every repository the
@@ -5172,22 +5273,26 @@ function setupGitHubRepos(card, detail) {
   const available = new Set(detail?.available ?? []);
   const watched = detail?.watched ?? [];
   const busy = UI.setup.githubBusy;
+  const connected = card.state === "connected";
   const rows = repos.map((repo, i) => `<div class="row"><label class="grow"><input type="checkbox" id="setup-github-repo-${i}" value="${esc(repo)}"${!watched.length || watched.includes(repo) ? " checked" : ""}> ${esc(repo)}</label>
     ${available.has(repo) ? "" : `<span class="dim-note">not covered by an installation</span>`}</div>`).join("");
   const form = `<div class="rows">${rows}</div>
-    <p><button class="btn primary" ${busy ? "disabled" : ""} onclick="doSetupGitHubWatch()">${busy ? "Saving…" : "Watch these repositories"}</button></p>
+    <p><button class="btn primary" ${busy ? "disabled" : ""} onclick="doSetupGitHubWatch()">${busy ? "Saving…" : connected ? "Watch these repositories" : "Watch these repositories and continue"}</button></p>
     ${said("github-setup:watch")}
-    <p class="qhint">The ticked repositories become the watch list in <code>config/config.yaml</code>, and the verification runs again on them.</p>`;
-  if (card.state === "connected") return `<details><summary>Change the watched repositories</summary>${form}</details>`;
-  return `<p>Choose the repositories Curia watches. The list is what the App's installations cover.</p>${form}`;
+    <p class="qhint">The ticked repositories become the watch list in <code>config/config.yaml</code>, and the verification runs again on them${connected ? "" : ". When it passes, setup continues to the next card"}.</p>`;
+  if (connected) return `<details><summary>Change the watched repositories</summary>${form}</details>`;
+  return `<p>Choose the repositories Curia watches. The list is what the App's installations cover, every one ticked. Untick any Curia shouldn't work on.</p>${form}`;
 }
 
 /* The one press of the watch choice (#891): the ticked repositories go to
    the sidecar, which lands them through the validated settings save and the
-   reload, and then the card verifies fresh on the new list. A refusal is the
+   reload, and then the card verifies fresh on the new list. A read that
+   connects a card that was not connected continues setup, so the press is
+   the guide's last step and nothing else is asked. A refusal is the
    sidecar's sentence and takes no fresh read, so the choice stays on the
    page for the operator to correct. */
 async function doSetupGitHubWatch() {
+  const wasConnected = setupCardOf("github")?.state === "connected";
   const detail = setupCardOf("github")?.detail ?? null;
   const repos = setupGitHubRepoList(detail).filter((repo, i) => document.getElementById(`setup-github-repo-${i}`)?.checked);
   UI.act.said = null;
@@ -5213,7 +5318,9 @@ async function doSetupGitHubWatch() {
     return null;
   }
   UI.setup.githubBusy = false;
-  return retrySetup();
+  await retrySetup();
+  if (!wasConnected && setupCardOf("github")?.state === "connected") return continueSetup();
+  return null;
 }
 
 /* The Discord card's own panel (#876), in the states the verifier reports.
@@ -5231,7 +5338,7 @@ const DISCORD_STAGES_WITH_TOKEN_FORM = ["token", "operator"];
 function setupDiscord(card, progress) {
   const d = UI.setup.discord;
   const detail = card.detail ?? null;
-  const stage = card.state === "failed" ? (detail?.stage ?? null) : null;
+  const stage = card.state === "connected" ? null : (detail?.stage ?? null);
   if (card.state === "connected" && detail) {
     const bridge = detail.bridge === "up"
       ? `<span class="dim-note">The bridge is running.</span>`
@@ -5244,7 +5351,9 @@ function setupDiscord(card, progress) {
     </div><p>${bridge}</p>
     <details><summary>Change the server or the channel</summary>${setupDiscordChannelForm(d, progress, detail)}</details>`;
   }
-  const secretPresent = card.state === "failed" || d?.secret === "present" || d?.secret === "refused";
+  /* A stage in the detail means the token is on disk: the wait for a server
+     and the channel choice are plain steps since #891, not failures. */
+  const secretPresent = card.state === "failed" || Boolean(stage) || d?.secret === "present" || d?.secret === "refused";
   if (!secretPresent) return `${setupDiscordGuide()}${setupDiscordTokenForm(d, true)}`;
   if (!d || d.loading) return `<p class="qhint">Reading the bot's servers…</p>`;
   /* A rate limit (#891) is a wait, not a refused token: the token form stays behind its fold. */
@@ -5457,11 +5566,16 @@ function setupTailscaleForm(t, progress, detail, card) {
   const operator = t?.operator ?? detail?.operator ?? null;
   const current = (t?.node?.dns_name ?? detail?.address ?? "").split(".")[0] || t?.machine_name || null;
   const who = requester
-    ? `<div class="setup-note"><b>You opened Curia as ${esc(requester)}</b> through Tailscale.${operator && operator.login !== requester ? ` The recorded operator is ${esc(operator.login)}.` : ""}${!operator ? " Confirm to make this identity the allowed operator. Until then, nobody is." : ""}</div>`
+    ? `<div class="setup-note"><b>You opened Curia as ${esc(requester)}</b> through Tailscale.${operator && operator.login !== requester ? ` The recorded operator is ${esc(operator.login)}.` : ""}${operator && operator.login === requester ? " This identity is the recorded operator." : ""}${!operator ? " Confirm to make this identity the allowed operator. Until then, nobody is." : ""}</div>`
     : `<div class="setup-note">This request carried no Tailscale identity. Open the Curia app through its Tailscale address to confirm the operator.</div>`;
-  const label = operator ? "Confirm again and verify" : "Confirm operator and verify";
+  /* The identity that is already the recorded operator has nothing to
+     confirm again (#891): the read Try again takes is the whole check. A
+     different identity at the card is a real write, so it keeps the press. */
+  const same = Boolean(requester && operator && operator.login === requester);
+  const label = operator ? `Confirm ${requester ?? "this identity"} as the operator` : "Confirm operator and verify";
+  const press = same ? "" : `<p><button class="btn primary" ${busy || !requester ? "disabled" : ""} onclick="doSetupTailscaleOperator()">${busy ? "Verifying…" : esc(label)}</button></p>`;
   return `${who}
-    <p><button class="btn primary" ${busy || !requester ? "disabled" : ""} onclick="doSetupTailscaleOperator()">${busy ? "Verifying…" : label}</button></p>
+    ${press}
     ${said("tailscale-setup:operator")}
     <p class="qhint">${current ? `This node is named <code>${esc(current)}</code> on the tailnet. ` : ""}The name was chosen at installation with <code>--name</code>. To change it, reinstall with another <code>--name</code>, or run <code>sudo tailscale set --hostname &lt;name&gt;</code> on the host and then <a href="#" onclick="doRestart();return false">Restart Curia</a>. Curia never installs or reconfigures Tailscale.</p>`;
 }
@@ -5821,14 +5935,14 @@ function setupFooter(card) {
     return `<div class="setup-primary"><span class="emoji" aria-hidden="true">${esc(card.footer.emoji || "✅")}</span><span class="fact">${esc(card.footer.primary)}</span></div>
       <div class="setup-secondary">${esc(card.footer.secondary)}</div>`;
   }
-  return `<div class="setup-pending"><span aria-hidden="true">○</span><span>${esc(card.pending)}</span></div>`;
+  return `<div class="setup-pending"><span aria-hidden="true">○</span><span>${esc(setupCardPending(card))}</span></div>`;
 }
 
 function setupCard(card, selected) {
   const work = setupWork(card.key);
   return `<button class="setup-card ${esc(card.key)} ${esc(card.state)}${work ? " working" : ""}${selected ? " on" : ""}" aria-pressed="${selected ? "true" : "false"}"
       onclick="selectSetupCard('${js(card.key)}')">
-    <div class="setup-head">${setupLogo(card.key)}<span class="setup-title">${esc(card.title)}</span><span class="setup-badge">${work ? "Working" : esc(card.badge)}</span></div>
+    <div class="setup-head">${setupLogo(card.key)}<span class="setup-title">${esc(card.title)}</span><span class="setup-badge">${work ? "Working" : esc(setupCardBadge(card))}</span></div>
     <div class="setup-foot">${setupFooter(card)}</div>
   </button>`;
 }
@@ -6039,18 +6153,12 @@ function setupPanel(card, p) {
   const tryAgain = card.state === "failed"
     ? `<button class="btn primary" ${busy ? "disabled" : ""} onclick="retrySetup()">${busy ? "Verifying…" : "Try again"}</button>`
     : "";
-  const allReady = setupConnected().length === SETUP_ORDER.length;
-  const run = setup?.full_loop?.run;
-  const forward = card.state === "connected"
-    ? (allReady
-      ? (run?.state === "running" ? `<button class="btn primary" disabled>Running the Full loop…</button>`
-        : run?.state === "complete" ? `<a class="btn primary" href="#home" onclick="goto('home');return false">Open Curia</a>`
-          : run?.state === "failed" ? `<button class="btn primary" ${UI.setup.loopBusy ? "disabled" : ""} onclick="retryFullLoop()">Try again</button>`
-            : `<button class="btn primary" ${setup?.full_loop?.ready && !UI.setup.loopBusy ? `onclick="runFullLoop()"` : "disabled"}>Run Full loop</button>`)
-      : `<button class="btn primary" onclick="continueSetup()">Continue setup</button>`)
-    : "";
+  /* One Continue per connected panel (#891): it selects the next card that
+     is not connected, or the run once every card is. The run's own presses
+     live on the run panel. */
+  const forward = card.state === "connected" ? `<button class="btn primary" onclick="continueSetup()">Continue</button>` : "";
   return `<div class="setup-panel">
-    <div class="eyebrow">Independent connection · ${esc(card.badge)}</div>
+    <div class="eyebrow">Independent connection · ${esc(setupCardBadge(card))}</div>
     <h2>${esc(card.title)}</h2>
     ${slot ? slot.content(card, progress, p) : ""}
     ${problem}
@@ -6115,6 +6223,7 @@ async function loadSetup() {
      flight: what it found, a failure or the connected state, is the answer. */
   setupSettled();
   render();
+  ensureGitHubSetupWait();
   ensureDiscordSetupRead();
   ensureTailscaleSetupRead();
   ensureOpenAISetupRead();
@@ -6141,6 +6250,7 @@ async function selectSetupCard(key) {
   UI.setup.panel = "card";
   UI.setup.note = null;
   render();
+  ensureGitHubSetupWait();
   ensureDiscordSetupRead();
   ensureTailscaleSetupRead();
   ensureOpenAISetupRead();
@@ -6148,7 +6258,8 @@ async function selectSetupCard(key) {
   await writeSetup({ step: key });
 }
 function continueSetup() {
-  const next = SETUP_ORDER.find((k) => setupCardOf(k)?.state !== "connected") ?? setupSelected();
+  const next = SETUP_ORDER.find((k) => setupCardOf(k)?.state !== "connected");
+  if (!next) return selectSetupRun();
   return selectSetupCard(next);
 }
 /* The safe checkpoint a step keeps for a reopen (#875 to #879 call this):

--- a/daemon/src/discordsetup.mjs
+++ b/daemon/src/discordsetup.mjs
@@ -440,11 +440,12 @@ export class DiscordSetup {
 
     const rows = await api('GET', '/users/@me/guilds')
     const guilds = rows.map((g) => ({ id: String(g.id), name: String(g.name ?? '') }))
-    if (!guilds.length) {
-      return fail('server', `${bot.username || 'The bot'} is in no server`, 'Add the bot to your server with the invite link in this panel, then try again.', { ...invite, guilds })
-    }
-    if (!settings.guild_id) {
-      return fail('server', `No server is selected for ${bot.username || 'the bot'}`, 'Select the server and the channel name in this panel, then select Connect channel.', { ...invite, guilds })
+    // The bot in no server yet, and no server chosen yet, are the steps
+    // between the token and the channel (#891): the card is plain with the
+    // stage, never failed, because the panel waits for the first and asks
+    // for the second on its own.
+    if (!guilds.length || !settings.guild_id) {
+      return { ok: false, unconnected: true, detail: { stage: 'server', ...invite, guilds } }
     }
     const row = rows.find((g) => String(g.id) === settings.guild_id)
     if (!row) {

--- a/daemon/src/githubsetup.mjs
+++ b/daemon/src/githubsetup.mjs
@@ -23,11 +23,17 @@
 // the repository, the count of open tickets, and what the minted credential
 // grants — never a fabricated ticket.
 //
-// Before the App exists the card is plain, not failed: `{ unconnected }`,
-// which the frame draws as "Ready to connect". Everything after is one
-// failed verification with one corrective action, in the order the operator
-// meets it: the App, the install, the mint, the grant, the watch list, the
-// tickets.
+// THE EXPECTED STATES ARE STEPS, NOT FAILURES (#891). The card is a guide
+// of three steps, and `detail.step` names the one the operator is at:
+// `create` (no App yet), `install` (the App exists and no installation
+// covers a repository yet), `watch` (installations cover repositories and
+// nothing is watched yet). Each of those is `{ unconnected }` with the
+// detail, which the frame draws plain, because on a fresh installation they
+// are what the operator meets on the way and none of them is wrong. A
+// failed verification is a real failure only: GitHub refused the App, a
+// mint failed, the installation can't be read, or a watched repository lost
+// its coverage. The rehearsal pressed Try again on the expected states and
+// read a red card every time; the guide replaces that.
 //
 // THE OPERATOR CHOOSES WHAT TO WATCH HERE (#891). A fresh installation has no
 // watched repository (#866 writes none, and the shipped watch list stays with
@@ -78,7 +84,7 @@ async function readTickets(repo, { token, fetchImpl }) {
 export function githubVerifier({ minter, watch, fetchImpl = globalThis.fetch }) {
   return async function verifyGitHub() {
     const app = minter()
-    if (!app) return { ok: false, unconnected: true }
+    if (!app) return { ok: false, unconnected: true, detail: { step: 'create' } }
 
     const watched = watch().map((w) => w.repo)
     const owners = [...new Set(watched.map(ownerOf))]
@@ -106,7 +112,7 @@ export function githubVerifier({ minter, watch, fetchImpl = globalThis.fetch }) 
     }
     const installedOn = new Set(installs.map((i) => String(i.owner ?? '').toLowerCase()))
     const ownerRows = owners.map((owner) => ({ owner, installed: installedOn.has(owner.toLowerCase()) }))
-    const detail = { owners: ownerRows, covered: [], watched, available: [], install_url }
+    const detail = { step: 'install', owners: ownerRows, covered: [], watched, available: [], install_url }
     const watchedOwners = new Set(owners.map((o) => o.toLowerCase()))
 
     // One real mint per installation, then that installation's own grant. A
@@ -149,22 +155,10 @@ export function githubVerifier({ minter, watch, fetchImpl = globalThis.fetch }) 
       tokens.set(owner.toLowerCase(), minted)
     }
 
-    if (!watched.length) {
-      if (!installs.length) {
-        return {
-          ok: false,
-          failed: 'curia\'s GitHub App is not installed on any account, so there is no repository to watch yet',
-          action: 'Install the App on the account that owns your repositories from the link in this panel, then try again.',
-          detail,
-        }
-      }
-      return {
-        ok: false,
-        failed: 'No repository is on the watch list, so there is nothing for the App installation to cover',
-        action: 'Choose the repositories Curia watches in this panel, then select Watch these repositories.',
-        detail,
-      }
-    }
+    if (detail.available.length) detail.step = 'watch'
+    // Nothing watched yet is the fresh installation on its way: the install
+    // step until an installation covers a repository, the choice after.
+    if (!watched.length) return { ok: false, unconnected: true, detail }
     const missing = ownerRows.filter((o) => !o.installed).map((o) => o.owner)
     if (missing.length === owners.length) {
       return {
@@ -210,7 +204,7 @@ export function githubVerifier({ minter, watch, fetchImpl = globalThis.fetch }) 
     const ready = `${list(capabilities, 'and')} ready`
     const tickets = `${open} open ticket${open === 1 ? '' : 's'}`
     const repoLine = detail.covered.length > 1 ? `${detail.covered[0]} + ${detail.covered.length - 1} more` : detail.covered[0]
-    Object.assign(detail, { open_tickets: open, ticket })
+    Object.assign(detail, { step: 'done', open_tickets: open, ticket })
     if (ticket) {
       return { ok: true, emoji: '🎫', primary: `#${ticket.number} · ${ticket.title}`, secondary: `${READY_LABEL} · ${ticket.repo} · ${tickets}`, detail }
     }

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -4573,11 +4573,24 @@ describe('integration setup (#874)', () => {
     assert.equal(page.setup.cards.find((c) => c.key === 'tailscale').state, 'unavailable', 'the card is what the read said')
   })
 
-  test('a connected card offers Continue setup to the next unconnected card, in rail order', async () => {
+  test('a connected card offers Continue to the next unconnected card, in rail order', async () => {
     page.setup = SETUP({ step: 'tailscale', cards: { tailscale: ALL.tailscale, github: ALL.github } })
-    assert.match(page.screenSetup(payload()), /onclick="continueSetup\(\)">Continue setup</)
+    assert.match(page.screenSetup(payload()), /onclick="continueSetup\(\)">Continue</)
     await page.continueSetup()
     assert.equal(page.setup.step, 'discord')
+  })
+
+  test('Continue on a connected panel with every card connected opens the run panel, and the panel offers no second press', async () => {
+    page.setup = SETUP({ step: 'tailscale', cards: ALL, full_loop: { ready: true, missing: [], reason: null, facts: { channel: '#curia' } } })
+    page.UI.setup.panel = 'card'
+    const html = page.screenSetup(payload())
+    const panel = /<section>([\s\S]*)<\/section>/.exec(html)[1]
+    assert.match(panel, /<button class="btn primary" onclick="continueSetup\(\)">Continue<\/button>/)
+    assert.doesNotMatch(panel, /runFullLoop|Try again/)
+    assert.equal((panel.match(/class="btn primary"/g) ?? []).length, 1, 'one Continue per connected panel')
+    await page.continueSetup()
+    assert.equal(page.UI.setup.panel, 'run')
+    assert.equal(page.setup.step, 'tailscale', 'no card is selected over the run')
   })
 
   test('the Full loop action stays unavailable with four connected cards until the gate supplies its facts', () => {
@@ -4670,7 +4683,7 @@ describe('integration setup (#874)', () => {
     assert.doesNotMatch(html, /onclick="runFullLoop\(\)"/, 'no second press while a run is live')
     assert.match(html, /<section><div class="setup-panel" id="setup-run">/, 'a live run is the selected panel (#891)')
     page.UI.setup.panel = 'card'
-    assert.match(page.screenSetup(payload()), /<button class="btn primary" disabled>Running the Full loop…<\/button>/, 'the card panel names the run as the forward action')
+    assert.match(page.screenSetup(payload()), /<button class="btn primary" onclick="continueSetup\(\)">Continue<\/button>/, 'the card panel continues to the run')
     assert.match(html, /href="https:\/\/github\.com\/alp82\/curia\/issues\/42"[^>]*>Ticket/)
     assert.match(html, /href="https:\/\/discord\.com\/channels\/2\/777"[^>]*>Discord thread/)
     assert.doesNotMatch(html, /Pull request ↗/, 'a link the run has not produced is not drawn')
@@ -4882,7 +4895,7 @@ describe('integration setup (#874)', () => {
     let html = page.screenSetup(p)
     assert.match(html, /href="https:\/\/github.com\/alp82\/curia\/issues\/861"[^>]*>#861 · Chart backup</)
     assert.match(html, />Manage installation</)
-    assert.match(html, /Continue setup/)
+    assert.match(html, />Continue</)
     page.setup = SETUP({ cards: { github: {
       ...ALL.github,
       detail: { owners: [{ owner: 'alp82', installed: true }], covered: ['alp82/curia'], open_tickets: 0, ticket: null },
@@ -4944,9 +4957,8 @@ describe('integration setup (#874)', () => {
 
   test('with no watched repository the panel lists what the installations cover, every repository ticked, and one press watches them', async () => {
     page.setup = SETUP({ cards: { github: {
-      state: 'failed', badge: 'Action required',
-      error: { failed: 'No repository is on the watch list, so there is nothing for the App installation to cover', action: 'Choose the repositories Curia watches in this panel, then select Watch these repositories.' },
-      detail: GITHUB_DETAIL({ available: ['alp82/curia', 'alp82/aistack', 'getalfredo/landing-page'] }),
+      state: 'unconnected', badge: 'Ready to connect',
+      detail: GITHUB_DETAIL({ step: 'watch', available: ['alp82/curia', 'alp82/aistack', 'getalfredo/landing-page'] }),
     } } })
     const p = payload()
     p.overview.github_app = APP({ owners: [] })
@@ -4954,7 +4966,7 @@ describe('integration setup (#874)', () => {
     assert.match(html, /id="setup-github-repo-0" value="alp82\/curia" checked/)
     assert.match(html, /id="setup-github-repo-1" value="alp82\/aistack" checked/)
     assert.match(html, /id="setup-github-repo-2" value="getalfredo\/landing-page" checked/)
-    assert.match(html, /onclick="doSetupGitHubWatch\(\)">Watch these repositories</)
+    assert.match(html, /onclick="doSetupGitHubWatch\(\)">Watch these repositories and continue</)
     assert.doesNotMatch(text(html), /Add one under Settings/)
     page.document.getElementById = (id) => ({ 'setup-github-repo-0': { checked: true }, 'setup-github-repo-1': { checked: false }, 'setup-github-repo-2': { checked: true } })[id] ?? null
     calls = []
@@ -4964,11 +4976,7 @@ describe('integration setup (#874)', () => {
   })
 
   test('with no installation at all the panel offers the App\'s own install link, and no repository to tick', () => {
-    page.setup = SETUP({ cards: { github: {
-      state: 'failed', badge: 'Action required',
-      error: { failed: "curia's GitHub App is not installed on any account, so there is no repository to watch yet", action: 'Install the App on the account that owns your repositories from the link in this panel, then try again.' },
-      detail: GITHUB_DETAIL(),
-    } } })
+    page.setup = SETUP({ cards: { github: { state: 'unconnected', badge: 'Ready to connect', detail: GITHUB_DETAIL({ step: 'install' }) } } })
     const p = payload()
     p.overview.github_app = APP({ owners: [] })
     const html = page.screenSetup(p)
@@ -5001,6 +5009,118 @@ describe('integration setup (#874)', () => {
     assert.deepEqual(calls.map((c) => [c.method, c.url]), [['POST', '/api/setup/github/watch']], 'a refused write takes no fresh read')
     assert.deepEqual(calls[0].body, { repos: ['alp82/curia', 'alp82/aistack'] })
     assert.match(text(page.screenSetup(p)), /cannot leave the watch list while curia-7 runs on it/)
+  })
+
+  // The GitHub card after the second rehearsal (#891): a three-step guide.
+  // "It should be 3 guided steps: 1. create the app 2. install the app
+  // 3. continue setup." An expected intermediate state, no App yet, no
+  // installation yet, nothing watched yet, is a step with the next action
+  // and never the red failure state; Try again exists on a real failure only.
+  const GITHUB_STEP = (step, detail = {}) => ({ state: 'unconnected', badge: 'Ready to connect', detail: GITHUB_DETAIL({ step, ...detail }) })
+  const stepper = (html) => /<ol class="setup-stepper"[\s\S]*?<\/ol>/.exec(html)?.[0] ?? ''
+
+  test('step 1 of the GitHub guide: with no App the card is plain, Create the App is the current step, and nothing on the card is a failure', () => {
+    page.setup = SETUP({ cards: { github: GITHUB_STEP('create') } })
+    const p = payload()
+    p.overview.github_app = APP({ configured: false, status: 'unconfigured', app: null, owners: [] })
+    const html = page.screenSetup(p)
+    const steps = stepper(html)
+    assert.match(steps, /<li class="current"[^>]*>[\s\S]*?Create the App/)
+    assert.match(steps, /<li class="todo"[^>]*>[\s\S]*?Install the App/)
+    assert.match(steps, /<li class="todo"[^>]*>[\s\S]*?Choose repositories and continue/)
+    assert.match(html, /onclick="doSetupGitHubApp\(\)">Create GitHub App</)
+    assert.match(html, /class="setup-card github unconnected on"/)
+    assert.doesNotMatch(html, /setup-problem|Try again|⚠️/)
+  })
+
+  test('step 2 of the GitHub guide: the App exists and no installation covers a repository, so the card names the step, offers the install link, and re-reads on the interval until one does', async () => {
+    page.setup = SETUP({ cards: { github: GITHUB_STEP('install') } })
+    page.payload = payload()
+    page.payload.overview.github_app = APP({ owners: [] })
+    let html = page.screenSetup(page.payload)
+    const steps = stepper(html)
+    assert.match(steps, /<li class="done"[^>]*>[\s\S]*?Create the App/)
+    assert.match(steps, /<li class="current"[^>]*>[\s\S]*?Install the App/)
+    assert.match(html, /class="setup-card github unconnected on"/, 'an expected step is never the red state')
+    assert.match(html, /<span class="setup-badge">Step 2 of 3<\/span>/)
+    assert.match(html, /href="https:\/\/github.com\/apps\/curia-box\/installations\/new"[^>]*>Install the App on GitHub</)
+    assert.match(text(html), /Curia checks again every 5 seconds while this panel is open/)
+    assert.doesNotMatch(html, /setup-problem|Try again|⚠️|doSetupGitHubWatch|doSetupGitHubApp/)
+
+    // The wait: the frame re-reads on the page's refresh interval, with no
+    // press, and stops itself the moment an installation covers a repository.
+    const timers = []
+    page.setTimeout = (callback, ms) => { timers.push({ callback, ms }); return timers.length }
+    page.clearTimeout = () => {}
+    let installed = false
+    page.fetch = async (url, init = {}) => {
+      calls.push({ url, method: init.method ?? 'GET', body: init.body ? JSON.parse(init.body) : null })
+      return { ok: true, json: async () => (init.method === 'POST' ? { ok: true } : SETUP({ cards: { github: installed ? GITHUB_STEP('watch', { available: ['alp82/curia', 'alp82/aistack'] }) : GITHUB_STEP('install') } })) }
+    }
+    calls = []
+    await page.loadSetup()
+    assert.equal(timers.length, 1, 'one wait is armed')
+    assert.equal(timers[0].ms, 5000, 'on the page\'s own refresh interval')
+    await timers[0].callback()
+    assert.equal(calls.filter((c) => c.url === '/api/setup' && c.method === 'GET').length, 2, 'the wait re-reads the frame')
+    assert.equal(timers.length, 2, 'and arms the next wait while nothing is covered')
+    installed = true
+    await timers[1].callback()
+    assert.equal(timers.length, 2, 'the wait ends once an installation covers a repository')
+    assert.equal(calls.filter((c) => c.method === 'POST').length, 0, 'the wait writes nothing')
+    html = page.screenSetup(page.payload)
+    assert.match(stepper(html), /<li class="current"[^>]*>[\s\S]*?Choose repositories and continue/)
+    assert.match(html, /id="setup-github-repo-0" value="alp82\/curia" checked/)
+  })
+
+  test('step 3 of the GitHub guide: every covered repository is ticked, and the one press writes the watch list, verifies, and continues to the next unconnected card', async () => {
+    page.setup = SETUP({ cards: { github: GITHUB_STEP('watch', { available: ['alp82/curia', 'alp82/aistack'] }) } })
+    page.payload = payload()
+    page.payload.overview.github_app = APP({ owners: [] })
+    let html = page.screenSetup(page.payload)
+    assert.match(html, /<span class="setup-badge">Step 3 of 3<\/span>/)
+    assert.match(html, /id="setup-github-repo-0" value="alp82\/curia" checked/)
+    assert.match(html, /id="setup-github-repo-1" value="alp82\/aistack" checked/)
+    assert.match(html, /onclick="doSetupGitHubWatch\(\)">Watch these repositories and continue</)
+    assert.doesNotMatch(html, /setup-problem|Try again|⚠️/)
+    assert.doesNotMatch(html, /Watch these repositories<\/button>/, 'one press, not two')
+    page.document.getElementById = (id) => ({ 'setup-github-repo-0': { checked: true }, 'setup-github-repo-1': { checked: true } })[id] ?? null
+    page.fetch = async (url, init = {}) => {
+      calls.push({ url, method: init.method ?? 'GET', body: init.body ? JSON.parse(init.body) : null })
+      return { ok: true, json: async () => (init.method === 'POST' ? { ok: true } : SETUP({ cards: { github: { ...ALL.github, detail: GITHUB_DETAIL({ covered: ['alp82/curia', 'alp82/aistack'], watched: ['alp82/curia', 'alp82/aistack'], available: ['alp82/curia', 'alp82/aistack'], open_tickets: 0, ticket: null }) } } })) }
+    }
+    calls = []
+    await page.doSetupGitHubWatch()
+    assert.deepEqual(calls.map((c) => [c.method, c.url]), [['POST', '/api/setup/github/watch'], ['GET', '/api/setup'], ['POST', '/api/setup']])
+    assert.deepEqual(calls[0].body, { repos: ['alp82/curia', 'alp82/aistack'] })
+    assert.deepEqual(calls[2].body, { step: 'discord' }, 'the connected read continues setup to the next unconnected card')
+    assert.equal(page.setup.step, 'discord')
+  })
+
+  test('a real GitHub failure keeps the red state and Try again: a watched repository lost its coverage', () => {
+    page.setup = SETUP({ cards: { github: {
+      state: 'failed', badge: 'Action required',
+      error: { failed: "The App installation on alp82 doesn't cover alp82/curia", action: 'Grant the App access to alp82/curia on the alp82 installation on GitHub, then try again.' },
+      detail: GITHUB_DETAIL({ step: 'watch', owners: [{ owner: 'alp82', installed: true }], watched: ['alp82/curia'], available: ['alp82/aistack'] }),
+    } } })
+    const p = payload()
+    p.overview.github_app = APP()
+    const html = page.screenSetup(p)
+    assert.match(html, /class="setup-card github failed on"/)
+    assert.match(html, /setup-problem/)
+    assert.match(html, /onclick="retrySetup\(\)">Try again</)
+    assert.match(stepper(html), /<li class="current"[^>]*>[\s\S]*?Choose repositories and continue/)
+    assert.match(html, /id="setup-github-repo-1" value="alp82\/curia" checked/, 'the step keeps its action beside the failure')
+  })
+
+  test('a connected GitHub card the operator reopens shows its facts and one press, Continue', () => {
+    page.setup = SETUP({ step: 'github', cards: { github: { ...ALL.github, detail: GITHUB_DETAIL({ owners: [{ owner: 'alp82', installed: true }], covered: ['alp82/curia'], watched: ['alp82/curia'], available: ['alp82/curia'], open_tickets: 0, ticket: null }) } } })
+    const p = payload()
+    p.overview.github_app = APP()
+    const html = page.screenSetup(p)
+    assert.match(html, /<button class="btn primary" onclick="continueSetup\(\)">Continue<\/button>/)
+    assert.doesNotMatch(html, /Try again|setup-stepper/)
+    assert.match(html, /<summary>Change the watched repositories<\/summary>/)
   })
 
   // The Discord card (#876). Before the token exists the panel guides the
@@ -5252,7 +5372,7 @@ describe('integration setup (#874)', () => {
     assert.match(html, /onclick="doSetupRestart\(\);return false">Restart Curia</)
     assert.match(html, /<div class="setup-secondary">Confirmation delivered · 6 commands registered<\/div>/)
     assert.doesNotMatch(html, /type="password"/, 'no token form on a connected card')
-    assert.match(html, /Continue setup/)
+    assert.match(html, />Continue</)
   })
 
   test('arriving at Setup takes its own read, and the read is a fresh verification every time', async () => {
@@ -5260,6 +5380,40 @@ describe('integration setup (#874)', () => {
     page.enter('setup')
     await new Promise((resolve) => setImmediate(resolve))
     assert.deepEqual(calls.map((c) => [c.method, c.url]), [['GET', '/api/setup'], ['GET', '/api/setup']])
+  })
+
+  // The second rehearsal (#891): "check could be implicit and then just
+  // needs a continue click". The wait for a server is an expected step, not
+  // a failure, and a write verifies on its own: the one press left after it
+  // is Continue.
+  test('the wait for a server is an expected step of the Discord card: plain, named as a step, with the invite link and no Try again', () => {
+    page.setup = SETUP({ step: 'discord', cards: { discord: { state: 'unconnected', badge: 'Ready to connect', detail: { stage: 'server', guilds: [], bot: { id: '2', username: 'curia-box' }, invite_url: 'https://discord.com/oauth2/authorize?client_id=5' } } } })
+    page.UI.setup.discord = DISCORD_OVERVIEW({ guilds: [], invite_url: 'https://discord.com/oauth2/authorize?client_id=5' })
+    const html = page.screenSetup(payload())
+    assert.match(html, /class="setup-card discord unconnected on"/)
+    assert.match(html, /<span class="setup-badge">Step 2 of 3<\/span>/)
+    assert.match(html, /href="https:\/\/discord\.com\/oauth2\/authorize\?client_id=5"/)
+    assert.match(text(html), /Waiting for the bot to join a server/)
+    assert.doesNotMatch(html, /setup-problem|Try again|⚠️|setup-discord-guild/)
+  })
+
+  test('Connect channel verifies on its own, and the connected Discord card leaves one press, Continue', async () => {
+    page.setup = SETUP({ step: 'discord', cards: { discord: { state: 'unconnected', badge: 'Ready to connect', detail: { stage: 'server', guilds: DISCORD_OVERVIEW().guilds } } } })
+    page.UI.setup.discord = DISCORD_OVERVIEW()
+    page.payload = payload()
+    page.document.getElementById = (id) => ({ 'setup-discord-guild': { value: '333333333333333333' }, 'setup-discord-channel': { value: 'curia' } })[id] ?? null
+    page.fetch = async (url, init = {}) => {
+      calls.push({ url, method: init.method ?? 'GET', body: init.body ? JSON.parse(init.body) : null })
+      if (url === '/api/setup/discord/channel') return { ok: true, json: async () => ({ ok: true, card: { key: 'discord', state: 'connected' } }) }
+      return { ok: true, json: async () => (init.method === 'POST' ? { ok: true } : SETUP({ step: 'discord', cards: { discord: { ...ALL.discord, detail: { guild: { id: '333333333333333333', name: "Alp's workshop" }, channel: { id: '4', name: 'curia', created: false, url: 'https://discord.com/channels/3/4' }, operator: { id: '1', username: 'alp', name: 'Alp' }, commands: ['next'], confirmation: { id: '7', at: new Date().toISOString(), posted: true, url: 'https://discord.com/channels/3/4/7' }, bridge: 'up' } } } })) }
+    }
+    calls = []
+    await page.doSetupDiscordChannel()
+    assert.deepEqual(calls.map((c) => [c.method, c.url]), [['POST', '/api/setup'], ['POST', '/api/setup/discord/channel'], ['GET', '/api/setup']], 'the write is followed by the verification, with no press between')
+    const html = page.screenSetup(page.payload)
+    assert.match(html, /class="setup-card discord connected on"/)
+    assert.match(html, /<button class="btn primary" onclick="continueSetup\(\)">Continue<\/button>/)
+    assert.doesNotMatch(html, /Try again|Verify|Check/)
   })
 
   // The Tailscale card (#877; the machine-name field dropped after #891).
@@ -5319,7 +5473,7 @@ describe('integration setup (#874)', () => {
     assert.deepEqual(calls[0].body, {}, 'neither a login nor a machine name is a field the page sends')
   })
 
-  test('a failed Tailscale card names the failure and the action, and keeps the confirmation so the operator can confirm again', () => {
+  test('a failed Tailscale card names the failure and the action, with Try again as the one press for the same identity', () => {
     page.setup = SETUP({ step: 'tailscale', cards: { tailscale: {
       state: 'failed', badge: 'Action required',
       error: { failed: 'The tailnet issues no HTTPS certificate for this node, so Serve can\'t publish the Curia app', action: 'Enable HTTPS certificates under DNS in the Tailscale admin console at https://login.tailscale.com/admin/dns, then try again.' },
@@ -5330,8 +5484,36 @@ describe('integration setup (#874)', () => {
     assert.match(html, /class="setup-card tailscale failed on"/)
     assert.match(text(html), /The tailnet issues no HTTPS certificate for this node/)
     assert.doesNotMatch(html, /<input/)
-    assert.match(html, /onclick="doSetupTailscaleOperator\(\)">Confirm again and verify</)
     assert.match(html, /onclick="retrySetup\(\)">Try again</)
+    assert.doesNotMatch(html, /doSetupTailscaleOperator/, 'confirming the same identity again would only repeat the read Try again takes')
+    assert.equal((/<section>([\s\S]*)<\/section>/.exec(html)[1].match(/class="btn primary"/g) ?? []).length, 1, 'Try again is the one press on the panel')
+    // Another identity at the same failed card is a real write, so the confirmation stays.
+    page.UI.setup.tailscale = TAILSCALE_OVERVIEW({ requester: 'other@example.com', operator: { login: 'alp@example.com', confirmed_at: '2026-09-02T10:00:00.000Z' }, first_operator: false })
+    assert.match(page.screenSetup(payload()), /onclick="doSetupTailscaleOperator\(\)">Confirm other@example\.com as the operator</)
+  })
+
+  test('the confirmation verifies on its own, and the connected Tailscale card leaves one press, Continue', async () => {
+    page.setup = SETUP({ step: 'tailscale', cards: { tailscale: { state: 'unconnected', badge: 'Ready to connect' } } })
+    page.UI.setup.tailscale = TAILSCALE_OVERVIEW()
+    page.payload = payload()
+    page.fetch = async (url, init = {}) => {
+      calls.push({ url, method: init.method ?? 'GET', body: init.body ? JSON.parse(init.body) : null })
+      if (url === '/api/setup/tailscale/operator') return { ok: true, json: async () => ({ ok: true, card: { key: 'tailscale', state: 'connected' } }) }
+      return { ok: true, json: async () => (init.method === 'POST' ? { ok: true } : SETUP({ step: 'tailscale', cards: { tailscale: { ...ALL.tailscale, detail: {
+        operator: { login: 'alp@example.com', confirmed_at: new Date().toISOString(), last_seen_at: null },
+        node: { installed: true, online: true, backend_state: 'Running', dns_name: 'curia.tail1234.ts.net', ips: ['100.98.118.33'], version: '1.98.10' },
+        address: 'curia.tail1234.ts.net', app_url: 'https://curia.tail1234.ts.net:8445/', machine_name: 'curia',
+        serve: { url: 'https://curia.tail1234.ts.net:8445/', route: { https: 8445, target: 'http://127.0.0.1:4273' }, created: false, error: null },
+        app: { status: 200, ms: 38, error: null }, verified_at: new Date().toISOString(),
+      } } } })) }
+    }
+    calls = []
+    await page.doSetupTailscaleOperator()
+    assert.deepEqual(calls.map((c) => [c.method, c.url]), [['POST', '/api/setup/tailscale/operator'], ['GET', '/api/setup']], 'the write is followed by the verification, with no press between')
+    const html = page.screenSetup(page.payload)
+    assert.match(html, /class="setup-card tailscale connected on"/)
+    assert.match(html, /<button class="btn primary" onclick="continueSetup\(\)">Continue<\/button>/)
+    assert.doesNotMatch(html, /Try again|Confirm again|doSetupTailscaleOperator/)
   })
 
   test('a connected Tailscale card draws the private address, the operator, the node, the Serve route, and the timed admission', () => {
@@ -5353,7 +5535,7 @@ describe('integration setup (#874)', () => {
     assert.match(text(html), /:8445 → http:\/\/127\.0\.0\.1:4273 · created by Curia/)
     assert.match(text(html), /Admitted alp@example\.com in 38 ms · Arrived through Tailscale/)
     assert.doesNotMatch(html, /Change the machine name/, 'the name is the tailnet\'s fact; nothing here changes it')
-    assert.match(html, /Continue setup/)
+    assert.match(html, />Continue</)
     assert.doesNotMatch(html, /Try again/)
   })
 
@@ -5584,7 +5766,7 @@ describe('integration setup (#874)', () => {
     assert.match(text(html), /Anthropic Ready to connect/)
     assert.match(html, /onclick="doSetupAnthropicLogin\(\)">Sign in to Anthropic</)
     assert.match(html, /<details><summary>Sign in to OpenAI again<\/summary>/)
-    assert.match(html, /Continue setup/)
+    assert.match(html, />Continue</)
     assert.doesNotMatch(html, /Try again/)
   })
 
@@ -5857,21 +6039,22 @@ describe('integration setup (#874)', () => {
 
   test('Watch these repositories and Restart Curia show their work the same way', async () => {
     const write = deferred()
-    page.setup = SETUP({ step: 'github', cards: { github: { state: 'failed', badge: 'Action required', error: { failed: 'No watched repository is covered', action: 'Choose the repositories.' }, detail: { available: ['alp82/curia'], watched: [], owners: [] } } } })
+    page.setup = SETUP({ step: 'github', cards: { github: { state: 'unconnected', badge: 'Ready to connect', detail: { step: 'watch', available: ['alp82/curia'], watched: [], owners: [] } } } })
     page.document.getElementById = (id) => (id === 'setup-github-repo-0' ? { checked: true } : null)
-    page.fetch = async (url) => {
+    page.fetch = async (url, init = {}) => {
       if (url === '/api/setup/github/watch') { await write.promise; return { ok: true, json: async () => ({ ok: true }) } }
-      return { ok: true, json: async () => SETUP({ step: 'github', cards: { github: ALL.github } }) }
+      return { ok: true, json: async () => (init.method === 'POST' ? { ok: true } : SETUP({ step: 'github', cards: { github: ALL.github } })) }
     }
     const pressed = page.doSetupGitHubWatch()
     let html = page.screenSetup(payload())
     assert.match(text(html), /Saving the watch list and verifying the repositories…/)
-    assert.doesNotMatch(html, /No watched repository is covered|Watch these repositories/)
+    assert.doesNotMatch(html, /Choose the repositories to watch|Watch these repositories/)
     write.resolve()
     await pressed
     html = page.screenSetup(payload())
     assert.doesNotMatch(html, /working/)
-    assert.match(html, /class="setup-card github connected on"/)
+    assert.match(html, /class="setup-card github connected"/)
+    assert.match(html, /class="setup-card discord unavailable on"/, 'the connecting read continues setup to the next card (#891)')
 
     page.setup = SETUP({ step: 'discord', cards: { discord: { ...ALL.discord, detail: { bridge: 'down', channel: { name: 'curia', url: 'https://discord.com/channels/2/4' }, guild: { name: 'g' }, confirmation: { posted: true, at: at(5), url: 'https://discord.com/channels/2/4/9' }, operator: { id: '1', name: 'alp' }, commands: ['start'] } } } })
     page.document.getElementById = () => null

--- a/daemon/test/discordsetup.test.mjs
+++ b/daemon/test/discordsetup.test.mjs
@@ -182,14 +182,14 @@ describe('the Discord card (#876)', () => {
       assert.ok(!JSON.stringify(out).includes(TOKEN))
     })
 
-    test('a bot in no server fails on the server, and the action is the invite link', async () => {
+    test('a bot in no server is the server step, plain and not failed, with the invite link in the detail', async () => {
       writeSecret(root, 'discord-bot-token', TOKEN)
       writeDiscordSettings(stateDir, { allowed_users: [OPERATOR] })
       const { verify } = setupOver(happy({ '/users/@me/guilds': [200, []] }))
       const answer = await verify({ progress: {} })
       assert.equal(answer.ok, false)
-      assert.match(answer.failed, /is in no server/)
-      assert.match(answer.action, /invite link/i)
+      assert.equal(answer.unconnected, true, 'waiting for the bot to join is a step, not a failure (#891)')
+      assert.equal(answer.failed, undefined)
       assert.equal(answer.detail.stage, 'server')
       assert.match(answer.detail.invite_url, /discord\.com\/oauth2\/authorize/)
     })
@@ -241,9 +241,8 @@ describe('the Discord card (#876)', () => {
       const { verify, d } = setupOver(happy({ [`/guilds/${GUILD}/channels`]: [200, []], [`POST /guilds/${GUILD}/channels`]: [201, textChannel({ id: '888' })] }))
       const answer = await verify({ progress: {} })
       assert.equal(answer.ok, false)
+      assert.equal(answer.unconnected, true, 'no server chosen yet is a step, not a failure (#891)')
       assert.equal(answer.detail.stage, 'server')
-      assert.match(answer.failed, /No server is selected/)
-      assert.match(answer.action, /Connect channel/)
       assert.deepEqual(answer.detail.guilds, [{ id: GUILD, name: 'Alp\'s workshop' }])
       assert.equal(d.calls.some((c) => c.method === 'POST'), false, 'a verification read creates nothing and posts nothing')
     })

--- a/daemon/test/githubsetup.test.mjs
+++ b/daemon/test/githubsetup.test.mjs
@@ -51,11 +51,11 @@ function verifierOver(routes, { watch = [{ repo: 'alp82/curia' }], minter } = {}
 describe('the GitHub card (#875)', () => {
   test('with no App secret on disk the card is unconnected, and GitHub is not asked anything', async () => {
     const { verify, gh } = verifierOver({}, { minter: null })
-    assert.deepEqual(await verify({ progress: {} }), { ok: false, unconnected: true })
+    assert.deepEqual(await verify({ progress: {} }), { ok: false, unconnected: true, detail: { step: 'create' } })
     assert.equal(gh.calls.length, 0)
   })
 
-  test('with no watched repository there is nothing an installation could cover, and the action is the choice in the panel', async () => {
+  test('with no watched repository there is nothing an installation could cover: the card is plain at the watch step, not failed', async () => {
     const { verify } = verifierOver({
       '/app/installations?per_page=100': [200, installations],
       'POST /app/installations/7/access_tokens': tokenAnswer,
@@ -63,8 +63,9 @@ describe('the GitHub card (#875)', () => {
     }, { watch: [] })
     const answer = await verify({ progress: {} })
     assert.equal(answer.ok, false)
-    assert.match(answer.failed, /no repository is on the watch list/i)
-    assert.match(answer.action, /Watch these repositories/)
+    assert.equal(answer.unconnected, true)
+    assert.equal(answer.failed, undefined, 'an expected step is never a failure')
+    assert.equal(answer.detail.step, 'watch')
   })
 
   test('an App GitHub refuses is one failed verification naming the refusal, with the App and the clock as the action', async () => {
@@ -82,6 +83,7 @@ describe('the GitHub card (#875)', () => {
     assert.match(answer.failed, /not installed on alp82 or getalfredo/)
     assert.match(answer.action, /Install the App on alp82/)
     assert.deepEqual(answer.detail, {
+      step: 'install',
       owners: [{ owner: 'alp82', installed: false }, { owner: 'getalfredo', installed: false }],
       covered: [], watched: ['alp82/curia', 'getalfredo/landing-page'], available: [], install_url: 'https://github.com/settings/installations',
     })
@@ -248,8 +250,8 @@ describe('the GitHub card after the rehearsal (#891)', () => {
     }, { watch: [] })
     const answer = await verify({ progress: {} })
     assert.equal(answer.ok, false)
-    assert.match(answer.failed, /No repository is on the watch list/)
-    assert.match(answer.action, /Watch these repositories/)
+    assert.equal(answer.unconnected, true, 'the choice is a step of the guide, not a failure')
+    assert.equal(answer.detail.step, 'watch')
     assert.deepEqual(answer.detail.available, ['alp82/curia', 'alp82/aistack', 'getalfredo/landing-page'])
     assert.deepEqual(answer.detail.watched, [])
     assert.deepEqual(answer.detail.owners, [])
@@ -257,12 +259,13 @@ describe('the GitHub card after the rehearsal (#891)', () => {
     assert.ok(!JSON.stringify(answer).includes(TOKEN))
   })
 
-  test('with no watched repository and no installation, the action is the install link, not the Settings screen', async () => {
+  test('with no watched repository and no installation, the card is plain at the install step with the install link, not failed', async () => {
     const { verify } = verifierOver({ '/app': appFacts, '/app/installations?per_page=100': [200, []] }, { watch: [] })
     const answer = await verify({ progress: {} })
     assert.equal(answer.ok, false)
-    assert.match(answer.failed, /not installed on any account/)
-    assert.match(answer.action, /Install the App/)
+    assert.equal(answer.unconnected, true)
+    assert.equal(answer.failed, undefined)
+    assert.equal(answer.detail.step, 'install')
     assert.deepEqual(answer.detail.available, [])
     assert.equal(answer.detail.install_url, 'https://github.com/apps/curia-box/installations/new')
   })

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -28,7 +28,7 @@ Curia checks the file as a whole, not only key by key. For example, the sandbox 
 
 ### The watch list is yours alone
 
-In an installation, `watch` has no shipped default. The service image carries the source deployment's own `curia.yaml`, and its watch list applies only to that deployment. Under an installation root the service reads the watch list from `config/config.yaml` and nowhere else. A fresh installation leaves the key out and watches nothing until you choose a repository: the **GitHub** card of the [Setup screen](integration-setup.md#choose-the-repositories-to-watch) lists the repositories your App installations cover and writes the ones you tick into this file, and the settings screen edits the same list.
+In an installation, `watch` has no shipped default. The service image carries the source deployment's own `curia.yaml`, and its watch list applies only to that deployment. Under an installation root the service reads the watch list from `config/config.yaml` and nowhere else. A fresh installation leaves the key out and watches nothing until you choose a repository: the **GitHub** card of the [Setup screen](integration-setup.md#step-3-choose-repositories-and-continue) lists the repositories your App installations cover and writes the ones you tick into this file, and the settings screen edits the same list.
 
 ## The file
 

--- a/docs/operator/guide/03-connect-services.md
+++ b/docs/operator/guide/03-connect-services.md
@@ -21,31 +21,34 @@ Each card writes one credential to an owner-only file under `secrets/` in the in
 
 From a device on your tailnet, open the address `curia install` printed, `https://<your node's MagicDNS name>:8445/`. Open it through Tailscale: a request on the host's loopback carries no identity and can't confirm an operator. On a fresh installation the app admits the first tailnet identity that arrives, and only to **Setup**. Select **Setup** if the app doesn't open on it.
 
-The rail on the left holds four cards, **GitHub**, **Discord**, **Tailscale**, and **Model provider**. Connect them in any order. After a card connects, **Continue setup** opens the next card that isn't connected. The frame, the card states, and what a reopen restores are in [Integration setup](../integration-setup.md).
+The rail on the left holds four cards, **GitHub**, **Discord**, **Tailscale**, and **Model provider**. Connect them in any order. Every write on a card verifies the card on its own, and a connected card has one press, **Continue**, which opens the next card that isn't connected. The frame, the card states, and what a reopen restores are in [Integration setup](../integration-setup.md).
 
 ## Connect GitHub
 
-1. On the **GitHub** card, keep the suggested App name or enter your own, then select **Create GitHub App**. The browser opens GitHub's own page with the App's manifest.
-2. On GitHub, select **Create GitHub App for &lt;you&gt;**. GitHub sends the browser back to the Setup screen, and the service converts the code into the App's key.
-3. Select **Install the App on GitHub**. On GitHub, install the App on the account that owns your repositories and grant it the repositories Curia may work on, then return and select **Try again**.
-4. The card lists every repository the installation covers, all ticked. Untick any Curia shouldn't work on, then select **Watch these repositories**. Curia writes the list into `config/config.yaml` and verifies again.
+The card guides you through three steps and shows which one you're at.
 
-The card connects when it shows **Connected and verified** and the footer names a real ticket that carries `ready-for-agent` and no assignee, or the covered repository with its open-ticket count. A fresh installation watches nothing until you choose here; the shipped `curia.yaml` watch list belongs to the source deployment and never applies to an installation. What the verification proves is in [Connect GitHub](../integration-setup.md#connect-github).
+1. **Create the App.** On the **GitHub** card, keep the suggested App name or enter your own, then select **Create GitHub App**. The browser opens GitHub's own page with the App's manifest. On GitHub, select **Create GitHub App for &lt;you&gt;**. GitHub sends the browser back to the Setup screen, and the service converts the code into the App's key.
+2. **Install the App.** The card reads **Step 2 of 3**. Select **Install the App on GitHub**. On GitHub, install the App on the account that owns your repositories and grant it the repositories Curia may work on, then return to the Setup screen. The panel waits and checks again on the page's refresh interval, so the repositories appear on their own within seconds. There is nothing to press.
+3. **Choose repositories and continue.** The card reads **Step 3 of 3** and lists every repository the installation covers, all ticked. Untick any Curia shouldn't work on, then select **Watch these repositories and continue**. Curia writes the list into `config/config.yaml`, verifies again, and opens the next card.
+
+The card connects when it shows **Connected and verified** and the footer names a real ticket that carries `ready-for-agent` and no assignee, or the covered repository with its open-ticket count. None of the steps is a failure: the red **Action required** state and **Try again** appear only when GitHub refuses the App, a token fails, or a watched repository loses its coverage. A fresh installation watches nothing until you choose here; the shipped `curia.yaml` watch list belongs to the source deployment and never applies to an installation. What the verification proves is in [Connect GitHub](../integration-setup.md#connect-github).
 
 ## Connect Discord
 
 1. In the [Discord developer portal](https://discord.com/developers/applications), select **New Application** and name it. Under **Bot**, turn on **Message Content Intent**, select **Reset Token**, and copy the token. Discord shows it once.
 2. In Discord, turn on **Developer Mode** under **Settings** > **Advanced**, then copy your user ID from your profile menu.
 3. On the **Discord** card, paste the token, enter your user ID, and select **Connect bot**.
-4. Select **Add the bot to a server** and approve it in Discord. The panel waits and checks again on the page's refresh interval, so the server appears on its own within seconds. Until then there is no server to select and no channel field.
-5. Select the server, keep the channel name `curia` or enter another, and select **Connect channel**.
+4. Select **Add the bot to a server** and approve it in Discord. The card reads **Step 2 of 3** while it waits and checks again on the page's refresh interval, so the server appears on its own within seconds. Until then there is no server to select and no channel field, and the wait is a step, not a failure.
+5. Select the server, keep the channel name `curia` or enter another, and select **Connect channel**. The card verifies as part of the same press and shows the result.
+6. Select **Continue**.
 
 The card connects when the footer shows the channel and the server, then `Confirmation delivered · <n> commands registered`, and Curia's confirmation message stands in the channel. The panel says whether the bridge is running. Until the service restarts once after the first connection, the card is verified and the bot doesn't answer yet: select **Restart Curia** in the panel. The details are in [Connect Discord](../integration-setup.md#connect-discord).
 
 ## Connect Tailscale
 
 1. On the **Tailscale** card, read the identity the panel names, `You opened Curia as <login> through Tailscale`. It's the login Tailscale stamped on your request. The panel also names the node and its address, the name `curia install` joined the tailnet under. There is nothing to type: the name was chosen at installation with `--name`, and the card doesn't change it. To change it, reinstall with another `--name`, or run `sudo tailscale set --hostname <name>` on the host and then select **Restart Curia** on the card.
-2. Select **Confirm operator and verify**.
+2. Select **Confirm operator and verify**. The press records the operator and verifies the card in one go, and the panel shows the result.
+3. Select **Continue**.
 
 From that moment the recorded login is the only identity the app and every published surface admit. The card connects when the footer shows the node's MagicDNS name, then `<login> · admitted in <n> ms`. The details are in [Connect Tailscale](../integration-setup.md#connect-tailscale).
 
@@ -66,7 +69,7 @@ To see the same facts on one terminal screen, run `curia doctor`; its `integrati
 
 ## If a card fails
 
-A failed card reads **Action required**, names the check that failed, and gives one corrective action, for example `curia's GitHub App is not installed on alp82` with the install link. Do what the action says, then select **Try again**, which runs every card's verification again. There is no background retry. The failed checks and their actions, card by card, are under [Connect services](troubleshooting.md#connect-services) in Troubleshooting.
+A failed card reads **Action required**, names the check that failed, and gives one corrective action, for example `curia's GitHub App is not installed on alp82` with the install link. Do what the action says, then select **Try again**, which runs every card's verification again. There is no background retry. A card on its way through its steps, GitHub waiting for an installation or Discord waiting for the bot to join a server, isn't failed: it re-reads on its own and offers no **Try again**. The failed checks and their actions, card by card, are under [Connect services](troubleshooting.md#connect-services) in Troubleshooting.
 
 ## Next
 

--- a/docs/operator/integration-setup.md
+++ b/docs/operator/integration-setup.md
@@ -19,11 +19,15 @@ Every card has the same height in every state, so a verification never moves the
 
 The footer never shows a decorative number. Before a card verifies, it names the data that will appear. After, it shows what Curia found.
 
+The GitHub and Discord cards are guides of three steps. While such a card is on its way, its badge counts the step, for example **Step 2 of 3**, and its footer names what the step waits for. An expected state on the way, no App yet, no installation yet, nothing watched yet, the bot in no server yet, is a step with its next action, never the red **Action required** state. That state, and **Try again**, appear on a real failure only: GitHub refused the App, a token failed, a watched repository lost its coverage, Discord refused the token, or the bot lost a permission.
+
 ## Connect GitHub
 
 The GitHub card creates a dedicated GitHub App for this installation through GitHub's manifest flow, then verifies that the App can reach at least one watched repository. Curia never asks for your GitHub password, a personal access token, or anything from GitHub's consent page. You sign in and approve on GitHub.
 
-### Create the App
+The card is a guide of three steps, and the panel shows which one you're at: **1 Create the App**, **2 Install the App**, **3 Choose repositories and continue**. Each step has one action, and the card moves to the next step on its own when the action is done.
+
+### Step 1: Create the App
 
 1. On the **GitHub** card, keep the suggested App name or enter your own. GitHub slugifies the name, and Curia posts as `<slug>[bot]`, so the name is read as the author of every commit, pull request, and gate approval. The name must be free across all of GitHub.
 2. Select **Create GitHub App**. Curia prepares the manifest (the five repository permissions from [The curia GitHub App](../github-app.md#2-grant-the-permissions), no webhook, installable on any account) and the browser opens GitHub's own page with that manifest.
@@ -31,17 +35,17 @@ The GitHub card creates a dedicated GitHub App for this installation through Git
 
 The service converts the code itself. It writes the App id and the private key to `secrets/github-app.json` in the installation root, owner-only, mode `0600`, and adopts the App in the running service. The key is never shown, never logged, and never sent to the browser. If the conversion fails, the card says why, and **Create GitHub App** starts the flow again.
 
-### Install the App
+### Step 2: Install the App
 
-After the App exists, the card offers the installation. On a fresh installation nothing is watched yet, so the card shows one **Install the App on GitHub** link. Install the App on the account that owns your repositories and grant it the repositories Curia may work on. On GitHub, **Only select repositories** is enough. Then select **Try again**.
+After the App exists, the card is at step 2 and the badge reads **Step 2 of 3**. On a fresh installation nothing is watched yet, so the panel shows one **Install the App on GitHub** link. Install the App on the account that owns your repositories and grant it the repositories Curia may work on. On GitHub, **Only select repositories** is enough. There is nothing to press afterwards: the panel says `Waiting for an installation that covers a repository` and reads the installations again on the Setup page's refresh interval (`poll_interval_s`, 5 seconds by default), so the card moves to step 3 within seconds of the installation, with no reload and no press.
 
-Once a repository is on the watch list, the card lists every watched owner instead, each with this read's installation state and an **Install on &lt;owner&gt;** or **Manage installation** link. The state comes from the same verification that turns the card, so an owner the card calls installed is installed on this read.
+Once a repository is on the watch list, the panel lists every watched owner instead, each with this read's installation state and an **Install on &lt;owner&gt;** or **Manage installation** link. The state comes from the same verification that turns the card, so an owner the card calls installed is installed on this read.
 
-### Choose the repositories to watch
+### Step 3: Choose repositories and continue
 
-After the App is installed, the card lists every repository the App's installations cover, each with a checkbox. On a fresh installation every repository is ticked. Untick the ones Curia shouldn't work on, then select **Watch these repositories**. The service writes the ticked repositories into `watch` in [`config/config.yaml`](configuration.md#the-watch-list-is-yours-alone) through the same validated save the settings screen uses, applies the list to the running service, and the card verifies again on the new list.
+When an installation covers at least one repository, the card is at step 3 and the panel lists every repository the App's installations cover, each with a checkbox. On a fresh installation every repository is ticked. Untick the ones Curia shouldn't work on, then select **Watch these repositories and continue**. The service writes the ticked repositories into `watch` in [`config/config.yaml`](configuration.md#the-watch-list-is-yours-alone) through the same validated save the settings screen uses, applies the list to the running service, and the card verifies again on the new list. When that verification connects the card, setup continues to the next card that isn't connected, in rail order. That one press is the whole step.
 
-A connected card keeps the same list under **Change the watched repositories**, with the watched repositories ticked. A watched repository that no installation covers stays on the list and is marked `not covered by an installation`; grant it on GitHub or untick it. A repository can't leave the list while an agent runs on it, and the card says so.
+A connected card keeps the same list under **Change the watched repositories**, with the watched repositories ticked, and the press there is **Watch these repositories**, which verifies again and stays on the card. A watched repository that no installation covers stays on the list and is marked `not covered by an installation`; grant it on GitHub or untick it. A repository can't leave the list while an agent runs on it, and the card says so.
 
 Curia doesn't remember the choice anywhere else. The watch list in `config/config.yaml` is the choice.
 
@@ -51,13 +55,13 @@ Every read of the card runs the same verification:
 
 1. GitHub accepts the App's own credential and lists its installations.
 2. For each installation, Curia mints an installation token with the write permissions agents run on and reads the repositories the installation grants. The token is used for this verification and dropped. It reaches no file and no log.
-3. At least one repository is on the watch list.
+3. At least one repository is on the watch list. With none, the card is at step 2 while no installation covers a repository and at step 3 once one does. Neither is a failure.
 4. At least one watched repository is covered by an installation.
 5. Curia reads the open tickets of the covered repositories with that token.
 
 The card connects when steps 1 to 5 pass. One covered watched repository is enough: a watched owner without an installation is shown as `missing access` in the owner rows and doesn't fail the card while another owner covers a watched repository. The footer shows a real discovered ticket, one that carries `ready-for-agent` and has no assignee, with its repository and the count of open tickets. When there is no such ticket, the footer names the covered repository, the count of open tickets (or `No open tickets`), and what the minted credential can do: `Issues, pull requests, and contents ready`. Curia never invents a ticket.
 
-A failed step names the failure and one action, for example `curia's GitHub App is not installed on alp82` with `Install the App on alp82 from the link in this panel and grant it alp82/curia, then try again.` The failure names only the owners this read found missing. Do what the action says and select **Try again**, which runs the whole verification again. The panel shows the result of the latest read only: a failure from an earlier read disappears when the new read connects the card.
+A failed check is a real failure: GitHub refused the App's credential, a token failed to mint, an installation can't be read, or a watched repository lost its coverage, for example `curia's GitHub App is not installed on alp82` with `Install the App on alp82 from the link in this panel and grant it alp82/curia, then try again.` The failure names only the owners this read found missing. The panel keeps the guide at the step the failure belongs to, so the install link or the repository list stays at hand beside the failure. Do what the action says and select **Try again**, which runs the whole verification again. The panel shows the result of the latest read only: a failure from an earlier read disappears when the new read connects the card.
 
 The card remembers only the App name (`progress.github.app_name`) for a reopen. The App id and key live in `secrets/github-app.json` and nowhere else.
 
@@ -65,7 +69,7 @@ The card remembers only the App name (`progress.github.app_name`) for a reopen. 
 
 The Discord card connects a dedicated bot you create in Discord's developer portal, then finds or creates the command channel Curia speaks in. You paste the bot token once. Curia writes it to `secrets/discord-bot-token` in the installation root, owner-only, mode `0600`, and never shows it again.
 
-The flow has three parts, in this order: the token, a wait until the bot is in a server, and the channel. Nothing is created in Discord until you select **Connect channel**.
+The card is a guide of three steps, in this order: the token, a wait until the bot is in a server, and the channel. Nothing is created in Discord until you select **Connect channel**. Two presses connect the card, **Connect bot** and **Connect channel**. Each press verifies on its own, and the one press left after the card connects is **Continue**.
 
 ### Create the bot
 
@@ -79,7 +83,7 @@ The token goes to the service and straight into its secret file. The user ID goe
 
 ### Add the bot to a server
 
-Until the bot is in at least one server, the panel says `Waiting for the bot to join a server` and shows only the invite link. There is no server to select and no channel to name yet, so the panel offers neither field.
+Until the bot is in at least one server, the card is at step 2, the badge reads **Step 2 of 3**, and the panel says `Waiting for the bot to join a server` and shows only the invite link. There is no server to select and no channel to name yet, so the panel offers neither field. The wait is a step of the guide, not a failure: the card stays plain and offers no **Try again**.
 
 1. Select **Add the bot to a server**. The link opens Discord's own authorization page with the `bot` and `applications.commands` scopes and the permissions Curia uses: View Channel, Send Messages, Embed Links, Attach Files, Read Message History, Create Public Threads, Send Messages in Threads, Manage Threads, and Manage Channels.
 2. Approve it in Discord.
@@ -92,7 +96,9 @@ While the panel waits, it reads the bot's servers again on the Setup page's refr
 2. Enter the command channel's name. The field suggests `curia`, but any name works, and you can change it before anything exists.
 3. Select **Connect channel**.
 
-**Connect channel** writes the server and the channel name to `state/discord.json`, then reuses a top-level text channel of that name when there is one and creates one when there is none, and registers Curia's slash commands on that server once. This press is the only step that creates anything in Discord: a verification read, whether on arrival, on the refresh, or on **Try again**, never picks a server for you, never creates a channel, and never registers the commands. A channel of that name under a category isn't the one, because the bridge opens only top-level channels. When Discord refuses the creation, the panel says why under the button, keeps your choice, and names the fix: give the bot Manage Channels, or create the text channel yourself, then select **Connect channel** again.
+The card is at step 3 while a server is there and none is chosen; the badge reads **Step 3 of 3**.
+
+**Connect channel** writes the server and the channel name to `state/discord.json`, then reuses a top-level text channel of that name when there is one and creates one when there is none, and registers Curia's slash commands on that server once. The card verifies fresh as part of the same press and shows the result: the connected state with **Continue**, or the failure with its action. This press is the only step that creates anything in Discord: a verification read, whether on arrival, on the refresh, or on **Try again**, never picks a server for you, never creates a channel, and never registers the commands. A channel of that name under a category isn't the one, because the bridge opens only top-level channels. When Discord refuses the creation, the panel says why under the button, keeps your choice, and names the fix: give the bot Manage Channels, or create the text channel yourself, then select **Connect channel** again.
 
 ### What verification proves
 
@@ -114,7 +120,7 @@ The card connects when steps 1 to 9 pass. The footer shows the channel and the s
 
 Curia looks for its own earlier confirmation before posting another, so opening **Setup** doesn't fill the channel with repeated lines. To get a fresh confirmation, delete the earlier one and select **Try again**.
 
-A failed step names the failure and one action, for example `curia can't Send Messages in #curia` with `Allow Send Messages for the bot in #curia's permissions, then try again.` Do what the action says and select **Try again**. When Discord refuses the token, the panel puts the token form first so you can submit a new one. Before you select a server, the card reads `No server is selected for <bot>`, and the action is the server and the channel in this panel.
+A failed step names the failure and one action, for example `curia can't Send Messages in #curia` with `Allow Send Messages for the bot in #curia's permissions, then try again.` Do what the action says and select **Try again**. When Discord refuses the token, the panel puts the token form first so you can submit a new one. The bot in no server yet and no server chosen yet are steps 2 and 3 of the guide, not failures.
 
 When the registered commands differ from Curia's, for example after an update that added a command or when another tool replaced them, the card reads `The commands registered in <server> differ from curia's: /tickets is not registered`, and the panel offers **Register commands**. That press registers the current manifest on the selected server, replacing what's there, and verifies fresh. The invite link is the fix only when Discord refuses the registration itself, which means the bot was added without the `applications.commands` scope.
 
@@ -140,7 +146,7 @@ On a fresh installation, no operator is recorded, so the app admits the first ta
 
 1. Open the Curia app at the address `curia install` printed, `https://<node>:8445/`, through Tailscale. A request on loopback carries no identity and can't confirm anything.
 2. On the **Tailscale** card, check the identity the panel names. It is the login Tailscale stamped on your request, and the browser can't change it. The panel also names the node and its address as facts. The name was chosen at installation with `--name`, and the card doesn't change it. To change it, reinstall with another `--name`, or run `sudo tailscale set --hostname <name>` on the host and then select **Restart Curia** on the card; the app is served under the name the sidecar read when it started. See [The tailnet step](install.md#the-tailnet-step).
-3. Select **Confirm operator and verify**.
+3. Select **Confirm operator and verify**. That one press records the operator and verifies the card. The panel then shows the result, the connected state with **Continue** or the failure with its action, and asks for nothing else.
 
 Curia records the login, when it was confirmed, and the node's machine name, read from the node, in `state/tailscale.json` in the installation root, mode `0600`. From that moment the recorded login is the whole identity allowlist under an installation root, for the service and the app alike, with no restart. The `identity.allow` list in `curia.yaml` belongs to the source deployment and admits nobody under an installation root.
 
@@ -157,7 +163,7 @@ Every read of the card runs the same verification, in this order:
 
 The card connects when steps 1 to 6 pass. The footer shows the private MagicDNS name, then `<login> · admitted in <n> ms`. The panel shows the private address as a link, the operator and when you confirmed, the node's addresses and Tailscale version, the Serve route, and when the operator last arrived through Tailscale since the service started.
 
-A failed step names the failure and one action, for example `The tailnet issues no HTTPS certificate for this node, so Serve can't publish the Curia app` with `Enable HTTPS certificates under DNS in the Tailscale admin console at https://login.tailscale.com/admin/dns, then try again.` Do what the action says and select **Try again**. The following table lists the checks and their actions.
+A failed step names the failure and one action, for example `The tailnet issues no HTTPS certificate for this node, so Serve can't publish the Curia app` with `Enable HTTPS certificates under DNS in the Tailscale admin console at https://login.tailscale.com/admin/dns, then try again.` Do what the action says and select **Try again**. While you are the recorded operator, **Try again** is the one press on a failed card: confirming the same identity again would only repeat that read. When you open the card as another identity, the panel says who the recorded operator is and offers **Confirm &lt;login&gt; as the operator**, which is a real change. The following table lists the checks and their actions.
 
 | Failed check | Action |
 |---|---|
@@ -294,16 +300,19 @@ The rail's count, `n/4 verified`, and the Home pointer read the same fresh resul
 
 A failed card names the verification that failed and exactly one corrective action, on the card and in the configuration panel. Do what the action says, then select **Try again**. **Try again** runs the verification again for every card. There is no background retry.
 
+A card on its way through its steps isn't failed. The GitHub card waiting for an installation and the Discord card waiting for the bot to join a server re-read on their own and offer no **Try again**, because the read they'd take is the one the panel already takes.
+
 While Curia can't reach the service at all, **Setup** says so instead of showing four unconnected cards, and offers **Try again**.
 
 ## What you see while Curia works
 
-Every action on a card, **Confirm operator and verify**, **Connect bot**, **Connect channel**, **Sign in**, **Submit** for a code, **Watch these repositories**, **Restart Curia**, and **Try again**, switches the card and its panel to an in-progress state the moment you select it. The card's badge reads **Working**, its footer names what Curia is doing (`Verifying the operator`, `Registering commands and posting the confirmation`, `Completing one minimal model request and applying the routing preset`), and the panel shows the same sentence over a thin moving line. Nothing that stood before stays: not the sign-in steps and not a previous failure. The state lasts until the next read for that card lands. A read that fails shows the failure and its action. A read that connects shows the connected state. A write the service refuses shows the refusal beside the form.
+Every action on a card, **Confirm operator and verify**, **Connect bot**, **Connect channel**, **Sign in**, **Submit** for a code, **Watch these repositories and continue**, **Restart Curia**, and **Try again**, switches the card and its panel to an in-progress state the moment you select it. The card's badge reads **Working**, its footer names what Curia is doing (`Verifying the operator`, `Registering commands and posting the confirmation`, `Completing one minimal model request and applying the routing preset`), and the panel shows the same sentence over a thin moving line. Nothing that stood before stays: not the sign-in steps and not a previous failure. The state lasts until the next read for that card lands. A read that fails shows the failure and its action. A read that connects shows the connected state. A write the service refuses shows the refusal beside the form.
 
 ## Moving through setup
 
-- After a card connects, **Continue setup** opens the next card that isn't connected, in rail order.
-- When GitHub, Discord, Tailscale, and at least one model provider are connected on the current read, the action becomes **Run Full loop**. Nothing else turns it: not the count on the rail, and not a saved result.
+- Every write on a card verifies the card on its own. There is no separate check to press: after **Connect bot**, **Connect channel**, **Confirm operator and verify**, or **Watch these repositories and continue**, the panel shows the result of that verification.
+- A connected panel has one press, **Continue**. It opens the next card that isn't connected, in rail order. When every card is connected, **Continue** opens the Full loop panel. A connected card you reopen shows its facts and the same **Continue**.
+- When GitHub, Discord, Tailscale, and at least one model provider are connected on the current read, the action under the rail becomes **Run Full loop**. Nothing else turns it: not the count on the rail, and not a saved result.
 - **Close setup** returns to Home. Closing the tab does the same.
 
 ## The Full loop


### PR DESCRIPTION
The live rehearsal of the packaged Curia lifecycle (#891, map #863) on 0.9.1 found two defects in the setup flow. This pull request fixes both on the GitHub, Discord, and Tailscale cards and in the shared card frame.

## What the operator found

- **GitHub:** "works but the flow is bad. it should be 3 guided steps: 1. create the app 2. install the app 3. continue setup (should be the watch these repositories selection step + continue setup combined). otherwise the try again just doesn't work and always shows error state which should only happen on real errors, not expected ones."
- **Discord and Tailscale:** "i had to click multiple times where less clicks could have been sufficient (like check -> continue, but check could be implicit and then just needs a continue click)."

## What changed

- **The GitHub card is a guide of three steps** with a step indicator: **1 Create the App** (the manifest handoff), **2 Install the App** (the install link per watched owner or the App's own, re-reading the frame on the page's refresh interval until an installation covers a repository, like the Discord wait from #939), **3 Choose repositories and continue** (every covered repository ticked and one press, **Watch these repositories and continue**, which writes the watch list, verifies, and selects the next unconnected card). The verifier in `daemon/src/githubsetup.mjs` answers the expected states, no App, no installation, nothing watched, as `{ unconnected }` with `detail.step`, so the frame draws them plain: the rail badge reads **Step n of 3** and the footer names what the step waits for. The red failure state and **Try again** are for real failures only: GitHub refused the App, a token failed to mint, an installation can't be read, or a watched repository lost its coverage. A failed card keeps the guide at the step the failure belongs to, so the action stays at hand.
- **Discord and Tailscale verify implicitly.** The Discord verifier answers the bot in no server and no server chosen as plain steps with `detail.stage`, so the wait is never red and offers no **Try again**. Every write, **Connect bot**, **Connect channel**, **Confirm operator and verify**, verifies on its own and shows the result. A failed Tailscale card offers **Try again** alone while the requester is the recorded operator, because confirming the same identity again would only repeat that read; another identity keeps **Confirm &lt;login&gt; as the operator**, which is a real write.
- **The shared frame has one Continue per connected panel.** It selects the next unconnected card, or the run panel once every card is connected. A connected card the operator reopens shows its facts and **Continue**. The run's own presses live on the run panel.

## Presses left per card

- GitHub: **Create GitHub App**, then **Watch these repositories and continue**.
- Discord: **Connect bot**, **Connect channel**, then **Continue**.
- Tailscale: **Confirm operator and verify**, then **Continue**.

## Tests and docs

- `daemon/test/dashboardpage.test.mjs`: the three GitHub steps and their transitions (the step-2 wait and the step-3 press that continues), no failure state for an expected step, a real failure keeping the red state, the Discord wait as a plain step, implicit verification plus **Continue** on Discord and Tailscale, and **Continue** opening the run when every card is connected. `daemon/test/githubsetup.test.mjs` and `daemon/test/discordsetup.test.mjs` pin the verifiers' plain answers.
- `docs/operator/integration-setup.md` and `docs/operator/guide/03-connect-services.md` follow the new flow.
- `cd cli && npm test`: 401 pass, 0 fail. `cd daemon && npm test`: 4452 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
