### PR TITLE
fix: recognize the ports Curia's host-network services hold

### DIFF
--- a/cli/src/preflight.mjs
+++ b/cli/src/preflight.mjs
@@ -6,6 +6,7 @@ import { createServer } from 'node:net'
 import { arch as osArch, cpus as osCpus, tmpdir, totalmem } from 'node:os'
 import { dirname, join } from 'node:path'
 
+import { INSTALLATION_LABEL } from './bundle.mjs'
 import { composeProject, parsePublishedPorts } from './compose.mjs'
 import { Refusal } from './exit.mjs'
 import { readInstallationRecord } from './root.mjs'
@@ -95,6 +96,10 @@ export const CLOCK_SKEW_LIMIT_SECONDS = 300
 
 const DOCKER_SOCKET = '/var/run/docker.sock'
 const PROBE_IMAGE = 'busybox:stable'
+
+// The label Compose puts on every container it starts, which is where a
+// container of the bundle carries the name of the service it runs.
+const COMPOSE_SERVICE_LABEL = 'com.docker.compose.service'
 const PROBE_TIMEOUT_MS = 60_000
 
 // The checks, in the order the report prints them. `severity` says what a
@@ -206,12 +211,12 @@ function holderName(port) {
 // update` and `curia rollback` run this same preflight, so a port Curia
 // binds must read as healthy, not as a conflict (#885).
 //
-// A busy port carries `service` when Compose listed it among the published
-// ports of this root's own project. That is the only honest test: the holder
-// is Curia's because Curia's Compose project says it publishes that port.
-// The process name `ss` reports is not evidence, because a published port is
-// held by a proxy in the container's namespace, whose name is whatever the
-// image called its main thread.
+// A busy port carries `service` when the port is this root's own: either
+// Compose listed it among the published ports of the root's project, or the
+// process that holds it runs in one of the installation's own containers.
+// The process name `ss` reports is never evidence, because the holder of a
+// published port is a proxy in the container's namespace, whose name is
+// whatever the image called its main thread.
 function portsCheck({ ports }) {
   const needed = SANDBOX_PORTS.perAgent * SANDBOX_PORTS.agents
   const total = SANDBOX_PORTS.to - SANDBOX_PORTS.from + 1
@@ -568,13 +573,13 @@ async function portFactsOf(ports, sandbox, root, probes) {
   const portFree = probes.portFree ?? hostProbes.portFree
   const busy = []
   for (const { port } of ports) {
-    if (!(await portFree(port))) busy.push({ port, process: await holderOf(port, probes) })
+    if (!(await portFree(port))) busy.push({ port, ...(await holderOf(port, probes)) })
   }
   if (busy.length > 0) {
-    const published = await publishedPortsOf(root, probes)
+    const claims = await installationClaims(root, probes)
     for (const entry of busy) {
-      const mine = published?.find((p) => p.port === entry.port)
-      if (mine) entry.service = mine.service
+      const service = claims && (claims.published.find((p) => p.port === entry.port)?.service ?? serviceHolding(entry, claims.containers, probes))
+      if (service) entry.service = service
     }
   }
   let sandboxFree = 0
@@ -592,11 +597,12 @@ function portFree(port) {
   })
 }
 
-// The host ports the root's own Compose project publishes, or null when this
-// root holds no installation, Compose cannot be asked, or its answer is not
-// readable. Null means "nothing here claims a port", which is the fresh-host
-// case `curia install` checks: a busy port is then someone else's.
-async function publishedPortsOf(root, probes) {
+// What this root's installation claims of the host's ports: the host ports
+// its Compose project publishes, and its own running containers. Null when
+// this root holds no installation, which is the fresh-host case `curia
+// install` checks: nothing here claims a port, so a busy port is someone
+// else's, and Docker is never asked.
+async function installationClaims(root, probes) {
   if (!root) return null
   let record = null
   try {
@@ -605,20 +611,66 @@ async function publishedPortsOf(root, probes) {
     return null
   }
   if (!record?.activeVersion) return null
-  const project = composeProject({ root, version: record.activeVersion })
-  const out = await probes.exec('docker', project.args('ps', '--format', 'json'))
-  if (!out.ok) return null
-  try {
-    return parsePublishedPorts(out.stdout)
-  } catch {
-    return null
+  return {
+    published: await publishedPortsOf(root, record.activeVersion, probes),
+    containers: await runningContainers(record.installationId, probes),
   }
 }
 
+// The host ports the root's own Compose project publishes. Empty when Compose
+// cannot be asked or its answer is not readable.
+async function publishedPortsOf(root, version, probes) {
+  const project = composeProject({ root, version })
+  const out = await probes.exec('docker', project.args('ps', '--format', 'json'))
+  if (!out.ok) return []
+  try {
+    return parsePublishedPorts(out.stdout)
+  } catch {
+    return []
+  }
+}
+
+// The installation's running containers, each with the process id Docker gave
+// its main process, found by the installation label and by nothing else, the
+// way `installationResources` finds them. `docker inspect` is the only place
+// that main process id is available.
+async function runningContainers(installationId, probes) {
+  if (!installationId) return []
+  const listed = await probes.exec('docker', ['ps', '--no-trunc', '--filter', `label=${INSTALLATION_LABEL}=${installationId}`, '--format', '{{.ID}}'])
+  if (!listed.ok) return []
+  const ids = listed.stdout.split('\n').map((line) => line.trim()).filter(Boolean)
+  if (ids.length === 0) return []
+  const format = `{{.Id}}\t{{.State.Pid}}\t{{index .Config.Labels "${COMPOSE_SERVICE_LABEL}"}}`
+  const inspected = await probes.exec('docker', ['inspect', '--format', format, ...ids])
+  if (!inspected.ok) return []
+  return inspected.stdout.split('\n').map((line) => {
+    const [id, pid, service] = line.split('\t')
+    return { id, pid: Number(pid), service: service?.trim() || 'Curia' }
+  }).filter((c) => c.id && Number.isInteger(c.pid))
+}
+
+// The service of the installation whose container holds the port, or null
+// when nothing of this installation holds it. This test is needed beside the
+// published ports because a host-network service publishes nothing: it binds
+// the host's port from inside its container, so Compose reports no publisher
+// for it and cannot see the port it holds. What identifies it instead is the
+// holder process. A service's own listener runs as the container's main
+// process, and a process it started shares the container's cgroup, which
+// names the container.
+function serviceHolding(entry, containers, probes) {
+  if (!entry.pid || containers.length === 0) return null
+  const own = containers.find((c) => c.pid === entry.pid)
+  if (own) return own.service
+  const cgroup = probes.readFile(`/proc/${entry.pid}/cgroup`) ?? ''
+  return containers.find((c) => cgroup.includes(c.id))?.service ?? null
+}
+
+// The holder of a busy port as `ss` sees it: the process name for the report
+// and its process id, which is what the container test matches on.
 async function holderOf(port, probes) {
   const out = await probes.exec('ss', ['-H', '-ltnp', `sport = :${port}`])
   const m = out.ok ? out.stdout.match(/users:\(\("([^"]+)",pid=(\d+)/) : null
-  return m ? `${m[1]} (pid ${m[2]})` : null
+  return m ? { process: `${m[1]} (pid ${m[2]})`, pid: Number(m[2]) } : { process: null, pid: null }
 }
 
 function firstLine(text) {

--- a/cli/test/doctor.test.mjs
+++ b/cli/test/doctor.test.mjs
@@ -10,7 +10,7 @@ import { runCli } from '../src/cli.mjs'
 import { packageVersion } from '../src/commands.mjs'
 import { EXIT } from '../src/exit.mjs'
 import { operatorConfigPath } from '../src/config.mjs'
-import { versionPaths } from '../src/root.mjs'
+import { readInstallationRecord, versionPaths } from '../src/root.mjs'
 import { fakeDocker, fakeTailscale, healthy, hostProbes, release as releaseIn, releaseProbesFor, stageOf as stageIn } from './fixtures/install.mjs'
 
 const VERSION = packageVersion
@@ -158,6 +158,27 @@ describe('curia doctor on a healthy installation', () => {
     assert.deepEqual([...new Set(first.docker.verbs())], ['ps'])
     const second = await doctor(i)
     assert.equal(second.out, first.out)
+  })
+
+  test('a port held by a host-network service of this installation passes and the exit stays ok', async () => {
+    const i = await installed()
+    const installationId = readInstallationRecord(i.root).installationId
+    const container = 'dd8f8b89761d0683687e763957a46a074c14aa1aadfc6efe028cfbdc2a884ec7'
+    const base = hostProbes()
+    const d = await doctor(i, {
+      host: {
+        portFree: async (port) => port !== 4272,
+        exec: async (file, args) => {
+          if (file === 'ss') return { ok: true, stdout: 'LISTEN 0 511 127.0.0.1:4272 0.0.0.0:* users:(("MainThread",pid=458794,fd=18))\n' }
+          if (file === 'docker' && args[0] === 'ps' && args.includes(`label=sh.curia.installation=${installationId}`)) return { ok: true, stdout: `${container}\n` }
+          if (file === 'docker' && args[0] === 'inspect') return { ok: true, stdout: `${container}\t458794\tdaemon\n` }
+          return base.exec(file, args)
+        },
+      },
+    })
+    assert.equal(status(d.out, 'required ports'), 'ok')
+    assert.match(line(d.out, 'required ports'), /4272 \(the timeline\) is held by this installation's daemon service/)
+    assert.equal(d.exit, EXIT.ok, d.out)
   })
 
   test('the command table routes doctor through the root boundary', async () => {

--- a/cli/test/preflight.test.mjs
+++ b/cli/test/preflight.test.mjs
@@ -438,7 +438,7 @@ describe('gatherHostFacts', () => {
       },
     })
     const facts = await gatherHostFacts({ uid: 1001, root: '/home/operator/.local/share/curia', ports: [{ port, holder: 'a test' }], sandbox: { from: port + 1, to: port + 3 } }, probes)
-    assert.deepEqual(facts.ports.busy, [{ port, process: 'node (pid 4242)' }])
+    assert.deepEqual(facts.ports.busy, [{ port, process: 'node (pid 4242)', pid: 4242 }])
     assert.equal(facts.ports.sandboxFree, 3)
     holder.close()
     // The probe listened on the sandbox ports and let them go: we can take one.
@@ -455,32 +455,133 @@ describe('gatherHostFacts', () => {
     const probes = fakeProbes()
     try {
       const facts = await gatherHostFacts({ uid: 1001, root, ports: [{ port, holder: 'a test' }], sandbox: { from: port + 1, to: port + 3 } }, probes)
-      assert.deepEqual(facts.ports.busy, [{ port, process: null }])
-      assert.ok(!probes.calls.some((c) => c.includes('ps')), 'no installation, so Compose is never asked which ports it publishes')
+      assert.deepEqual(facts.ports.busy, [{ port, process: null, pid: null }])
+      assert.ok(!probes.calls.some((c) => c.includes('ps')), 'no installation, so Docker is never asked which ports or containers are Curia\'s')
+      assert.ok(!probes.calls.some((c) => c.includes('inspect')), 'no installation, so no container is inspected')
     } finally {
       holder.close()
       rmSync(root, { recursive: true, force: true })
     }
   })
 
-  test('a running installation names the service that publishes the busy port', async () => {
+  // A running installation, the way the rehearsal host of #891 has one: a
+  // record in `state/`, an active version, and containers that carry the
+  // installation label.
+  function runningInstallation() {
+    const root = mkdtempSync(join(tmpdir(), 'curia-running-'))
+    mkdirSync(join(root, 'state'), { recursive: true })
+    const record = createInstallationRecord('0.11.0')
+    writeFileSync(recordPath(root), JSON.stringify(record))
+    return { root, record }
+  }
+
+  const DAEMON_CONTAINER = 'dd8f8b89761d0683687e763957a46a074c14aa1aadfc6efe028cfbdc2a884ec7'
+  const DASHBOARD_CONTAINER = 'deffa3bf5c7f0683687e763957a46a074c14aa1aadfc6efe028cfbdc2a884ec7'
+
+  // Probes for a running installation: what its Compose project publishes,
+  // which containers carry its label and with which main process, what `ss`
+  // says about the busy port, and what `/proc/<pid>/cgroup` holds.
+  function installationProbes({ record, published = [], containers = [], ss = '', cgroup = {} }) {
+    const base = fakeProbes()
+    const asked = []
+    const probes = fakeProbes({
+      exec: async (file, args) => {
+        asked.push([file, ...args].join(' '))
+        if (file === 'docker' && args[0] === 'compose') return { ok: true, stdout: published.map((row) => JSON.stringify(row)).join('\n'), stderr: '', code: 0 }
+        if (file === 'docker' && args[0] === 'ps') {
+          assert.ok(args.includes(`label=sh.curia.installation=${record.installationId}`), `the container list is filtered by the installation label: ${args.join(' ')}`)
+          return { ok: true, stdout: containers.map((c) => c.id).join('\n'), stderr: '', code: 0 }
+        }
+        if (file === 'docker' && args[0] === 'inspect') return { ok: true, stdout: containers.map((c) => `${c.id}\t${c.pid}\t${c.service}`).join('\n'), stderr: '', code: 0 }
+        if (file === 'ss') return { ok: true, stdout: ss }
+        return base.exec(file, args)
+      },
+      readFile: (path) => cgroup[path] ?? base.readFile(path),
+    })
+    probes.asked = asked
+    return probes
+  }
+
+  async function busyPortFacts(probes, root, port) {
+    return gatherHostFacts({ uid: 1001, root, ports: [{ port, holder: 'a test' }], sandbox: { from: port + 1, to: port + 3 } }, probes)
+  }
+
+  test('a published port names the service Compose says publishes it', async () => {
     const holder = createServer()
     await new Promise((r) => holder.listen(0, '127.0.0.1', r))
     const port = holder.address().port
-    const root = mkdtempSync(join(tmpdir(), 'curia-running-'))
-    mkdirSync(join(root, 'state'), { recursive: true })
-    writeFileSync(recordPath(root), JSON.stringify(createInstallationRecord('0.11.0')))
-    const ps = JSON.stringify({ Service: 'tmux', State: 'running', Publishers: [{ URL: '127.0.0.1', TargetPort: 7681, PublishedPort: port, Protocol: 'tcp' }] })
-    const probes = fakeProbes({
-      exec: async (file, args) => {
-        if (file === 'docker' && args[0] === 'compose') return { ok: true, stdout: `${ps}\n`, stderr: '', code: 0 }
-        if (file === 'ss') return { ok: true, stdout: '' }
-        return fakeProbes().exec(file, args)
-      },
+    const { root, record } = runningInstallation()
+    const probes = installationProbes({
+      record,
+      published: [{ Service: 'overseer', State: 'running', Publishers: [{ URL: '127.0.0.1', TargetPort: 4274, PublishedPort: port, Protocol: 'tcp' }] }],
+      containers: [{ id: DAEMON_CONTAINER, pid: 458794, service: 'daemon' }],
+      ss: `LISTEN 0 4096 127.0.0.1:${port} 0.0.0.0:* users:(("docker-proxy",pid=459001,fd=4))\n`,
     })
     try {
-      const facts = await gatherHostFacts({ uid: 1001, root, ports: [{ port, holder: 'a test' }], sandbox: { from: port + 1, to: port + 3 } }, probes)
-      assert.deepEqual(facts.ports.busy, [{ port, process: null, service: 'tmux' }])
+      const facts = await busyPortFacts(probes, root, port)
+      assert.deepEqual(facts.ports.busy, [{ port, process: 'docker-proxy (pid 459001)', pid: 459001, service: 'overseer' }])
+    } finally {
+      holder.close()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('a host-network service is recognized by the container it runs as', async () => {
+    const holder = createServer()
+    await new Promise((r) => holder.listen(0, '127.0.0.1', r))
+    const port = holder.address().port
+    const { root, record } = runningInstallation()
+    const probes = installationProbes({
+      record,
+      published: [{ Service: 'dashboard', State: 'running', Publishers: [] }],
+      containers: [{ id: DASHBOARD_CONTAINER, pid: 458570, service: 'dashboard' }],
+      ss: `LISTEN 0 511 127.0.0.1:${port} 0.0.0.0:* users:(("MainThread",pid=458570,fd=18))\n`,
+    })
+    try {
+      const facts = await busyPortFacts(probes, root, port)
+      assert.deepEqual(facts.ports.busy, [{ port, process: 'MainThread (pid 458570)', pid: 458570, service: 'dashboard' }])
+    } finally {
+      holder.close()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('a child of a host-network container is recognized by its cgroup', async () => {
+    const holder = createServer()
+    await new Promise((r) => holder.listen(0, '127.0.0.1', r))
+    const port = holder.address().port
+    const { root, record } = runningInstallation()
+    const probes = installationProbes({
+      record,
+      containers: [{ id: DAEMON_CONTAINER, pid: 458794, service: 'daemon' }],
+      ss: `LISTEN 0 511 127.0.0.1:${port} 0.0.0.0:* users:(("ttyd",pid=459200,fd=7))\n`,
+      cgroup: { '/proc/459200/cgroup': `0::/system.slice/docker-${DAEMON_CONTAINER}.scope\n` },
+    })
+    try {
+      const facts = await busyPortFacts(probes, root, port)
+      assert.equal(facts.ports.busy[0].service, 'daemon')
+    } finally {
+      holder.close()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('a foreign holder on a running installation stays foreign', async () => {
+    const holder = createServer()
+    await new Promise((r) => holder.listen(0, '127.0.0.1', r))
+    const port = holder.address().port
+    const { root, record } = runningInstallation()
+    const probes = installationProbes({
+      record,
+      containers: [{ id: DAEMON_CONTAINER, pid: 458794, service: 'daemon' }],
+      ss: `LISTEN 0 511 127.0.0.1:${port} 0.0.0.0:* users:(("nginx",pid=4242,fd=6))\n`,
+    })
+    try {
+      const facts = await busyPortFacts(probes, root, port)
+      assert.deepEqual(facts.ports.busy, [{ port, process: 'nginx (pid 4242)', pid: 4242 }])
+      const report = evaluateHostFacts(ubuntu({ ports: { busy: facts.ports.busy, sandboxFree: 300 } }))
+      assert.equal(report.ok, false)
+      assert.match(check(report, 'required ports').observed, /nginx \(pid 4242\)/)
     } finally {
       holder.close()
       rmSync(root, { recursive: true, force: true })

--- a/docs/operator/doctor.md
+++ b/docs/operator/doctor.md
@@ -99,6 +99,10 @@ A script can run `curia doctor` and branch on `0` against the rest. A warning ne
 
 When a credential key such as `GH_TOKEN` is set in your shell, the `environment` check names the key and never its value.
 
+## The required ports on a running installation
+
+On a running installation, Curia's own containers hold the loopback ports, and that's the healthy state. The `required ports` check reports `ok` and names the service that holds each one, such as `4272 (the timeline) is held by this installation's daemon service`. It recognizes two shapes: a port the installation's Compose project publishes, and a port a host-network service binds from inside its container, which publishes nothing and is recognized by the container's process id and cgroup instead. A port held by anything else is `refused`, and the action is to stop that program or move it to another port. See [How Curia recognizes a port of its own](supported-hosts.md#how-curia-recognizes-a-port-of-its-own).
+
 ## Provenance and the GitHub CLI
 
 The `image provenance` check asks `gh attestation verify` for each of the five image digests, the agent image's included. The GitHub CLI is optional on a supported host, and it isn't a prerequisite of the bootstrap.

--- a/docs/operator/supported-hosts.md
+++ b/docs/operator/supported-hosts.md
@@ -77,7 +77,7 @@ The following table lists every check, what it can do, the condition it reports,
 | architecture | Refuse | The processor is not x86-64. | Install Curia on an x86-64 host. |
 | host capacity | Warn | CPU, memory, or free disk is below the minimum or the recommended profile. | Give the host the named profile. |
 | required ports | Refuse | One of the five loopback ports is held by another program, named when `ss` can see it. | Stop that program or move it to another port. |
-| required ports | Pass | A loopback port is held by a container of this installation's own Compose project, which is the healthy state on a running host. The line names the service that publishes it. `curia update` and `curia rollback` run this check on a running installation, so it has to tell Curia's containers from a foreign program. | Nothing. |
+| required ports | Pass | A loopback port is held by a container of this installation, which is the healthy state on a running host. The line names the service that holds it. `curia update` and `curia rollback` run this check on a running installation, so it has to tell Curia's containers from a foreign program. See [How Curia recognizes a port of its own](#how-curia-recognizes-a-port-of-its-own). | Nothing. |
 | required ports | Refuse | Fewer than 12 ports are free in `9000` to `9299`. | Free at least 12 ports in that range. |
 | Docker Engine | Refuse | Docker is not installed. | Install Docker Engine 24.0 or later from the [Docker Engine install page](https://docs.docker.com/engine/install/). |
 | Docker Engine | Refuse | Your user can't open `/var/run/docker.sock`. | Run `sudo usermod -aG docker $USER`, then log out and in. |
@@ -100,6 +100,15 @@ The following table lists every check, what it can do, the condition it reports,
 The node's login, the Tailscale operator permission, and the tailnet's HTTPS certificate are not preflight checks. They belong to the `tailnet` step of `curia install`, which logs the node in when it isn't and refuses on the other two with the exact command or setting; `curia reinstall`, `curia update`, and `curia rollback` inspect the same three facts in their `preflight` step and refuse without logging in. See [The tailnet step](install.md#the-tailnet-step).
 
 The unsupported categories that the specification names, such as Windows Subsystem for Linux, nested containers, immutable hosts, hosts without systemd, and rootless Docker, are not refused by name. When every functional check passes, installation continues, with a warning where the check can tell.
+
+### How Curia recognizes a port of its own
+
+On a host that holds no installation, every busy required port is another program's, and Curia asks Docker nothing. When the root holds an installation, Curia has to tell its own containers from a foreign program, because `curia update` and `curia rollback` run this check while the installation runs. The services hold their ports in two different shapes, and each has its own test:
+
+- **A published port.** The `overseer` service publishes `127.0.0.1:4274` through Docker, so `docker compose ps --format json` lists the port under the service's publishers. A busy port that the root's own project publishes passes, and the line names that service.
+- **A port a host-network service holds.** The `daemon`, `dashboard`, and `ttyd` services run with `network_mode: host` and bind the host's port from inside the container, so they publish nothing and Compose reports no publisher for them. Curia lists the installation's running containers by the `sh.curia.installation` label and reads each one's main process id. A busy port passes when the process that holds it is a container's main process, or when `/proc/<pid>/cgroup` names one of those containers, which covers a process the service started.
+
+The process name that `ss` prints is never the evidence. It's whatever the image called its main thread, which is why a healthy host reports holders such as `MainThread` and `ttyd`. A holder that matches neither test is foreign, and the check still refuses.
 
 ## What preflight doesn't check
 


### PR DESCRIPTION
The live rehearsal of the packaged lifecycle (#891, map #863) ran `curia doctor` and `curia update` on a healthy 0.11.1 installation on the Ubuntu 24.04 rehearsal host. [#979](https://github.com/alp82/curia/pull/979) taught the required-ports check to pass a port this installation holds, through `docker compose ps --format json` and its `Publishers[].PublishedPort`. On that host it identifies one of the four busy ports, so both commands still refuse:

```
refused  required ports  port 4272 (the timeline) is held by MainThread (pid 458794); 4273 (the Curia app) is held by MainThread (pid 458570); 7681 (the attach surface) is held by ttyd (pid 458801).
```

## The finding

The `daemon`, `dashboard`, and `ttyd` services declare `network_mode: host` in the bundle, so they publish nothing through Docker: they bind the host's port from inside the container. Compose reports `Publishers: []` for them and `docker port` prints nothing. Only `overseer`, which publishes `127.0.0.1:4274->4274`, has a publisher, which is why 4274 dropped off the refusal and the other three did not.

What identifies a host-network service is the holder process, measured on the same host:

```
$ for c in $(docker ps --filter "label=sh.curia.installation" --format "{{.ID}}"); do echo $c $(docker inspect -f "{{.State.Pid}}" $c); done
dd8f8b89761d 458794   # daemon
fedba28e6ff3 458801   # ttyd
deffa3bf5c7f 458570   # dashboard
$ ss -lptn 'sport = :4273'
LISTEN 127.0.0.1:4273  users:(("MainThread",pid=458570,fd=18))
$ cat /proc/458570/cgroup
0::/system.slice/docker-deffa3bf5c7f0683687e763957a46a074c14aa1aadfc6efe028cfbdc2a884ec7.scope
```

The holder process id is the container's own main process id, and the holder's cgroup names the container id.

## The fix

The check keeps the Publishers match for a published port such as the overseer's, and adds the host-network case. For the installation's running containers, found by the `sh.curia.installation` label that `cli/src/resources.mjs` already uses, preflight reads each container's id and main process id. A busy required port passes when its holder process id is one of those process ids, or when `/proc/<holder pid>/cgroup` names one of those container ids, which covers a process the service started. The line names the service, not the process id, the way #979 does.

A holder that matches neither test still refuses with the existing text and action. A host with no installation record still asks Docker nothing, so the fresh-host path is unchanged. The process name `ss` prints is never the evidence: it's whatever the image called its main thread, which is what the rehearsal saw as `MainThread`.

## Tests and docs

Every probe stays injectable, so the tests need no Docker. They cover a published port in the overseer's shape, a host-network port matched by process id, one matched by cgroup only, a foreign holder on a running installation, and a fresh host. A doctor test proves the `required ports` line reads `ok` and the exit code stays `0` when a host-network service holds a port.

`cd cli && npm test`: 412 pass, 0 fail, 0 cancelled. `cd daemon && npm test`: 4531 pass, 0 fail, 0 cancelled, 1 skipped (the opt-in image build).

Docs: `docs/operator/supported-hosts.md` gains "How Curia recognizes a port of its own" and its check row now points at it; `docs/operator/doctor.md` gains "The required ports on a running installation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
