### PR TITLE
fix: offer Discord permission recovery from setup

### DIFF
--- a/daemon/assets/dashboard.html
+++ b/daemon/assets/dashboard.html
@@ -5458,6 +5458,7 @@ function setupDiscord(card, progress) {
   const bot = d.bot ? `<div class="rows"><div class="row"><span class="key grow">Bot</span><span>${esc(d.bot.username)}${d.invite_url ? ` · <a href="${esc(d.invite_url)}" target="_blank" rel="noopener">Add the bot to a server</a>` : ""}</span></div></div>` : "";
   const problem = d.error && (!stage || stage === "rate_limit") ? `<p class="qhint">${esc(d.error)}</p>` : "";
   return `${bot}${problem}
+    ${stage === "authority" && detail?.permission_repair_url ? `<p><a class="btn primary" href="${esc(detail.permission_repair_url)}" target="_blank" rel="noopener">Update bot permissions</a></p><p class="qhint">Approve Curia’s required permissions in Discord, then return here and select Try again. You don’t need to remove the bot or replace its token.</p>` : ""}
     ${tokenFirst ? setupDiscordTokenForm(d, true) : ""}
     ${stage === "commands" ? setupDiscordCommandsForm() : ""}
     ${setupDiscordChannelForm(d, progress, detail)}

--- a/daemon/src/discordsetup.mjs
+++ b/daemon/src/discordsetup.mjs
@@ -478,6 +478,13 @@ export class DiscordSetup {
     const held = channelPermissions({ base: row.permissions, overwrites: channel.permission_overwrites ?? [], roles, botId: bot.id, guildId: guild.id })
     const missing = CHANNEL_PERMISSIONS.filter((p) => !(held & p.bit)).map((p) => p.name)
     if (missing.length) {
+      const base = BigInt(row.permissions ?? 0)
+      const serverMissing = CHANNEL_PERMISSIONS.filter((p) => missing.includes(p.name) && !(base & ADMINISTRATOR) && !(base & p.bit)).map((p) => p.name)
+      if (serverMissing.length) {
+        facts.permission_repair_url = `${inviteUrl(appId)}&guild_id=${guild.id}&disable_guild_select=true`
+        return fail('authority', `curia can't ${list(missing, 'or')} in #${channelFacts.name}`,
+          'Select Update bot permissions and approve the requested permissions in Discord, then try again. You don’t need to remove the bot. Channel overrides may still need a separate change.', facts)
+      }
       return fail('authority', `curia can't ${list(missing, 'or')} in #${channelFacts.name}`, permissionsAction(missing, channelFacts.name), facts)
     }
 

--- a/daemon/test/dashboardpage.test.mjs
+++ b/daemon/test/dashboardpage.test.mjs
@@ -5406,6 +5406,17 @@ describe('integration setup (#874)', () => {
   // #891: a read never registers the commands. A card that failed on them
   // offers one press, Register commands, and never the invite link as the
   // fix; the press lands on the sidecar with no field and re-reads the frame.
+  test('missing server permissions show a repair link, but channel overrides do not', () => {
+    const detail = { stage: 'authority', permission_repair_url: 'https://discord.com/oauth2/authorize?client_id=555&permissions=329101986896&guild_id=333&disable_guild_select=true' }
+    page.UI.setup.discord = DISCORD_OVERVIEW()
+    const card = { state: 'failed', detail }
+    const html = page.setupDiscord(card, {})
+    assert.match(html, /href="https:\/\/discord.com\/oauth2\/authorize\?client_id=555&amp;permissions=329101986896&amp;guild_id=333&amp;disable_guild_select=true"[^>]*>Update bot permissions</)
+    assert.match(text(html), /You don’t need to remove the bot or replace its token/)
+    delete detail.permission_repair_url
+    assert.doesNotMatch(page.setupDiscord(card, {}), /Update bot permissions/)
+  })
+
   test('a Discord card that failed on the commands offers Register commands, and the press registers once, then verifies fresh', async () => {
     page.setup = SETUP({ step: 'discord', cards: { discord: {
       state: 'failed', badge: 'Action required',

--- a/daemon/test/discordsetup.test.mjs
+++ b/daemon/test/discordsetup.test.mjs
@@ -484,6 +484,23 @@ describe('the Discord card (#876)', () => {
   })
 
   describe('channel authority', () => {
+    test('missing server permissions offer authorization for the same bot and server with every required permission', async () => {
+      connected()
+      const { verify } = setupOver(happy({
+        '/users/@me/guilds': [200, [guildRow({ permissions: String(INVITE_PERMISSIONS & ~(1n << 34n)) })]],
+      }))
+      const answer = await verify({ progress: {} })
+      assert.equal(answer.ok, false)
+      assert.match(answer.failed, /Manage Threads/)
+      assert.match(answer.action, /Update bot permissions/)
+      const url = new URL(answer.detail.permission_repair_url)
+      assert.equal(url.origin, 'https://discord.com')
+      assert.equal(url.searchParams.get('client_id'), APP)
+      assert.equal(url.searchParams.get('guild_id'), GUILD)
+      assert.equal(url.searchParams.get('disable_guild_select'), 'true')
+      assert.equal(url.searchParams.get('permissions'), String(INVITE_PERMISSIONS))
+      assert.equal(url.searchParams.get('scope'), 'bot applications.commands')
+    })
     // The bits are Discord's own, from its permissions table. The invite link
     // asks for every one of them, so the bot added through the card holds
     // what the bridge and the agents use in the channel and its threads.
@@ -514,6 +531,7 @@ describe('the Discord card (#876)', () => {
       assert.equal(answer.ok, false)
       assert.equal(answer.detail.stage, 'authority')
       assert.match(answer.failed, /can't Manage Webhooks in #curia/)
+      assert.equal(answer.detail.permission_repair_url, undefined, 'a channel denial is not fixed by server authorization')
       assert.match(answer.action, /Allow Manage Webhooks for the bot in #curia's permissions/)
       assert.match(answer.action, /Manage Webhooks .*speaker identity/i)
       assert.deepEqual(lintReply(answer.action), [])

--- a/docs/operator/integration-setup.md
+++ b/docs/operator/integration-setup.md
@@ -120,6 +120,8 @@ While the panel waits, it reads the bot's servers again on the Setup page's refr
 
 ### Choose the channel
 
+If verification finds missing server permissions, select **Update bot permissions**. The link opens Discord authorization for the existing bot and selected server, requesting the full permission set. Approve the permissions, return to Setup, and select **Try again**. You don't need to remove the bot or replace its token. A channel override can still deny a permission after authorization; in that case, Setup names the channel permission to change.
+
 1. Select the server.
 2. Enter the command channel's name. The field suggests `curia`, but any name works, and you can change it before anything exists.
 3. Select **Connect channel**.


### PR DESCRIPTION
## Change

Setup offers Update bot permissions when a required permission is missing at server level. The Discord authorization link uses the existing application, pins the selected server, and requests the complete shared permission set. The operator returns to Try again without removing the bot or replacing its token. Channel-only denials retain channel-permission guidance.

## Verification

- 433 focused tests passed, including the repair URL and rendered recovery link.
- Full daemon suite: 4539 passed, 0 failed, 0 cancelled, 1 skipped.
- Operator documentation updated.

Release level: patch. Not deployed; no Discord permissions changed.