### PR TITLE
fix: pass the purge confirmation through the bootstrap

### DIFF
--- a/daemon/test/bootstrap.test.mjs
+++ b/daemon/test/bootstrap.test.mjs
@@ -438,6 +438,48 @@ describe('the bootstrap script', () => {
     assert.match(r.err, /purge/)
   })
 
+  // The rehearsal's second defect (#891): the bootstrap is the only way to
+  // purge once `curia uninstall` has removed the launcher, and it took no
+  // `--confirm`, so the noninteractive half of the confirmation contract
+  // (#887) had no way in. The value is the purge's to judge, not this
+  // script's.
+  test('passes --confirm through to the purge, which needs no terminal for it', async () => {
+    catalogue()
+    const r = await run(['--purge', '--root', '/srv/curia', '--confirm', '/srv/curia'])
+    assert.equal(r.exit, 0, `${r.out}\n${r.err}`)
+    assert.deepEqual(r.handoff.argv, ['purge', '--confirm', '/srv/curia'])
+    assert.equal(r.handoff.root, '/srv/curia')
+    assert.match(r.out, /handing off to curia purge/)
+    assert.deepEqual(r.leftover, [])
+  })
+
+  test('leaves a --confirm that names another path to the purge to refuse', async () => {
+    catalogue()
+    const root = installedRoot()
+    const r = await run(['--purge', '--root', root, '--confirm', '/srv/elsewhere'])
+    assert.equal(r.exit, EXIT.refused, `${r.out}\n${r.err}`)
+    assert.match(r.out, /\[2\/6\] confirm/)
+    assert.match(r.err, new RegExp(`--confirm names /srv/elsewhere, not the installation root ${root}`))
+    assert.equal(fs.existsSync(path.join(root, 'state', 'installation.json')), true, 'nothing changed')
+    assert.deepEqual(r.leftover, [])
+  })
+
+  test('refuses --confirm without --purge, and --confirm without a value, as usage errors', async () => {
+    catalogue()
+    served.hits = []
+    const installing = await run(['--confirm', '/srv/curia'])
+    assert.equal(installing.exit, EXIT.usage, `${installing.out}\n${installing.err}`)
+    assert.match(installing.err, /--confirm is a purge option/)
+    assert.equal(installing.handoff, null)
+    const valueless = await run(['--purge', '--confirm'])
+    assert.equal(valueless.exit, EXIT.usage, `${valueless.out}\n${valueless.err}`)
+    assert.match(valueless.err, /--confirm needs the installation root/)
+    assert.equal(valueless.handoff, null)
+    assert.deepEqual(served.hits, [], 'nothing was downloaded')
+    const help = await run(['--help'])
+    assert.match(help.out, /--confirm <root>/)
+  })
+
   test('refuses an interrupted download and leaves nothing behind', async () => {
     catalogue()
     served.truncate = `/releases/download/v${STABLE}/${releaseAssets(STABLE).bundle}`

--- a/deploy/bootstrap/curia-install.sh
+++ b/deploy/bootstrap/curia-install.sh
@@ -11,6 +11,7 @@
 #     bash curia-install.sh --version 1.2.4       an exact published version
 #     bash curia-install.sh --purge               purge the default root
 #     bash curia-install.sh --purge --root DIR    purge an explicit root
+#     bash curia-install.sh --purge --confirm DIR confirm without a terminal
 #
 # A purge is different: it removes what is installed, so it runs the
 # interface the installation already holds and downloads nothing. The
@@ -32,7 +33,8 @@
 # stage is removed when it returns.
 #
 # Exit codes are the lifecycle interface's: 0 ok, 1 failed, 2 usage, 3
-# refused (nothing changed). A hand-off exits with the interface's own code.
+# refused (nothing changed). A hand-off exits with the interface's own code,
+# so a `--confirm` that names another path is the purge's own refusal, 3.
 #
 # The four origins can be pointed at a local artifact server, which is how
 # the test suite runs this script without a network. Every check still
@@ -81,7 +83,7 @@ check_self
 usage() {
   cat <<'EOF'
 usage: bash curia-install.sh [--root <dir>] [--name <machine-name>] [--version <version> [--prerelease]]
-       bash curia-install.sh --purge [--root <dir>] [--version <version> [--prerelease]]
+       bash curia-install.sh --purge [--root <dir>] [--confirm <root>] [--version <version> [--prerelease]]
 
 Options:
   --root <dir>         The installation root. Default: CURIA_ROOT, else
@@ -96,9 +98,15 @@ Options:
                        the root already holds, and acquires a verified one
                        temporarily only when the root holds none. Installs
                        nothing.
+  --confirm <root>     Confirm the purge without a terminal, the way `curia
+                       purge --confirm <root>` does. The value must be the
+                       exact root being purged. On a terminal, leave it out
+                       and type the root when the purge asks. Purge only.
   --help               Print this text.
 
-Exit codes: 0 ok, 1 failed, 2 usage, 3 refused (nothing changed).
+Exit codes: 0 ok, 1 failed, 2 usage, 3 refused (nothing changed). The purge
+judges --confirm itself: a value that is not the root being purged is its
+refusal, exit 3, with nothing changed.
 EOF
 }
 
@@ -190,6 +198,8 @@ sri_to_hex() {
 
 ROOT=''
 NAME=''
+CONFIRM=''
+CONFIRMED='false'
 REQUESTED=''
 PRERELEASE='false'
 COMMAND='install'
@@ -210,6 +220,12 @@ parse_args() {
       --version)
         [ "$#" -ge 2 ] || { printf 'curia-install: --version needs a version\n' >&2; exit "$EXIT_USAGE"; }
         REQUESTED=$2
+        shift 2
+        ;;
+      --confirm)
+        [ "$#" -ge 2 ] || { printf 'curia-install: --confirm needs the installation root as its value\n' >&2; exit "$EXIT_USAGE"; }
+        CONFIRM=$2
+        CONFIRMED='true'
         shift 2
         ;;
       --prerelease) PRERELEASE='true'; shift ;;
@@ -252,6 +268,10 @@ check_name() {
     printf 'curia-install: --name is an installation option; a purge takes none\n' >&2
     exit "$EXIT_USAGE"
   fi
+  if [ "$CONFIRMED" = 'true' ] && [ "$COMMAND" != 'purge' ]; then
+    printf 'curia-install: --confirm is a purge option; an installation takes none\n' >&2
+    exit "$EXIT_USAGE"
+  fi
   if [ -n "$NAME" ]; then
     case "$NAME" in
       *[!a-z0-9-]*|-*|*-|'')
@@ -288,8 +308,10 @@ check_name() {
 #
 # Only case 3 can refuse for want of a stable release, and that refusal names
 # `--version`. Every other refusal and every verification the purge already
-# had are kept, the confirmation on the terminal among them: the interface,
-# not this script, owns the confirmation.
+# had are kept, the confirmation among them: the interface, not this script,
+# owns the confirmation. On a terminal the purge asks for the root; without
+# one, `--confirm <root>` is the answer, and this script passes the value
+# through unread, so a value that is not the root is the purge's refusal.
 
 INSTALLED_VERSION=''
 INSTALLED_NODE=''
@@ -385,9 +407,22 @@ main() {
     say "origins overridden: package $NPM_REGISTRY, release $RELEASE_DOWNLOADS, runtime $NODE_DIST, index $STABLE_INDEX_URL"
   fi
 
+  # What the hand-off adds to the command. `--name` is the installation's,
+  # `--confirm` the purge's: the value is passed through untouched, because
+  # the purge, not this script, decides whether it names the root.
+  local -a passed=()
+  if [ -n "$NAME" ]; then
+    passed+=(--name "$NAME")
+  fi
+  if [ "$CONFIRMED" = 'true' ]; then
+    passed+=(--confirm "$CONFIRM")
+  fi
+
   local status=0
   say "bootstrap $CURIA_BOOTSTRAP_VERSION"
-  if [ "$COMMAND" = 'purge' ]; then
+  if [ "$COMMAND" = 'purge' ] && [ "$CONFIRMED" = 'true' ]; then
+    say "purge of $ROOT: --confirm answers the confirmation, and nothing is installed"
+  elif [ "$COMMAND" = 'purge' ]; then
     say "purge of $ROOT: it asks for confirmation, and nothing is installed"
   else
     say "installation root: $ROOT"
@@ -402,7 +437,7 @@ main() {
     verify_installed_interface
     export CURIA_ROOT="$ROOT"
     say "handing off to curia purge ($PACKAGE@$INSTALLED_VERSION on the installed runtime)"
-    "$INSTALLED_NODE" "$INSTALLED_CLI" purge || status=$?
+    "$INSTALLED_NODE" "$INSTALLED_CLI" purge ${passed[@]+"${passed[@]}"} || status=$?
     exit "$status"
   fi
 
@@ -569,11 +604,7 @@ EOF
   fi
   say "handing off to curia $COMMAND ($PACKAGE@$version on Node.js $reported)"
   status=0
-  if [ -n "$NAME" ]; then
-    "$node" "$STAGE/cli/bin/curia.mjs" "$COMMAND" --name "$NAME" || status=$?
-  else
-    "$node" "$STAGE/cli/bin/curia.mjs" "$COMMAND" || status=$?
-  fi
+  "$node" "$STAGE/cli/bin/curia.mjs" "$COMMAND" ${passed[@]+"${passed[@]}"} || status=$?
   exit "$status"
 }
 

--- a/docs/operator/bootstrap.md
+++ b/docs/operator/bootstrap.md
@@ -10,7 +10,7 @@ Download the script to a file, then run it as the user that will own the install
 curl -fsSLO https://github.com/alp82/curia/releases/latest/download/curia-install.sh && bash curia-install.sh
 ```
 
-That's the whole installation command. Don't pipe `curl` into `bash`: the script refuses to run from a pipe, because it can't check that a piped copy downloaded completely. Downloading it to a file first is what lets it check, and it's also what lets `curia purge` ask you for confirmation on your terminal.
+That's the whole installation command. Don't pipe `curl` into `bash`: the script refuses to run from a pipe, because it can't check that a piped copy downloaded completely. Downloading it to a file first is what lets it check, and it's also what lets `curia purge` ask you for confirmation on your terminal. Without a terminal, `--purge --confirm <root>` answers the question instead.
 
 The script takes the following options.
 
@@ -21,6 +21,7 @@ The script takes the following options.
 | `--version <version>` | Installs an exact published version instead of the stable release the signed index names. A withdrawn version is refused. |
 | `--prerelease` | Allows `--version` to name a prerelease, which is never selected otherwise. |
 | `--purge` | Purge mode. See [Purge mode](#purge-mode). |
+| `--confirm <root>` | Confirms the purge without a terminal. The script passes the value to `curia purge`, which requires it to be the exact root being purged; see [The confirmation](purge.md#the-confirmation). Purge only: with no `--purge`, it's a usage error (exit code `2`) before any download. |
 | `--help` | Prints the options and exit codes. |
 
 The script is published with every release, under its one fixed name, so `releases/latest/download/curia-install.sh` is always the current one. It doesn't pin a Curia version: which version it installs comes from the stable-release index, as [How a version is selected](command-reference.md#how-a-version-is-selected) describes. Its own version is stamped inside, and it prints it first, so a support question can name the bootstrap that ran.
@@ -34,7 +35,7 @@ The script runs one linear sequence and prints each step. Nothing runs until eve
 3. **Downloads everything into one temporary stage.** From the npm registry: the registry's record of `@curia-sh/cli@<version>` and the package tarball, at the registry's fixed tarball address, never at an address read from a download. From nodejs.org: `SHASUMS256.txt` for the Node.js version the package pins and the Linux x64 tarball. From the GitHub release: the Compose bundle, its `.sha256` file, and the release manifest. Each file lands under a temporary name and is renamed only when `curl` reports a complete transfer, so a partial file is never read as a whole one. The stage lives under `$TMPDIR` (`/tmp` by default) and is removed when the script exits, whatever happens.
 4. **Proves the downloads in the shell.** The tarball's SHA-512 must equal the integrity value the registry records. The package's `package.json` must name the selected version. The Node.js tarball's SHA-256 must equal the one `SHASUMS256.txt` lists for it. The bundle's SHA-256 must equal both its `.sha256` file and the checksum the release manifest binds, and the manifest must be for the selected version. Then the runtime is unpacked, and `node --version` must report the pinned version.
 5. **Has the staged lifecycle interface prove the rest.** On the staged runtime, the staged package's own code verifies the stable-release index against the key the package ships, selects the version again and requires it to be the one staged, and runs every check in [What Curia verifies before activation](release-manifest.md#what-curia-verifies-before-activation): the manifest, the version, the package integrity, the bundle checksum, the image digests, and the release copy of the manifest. It reads the files already on disk and reaches no network.
-6. **Hands off.** It runs `curia install` (with `--name` when you passed one) or `curia purge` from the stage, on the staged runtime, with `CURIA_ROOT` set to the root and, for an installation, `CURIA_STAGE` set to the stage. The lifecycle interface owns the root, the record, the launcher, and every confirmation from there. The script exits with the interface's own exit code. What `curia install` does from the hand-off to a running Curia is in [Install and reinstall](install.md).
+6. **Hands off.** It runs `curia install` (with `--name` when you passed one) or `curia purge` (with `--confirm` when you passed one) from the stage, on the staged runtime, with `CURIA_ROOT` set to the root and, for an installation, `CURIA_STAGE` set to the stage. The lifecycle interface owns the root, the record, the launcher, and every confirmation from there. The script exits with the interface's own exit code. What `curia install` does from the hand-off to a running Curia is in [Install and reinstall](install.md).
 
 The stage holds the unpacked runtime at `node/` and the unpacked package at `cli/`, plus the retained `cli.tgz`, `bundle.tar.gz`, and `bundle.tar.gz.sha256`, the same names an installed version keeps under `versions/<version>/`, so `curia doctor` can re-verify them later.
 
@@ -70,7 +71,13 @@ A purge removes an installation and activates nothing, so it needs no release, a
 2. **The release `--version` names**, acquired and proven exactly as an installation does, in a temporary stage.
 3. **The stable release the index names**, acquired and proven the same way. Only this case can refuse for want of a stable release, and that refusal names `--version` too.
 
-The script then runs `curia purge` with `CURIA_ROOT` set to the root. `curia purge` shows the root, asks you to type it as the one confirmation, and removes the installation's Docker resources, its Serve routes, the unused release images, and last the root, as [Purge and external cleanup](purge.md) describes. The script hands off only the root, so the confirmation is the question on your terminal, which is one more reason the script refuses a pipe. The script writes no launcher, creates no root, and removes the stage when the interface returns. A nondefault root stays explicit in the command: with no `--root`, the default root is purged.
+The script then runs `curia purge` with `CURIA_ROOT` set to the root. `curia purge` shows the root, takes the one confirmation, and removes the installation's Docker resources, its Serve routes, the unused release images, and last the root, as [Purge and external cleanup](purge.md) describes. On a terminal the confirmation is the question `curia purge` asks there, which is one more reason the script refuses a pipe. Without a terminal, `--confirm <root>` is the answer:
+
+```sh
+bash curia-install.sh --purge --root /srv/curia --confirm /srv/curia
+```
+
+The script passes the value through unread. The value must be the root being purged, so another path is refused by `curia purge` with exit code `3` and nothing changed, and `--confirm` without `--purge` is a usage error, exit code `2`. The script writes no launcher, creates no root, and removes the stage when the interface returns. A nondefault root stays explicit in the command: with no `--root`, the default root is purged.
 
 ## Origins
 

--- a/docs/operator/guide/09-uninstall-or-purge.md
+++ b/docs/operator/guide/09-uninstall-or-purge.md
@@ -105,7 +105,11 @@ When the launcher is gone, run the bootstrap's purge mode, which asks the same q
 curl -fsSLO https://github.com/alp82/curia/releases/latest/download/curia-install.sh && bash curia-install.sh --purge
 ```
 
-Add `--root <dir>` for a nondefault root, the same root the uninstall printed. With no `--root`, the default root is purged.
+Add `--root <dir>` for a nondefault root, the same root the uninstall printed. With no `--root`, the default root is purged. Without a terminal, add `--confirm <root>` here too: the bootstrap passes it to `curia purge`, and the value must be the root being purged.
+
+```sh
+bash curia-install.sh --purge --root /srv/curia --confirm /srv/curia
+```
 
 The bootstrap runs the interface the root already holds, under `versions/<active>/`, and verifies it before it runs it, so it downloads nothing. After a `curia uninstall`, which empties `versions/`, it acquires and verifies one instead: the stable release the index names, or the release you add with `--version <version>` when the index names none. See [Purge from the bootstrap](../purge.md#purge-from-the-bootstrap).
 

--- a/docs/operator/purge.md
+++ b/docs/operator/purge.md
@@ -57,6 +57,8 @@ One confirmation authorizes the whole deletion, and the confirmation is the exac
 
   `--confirm` with any value other than the installation root is refused with exit code `3` and nothing changed. `--confirm=<root>` is the same flag. On a terminal, `--confirm <root>` skips the question.
 
+  The bootstrap's purge mode takes the same flag and passes the value through: `bash curia-install.sh --purge --confirm <root>`. That's the form to use after `curia uninstall`, when the launcher is gone and the host has no terminal; see [Purge from the bootstrap](#purge-from-the-bootstrap).
+
 The two forms say the same thing: you named the exact directory that goes. A script that purges several installations names each root once.
 
 ## Which images go
@@ -123,7 +125,13 @@ Where the interface that runs the purge comes from depends on what the root stil
 
 `curia uninstall` empties `versions/`, so a purge after an uninstall takes case 2 or case 3, and a purge over an installed Curia takes case 1.
 
-Pass `--root <dir>` for a nondefault root, the same root the uninstall printed. The bootstrap hands off only the root, so the confirmation is the question on your terminal; the bootstrap refuses to run from a pipe for that reason. The root's `run/` directory may be gone by then, and purge creates it for the lock before it takes one. The bootstrap writes no launcher, creates no root, and removes its stage when the command returns; see [Purge mode](bootstrap.md#purge-mode).
+Pass `--root <dir>` for a nondefault root, the same root the uninstall printed. The bootstrap hands the confirmation to `curia purge` and judges nothing itself. On a terminal, `curia purge` asks its question there, which is one reason the bootstrap refuses to run from a pipe. Without a terminal, add `--confirm <root>`:
+
+```sh
+bash curia-install.sh --purge --root /srv/curia --confirm /srv/curia
+```
+
+The value must be the root being purged, and every rule of [The confirmation](#the-confirmation) still holds: another path is refused by `curia purge` with exit code `3` and nothing changed. `--confirm` without `--purge` is a usage error, exit code `2`. The root's `run/` directory may be gone by then, and purge creates it for the lock before it takes one. The bootstrap writes no launcher, creates no root, and removes its stage when the command returns; see [Purge mode](bootstrap.md#purge-mode).
 
 ## After a purge
 

--- a/docs/operator/uninstall.md
+++ b/docs/operator/uninstall.md
@@ -58,6 +58,8 @@ Curia is uninstalled. The installation at /home/you/.local/share/curia is preser
 
 Both commands are the bootstrap, because the launcher is gone. A nondefault root appears as `--root <dir>` on both lines.
 
+The purge line asks you to type the root on your terminal. Without one, add `--confirm <root>`, the same flag `curia purge` takes; see [The confirmation](purge.md#the-confirmation).
+
 The uninstall emptied `versions/`, so the purge line has no installed interface to run and acquires a verified one: it takes the stable release the index names, or the release you add with `--version <version>` when the index names none. A purge over an installed Curia runs the interface under `versions/` instead and downloads nothing. See [Purge from the bootstrap](purge.md#purge-from-the-bootstrap).
 
 When Curia holds identifiers of external resources, the command lists them under `External resources Curia never deletes`, with the page where you remove each one: the GitHub App ID, the Discord server and channel, and the Tailscale machine name. The list is a checklist for you. Curia looks nothing up and revokes nothing. The list never holds a token or a key.


### PR DESCRIPTION
The live rehearsal of the packaged lifecycle on a Debian 13 host running 0.11.0 (#891) found this. `curia purge` has two confirmation forms by its contract (#887): you type the exact root on a terminal, or you pass `--confirm <root>` when there is none. The bootstrap's purge mode accepted no `--confirm`, so it answered with its usage text:

```
$ bash curia-install.sh --purge --version 0.11.0 --confirm /home/curia/.local/share/curia
Usage: ...
exit 2
```

## The gap

After `curia uninstall` the launcher is gone, and the bootstrap is the only way to purge. With no `--confirm` there, the noninteractive half of the confirmation contract was unreachable: on a host without a terminal, an uninstalled installation could not be removed at all. The operator's only way through was to install Curia again just to get a launcher that takes the flag.

## The fix

The bootstrap takes `--confirm <root>` and hands it to `curia purge`, next to `--name` for an installation, on both purge paths: the interface the root already holds, and the one the script acquires. The script never reads the value. Every rule stays where it was, with the purge:

- The value must be the exact root being purged. Another path is the purge's own refusal, exit code `3`, with nothing changed.
- `--confirm` without `--purge`, or without a value, is a usage error, exit code `2`, before any download.

`--confirm` is in the usage text and in its exit-code list.

## Tests

`daemon/test/bootstrap.test.mjs` gains three tests against the local artifact server:

- `--purge --confirm <root>` reaches the purge with the flag, from a child with no terminal;
- a `--confirm` naming another path is refused by the purge itself, with the installation record still there;
- `--confirm` without `--purge`, and `--confirm` without a value, are usage errors that download nothing.

`cd cli && npm test`: 401 pass, 0 fail, 0 cancelled. `cd daemon && npm test`: 4531 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

## Docs

`docs/operator/purge.md`, `docs/operator/uninstall.md`, `docs/operator/bootstrap.md`, and `docs/operator/guide/09-uninstall-or-purge.md` now give both confirmation forms wherever the bootstrap's purge appears, with the flag in the bootstrap's option table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
