### PR TITLE
fix: ask for every permission the Discord bot needs in one invite

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -5452,7 +5452,7 @@ function setupDiscordCommandsForm() {
 function setupDiscordWait(d, detail) {
   const invite = d?.invite_url || detail?.invite_url;
   const every = payload?.poll_interval_s ?? 5;
-  return `<p class="qhint">Waiting for the bot to join a server. ${invite ? `<a href="${esc(invite)}" target="_blank" rel="noopener">Add the bot to your server</a> and approve it in Discord.` : ""}
+  return `<p class="qhint">Waiting for the bot to join a server. ${invite ? `<a href="${esc(invite)}" target="_blank" rel="noopener">Add the bot to your server</a> and approve it in Discord. The link asks for every permission Curia uses in the command channel, Manage Webhooks among them, which is what speaker identity needs. Approve them all.` : ""}
     Curia checks again every ${esc(every)} seconds while this panel is open, and the server appears here on its own.</p>`;
 }
 

--- a/daemon/src/bridge.mjs
+++ b/daemon/src/bridge.mjs
@@ -318,6 +318,45 @@ export function interruptedReceipt(content, { by, session, graceMs }) {
 // interpretation. `tickets` renames `frontier` on the command surface.
 // Exported for the Discord card of integration setup (#876), which registers
 // the same manifest over REST before the bridge has started.
+// Every permission the bridge and the agents use in the command channel and
+// its threads, by Discord's bit and with the reason. One list (#891): the
+// Setup card's invite link asks for these, the card's verification checks
+// them in the channel, and `probePermissions` checks them at start, so the
+// three cannot drift. `scope: 'server'` marks a permission the bridge needs
+// once on the server, to create the channel, and not in the channel.
+const bit = (n) => 1n << BigInt(n)
+export const BOT_PERMISSIONS = Object.freeze([
+  { name: 'View Channel', bit: bit(10), why: 'read the command channel' },
+  { name: 'Send Messages', bit: bit(11), why: 'post in the command channel' },
+  { name: 'Send Messages in Threads', bit: bit(38), why: 'post in ticket threads' },
+  { name: 'Create Public Threads', bit: bit(35), why: 'open a thread per ticket' },
+  { name: 'Manage Threads', bit: bit(34), why: 'rename, archive, and delete ticket threads' },
+  { name: 'Embed Links', bit: bit(14), why: 'post escalation embeds and links' },
+  { name: 'Attach Files', bit: bit(15), why: 'attach files and images' },
+  { name: 'Read Message History', bit: bit(16), why: 'find earlier messages and its own confirmation' },
+  { name: 'Add Reactions', bit: bit(6), why: 'mark a message as read or refused' },
+  { name: 'Use Application Commands', bit: bit(31), why: 'serve the slash commands' },
+  { name: 'Manage Webhooks', bit: bit(29), why: 'speaker identity: agent prose posts under the curia name' },
+  { name: 'Manage Channels', bit: bit(4), why: 'create the command channel when it does not exist', scope: 'server' },
+].map(Object.freeze))
+
+// The permissions the bot must hold in the channel itself.
+export const CHANNEL_PERMISSIONS = Object.freeze(BOT_PERMISSIONS.filter((p) => p.scope !== 'server'))
+
+const listNames = (items, word = 'and') => {
+  if (items.length <= 1) return items.join('')
+  if (items.length === 2) return `${items[0]} ${word} ${items[1]}`
+  return `${items.slice(0, -1).join(', ')}, ${word} ${items[items.length - 1]}`
+}
+
+// One sentence per missing permission that has a reason worth naming, and
+// the grant. Shared by the card's verification and the bridge's start.
+export function permissionsAction(missing, channelName) {
+  const reasons = CHANNEL_PERMISSIONS.filter((p) => missing.includes(p.name) && p.name === 'Manage Webhooks')
+    .map((p) => `${p.name} is for ${p.why}.`)
+  return `Allow ${listNames(missing)} for the bot in #${channelName}'s permissions, then try again.${reasons.length ? ` ${reasons.join(' ')}` : ''}`
+}
+
 export const SLASH_MANIFEST = [
   new SlashCommandBuilder().setName('tickets').setDescription('List takeable tickets')
     .addStringOption((o) => o.setName('repo').setDescription('Limit to one repo (any unambiguous part of the name)')),
@@ -521,6 +560,7 @@ export class DiscordBridge {
     // Agent prose transport: `ok` is null until the start probe answers.
     this.speakers = { ok: null, reason: null }
     this.speakerNoticed = false
+    this.permissions = { ok: null, missing: [] }
     this.client = new Client({
       intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
     })
@@ -563,8 +603,9 @@ export class DiscordBridge {
     this.#watchGateway()
     this.#setHealth('up', { reason: 'ready' })
     this.log(`[bridge] ready: guild=${this.guild.name} channel=#${this.channel.name}`)
-    // Last, and after health is up: the probe announces in the channel, which
-    // needs a bridge that works. It never fails a start.
+    // Last, and after health is up: the probes announce in the channel, which
+    // needs a bridge that works. They never fail a start.
+    await this.probePermissions()
     await this.probeSpeakers()
   }
 
@@ -621,6 +662,7 @@ export class DiscordBridge {
       last_error: this.health.last_error,
       // #143: the channel says it once, `/state` says it whenever asked.
       speakers: this.speakers,
+      permissions: this.permissions,
     }
   }
 
@@ -1323,6 +1365,33 @@ export class DiscordBridge {
     } catch (e) {
       await this.#speakerFault(e)
     }
+  }
+
+  // The whole list at start (#891), from the channel's own view of the bot.
+  // A missing permission is named with the grant; Manage Webhooks among them
+  // also latches the speaker notice, so the speaker probe that follows does
+  // not say it a second time. A channel that cannot be asked is unknown, not
+  // a failure. Public because `start()` needs a live gateway and the tests
+  // do not.
+  static PERMISSIONS = BOT_PERMISSIONS
+
+  async probePermissions() {
+    const held = this.channel?.permissionsFor?.(this.client?.user)
+    if (!held) {
+      this.permissions = { ok: null, missing: [] }
+      return
+    }
+    const missing = CHANNEL_PERMISSIONS.filter((p) => !held.has(p.bit)).map((p) => p.name)
+    this.permissions = { ok: missing.length === 0, missing }
+    if (!missing.length) return
+    const notice = DiscordBridge.permissionsNotice(missing, this.channel.name)
+    this.log(`[bridge] ${notice}`)
+    if (missing.includes('Manage Webhooks')) this.speakerNoticed = true
+    await this.announce(notice).catch((err) => this.log(`permission notice failed: ${err.message}`))
+  }
+
+  static permissionsNotice(missing, channelName) {
+    return `⚠️ curia lacks ${listNames(missing)} in #${channelName}. ${permissionsAction(missing, channelName)}`
   }
 
   // One notice per bridge instance, either way. The probe carries the usual

--- a/daemon/src/discordsetup.mjs
+++ b/daemon/src/discordsetup.mjs
@@ -56,7 +56,7 @@ import { readSecret, writeSecret, secretPath, redact, SecretError } from '../../
 import {
   readDiscordSettings, writeDiscordSettings, discordSettingsFromEnv, discordSettingsPath, DEFAULT_CHANNEL,
 } from './discordsettings.mjs'
-import { SLASH_MANIFEST } from './bridge.mjs'
+import { SLASH_MANIFEST, BOT_PERMISSIONS, CHANNEL_PERMISSIONS, permissionsAction } from './bridge.mjs'
 
 export const DISCORD_API = 'https://discord.com/api/v10'
 
@@ -71,23 +71,12 @@ const TOKEN_RE = /^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{20,}$/
 const SNOWFLAKE = /^[0-9]{5,25}$/
 const CHANNEL_NAME = /^[a-z0-9][a-z0-9_-]{0,99}$/
 
-// The permissions the bridge uses in the command channel, by Discord's bit.
-// The invite link asks for these plus Manage Channels, which is what
-// creating the channel takes when it does not exist.
-const bit = (n) => 1n << BigInt(n)
-export const CHANNEL_PERMISSIONS = Object.freeze([
-  Object.freeze({ name: 'View Channel', bit: bit(10) }),
-  Object.freeze({ name: 'Send Messages', bit: bit(11) }),
-  Object.freeze({ name: 'Embed Links', bit: bit(14) }),
-  Object.freeze({ name: 'Attach Files', bit: bit(15) }),
-  Object.freeze({ name: 'Read Message History', bit: bit(16) }),
-  Object.freeze({ name: 'Manage Threads', bit: bit(34) }),
-  Object.freeze({ name: 'Create Public Threads', bit: bit(35) }),
-  Object.freeze({ name: 'Send Messages in Threads', bit: bit(38) }),
-])
-const MANAGE_CHANNELS = bit(4)
-const ADMINISTRATOR = bit(3)
-export const INVITE_PERMISSIONS = CHANNEL_PERMISSIONS.reduce((bits, p) => bits | p.bit, 0n) | MANAGE_CHANNELS
+// The permissions the bot needs, by Discord's bit: the bridge's own list
+// (#891), so the invite link, this card's verification, and the bridge's
+// start check one set. The invite link asks for every one of them.
+export { BOT_PERMISSIONS, CHANNEL_PERMISSIONS }
+const ADMINISTRATOR = 1n << 3n
+export const INVITE_PERMISSIONS = BOT_PERMISSIONS.reduce((bits, p) => bits | p.bit, 0n)
 export const inviteUrl = (appId) => `https://discord.com/oauth2/authorize?client_id=${appId}&scope=bot%20applications.commands&permissions=${INVITE_PERMISSIONS}`
 
 const GUILD_TEXT = 0
@@ -489,7 +478,7 @@ export class DiscordSetup {
     const held = channelPermissions({ base: row.permissions, overwrites: channel.permission_overwrites ?? [], roles, botId: bot.id, guildId: guild.id })
     const missing = CHANNEL_PERMISSIONS.filter((p) => !(held & p.bit)).map((p) => p.name)
     if (missing.length) {
-      return fail('authority', `curia can't ${list(missing, 'or')} in #${channelFacts.name}`, `Allow ${list(missing)} for the bot in #${channelFacts.name}'s permissions, then try again.`, facts)
+      return fail('authority', `curia can't ${list(missing, 'or')} in #${channelFacts.name}`, permissionsAction(missing, channelFacts.name), facts)
     }
 
     // The commands: read, never registered here (#891). Connect channel and

--- a/daemon/test/discordsetup.test.mjs
+++ b/daemon/test/discordsetup.test.mjs
@@ -19,7 +19,9 @@ import path from 'node:path'
 
 import { writeSecret, readSecret } from '../../cli/src/secrets.mjs'
 import { writeDiscordSettings, readDiscordSettings } from '../src/discordsettings.mjs'
-import { DiscordSetup, CONFIRMATION_MARK, CHANNEL_PERMISSIONS, channelPermissions } from '../src/discordsetup.mjs'
+import { DiscordSetup, CONFIRMATION_MARK, BOT_PERMISSIONS, CHANNEL_PERMISSIONS, INVITE_PERMISSIONS, inviteUrl, channelPermissions } from '../src/discordsetup.mjs'
+import { DiscordBridge } from '../src/bridge.mjs'
+import { lintReply } from '../src/messaging.mjs'
 import { SLASH_MANIFEST } from '../src/bridge.mjs'
 
 const TOKEN = 'MTIzNDU2Nzg5MDEyMzQ1Njc4.GaBcDe.this-token-must-never-be-shown-anywhere-1234'
@@ -47,8 +49,8 @@ function discord(routes) {
 }
 
 // Guild-level permissions the bot holds in the fake server: everything the
-// channel needs plus Manage Channels, as the invite link asks for.
-const ALL = String(CHANNEL_PERMISSIONS.reduce((bits, p) => bits | p.bit, 0n) | (1n << 4n))
+// invite link asks for.
+const ALL = String(INVITE_PERMISSIONS)
 
 const guildRow = (over = {}) => ({ id: GUILD, name: 'Alp\'s workshop', permissions: ALL, ...over })
 const textChannel = (over = {}) => ({ id: CHANNEL, type: 0, name: 'curia', parent_id: null, permission_overwrites: [], ...over })
@@ -482,6 +484,41 @@ describe('the Discord card (#876)', () => {
   })
 
   describe('channel authority', () => {
+    // The bits are Discord's own, from its permissions table. The invite link
+    // asks for every one of them, so the bot added through the card holds
+    // what the bridge and the agents use in the channel and its threads.
+    test('the invite link asks for every permission the bot needs, in one bitfield (#891)', () => {
+      assert.deepEqual(BOT_PERMISSIONS.map((p) => p.name), [
+        'View Channel', 'Send Messages', 'Send Messages in Threads', 'Create Public Threads', 'Manage Threads',
+        'Embed Links', 'Attach Files', 'Read Message History', 'Add Reactions', 'Use Application Commands',
+        'Manage Webhooks', 'Manage Channels',
+      ])
+      assert.equal(INVITE_PERMISSIONS, 329101986896n)
+      assert.equal(inviteUrl(APP), `https://discord.com/oauth2/authorize?client_id=${APP}&scope=bot%20applications.commands&permissions=329101986896`)
+      for (const p of BOT_PERMISSIONS) assert.ok(INVITE_PERMISSIONS & p.bit, `${p.name} is in the invite`)
+    })
+
+    test('the list the card verifies is the list the bridge checks at start', () => {
+      assert.equal(BOT_PERMISSIONS, DiscordBridge.PERMISSIONS)
+      const channelNames = CHANNEL_PERMISSIONS.map((p) => p.name)
+      assert.ok(channelNames.includes('Manage Webhooks'))
+      assert.ok(!channelNames.includes('Manage Channels'), 'creating the channel is the server-level need, not a channel one')
+    })
+
+    test('a channel that denies Manage Webhooks fails on authority, with speaker identity as the reason and the grant as the action (#891)', async () => {
+      connected()
+      const { verify } = setupOver(happy({
+        [`/guilds/${GUILD}/channels`]: [200, [textChannel({ permission_overwrites: [{ id: GUILD, type: 0, allow: '0', deny: String(1n << 29n) }] })]],
+      }))
+      const answer = await verify({ progress: {} })
+      assert.equal(answer.ok, false)
+      assert.equal(answer.detail.stage, 'authority')
+      assert.match(answer.failed, /can't Manage Webhooks in #curia/)
+      assert.match(answer.action, /Allow Manage Webhooks for the bot in #curia's permissions/)
+      assert.match(answer.action, /Manage Webhooks .*speaker identity/i)
+      assert.deepEqual(lintReply(answer.action), [])
+    })
+
     test('is computed the way Discord computes it: base, then @everyone, then roles, then the member, and Administrator is everything', () => {
       const send = 1n << 11n
       const view = 1n << 10n

--- a/daemon/test/speakers.test.mjs
+++ b/daemon/test/speakers.test.mjs
@@ -127,6 +127,49 @@ describe('speaker-identity degradation (#143)', () => {
     assert.match(announced[2], /Speaker identity is off/)
   })
 
+  // #891: the bot added through the Setup card's own invite link lacked
+  // Manage Webhooks, and the first word of it was the speaker notice. The
+  // bridge now checks the whole list at start, names every missing
+  // permission with the action, and the speaker probe does not say the
+  // same thing twice.
+  describe('the startup permission check (#891)', () => {
+    const grant = (...missing) => {
+      const denied = new Set(missing)
+      bridge.channel.name = 'curia'
+      bridge.channel.permissionsFor = () => ({ has: (bit) => !DiscordBridge.PERMISSIONS.some((p) => p.bit === bit && denied.has(p.name)) })
+    }
+
+    test('names every missing permission once, with the grant as the action, and the speaker probe does not repeat it', async () => {
+      grant('Manage Webhooks', 'Add Reactions')
+      webhookFault = missingPermissions()
+      await bridge.probePermissions()
+      await bridge.probeSpeakers()
+
+      assert.equal(announced.length, 1)
+      assert.match(announced[0], /lacks Add Reactions and Manage Webhooks in #curia/)
+      assert.match(announced[0], /Manage Webhooks .*speaker identity/i)
+      assert.match(announced[0], /Allow Add Reactions and Manage Webhooks for the bot in #curia/)
+      assert.deepEqual(lintReply(announced[0]), [])
+      assert.deepEqual(bridge.status().permissions, { ok: false, missing: ['Add Reactions', 'Manage Webhooks'] })
+      assert.equal(bridge.status().speakers.ok, false)
+    })
+
+    test('a bot that holds everything announces nothing', async () => {
+      grant()
+      await bridge.probePermissions()
+      await bridge.probeSpeakers()
+      assert.deepEqual(announced, [])
+      assert.deepEqual(bridge.status().permissions, { ok: true, missing: [] })
+    })
+
+    test('a channel that cannot be asked is not a failure', async () => {
+      bridge.channel.permissionsFor = () => null
+      await bridge.probePermissions()
+      assert.deepEqual(announced, [])
+      assert.deepEqual(bridge.status().permissions, { ok: null, missing: [] })
+    })
+  })
+
   test('a webhook that fails for another reason is announced with its own words', async () => {
     webhookFault = new Error('503 Service Unavailable')
     await bridge.probeSpeakers()

--- a/docs/operator/guide/03-connect-services.md
+++ b/docs/operator/guide/03-connect-services.md
@@ -38,7 +38,7 @@ The card connects when it shows **Connected and verified** and the footer names 
 1. In the [Discord developer portal](https://discord.com/developers/applications), select **New Application** and name it. Under **Bot**, turn on **Message Content Intent**, select **Reset Token**, and copy the token. Discord shows it once.
 2. In Discord, turn on **Developer Mode** under **Settings** > **Advanced**, then copy your user ID from your profile menu.
 3. On the **Discord** card, paste the token, enter your user ID, and select **Connect bot**.
-4. Select **Add the bot to a server** and approve it in Discord. The card reads **Step 2 of 3** while it waits and checks again on the page's refresh interval, so the server appears on its own within seconds. Until then there is no server to select and no channel field, and the wait is a step, not a failure.
+4. Select **Add the bot to a server** and approve it in Discord with every permission the link asks for. They are the ones Curia uses in the command channel and its threads: posting, threads, embeds, files, history, reactions, slash commands, Manage Webhooks for speaker identity (agent prose under the curia name), and Manage Channels to create the channel. The full table is under [Add the bot to a server](../integration-setup.md#add-the-bot-to-a-server). The card reads **Step 2 of 3** while it waits and checks again on the page's refresh interval, so the server appears on its own within seconds. Until then there is no server to select and no channel field, and the wait is a step, not a failure.
 5. Select the server, keep the channel name `curia` or enter another, and select **Connect channel**. The card verifies as part of the same press and shows the result.
 6. Select **Continue**.
 

--- a/docs/operator/integration-setup.md
+++ b/docs/operator/integration-setup.md
@@ -85,8 +85,25 @@ The token goes to the service and straight into its secret file. The user ID goe
 
 Until the bot is in at least one server, the card is at step 2, the badge reads **Step 2 of 3**, and the panel says `Waiting for the bot to join a server` and shows only the invite link. There is no server to select and no channel to name yet, so the panel offers neither field. The wait is a step of the guide, not a failure: the card stays plain and offers no **Try again**.
 
-1. Select **Add the bot to a server**. The link opens Discord's own authorization page with the `bot` and `applications.commands` scopes and the permissions Curia uses: View Channel, Send Messages, Embed Links, Attach Files, Read Message History, Create Public Threads, Send Messages in Threads, Manage Threads, and Manage Channels.
-2. Approve it in Discord.
+1. Select **Add the bot to a server**. The link opens Discord's own authorization page with the `bot` and `applications.commands` scopes and every permission Curia uses.
+2. Approve it in Discord, with all of the permissions. The following table names each one and why the bot needs it.
+
+| Permission | Why the bot needs it |
+| --- | --- |
+| View Channel | Read the command channel. |
+| Send Messages | Post in the command channel. |
+| Send Messages in Threads | Post in ticket threads. |
+| Create Public Threads | Open a thread per ticket. |
+| Manage Threads | Rename, archive, and delete ticket threads. |
+| Embed Links | Post escalation embeds and links. |
+| Attach Files | Attach files and images. |
+| Read Message History | Find earlier messages and its own confirmation. |
+| Add Reactions | Mark a message as read or refused. |
+| Use Application Commands | Serve the slash commands. |
+| Manage Webhooks | Speaker identity: agent prose posts under the curia name through a channel webhook. Without it, the bridge posts `Speaker identity is off` and agent prose uses the bot identity. |
+| Manage Channels | Create the command channel when it does not exist. Needed on the server, not in the channel. |
+
+The invite link, the card's channel verification, and the bridge's own check at start read one list, `BOT_PERMISSIONS` in `daemon/src/bridge.mjs`, so a permission the bridge starts to use is asked for by the invite and checked by the card in the same change. The #891 rehearsal found an invite that omitted Manage Webhooks: the card connected, and the first word of the gap was the bridge's notice in the channel.
 
 While the panel waits, it reads the bot's servers again on the Setup page's refresh interval (`poll_interval_s`, 5 seconds by default), so the server appears within seconds of the approval, with no reload and no press. The moment a server is there, the card verifies fresh and the panel shows the server select and the channel field.
 
@@ -110,7 +127,7 @@ Every read of the card runs the same verification, in this order:
 4. The bot is in at least one server, and you selected one of them.
 5. Your user ID is a member of that server.
 6. The command channel exists top-level as a text channel. Verification never creates it; **Connect channel** does.
-7. In that channel, the bot holds every permission the bridge uses.
+7. In that channel, the bot holds every permission the bridge uses: the table under [Add the bot to a server](#add-the-bot-to-a-server), Manage Channels aside.
 8. The slash commands registered on that server match Curia's, by name and description. Verification reads them and never registers them; **Connect channel** and the bridge's start do, and **Register commands** does it again.
 9. A confirmation message from Curia stands in the channel. Curia posts one when none is there.
 
@@ -120,7 +137,7 @@ The card connects when steps 1 to 9 pass. The footer shows the channel and the s
 
 Curia looks for its own earlier confirmation before posting another, so opening **Setup** doesn't fill the channel with repeated lines. To get a fresh confirmation, delete the earlier one and select **Try again**.
 
-A failed step names the failure and one action, for example `curia can't Send Messages in #curia` with `Allow Send Messages for the bot in #curia's permissions, then try again.` Do what the action says and select **Try again**. When Discord refuses the token, the panel puts the token form first so you can submit a new one. The bot in no server yet and no server chosen yet are steps 2 and 3 of the guide, not failures.
+A failed step names the failure and one action, for example `curia can't Send Messages in #curia` with `Allow Send Messages for the bot in #curia's permissions, then try again.` When Manage Webhooks is what's missing, the action says that it is for speaker identity. Do what the action says and select **Try again**. The bridge runs the same check when it starts and posts the same words in the channel when a permission was withdrawn after the card connected. When Discord refuses the token, the panel puts the token form first so you can submit a new one. The bot in no server yet and no server chosen yet are steps 2 and 3 of the guide, not failures.
 
 When the registered commands differ from Curia's, for example after an update that added a command or when another tool replaced them, the card reads `The commands registered in <server> differ from curia's: /tickets is not registered`, and the panel offers **Register commands**. That press registers the current manifest on the selected server, replacing what's there, and verifies fresh. The invite link is the fix only when Discord refuses the registration itself, which means the bot was added without the `applications.commands` scope.
 


### PR DESCRIPTION
## The defect

In the #891 rehearsal of the packaged lifecycle, the operator added the bot through the Discord card's own **Add the bot to a server** link and connected the channel. The bridge then posted in the channel: `Speaker identity is off: the bot lacks Manage Webhooks on this channel`. The invite link's `permissions=` bitfield omitted Manage Webhooks, and the card's channel verification didn't check for it, so the card reported a connected channel that the bridge couldn't use in full.

## The fix

One exported list, `BOT_PERMISSIONS` in `daemon/src/bridge.mjs`, now names every permission the bridge and the agents use in the command channel and its threads, with the reason for each. Three readers share it:

- The invite link's bitfield (`INVITE_PERMISSIONS`, `inviteUrl` in `daemon/src/discordsetup.mjs`).
- The card's channel verification, which names any missing permission with the grant action, and says that Manage Webhooks is for speaker identity.
- The bridge's new start check, `probePermissions`, which posts the same words once in the channel and latches the speaker notice so the speaker probe doesn't say it twice. `/state` carries the result as `permissions`.

The list: View Channel, Send Messages, Send Messages in Threads, Create Public Threads, Manage Threads, Embed Links, Attach Files, Read Message History, Add Reactions, Use Application Commands, Manage Webhooks, and Manage Channels (server-level, to create the channel, not checked in the channel).

The card's wait hint says the link asks for every permission Curia uses and why. `docs/operator/integration-setup.md#connect-discord` carries the table of permissions and reasons, and `docs/operator/guide/03-connect-services.md` names them in the step.

## Tests

`daemon/test/discordsetup.test.mjs`: the invite URL carries the bitfield `329101986896`, a channel that denies Manage Webhooks fails verification with the grant action and the speaker-identity reason, and the list is the bridge's. `daemon/test/speakers.test.mjs`: the start check names every missing permission once and the speaker probe doesn't repeat it, a bot that holds everything announces nothing, and a channel that can't be asked isn't a failure.

`cd cli && npm test`: 401 pass, 0 fail. `cd daemon && npm test`: 4487 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

Rehearsal: #891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
