### PR TITLE
fix: end quietly when a reader closes the interface's output

### DIFF
--- a/cli/bin/curia.mjs
+++ b/cli/bin/curia.mjs
@@ -5,11 +5,24 @@
 // `npm install -g @curia-sh/cli` links it as `curia` too, which is how the
 // package is invoked before an installation exists.
 
-import { runCli } from '../src/cli.mjs'
+import { endQuietlyOnClosedOutput, runCli } from '../src/cli.mjs'
+import { EXIT } from '../src/exit.mjs'
 
-process.exitCode = await runCli({
+// What the run has settled on so far. It stays null while a command is
+// running, so a reader that closes mid-operation is told the work did not
+// finish. `endQuietlyOnClosedOutput` explains both codes.
+let outcome = null
+
+endQuietlyOnClosedOutput({
+  stdout: process.stdout,
+  stderr: process.stderr,
+  status: () => (outcome === null ? EXIT.failed : outcome),
+})
+
+outcome = await runCli({
   argv: process.argv.slice(2),
   env: process.env,
   stdout: process.stdout,
   stderr: process.stderr,
 })
+process.exitCode = outcome

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -51,6 +51,40 @@ export async function runCli({ argv, env, stdout, stderr, uid = process.getuid()
   }
 }
 
+// Ends the process quietly when the reader on the other end of stdout or
+// stderr goes away. `curia version | head -1`, `curia doctor | head`, and
+// `curia doctor | grep -m1 ...` are ordinary things an operator or a script
+// runs, and the reader closes the pipe as soon as it has what it wanted. Node
+// reports that as an `EPIPE` write error on the stream, and with nobody
+// listening it becomes an unhandled 'error' event: a stack trace on a run that
+// did nothing wrong. A closed output is not a Curia failure, so the interface
+// ends the way a Unix tool does, with no trace and no report.
+//
+// THE EXIT STATUS COMES FROM `status()`, which the caller answers from where
+// the run got to:
+//
+//   - The command already returned. It did its work and wrote everything it
+//     had; only the reader left. That run succeeded, so the process exits with
+//     the code the command chose.
+//   - The command is still running. A write it will never complete cuts it off
+//     mid-operation, and its outcome is unknown, so the process exits `failed`.
+//     The message that normally says what to do next has nowhere to go.
+//
+// EVERY OTHER WRITE ERROR KEEPS ITS CURRENT BEHAVIOR. A full disk or a
+// vanished terminal is a real failure, and rethrowing from here leaves it an
+// uncaught exception with its stack, exactly as before.
+//
+// This is the one place the interface handles its own streams. Commands write
+// and never think about the reader.
+export function endQuietlyOnClosedOutput({ stdout, stderr, status, exit = (code) => process.exit(code) }) {
+  const onError = (e) => {
+    if (e?.code !== 'EPIPE') throw e
+    exit(status())
+  }
+  stdout.on('error', onError)
+  stderr.on('error', onError)
+}
+
 export function usage(commands = lifecycleCommands) {
   const width = Math.max(...Object.keys(commands).map((n) => n.length))
   const lines = Object.entries(commands).map(([n, c]) => `  ${n.padEnd(width)}  ${c.summary}`)

--- a/cli/test/cli.test.mjs
+++ b/cli/test/cli.test.mjs
@@ -4,8 +4,11 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
+import { spawn, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
-import { runCli } from '../src/cli.mjs'
+import { endQuietlyOnClosedOutput, runCli } from '../src/cli.mjs'
 import { EXIT } from '../src/exit.mjs'
 
 const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
@@ -152,5 +155,85 @@ describe('exit behavior', () => {
     })
     assert.equal(exit, EXIT.failed)
     assert.match(io.err(), /^curia doctor: the socket vanished\n$/)
+  })
+})
+
+// The interface owns its streams, so a reader that closes early is its problem
+// to handle. `curia version | head -1` is an ordinary thing for an operator or
+// a script to run, and it has to end the way a Unix tool does.
+describe('a reader that closes the output', () => {
+  const binary = fileURLToPath(new URL('../bin/curia.mjs', import.meta.url))
+
+  // Runs the real binary with the read end of its stdout already closed, which
+  // is what `head` leaves behind once it has the line it wanted.
+  function runWithClosedOutput(args, env) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [binary, ...args], { stdio: ['ignore', 'pipe', 'pipe'], env })
+      let err = ''
+      child.stderr.setEncoding('utf8')
+      child.stderr.on('data', (s) => { err += s })
+      child.stdout.destroy()
+      child.on('error', reject)
+      child.on('close', (code, signal) => resolve({ code, signal, err }))
+    })
+  }
+
+  // The same command with a reader that stays, for the exit code a closed
+  // reader must not change.
+  function runWithOpenOutput(args, env) {
+    return spawnSync(process.execPath, [binary, ...args], { encoding: 'utf8', env }).status
+  }
+
+  // `version` writes a line at a time and `help` writes one long block, so
+  // between them they cover both shapes of output. `doctor` is not here
+  // because it refuses a scratch root before it writes anything to stdout.
+  for (const command of ['version', 'help']) {
+    test(`${command} ends quietly and keeps the exit code it would have had`, async () => {
+      const root = tempRoot()
+      try {
+        const env = { PATH: process.env.PATH, CURIA_ROOT: root }
+        const r = await runWithClosedOutput([command], env)
+        assert.doesNotMatch(r.err, /EPIPE/)
+        assert.doesNotMatch(r.err, /^\s+at /m)
+        assert.doesNotMatch(r.err, /Unhandled 'error' event/)
+        assert.equal(r.signal, null)
+        assert.equal(r.code, runWithOpenOutput([command], env))
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+  }
+
+  test('a closed pipe after the command returns exits with the code the command chose', () => {
+    const stdout = new EventEmitter()
+    const exits = []
+    endQuietlyOnClosedOutput({ stdout, stderr: new EventEmitter(), status: () => EXIT.ok, exit: (c) => exits.push(c) })
+    stdout.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+    assert.deepEqual(exits, [EXIT.ok])
+  })
+
+  test('a closed pipe while the command is still working exits failed', () => {
+    const stdout = new EventEmitter()
+    const exits = []
+    endQuietlyOnClosedOutput({ stdout, stderr: new EventEmitter(), status: () => EXIT.failed, exit: (c) => exits.push(c) })
+    stdout.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+    assert.deepEqual(exits, [EXIT.failed])
+  })
+
+  test('a closed stderr ends quietly too', () => {
+    const stderr = new EventEmitter()
+    const exits = []
+    endQuietlyOnClosedOutput({ stdout: new EventEmitter(), stderr, status: () => EXIT.ok, exit: (c) => exits.push(c) })
+    stderr.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+    assert.deepEqual(exits, [EXIT.ok])
+  })
+
+  test('a write error that is not a closed pipe stays unhandled', () => {
+    const stdout = new EventEmitter()
+    const exits = []
+    endQuietlyOnClosedOutput({ stdout, stderr: new EventEmitter(), status: () => EXIT.ok, exit: (c) => exits.push(c) })
+    const full = Object.assign(new Error('no space left on device'), { code: 'ENOSPC' })
+    assert.throws(() => stdout.emit('error', full), /no space left on device/)
+    assert.deepEqual(exits, [])
   })
 })

--- a/docs/operator/command-reference.md
+++ b/docs/operator/command-reference.md
@@ -108,6 +108,8 @@ Every command and the launcher use the same four exit codes, so a script can bra
 
 A refusal is not a failure. It means Curia checked a precondition, such as a missing runtime file or an unsupported host, and stopped before touching anything. The host preconditions are in [Supported hosts and preflight checks](supported-hosts.md).
 
+You can pipe any command into a reader that stops early, such as `curia version | head -1` or `curia doctor | grep -m1 refused`. A closed pipe is not a Curia failure. The command ends quietly, with no error and no stack trace, and keeps the exit code it had already earned. A reader that closes while an operation is still running ends the command mid-work, and that exits `1`, because the operation did not finish.
+
 ## Environment
 
 `CURIA_ROOT` names the installation root. The launcher sets it for you. Set it yourself only when you run the lifecycle interface without the launcher, such as from a development checkout. The value must be an absolute path.


### PR DESCRIPTION
The live rehearsal of the packaged lifecycle (#891, map #863) found that piping any `curia` command into a reader that stops early crashes the interface. On the Ubuntu 24.04 host running 0.12.0:

```
$ curia version | head -1
node:events:487
      throw er; // Unhandled 'error' event
Error: write EPIPE
    at Object.version [as run] (file:///home/curia/.local/share/curia/versions/0.12.0/cli/src/commands.mjs:30:10)
    at runCli (file:///home/curia/.local/share/curia/versions/0.12.0/cli/src/cli.mjs:43:26)
    at file:///home/curia/.local/share/curia/versions/0.12.0/cli/bin/curia.mjs:10:26
  errno: -32, code: 'EPIPE', syscall: 'write'
```

`head` closes the pipe as soon as it has its line. Node reports the next write as an `EPIPE` error on `process.stdout`, and with nobody listening it became an unhandled 'error' event: a stack trace and exit 1 on a run that did nothing wrong. `curia version | head -1`, `curia doctor | head`, and `curia doctor | grep -m1 ...` are ordinary things an operator or a script does. A closed output is not a Curia failure.

## The fix

`endQuietlyOnClosedOutput` in `cli/src/cli.mjs` is the one place the interface handles its own streams, and `cli/bin/curia.mjs` installs it before anything runs. An `EPIPE` on stdout or stderr ends the process the way a Unix tool does, with no trace and no report. Commands write and never think about the reader.

## The exit status

The status comes from where the run got to.

- The command already returned. It did its work and wrote everything it had; only the reader left. That run succeeded, so the process exits with the code the command chose, usually `0`.
- The command is still running. A write it will never complete cuts it off mid-operation, and its outcome is unknown, so the process exits `1`, `failed`. The message that normally says what to do next has nowhere to go.

Every other write error keeps its current behavior. Rethrowing from the handler leaves a full disk or a vanished terminal an uncaught exception with its stack, exactly as before, and nothing swallows an error from a lifecycle operation itself.

## The rest of the surface

Nothing else shares this shape.

- `deploy/bootstrap/curia-install.sh` already ends correctly, because Bash takes the default SIGPIPE and dies without a message. `bash curia-install.sh --help | head -1` prints the line, exits `0`, and writes nothing to stderr.
- The daemon's `bin/` files are npm-script tools that CI or the overseer container runs with output redirected to a file, not an interface an operator pipes.

## Tests

`cli/test/cli.test.mjs` spawns the real binary with the read end of its stdout already closed, for `version` (a line at a time) and `help` (one long block), and asserts no stack trace on stderr, no signal, and the same exit code the command has with a reader that stays. Both fail on `main` and pass here. Unit tests cover both exit statuses, a closed stderr, and a write error that is not a closed pipe. No network and no Docker.

`cd cli && npm test`: 420 pass, 0 fail, 0 cancelled. `cd daemon && npm test`: 4531 pass, 0 fail, 0 cancelled, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013So3Lgy6Xnuhj2DwEEJB8e
