### PR TITLE
fix: the overseer console pane starts in manual mode, in the wrong directory

### DIFF
--- a/daemon/bin/curia-overseer-pane.mjs
+++ b/daemon/bin/curia-overseer-pane.mjs
@@ -13,6 +13,7 @@ import { modelCredentialEnv, overseerConfigDirFor, overseerHomeFor, overseerProc
 import { buildSystemPrompt, checkoutReport, toolsFor } from '../src/overseerprompt.mjs'
 import { installCredentialConfig } from '../src/overseercreds.mjs'
 import { agentEnv, seedConfigDir } from '../src/workspace.mjs'
+import { conversationHomeFor } from '../src/overseeridentity.mjs'
 
 const DIR = path.dirname(fileURLToPath(import.meta.url))
 const CONFIG = process.env.CURIA_CONFIG ?? path.resolve(DIR, '..', '..', 'config', 'curia.yaml')
@@ -61,6 +62,10 @@ const prompt = [
 const { allowed, disallowed } = toolsFor({ shell: true })
 const args = [
   run.resume ? '--resume' : '--session-id', run.session,
+  // `overseerpane.mjs` waits for `⏵⏵|bypass permissions` in the pane before it
+  // types anything. Without this flag the harness sits in manual mode, that
+  // marker never appears, and every conversation dies at the 30 s timeout.
+  '--permission-mode', 'bypassPermissions',
   '--model', OVERSEER_CONTAINER_MODEL,
   '--append-system-prompt', prompt,
   '--allowed-tools', allowed.join(','),
@@ -72,5 +77,11 @@ const env = {
   ...agentEnv(configDir, 'claude', { sandboxed: true }),
   ...credential.env,
 }
-const child = spawn(claudeBinary(), args, { cwd: home, env, stdio: 'inherit' })
+// #701 gave each conversation its own directory: the daemon writes this one's
+// `.mcp.json` there, and reads its transcript from the project slug that
+// directory produces. The pane has to run in it, or the harness connects no
+// curia server and the Chat screen finds no transcript.
+const paneCwd = conversationHomeFor(home, run.session)
+fs.mkdirSync(paneCwd, { recursive: true })
+const child = spawn(claudeBinary(), args, { cwd: paneCwd, env, stdio: 'inherit' })
 process.exitCode = await wait(child)


### PR DESCRIPTION
Closes #962.

Two defects in `daemon/bin/curia-overseer-pane.mjs`, each fatal to a live overseer conversation on its own. Both found while standing up a fresh box; both fixed and verified live, one at a time.

## 1. The pane never reached its composer

`daemon/src/overseerpane.mjs:33` waits for `/(?:⏵⏵|bypass permissions)/i` before it types anything. The launcher passed no `--permission-mode`, and the seeded `settings.json` carries `skipDangerousModePermissionPrompt` but no `defaultMode` — so the harness sat in manual mode:

```
  ⏸ manual mode on · ? for shortcuts · ← for agents
```

`⏵⏵` never appears, `waitForClaudePane` times out at 30 s, and every conversation ends as `overseer pane curia-console-1 did not reach its composer`.

Dispatch was never affected: `config/routing.yaml:127` already carries the flag. Only the console lacked it.

## 2. The pane ran in the shared overseer home

`overseerHomeFor(root)` rather than `conversationHomeFor(home, session)`. #701 put two things in the conversation's own directory:

- the conversation's `.mcp.json` — so the harness connected **no** curia server. `/mcp` reported no project server, the model held no verb, and `start 287` came back as *"I don't have a start tool available in this session"*. The overseer could read a repo and say nothing could be done with it.
- the project slug its transcript lands under — so the Chat screen showed `no transcript yet` and `curia-console-1 never started a turn on the message`, while the pane held a full conversation.

One `cwd` explains all three symptoms.

## Verified live, in order

With fix 1 alone, the pane reached its composer and the overseer answered — it ran `gh issue list` over the watched repo and returned three prioritised tickets in 37 s. It still held no verb.

With fix 2, `/mcp` reads `curia · ✔ connected · 11 tools` from the conversation's own directory, the transcript renders in Chat, and a dispatch goes all the way through:

```
command: "start 287"
curia commits as curia-abernier[bot]
Picked ticket #287 to start, on session curia-287
stop hook curia-287: blocking stop 1/3 — call `request_review` and get an approval
```

## Where this came from

An **unsupported** box: arm64 Lima VM on macOS, source `deploy/compose.yaml` rather than `curia install`. Both fixes are argv and path only, so the architecture isn't involved — but you should know where the report comes from, and neither fix is one I can claim to have exercised on a supported host.

## One observation, not fixed here

The pane's first line is:

```
Permission deny rule "ToolSearch" matches no known tool — check for typos.
```

`DISALLOWED_TOOLS` names a tool this Claude Code (2.1.220, the one the agent image pins) no longer knows. Harmless as far as I could tell — the verbs arrive — but `overseerprompt.mjs:230` says the ban is load-bearing beside `ENABLE_TOOL_SEARCH=0`, so it may be worth a look on your side. I left it alone rather than change a control I can't validate.

Also, for what it's worth, the shell posture ends up holding rather more than the four reading tools the comment describes — the model listed `Artifact`, `CronCreate`, `EnterWorktree`, `Workflow`, `Task*`, `Skill`, `SendMessage` among its callable tools, alongside the curia verbs. `Write` and `Edit` were correctly absent. A denylist of known names doesn't hold as the harness grows new built-ins. Separate concern, not touched here.
