### PR TITLE
fix: let curia doctor pass on a running installation without GitHub CLI

### DIFF
--- a/cli/src/compose.mjs
+++ b/cli/src/compose.mjs
@@ -129,16 +129,38 @@ export async function startProject(project, { docker = dockerRunner, stdout }) {
 
 // `docker compose ps --format json` prints one object per line since Compose
 // 2.21 and one array before that. Both read into the same list.
-export function parseServiceStates(text) {
+function parseRows(text) {
   const trimmed = text.trim()
   if (trimmed === '') return []
-  const rows = trimmed.startsWith('[') ? JSON.parse(trimmed) : trimmed.split('\n').map((line) => JSON.parse(line))
-  return rows.map((row) => ({
+  return trimmed.startsWith('[') ? JSON.parse(trimmed) : trimmed.split('\n').map((line) => JSON.parse(line))
+}
+
+export function parseServiceStates(text) {
+  return parseRows(text).map((row) => ({
     service: row.Service,
     state: row.State ?? '',
     health: row.Health ?? '',
     exitCode: Number.isInteger(row.ExitCode) ? row.ExitCode : null,
   }))
+}
+
+// The host ports the project's containers publish, as [{ port, service }].
+// Compose reports one `Publishers` entry per mapping; an entry with no
+// `PublishedPort` binds nothing on the host.
+export function parsePublishedPorts(text) {
+  const seen = new Set()
+  const published = []
+  for (const row of parseRows(text)) {
+    for (const publisher of row.Publishers ?? []) {
+      const port = Number(publisher?.PublishedPort)
+      if (!Number.isInteger(port) || port <= 0) continue
+      const key = `${port}:${row.Service}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      published.push({ port, service: row.Service })
+    }
+  }
+  return published
 }
 
 export async function serviceStates(project, { docker = dockerRunner }) {

--- a/cli/src/manifest.mjs
+++ b/cli/src/manifest.mjs
@@ -220,7 +220,9 @@ export const PROVENANCE_CHECKS = Object.freeze([
 //   bundle           { archive, checksum, compose? }: the archive bytes, the
 //                    `.sha256` text, and (installed) the on-disk compose file
 //   installed        (installed only) { manifest, packageJson } texts on disk
-//   attestations     (installed only) { <service>: { ok, error } }
+//   attestations     (installed only) { <service>: { ok, unavailable, error } },
+//                    where `unavailable` says the GitHub CLI is absent, so
+//                    nothing was proved either way
 //
 // A fact that is null is a missing artifact and fails its check. The
 // provenance checks run when `installed` is present, so the doctor path
@@ -248,6 +250,7 @@ export function evaluateRelease(facts) {
 }
 
 const passed = (name, observed) => ({ name, status: 'passed', observed, action: null })
+const warning = (name, observed, action) => ({ name, status: 'warning', observed, action })
 const failed = (name, observed, action) => ({ name, status: 'failed', observed, action })
 
 const DOWNLOAD_AGAIN = 'Download the release again and run the command again. If it fails the same way, the release is damaged: do not install it, and report it at https://github.com/alp82/curia/issues.'
@@ -429,23 +432,41 @@ export function attestationCommand(reference, { commit }) {
   return `gh attestation verify oci://${reference} --repo ${RELEASE_REPOSITORY} --signer-workflow ${RELEASE_REPOSITORY}/${RELEASE_WORKFLOW} --source-digest ${commit}`
 }
 
+const GH_INSTALL = "Install the GitHub CLI from https://github.com/cli/cli#installation, run 'gh auth login', and run 'curia doctor' again."
+
+// Provenance is a doctor check, not a bootstrap dependency (#849), so the
+// GitHub CLI is optional on a supported host. A `gh` that isn't there proves
+// nothing about the images, which is a warning that names what went
+// unverified. A `gh` that answers and rejects an attestation is evidence
+// against the images, which still fails.
 function imageProvenanceCheck({ attestations }, opened) {
   if (!opened.manifest) return failed('image provenance', 'no manifest could be read, so no image can be attested.', DOWNLOAD_AGAIN)
   const bad = []
+  const unverified = []
   for (const [service, { digest }] of Object.entries(opened.manifest.images)) {
     const result = attestations?.[service]
-    if (!result || !result.ok) bad.push({ service, reference: imageReference(service, digest), error: firstLine(result?.error) || 'no answer' })
+    if (result?.ok) continue
+    const entry = { service, reference: imageReference(service, digest), error: firstLine(result?.error) || 'no answer' }
+    if (result?.unavailable) unverified.push(entry)
+    else bad.push(entry)
   }
   if (bad.length) {
     const first = bad[0]
     return failed('image provenance', `${bad.map((b) => `${b.service}: ${b.error}`).join('; ')}.`, `Run '${attestationCommand(first.reference, opened.manifest.source)}' to see the full answer. If gh is not logged in, run 'gh auth login' first.`)
   }
+  if (unverified.length) {
+    return warning('image provenance', `the build attestation of ${unverified.map((u) => u.service).join(', ')} was not checked, because the GitHub CLI is not installed on this host.`, GH_INSTALL)
+  }
   return passed('image provenance', `${Object.keys(opened.manifest.images).length} images attested by ${RELEASE_REPOSITORY} ${RELEASE_WORKFLOW} at ${opened.manifest.source.commit.slice(0, 7)}`)
 }
 
+// A registry that doesn't answer leaves the publication record unread, which
+// is a warning. It is not a hole in the install path: `package integrity`
+// reads the same answer and fails hard when it is missing, so a package can
+// never be activated on an unread registry.
 function packageProvenanceCheck({ version, package: pkg }) {
   if (!pkg || pkg.error) {
-    return failed('package provenance', `the npm registry did not answer for ${PACKAGE_NAME}: ${pkg?.error ?? 'no answer'}.`, 'Check outbound access to registry.npmjs.org and run the command again.')
+    return warning('package provenance', `the npm registry did not answer for ${PACKAGE_NAME}, so the publication record of ${version} was not read: ${pkg?.error ?? 'no answer'}.`, "Check outbound access to registry.npmjs.org and run 'curia doctor' again.")
   }
   if (pkg.attested !== true) {
     return failed('package provenance', `the registry records no provenance for ${PACKAGE_NAME}@${version}.`, `Run 'npm audit signatures' against an install of ${PACKAGE_NAME}@${version} to see the registry's answer, and report a stable release without provenance at https://github.com/alp82/curia/issues.`)
@@ -460,7 +481,7 @@ function firstLine(text) {
 // ---------------------------------------------------------------------------
 // Rendering.
 
-const STATUS_WORD = { passed: 'ok', failed: 'failed' }
+const STATUS_WORD = { passed: 'ok', warning: 'warning', failed: 'failed' }
 
 export function renderVerification(report) {
   const width = Math.max(...report.checks.map((c) => c.name.length))
@@ -469,9 +490,11 @@ export function renderVerification(report) {
     lines.push(`${STATUS_WORD[c.status].padEnd(8)} ${c.name.padEnd(width)}  ${c.observed}`)
     if (c.action) lines.push(`${''.padEnd(9 + width + 2)}${c.action}`)
   }
-  const failedCount = report.checks.filter((c) => c.status === 'failed').length
-  const passedCount = report.checks.length - failedCount
-  const summary = [`${passedCount} checks passed`]
+  const count = (status) => report.checks.filter((c) => c.status === status).length
+  const failedCount = count('failed')
+  const warningCount = count('warning')
+  const summary = [`${count('passed')} checks passed`]
+  if (warningCount > 0) summary.push(`${warningCount} warning${warningCount === 1 ? '' : 's'}`)
   if (failedCount > 0) summary.push(`failed: ${failedCount} condition${failedCount === 1 ? '' : 's'}`)
   lines.push(summary.join(', ') + '.')
   return lines.join('\n') + '\n'
@@ -506,7 +529,8 @@ export const releaseProbes = Object.freeze({
     const [, ...args] = attestationCommand(reference, { commit }).split(' ')
     execFile('gh', [...args, '--format', 'json'], { timeout: 60_000, maxBuffer: 4 * 1024 * 1024 }, (error, stdout, stderr) => {
       if (!error) return resolve({ ok: true })
-      resolve({ ok: false, error: error.code === 'ENOENT' ? 'gh is not installed' : (stderr || error.message) })
+      if (error.code === 'ENOENT') return resolve({ ok: false, unavailable: true, error: 'gh is not installed' })
+      resolve({ ok: false, error: stderr || error.message })
     })
   }),
 })

--- a/cli/src/preflight.mjs
+++ b/cli/src/preflight.mjs
@@ -6,7 +6,9 @@ import { createServer } from 'node:net'
 import { arch as osArch, cpus as osCpus, tmpdir, totalmem } from 'node:os'
 import { dirname, join } from 'node:path'
 
+import { composeProject, parsePublishedPorts } from './compose.mjs'
 import { Refusal } from './exit.mjs'
+import { readInstallationRecord } from './root.mjs'
 
 // The supported-host preflight (#868, implementing #850 and the direct-check
 // constraints of #857).
@@ -103,7 +105,7 @@ export const CHECKS = Object.freeze([
   Object.freeze({ name: 'operating system', severity: 'blocking', summary: 'The release is Ubuntu 24.04 LTS or Debian 13.' }),
   Object.freeze({ name: 'architecture', severity: 'blocking', summary: 'The processor is x86-64.' }),
   Object.freeze({ name: 'host capacity', severity: 'warning', summary: 'CPU, memory, and free disk meet the minimum and recommended profiles.' }),
-  Object.freeze({ name: 'required ports', severity: 'blocking', summary: 'The five loopback ports are free and the sandbox range can hold four agents.' }),
+  Object.freeze({ name: 'required ports', severity: 'blocking', summary: 'The five loopback ports are free, or held by this installation, and the sandbox range can hold four agents.' }),
   Object.freeze({ name: 'Docker Engine', severity: 'mixed', summary: 'A running Docker Engine the operator can reach, in the tested range.' }),
   Object.freeze({ name: 'Docker capabilities', severity: 'blocking', summary: 'A probe container reads a bind mount and reaches the host network.' }),
   Object.freeze({ name: 'Docker Compose', severity: 'mixed', summary: 'The Compose v2 plugin, in the tested range.' }),
@@ -195,20 +197,40 @@ function capacityCheck({ cpus, memoryBytes, disk }) {
   return passed('host capacity', seen)
 }
 
+function holderName(port) {
+  return REQUIRED_PORTS.find((p) => p.port === port)?.holder ?? 'Curia'
+}
+
+// The check proves the five ports are available to this installation, which
+// on a running host means Curia's own containers already hold them. `curia
+// update` and `curia rollback` run this same preflight, so a port Curia
+// binds must read as healthy, not as a conflict (#885).
+//
+// A busy port carries `service` when Compose listed it among the published
+// ports of this root's own project. That is the only honest test: the holder
+// is Curia's because Curia's Compose project says it publishes that port.
+// The process name `ss` reports is not evidence, because a published port is
+// held by a proxy in the container's namespace, whose name is whatever the
+// image called its main thread.
 function portsCheck({ ports }) {
   const needed = SANDBOX_PORTS.perAgent * SANDBOX_PORTS.agents
   const total = SANDBOX_PORTS.to - SANDBOX_PORTS.from + 1
-  if (ports.busy.length > 0) {
-    const list = ports.busy.map((b) => {
-      const holder = REQUIRED_PORTS.find((p) => p.port === b.port)?.holder ?? 'Curia'
-      return `${b.port} (${holder}) is held by ${b.process ?? 'another program'}`
-    }).join('; ')
+  const foreign = ports.busy.filter((b) => !b.service)
+  if (foreign.length > 0) {
+    const list = foreign.map((b) => `${b.port} (${holderName(b.port)}) is held by ${b.process ?? 'another program'}`).join('; ')
     return refused('required ports', `port ${list}.`, 'Stop the program that listens on that port, or move it to another port, and run the command again.')
   }
   if (ports.sandboxFree < needed) {
     return refused('required ports', `only ${ports.sandboxFree} of the ${total} ports from ${SANDBOX_PORTS.from} to ${SANDBOX_PORTS.to} are free, and four agents need ${needed}.`, `Free at least ${needed} ports in that range and run the command again.`)
   }
-  return passed('required ports', `${REQUIRED_PORTS.map((p) => p.port).join(', ')} free; ${ports.sandboxFree} of ${total} sandbox ports free`)
+  const mine = ports.busy.map((b) => `${b.port} (${holderName(b.port)}) is held by this installation's ${b.service} service`)
+  const free = REQUIRED_PORTS.filter((p) => !ports.busy.some((b) => b.port === p.port)).map((p) => p.port)
+  const observed = [
+    ...mine,
+    free.length > 0 ? `${free.join(', ')} free` : null,
+    `${ports.sandboxFree} of ${total} sandbox ports free`,
+  ].filter(Boolean).join('; ')
+  return passed('required ports', observed)
 }
 
 // Compares dotted versions numerically, ignoring a suffix such as `-ce`.
@@ -401,7 +423,7 @@ export async function gatherHostFacts({ uid, root, ports = REQUIRED_PORTS, sandb
     dockerFacts(probes),
     composeFacts(probes),
     tailscaleFacts(probes),
-    portFactsOf(ports, sandbox, probes),
+    portFactsOf(ports, sandbox, root, probes),
     Promise.all(RELEASE_ORIGINS.map((origin) => probes.fetchOrigin(origin))),
   ])
   return {
@@ -542,11 +564,18 @@ async function tailscaleFacts(probes) {
 // A port is free when the operator can listen on it on every interface. The
 // listener is closed before the answer is returned. The holder of a busy
 // port comes from `ss`, when it is present and may name the process.
-async function portFactsOf(ports, sandbox, probes) {
+async function portFactsOf(ports, sandbox, root, probes) {
   const portFree = probes.portFree ?? hostProbes.portFree
   const busy = []
   for (const { port } of ports) {
     if (!(await portFree(port))) busy.push({ port, process: await holderOf(port, probes) })
+  }
+  if (busy.length > 0) {
+    const published = await publishedPortsOf(root, probes)
+    for (const entry of busy) {
+      const mine = published?.find((p) => p.port === entry.port)
+      if (mine) entry.service = mine.service
+    }
   }
   let sandboxFree = 0
   for (let port = sandbox.from; port <= sandbox.to; port += 1) {
@@ -561,6 +590,29 @@ function portFree(port) {
     server.once('error', () => resolve(false))
     server.listen({ port, host: '0.0.0.0', exclusive: true }, () => server.close(() => resolve(true)))
   })
+}
+
+// The host ports the root's own Compose project publishes, or null when this
+// root holds no installation, Compose cannot be asked, or its answer is not
+// readable. Null means "nothing here claims a port", which is the fresh-host
+// case `curia install` checks: a busy port is then someone else's.
+async function publishedPortsOf(root, probes) {
+  if (!root) return null
+  let record = null
+  try {
+    record = readInstallationRecord(root)
+  } catch {
+    return null
+  }
+  if (!record?.activeVersion) return null
+  const project = composeProject({ root, version: record.activeVersion })
+  const out = await probes.exec('docker', project.args('ps', '--format', 'json'))
+  if (!out.ok) return null
+  try {
+    return parsePublishedPorts(out.stdout)
+  } catch {
+    return null
+  }
 }
 
 async function holderOf(port, probes) {

--- a/cli/test/doctor.test.mjs
+++ b/cli/test/doctor.test.mjs
@@ -313,6 +313,16 @@ describe('curia doctor and release provenance', () => {
     assert.equal(status(d.out, 'package integrity'), 'ok')
   })
 
+  test('a host without the GitHub CLI warns on image provenance and exits ok', async () => {
+    const i = await installed()
+    const d = await doctor(i, { release: { attestation: async () => ({ ok: false, unavailable: true, error: 'gh is not installed' }) } })
+    assert.equal(status(d.out, 'image provenance'), 'warning')
+    assert.match(d.out, /GitHub CLI is not installed/)
+    assert.match(d.out, /gh auth login/)
+    assert.doesNotMatch(d.out, /failed:/)
+    assert.equal(d.exit, EXIT.ok, d.out)
+  })
+
   test('a drifted installed file fails with reinstall as the action', async () => {
     const i = await installed()
     const compose = versionPaths(i.root, VERSION).bundle

--- a/cli/test/manifest.test.mjs
+++ b/cli/test/manifest.test.mjs
@@ -494,6 +494,35 @@ describe('verifying an installed release', () => {
     assert.match(check(report, 'image provenance').action, /--signer-workflow alp82\/curia\/\.github\/workflows\/release\.yml/)
   })
 
+  test('a host without the GitHub CLI warns on image provenance and still verifies', async () => {
+    const r = release()
+    const root = install(r)
+    const stdout = sink()
+    const report = await verifyInstalledRelease({ root, version: VERSION, stdout }, probesFor(r, {
+      attestation: async () => ({ ok: false, unavailable: true, error: 'gh is not installed' }),
+    }))
+    assert.equal(report.ok, true, stdout.text())
+    assert.equal(report.refusal, null)
+    const c = check(report, 'image provenance')
+    assert.equal(c.status, 'warning')
+    assert.match(c.observed, /GitHub CLI is not installed/)
+    assert.match(c.observed, /daemon, tmux, dashboard, overseer, agent/)
+    assert.match(c.action, /gh auth login/)
+    assert.match(c.action, /curia doctor/)
+    assert.match(stdout.text(), /^warning\s+image provenance\s+/m)
+    assert.match(stdout.text(), /8 checks passed, 1 warning\.$/m)
+  })
+
+  test('a registry that does not answer warns on package provenance, and the integrity check still fails', async () => {
+    const r = release()
+    const root = install(r)
+    const report = await verifyInstalledRelease({ root, version: VERSION, stdout: sink() }, probesFor(r, { packument: async () => ({ error: 'getaddrinfo ENOTFOUND registry.npmjs.org' }) }))
+    failedOnly(report, 'package integrity')
+    const c = check(report, 'package provenance')
+    assert.equal(c.status, 'warning')
+    assert.match(c.observed, /did not answer/)
+  })
+
   test('a package the registry does not record provenance for fails the package provenance check', async () => {
     const r = release()
     const root = install(r)

--- a/cli/test/preflight.test.mjs
+++ b/cli/test/preflight.test.mjs
@@ -1,7 +1,7 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:net'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -11,6 +11,7 @@ import {
   evaluateHostFacts, gatherHostFacts, renderPreflight, preflight,
 } from '../src/preflight.mjs'
 import { Refusal } from '../src/exit.mjs'
+import { createInstallationRecord, recordPath } from '../src/root.mjs'
 
 const GiB = 1024 ** 3
 
@@ -133,6 +134,23 @@ describe('a supported host passes', () => {
     assert.equal(check(report, 'Docker Compose').status, 'passed')
   })
 
+  test('a running installation holding its own ports passes, naming the services', () => {
+    const busy = [
+      { port: 4272, service: 'daemon' },
+      { port: 4273, service: 'dashboard' },
+      { port: 4274, service: 'overseer' },
+      { port: 7681, service: 'tmux' },
+    ]
+    const report = evaluateHostFacts(ubuntu({ ports: { busy, sandboxFree: 288 } }))
+    assert.equal(report.ok, true)
+    const ports = check(report, 'required ports')
+    assert.equal(ports.status, 'passed')
+    assert.match(ports.observed, /4272 \(the timeline\) is held by this installation's daemon service/)
+    assert.match(ports.observed, /7681 \(the attach surface\) is held by this installation's tmux service/)
+    assert.match(ports.observed, /7682 .* free/)
+    assert.doesNotMatch(ports.observed, /pid/, 'the service is named, not a process id')
+  })
+
   test('the operating-system check reports the release it saw', () => {
     assert.match(check(evaluateHostFacts(debian()), 'operating system').observed, /Debian GNU\/Linux 13/)
   })
@@ -164,6 +182,17 @@ describe('refused conditions stop the operation', () => {
   test('a required port in use', () => {
     const facts = ubuntu({ ports: { busy: [{ port: 7681, process: 'ttyd (pid 4242)' }], sandboxFree: 300 } })
     refusedOn(evaluateHostFacts(facts), 'required ports', /7681.*ttyd \(pid 4242\)/, /Stop the program/)
+  })
+
+  test('a foreign holder still refuses on a running installation', () => {
+    const busy = [
+      { port: 4272, service: 'daemon' },
+      { port: 4274, process: 'another program' },
+    ]
+    const facts = ubuntu({ ports: { busy, sandboxFree: 288 } })
+    const report = evaluateHostFacts(facts)
+    refusedOn(report, 'required ports', /4274 \(the overseer\) is held by another program/, /Stop the program/)
+    assert.doesNotMatch(check(report, 'required ports').observed, /4272/, 'a port this installation holds is not named as a conflict')
   })
 
   test('too few free sandbox ports for the default concurrency', () => {
@@ -416,6 +445,46 @@ describe('gatherHostFacts', () => {
     const again = createServer()
     await new Promise((resolve, reject) => again.once('error', reject).listen(port + 1, '0.0.0.0', resolve))
     again.close()
+  })
+
+  test('a fresh host asks Compose nothing and reports the busy port as foreign', async () => {
+    const holder = createServer()
+    await new Promise((r) => holder.listen(0, '127.0.0.1', r))
+    const port = holder.address().port
+    const root = mkdtempSync(join(tmpdir(), 'curia-fresh-'))
+    const probes = fakeProbes()
+    try {
+      const facts = await gatherHostFacts({ uid: 1001, root, ports: [{ port, holder: 'a test' }], sandbox: { from: port + 1, to: port + 3 } }, probes)
+      assert.deepEqual(facts.ports.busy, [{ port, process: null }])
+      assert.ok(!probes.calls.some((c) => c.includes('ps')), 'no installation, so Compose is never asked which ports it publishes')
+    } finally {
+      holder.close()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('a running installation names the service that publishes the busy port', async () => {
+    const holder = createServer()
+    await new Promise((r) => holder.listen(0, '127.0.0.1', r))
+    const port = holder.address().port
+    const root = mkdtempSync(join(tmpdir(), 'curia-running-'))
+    mkdirSync(join(root, 'state'), { recursive: true })
+    writeFileSync(recordPath(root), JSON.stringify(createInstallationRecord('0.11.0')))
+    const ps = JSON.stringify({ Service: 'tmux', State: 'running', Publishers: [{ URL: '127.0.0.1', TargetPort: 7681, PublishedPort: port, Protocol: 'tcp' }] })
+    const probes = fakeProbes({
+      exec: async (file, args) => {
+        if (file === 'docker' && args[0] === 'compose') return { ok: true, stdout: `${ps}\n`, stderr: '', code: 0 }
+        if (file === 'ss') return { ok: true, stdout: '' }
+        return fakeProbes().exec(file, args)
+      },
+    })
+    try {
+      const facts = await gatherHostFacts({ uid: 1001, root, ports: [{ port, holder: 'a test' }], sandbox: { from: port + 1, to: port + 3 } }, probes)
+      assert.deepEqual(facts.ports.busy, [{ port, process: null, service: 'tmux' }])
+    } finally {
+      holder.close()
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
   test('a host without Docker, Compose, or Tailscale reports each as absent', async () => {

--- a/docs/operator/doctor.md
+++ b/docs/operator/doctor.md
@@ -25,7 +25,7 @@ The output has nine sections in the order the following table lists. Every check
 | `host` | The twelve preflight checks of [Supported hosts and preflight checks](supported-hosts.md#the-checks). | The host carries Curia. | The same conditions preflight refuses or warns about. A refused condition is reported as `refused`; the doctor doesn't stop on it. |
 | `installation` | `installation` | The root holds an installation record, `versions/<active version>/` is complete, and the launcher exists. | No installation (the action is the bootstrap command), an incomplete version (`curia reinstall`), or a missing launcher (a warning). |
 | `configuration` | `operator configuration` | `config/config.yaml` passes the [operator configuration](configuration.md) contract. The line lists the keys it sets. | The contract's exact message: the path, the line, the key, and the rule. An absent file is a warning, because the shipped defaults apply. |
-| `release` | The nine checks of [What `curia doctor` verifies](release-manifest.md#what-curia-doctor-verifies). | The retained artifacts verify, the installed files match them, every image is attested, and the registry records provenance for the package. | A missing, malformed, substituted, mismatched, drifted, or unattested artifact. |
+| `release` | The nine checks of [What `curia doctor` verifies](release-manifest.md#what-curia-doctor-verifies). | The retained artifacts verify, the installed files match them, every image is attested, and the registry records provenance for the package. | A missing, malformed, substituted, mismatched, drifted, or unattested artifact. A provenance check that couldn't run, because the GitHub CLI is absent or the registry didn't answer, is a warning: see [Provenance and the GitHub CLI](#provenance-and-the-github-cli). |
 | `secrets` | `secret files` | Each of the four [secret files](secrets.md#the-secret-files) is reported as present or absent. | A file that is a symbolic link, that another user owns, or that other users can read. The line names the `chmod` to run. |
 | `secrets` | `environment` | No credential key is set in your shell. | A warning that names the key, such as `GH_TOKEN`, and the secret file to use instead. |
 | `containers` | `containers` | The five services are `healthy` in `docker compose ps`. | A service that exited, is unhealthy, or is missing from the project fails, with the `docker compose ... logs <service>` command as the action. A service still starting is a warning. |
@@ -101,7 +101,14 @@ When a credential key such as `GH_TOKEN` is set in your shell, the `environment`
 
 ## Provenance and the GitHub CLI
 
-The `image provenance` check asks `gh attestation verify` for each of the five image digests, the agent image's included, and needs the GitHub CLI logged in to GitHub. When it isn't, the check fails and its action prints the exact command to run once `gh auth login` is done. Nothing else in Curia depends on that login, and `curia install` and `curia update` don't run this check: the doctor is where publication provenance is verified without weakening the verification that runs before activation. The manual commands are in [The release manifest and release verification](release-manifest.md#what-curia-doctor-verifies).
+The `image provenance` check asks `gh attestation verify` for each of the five image digests, the agent image's included. The GitHub CLI is optional on a supported host, and it isn't a prerequisite of the bootstrap.
+
+- When `gh` isn't installed, the check is a **warning**. It names the images it didn't check and tells you to install the GitHub CLI, run `gh auth login`, and run `curia doctor` again. The exit code stays `0` when every other check passes.
+- When `gh` is installed and answers, the check reports what it answered. A missing or rejected attestation **fails**, and the action prints the exact command to run. If `gh` isn't logged in, run `gh auth login` first.
+
+The `package provenance` check reads the npm registry's publication record the same way: a registry that doesn't answer is a warning, and a registry that answers and records no provenance for the version fails. A registry that can't be reached never lets a package through unverified, because the `package integrity` check reads the same answer and fails hard without it.
+
+Nothing else in Curia depends on the GitHub CLI, and `curia install` and `curia update` don't run these checks: the doctor is where publication provenance is verified without weakening the verification that runs before activation. The manual commands are in [The release manifest and release verification](release-manifest.md#what-curia-doctor-verifies).
 
 ## When to run it
 

--- a/docs/operator/guide/06-check-the-installation.md
+++ b/docs/operator/guide/06-check-the-installation.md
@@ -35,7 +35,7 @@ The line under a `failed` or `refused` check is the one corrective action. Take 
 
 Two checks need a note:
 
-- `image provenance` asks `gh attestation verify` and needs the GitHub CLI logged in. When it isn't, the action prints the command to run after `gh auth login`. Nothing else in Curia depends on that login.
+- `image provenance` asks `gh attestation verify`, which needs the [GitHub CLI](https://github.com/cli/cli#installation) installed and logged in. The GitHub CLI is optional: without it the check is a `warning` that names the images it didn't verify, and the exit code stays `0`. With it installed, an attestation that is missing or doesn't verify is a `failed` check, and the action prints the command to run after `gh auth login`. Nothing else in Curia depends on that login.
 - Exit code `3` means the installation root itself refused the command before any check ran, for example a directory another user owns. The message names the path and the fix; see [When a lifecycle command refuses the root](../command-reference.md#when-a-lifecycle-command-refuses-the-root).
 
 The failures by message are under [Check the installation](troubleshooting.md#check-the-installation) in Troubleshooting.

--- a/docs/operator/guide/troubleshooting.md
+++ b/docs/operator/guide/troubleshooting.md
@@ -110,7 +110,9 @@ A rejected review isn't a failure. The agent takes your feedback and asks for re
 |---|---|---|
 | Exit `1` with `failed` or `refused` lines | A condition the doctor found. | Take the action under each line, then run `curia doctor` again. |
 | Exit `3` before any section | The installation root refused the command. | Fix the named path; see [When a lifecycle command refuses the root](../command-reference.md#when-a-lifecycle-command-refuses-the-root). |
-| `image provenance` failed with a `gh attestation verify` command | The GitHub CLI isn't logged in. | Run `gh auth login`, then `curia doctor` again. |
+| `image provenance` warned that the GitHub CLI isn't installed | The GitHub CLI is optional, so the attestations went unchecked. The exit code is still `0`. | To check them, install the [GitHub CLI](https://github.com/cli/cli#installation), run `gh auth login`, then `curia doctor` again. |
+| `image provenance` failed with a `gh attestation verify` command | The GitHub CLI answered and an attestation is missing or didn't verify. | Run the command the line prints to see the full answer. If `gh` isn't logged in, run `gh auth login`, then `curia doctor` again. |
+| `required ports` refused a port, and Curia is running | Another program holds a port Curia's own containers need. A port Curia's containers already hold passes and names the service. | Stop that program or move it to another port, then rerun. |
 | `installation` names a missing file under `versions/` | The active version is incomplete. | Run `curia reinstall`, or the bootstrap when the launcher is gone. |
 | `integrations` is skipped | The service didn't answer on `127.0.0.1:4271`. | Fix the `containers` or `service` line first. |
 

--- a/docs/operator/release-manifest.md
+++ b/docs/operator/release-manifest.md
@@ -82,7 +82,7 @@ After the checks pass, Curia keeps the verified artifacts as it downloaded them,
 | image provenance | Each of the five image digests in the manifest, the agent image's included, carries a build attestation signed by the release workflow of `alp82/curia` at the manifest's commit. Curia asks `gh attestation verify` for each digest. |
 | package provenance | The npm registry records publication provenance for `@curia-sh/cli@<version>`. |
 
-The image provenance check needs the GitHub CLI, `gh`, logged in to GitHub. When it isn't, the check fails and the message says so. Nothing else in Curia depends on that login.
+The image provenance check needs the GitHub CLI, `gh`, logged in to GitHub. The GitHub CLI is optional on a supported host: when it isn't installed, the check is a warning that names the images it didn't check, and `curia doctor` still exits `0` when everything else passes. When `gh` is installed and answers, an attestation that is missing or doesn't verify fails. The package provenance check reads the npm registry the same way: a registry that doesn't answer warns, and a registry that records no provenance for the version fails. Nothing else in Curia depends on the GitHub CLI or on that login.
 
 To run the same provenance checks by hand, use the following commands, with the values from the manifest of the active version:
 
@@ -109,5 +109,6 @@ A failed check names the condition and one corrective action. The following tabl
 | Mismatched | The manifest is for another version than the one requested, `package.json` names another version, or the release asset manifest differs from the package copy. | Ask for the version the artifacts belong to, or download the version you asked for. Two copies of one manifest that disagree mean the release and the package were published apart: don't install it, and report it. |
 | Drifted (doctor only) | An installed file differs from the retained artifact. | Run `curia reinstall` to restore the version from the release, or `curia update`. |
 | Unattested (doctor only) | An image digest carries no attestation from the release workflow, or the registry records no provenance for the package. | Run the `gh attestation verify` command the message prints to see the full answer. If `gh` isn't logged in, log in and run `curia doctor` again. An image or package without provenance is a release to report. |
+| Unverified (doctor only, a warning) | The GitHub CLI isn't installed, or the npm registry didn't answer, so a provenance check couldn't run. Nothing failed. | Install the [GitHub CLI](https://github.com/cli/cli#installation) and run `gh auth login`, or restore outbound access to `registry.npmjs.org`, then run `curia doctor` again. |
 
 Curia never prints a full digest, a full integrity value, or a manifest body in a report. The first twelve characters of a checksum are enough to compare with the file on the release page.

--- a/docs/operator/supported-hosts.md
+++ b/docs/operator/supported-hosts.md
@@ -32,6 +32,10 @@ Curia detects and verifies these three, and never installs or reconfigures them:
 
 A version newer than the tested range produces a warning, not a refusal. A supported host also needs `bash`, `curl`, `tar`, `gzip`, the coreutils checksum tools (`sha256sum`, `sha512sum`, `base64`, `od`), and CA certificates for [the bootstrap](bootstrap.md), and `ss` from `iproute2` for the port check to name a process. All of these ship with both supported systems.
 
+### The GitHub CLI is optional
+
+The [GitHub CLI](https://github.com/cli/cli#installation) (`gh`) is not a prerequisite. Nothing in the installation, the update, or the running system needs it. What it buys you is one check: with `gh` installed and logged in (`gh auth login`), `curia doctor` asks `gh attestation verify` whether each of the five image digests carries a build attestation from Curia's release workflow, and reports the answer. Without it, that check is a warning that names the images it didn't verify, and `curia doctor` still exits `0` when everything else passes. See [Provenance and the GitHub CLI](doctor.md#provenance-and-the-github-cli).
+
 You run every lifecycle command as your own user, never as root. Curia never escalates privileges.
 
 ## Network
@@ -73,6 +77,7 @@ The following table lists every check, what it can do, the condition it reports,
 | architecture | Refuse | The processor is not x86-64. | Install Curia on an x86-64 host. |
 | host capacity | Warn | CPU, memory, or free disk is below the minimum or the recommended profile. | Give the host the named profile. |
 | required ports | Refuse | One of the five loopback ports is held by another program, named when `ss` can see it. | Stop that program or move it to another port. |
+| required ports | Pass | A loopback port is held by a container of this installation's own Compose project, which is the healthy state on a running host. The line names the service that publishes it. `curia update` and `curia rollback` run this check on a running installation, so it has to tell Curia's containers from a foreign program. | Nothing. |
 | required ports | Refuse | Fewer than 12 ports are free in `9000` to `9299`. | Free at least 12 ports in that range. |
 | Docker Engine | Refuse | Docker is not installed. | Install Docker Engine 24.0 or later from the [Docker Engine install page](https://docs.docker.com/engine/install/). |
 | Docker Engine | Refuse | Your user can't open `/var/run/docker.sock`. | Run `sudo usermod -aG docker $USER`, then log out and in. |


### PR DESCRIPTION
The first live rehearsal of the packaged lifecycle (#891, map #863) ran `curia doctor` on a healthy, fully connected 0.11.0 installation on the Ubuntu 24.04 rehearsal host. It reported 31 checks passed, 1 warning, and exit 1 on two checks with nothing wrong to report:

```
refused  required ports  port 4272 (the timeline) is held by MainThread (pid 380259); 4273 (the Curia app) is held by MainThread (pid 380019); 4274 (the overseer) is held by another program; 7681 (the attach surface) is held by ttyd (pid 380252).
failed   image provenance  daemon: gh is not installed; tmux: gh is not installed; dashboard: gh is not installed; overseer: gh is not installed; agent: gh is not installed.
```

## The ports

The required-ports check exists to prove a fresh host has the five loopback ports free. On a running installation the holders are Curia's own containers, which is the healthy state, and `curia update` and `curia rollback` run the same preflight, so the check refused a healthy installation.

The check now tells "held by this installation" from "held by something else". When the root holds an installation, preflight asks that root's own Compose project which host ports it publishes, through `docker compose ps --format json`, and matches the published list against the busy ports. A port the project publishes passes and names the service; a port held by anything else still refuses. A host with no installation is unchanged: nothing claims a port, so every busy port is foreign.

Compose's own answer is the only honest evidence available. A published port is held by a proxy inside the container's network namespace, so the process name `ss` reports is whatever the image called its main thread, which is exactly what the rehearsal saw as `MainThread` and `another program`.

## Provenance

`gh` is not installed on a supported host and is not a documented prerequisite, so `verifyInstalledRelease`'s `image provenance` check failed and `curia doctor` exited 1 on a healthy installation. The decision from #849 is that provenance stays a doctor check, not a bootstrap dependency, so an absent `gh` proves nothing and must not be a failure.

An absent `gh` is now a warning that names the images it did not check and the one action: install the GitHub CLI, run `gh auth login`, and run `curia doctor` again. A `gh` that is present and reports a bad or missing attestation still fails, with the exact verify command as its action. `package provenance` reads the npm registry the same way: a registry that does not answer warns, and a registry that answers and records no provenance fails. That opens no hole in the install path, because `package integrity` reads the same registry answer and fails hard without it. `curia doctor` already exits 0 when only warnings remain, and the release report now counts warnings separately in its summary line.

## Tests and docs

New tests cover a fresh host, a running installation holding its own ports, a foreign holder on a running installation, no `gh`, `gh` present with a good attestation, and `gh` present with a bad one. `cd cli && npm test`: 408 pass, 0 fail. `cd daemon && npm test`: 4525 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

Docs updated: `docs/operator/doctor.md`, `docs/operator/guide/06-check-the-installation.md`, `docs/operator/guide/troubleshooting.md`, `docs/operator/supported-hosts.md` (the GitHub CLI is optional, and what it buys), and `docs/operator/release-manifest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
