### PR TITLE
fix: recover Test run map updates without redispatch

### DIFF
--- a/daemon/src/dispatch.mjs
+++ b/daemon/src/dispatch.mjs
@@ -70,7 +70,7 @@ import {
   writeEnvFile,
 } from './sandbox.mjs'
 import {
-  resolveAndLand, summariseOutcome, nonCleanComment, landBranch, prLinkComment, chartingComment,
+  resolveAndLand, repairMapPointer, summariseOutcome, nonCleanComment, landBranch, prLinkComment, chartingComment,
   verdictComment, judgementComment, verdictNote, verdictCarrier,
 } from './resolve.mjs'
 import { smallPrint } from './messaging.mjs'
@@ -5487,6 +5487,16 @@ export class Dispatcher {
   // that nothing on disk points back to.
   #epochSpawn(session) {
     return this.reduction.questions.epochSpawn(session)
+  }
+
+  async repairTicketMap({ repo, ticket, map, summary }) {
+    const issue = await this.deps.fetchIssue(repo, ticket)
+    if (issue.state !== 'closed') throw new Error('The ticket is open. Map-only recovery requires a closed ticket.')
+    return repairMapPointer({ repo, ticket, issue, result: { summary }, expectedMap: map,
+      deps: this.deps,
+      journal: (type, data) => this.reduction.journal(type, data),
+      withMapLock: (key, fn) => this.#withMapLock(key, fn),
+    })
   }
 
   async #resolveTicket(agentName, repo, ticket, result, w) {

--- a/daemon/src/fullloop.mjs
+++ b/daemon/src/fullloop.mjs
@@ -122,9 +122,11 @@ export class FullLoop {
   // and `overseerSessions()` names the overseer panes in a turn. `dataDir`
   // is where reply files land, which the escalation message names. Every one
   // of these is a seam a test fills without a network.
-  constructor({ discover, dispatch, tracker = {}, journal, lastRun, eventsSince, now = () => new Date(), wait = sleep, log = () => {}, agentLive = () => false, overseerSessions = () => [], dataDir = null }) {
+  constructor({ discover, dispatch, repairMap = null, tracker = {}, journal, lastRun, eventsSince, now = () => new Date(), wait = sleep, log = () => {}, agentLive = () => false, overseerSessions = () => [], dataDir = null }) {
     this.discover = discover
     this.dispatch = dispatch
+    this.repairMap = repairMap
+    this.repairingMap = null
     this.tracker = tracker
     this.journal = journal
     this.lastRun = lastRun
@@ -176,13 +178,19 @@ export class FullLoop {
   }
 
   // Same-step retry. Creation and discovery rerun their reads and writes on
-  // the same map; every later ticket leg is a fresh dispatch of the same
+  // the same map; map-update recovery preserves the completed ticket receipt.
+  // Other later ticket legs are a fresh dispatch of the same
   // ticket, because the agent that would have walked it is gone (that is
   // what failed the leg); the map close re-reads the map.
   async retry() {
+    if (this.repairingMap) return this.repairingMap
     const current = this.status()
     if (current.state === 'running') throw refuse(`A Test run is running on ${current.repo}${current.ticket ? `#${current.ticket.number}` : ''}; there is nothing to retry yet.`)
     if (current.state !== 'failed') throw refuse('There is nothing to retry.')
+    if (current.failed.leg === 'map_update') {
+      this.repairingMap = this.#repairMap(current).finally(() => { this.repairingMap = null })
+      return this.repairingMap
+    }
     this.journal('full_loop_retry', { repo: current.repo, ticket: current.ticket?.number ?? null, map: current.map?.number ?? null, leg: current.failed.leg })
     if (current.failed.leg === 'map_closed') {
       await this.#readMapClosed(current.repo, current.map.number)
@@ -190,6 +198,26 @@ export class FullLoop {
       await this.#advance()
     } else {
       this.#launch(current.repo, current.ticket.number)
+    }
+    return this.status()
+  }
+
+  async #repairMap(current) {
+    const { rows } = this.#load()
+    const ticket = current.ticket.number
+    const spawn = rows.filter((r) => r.type === 'agent_spawned' && r.agent === `curia-${ticket}`).at(-1)
+    const receipt = rows.find((r) => r.id > (spawn?.id ?? Infinity) && r.type === 'ticket_resolved' && r.ticket === String(ticket))
+    const repo = current.repo
+    try {
+      if (!receipt || receipt.ev.land !== 'merged' || !RESOLVED.has(receipt.ev.close) || !RESOLVED.has(receipt.ev.comment)) {
+        throw new Error('No completed merge and ticket-resolution receipt is available. No map was changed.')
+      }
+      if (!this.repairMap) throw new Error('Map recovery is unavailable in this service.')
+      const result = await this.repairMap({ repo, ticket, map: current.map.number, summary: receipt.ev.summary ?? current.ticket.title })
+      if (!MAP_DONE.has(result?.state) || result.number !== current.map.number) throw new Error(`Map verification returned ${result?.state ?? 'no result'}.`)
+      this.journal('full_loop_map_repaired', { repo, ticket, map: current.map.number, receipt_id: receipt.id, state: result.state })
+    } catch (e) {
+      this.journal('full_loop_failed', { repo, ticket, leg: 'map_update', cause: `Map recovery failed: ${e.message}`, action: 'Fix the map recovery error, then select Try again. The completed ticket will not be dispatched again.' })
     }
     return this.status()
   }
@@ -562,15 +590,28 @@ export class FullLoop {
         }],
         ['map_update', () => {
           const done = after(at, (r) => r.type === 'ticket_resolved' && r.ticket === ticket)
-          if (!done || !MAP_DONE.has(done.ev.map)) return null
+          if (!done) return null
+          const repaired = after(done.id, (r) => r.type === 'full_loop_map_repaired' && r.ticket === ticket && r.ev.receipt_id === done.id && r.ev.map === map.number && MAP_DONE.has(r.ev.state))
+          const accepted = MAP_DONE.has(done.ev.map) ? done : repaired
+          if (!accepted) return null
           resolvedRow = done
-          return [done, out.links.map]
+          return [accepted, out.links.map]
         }],
       ]
       let stopped = false
       for (const [key, judge] of walk) {
         const found = judge()
         if (!found) {
+          if (key === 'map_update') {
+            const done = after(at, (r) => r.type === 'ticket_resolved' && r.ticket === ticket)
+            if (done) {
+              const lost = failedRow('map_update', done.id, t.number)
+              shown.state = 'failed'
+              fail(key, lost?.ev.cause ?? `The ticket was merged and closed, but its map update was not verified (map: ${done.ev.map ?? 'missing'}).`,
+                lost?.ev.action ?? 'Select Try again to repair and verify the map update. The completed ticket will not be dispatched again.', lost?.ts ?? done.ts)
+              return this.#finish(out, started)
+            }
+          }
           if (closing) {
             shown.state = 'failed'
             const why = closing.ev.reason ?? closing.ev.error ?? CLOSING[closing.type]

--- a/daemon/src/github.mjs
+++ b/daemon/src/github.mjs
@@ -76,8 +76,21 @@ export function flatFrontier(repo) {
 }
 
 // Lazy full issue (body included) at dispatch time.
-export async function fetchIssue(repo, n) {
-  return JSON.parse(await gh(['api', `repos/${repo}/issues/${n}`], { repo }))
+export async function fetchIssue(repo, n, { request = gh } = {}) {
+  const issue = JSON.parse(await request(['api', `repos/${repo}/issues/${n}`], { repo }))
+  // Installation-token responses can omit parent_issue_url even for a child.
+  // Only a 404 from the parent endpoint means no parent; other read failures
+  // must not silently turn a map ticket into an unrelated ticket.
+  if (!parentNumberOf(issue) && !issue.pull_request) {
+    try {
+      const parent = JSON.parse(await request(['api', `repos/${repo}/issues/${n}/parent`], { repo }))
+      if (!Number.isSafeInteger(parent?.number) || parent.number <= 0) throw new Error('GitHub returned an invalid parent issue')
+      issue.parent_issue_url = `https://api.github.com/repos/${repo}/issues/${parent.number}`
+    } catch (e) {
+      if (!/\bHTTP 404\b/.test(e.message)) throw e
+    }
+  }
+  return issue
 }
 
 // The login assigned here is the operator's, not the caller's (#390). The daemon
@@ -162,9 +175,7 @@ export function blockedByOf(repo, n) {
   return ghJSONL(['api', '--paginate', `repos/${repo}/issues/${n}/dependencies/blocked_by`, '--jq', '.[]'], { repo })
 }
 
-// The sub-issue parent, straight off the issue payload — `parent_issue_url` is
-// present on children and absent on everything else (verified live). One read,
-// instead of scanning every map's sub_issues for this number.
+// Parse the parent normalized by fetchIssue, not an unverified raw response.
 export function parentNumberOf(issue) {
   const m = String(issue?.parent_issue_url ?? '').match(/\/issues\/(\d+)$/)
   return m ? Number(m[1]) : null

--- a/daemon/src/index.mjs
+++ b/daemon/src/index.mjs
@@ -1747,6 +1747,7 @@ reduction.onNotesExpired = (ev) => dispatcher.announceExpiredNotes(ev)
 fullLoop = new FullLoop({
   discover: async (repo) => (await dispatcher.frontier(repo))[0] ?? { repo, error: `${repo} is not a watched repository` },
   dispatch: (repo, n) => dispatcher.start(n, { repo, by: 'setup' }),
+  repairMap: (request) => dispatcher.repairTicketMap(request),
   // The Test run's own map and tickets (#891), written as the daemon writes
   // every other issue, under the App's token for the owner.
   tracker: { createIssue, addSubIssue, addBlockedBy, fetchIssue },

--- a/daemon/src/resolve.mjs
+++ b/daemon/src/resolve.mjs
@@ -370,6 +370,34 @@ export async function landBranch({
 // same body in another window — GitHub offers no conditional issue update — so
 // the write is bracketed by a fresh read and a verifying re-read, and the line
 // itself is journalled.
+export async function repairMapPointer({ repo, ticket, issue, result, deps, journal, withMapLock, expectedMap = null }) {
+  const parent = parentNumberOf(issue)
+  if (expectedMap !== null && parent !== expectedMap) throw new Error('The ticket no longer belongs to the Test run map. No map was changed.')
+  if (!parent) return { state: 'none' }
+  const parentIssue = await deps.fetchIssue(repo, parent)
+  if (!hasLabel(parentIssue, 'wayfinder:map')) return { state: 'parent-not-a-map', number: parent }
+  return withMapLock(`${repo}#${parent}`, async () => {
+    const fresh = await deps.fetchIssue(repo, parent)
+    const existing = mapPointerFor(fresh.body, repo, ticket)
+    if (existing) {
+      journal('map_pointer_present', { repo, map: parent, ticket, line: existing })
+      return { state: 'present', number: parent }
+    }
+    const line = pointerLine({ title: issue.title ?? `#${ticket}`, url: issue.html_url ?? `https://github.com/${repo}/issues/${ticket}`, gist: result.headline || result.summary })
+    const next = insertMapPointer(fresh.body, line)
+    if (!next) {
+      journal('map_pointer_failed', { repo, map: parent, ticket, line, reason: 'no "## Decisions so far" section' })
+      return { state: 'no-section', number: parent, line }
+    }
+    await deps.setIssueBody(repo, parent, next)
+    journal('map_pointer_appended', { repo, map: parent, ticket, line })
+    const check = await deps.fetchIssue(repo, parent)
+    const verified = Boolean(mapPointerFor(check.body, repo, ticket))
+    if (!verified) journal('map_pointer_unverified', { repo, map: parent, ticket, line })
+    return { state: verified ? 'appended' : 'append-unverified', number: parent, line }
+  })
+}
+
 export async function resolveAndLand({
   repo, ticket, agent, result, wtPath, branch, epochTs, login, model,
   deps, journal, withMapLock, log = () => {},
@@ -427,48 +455,13 @@ export async function resolveAndLand({
 
   // --- 3. map pointer --------------------------------------------------------
   const parent = parentNumberOf(issue)
-  if (parent) {
-    try {
-      const parentIssue = await deps.fetchIssue(repo, parent)
-      if (!hasLabel(parentIssue, 'wayfinder:map')) {
-        out.map = { state: 'parent-not-a-map', number: parent }
-      } else {
-        out.map = await withMapLock(`${repo}#${parent}`, async () => {
-          // read INSIDE the lock: the body this write is derived from must be
-          // the newest one this daemon can see
-          const fresh = await deps.fetchIssue(repo, parent)
-          const existing = mapPointerFor(fresh.body, repo, ticket)
-          if (existing) {
-            journal('map_pointer_present', { repo, map: parent, ticket, line: existing })
-            return { state: 'present', number: parent }
-          }
-          // The HEADLINE is the gist when the report carries one (#419). The
-          // map's Decisions-so-far is an index — one line per closed ticket —
-          // and a headline is that line already. Without one the summary is
-          // flattened to one line, which is what this did before the field
-          // existed.
-          const line = pointerLine({ title, url, gist: result.headline || result.summary })
-          const next = insertMapPointer(fresh.body, line)
-          if (!next) {
-            journal('map_pointer_failed', { repo, map: parent, ticket, line, reason: 'no "## Decisions so far" section' })
-            return { state: 'no-section', number: parent, line }
-          }
-          await deps.setIssueBody(repo, parent, next)
-          // journal the line whatever the verification says: this is what makes
-          // a lost update replayable
-          journal('map_pointer_appended', { repo, map: parent, ticket, line })
-          const check = await deps.fetchIssue(repo, parent)
-          const verified = Boolean(mapPointerFor(check.body, repo, ticket))
-          if (!verified) journal('map_pointer_unverified', { repo, map: parent, ticket, line })
-          return { state: verified ? 'appended' : 'append-unverified', number: parent, line }
-        })
-        if (out.map.state === 'appended') out.repaired.push(`map pointer on #${parent}`)
-      }
-    } catch (e) {
-      out.map = { state: 'error', number: parent, error: e.message }
-      out.warnings.push(`the map pointer on #${parent} could not be written (${e.message})`)
-      journal('map_pointer_failed', { repo, map: parent, ticket, reason: e.message })
-    }
+  try {
+    out.map = await repairMapPointer({ repo, ticket, issue, result, deps, journal, withMapLock })
+    if (out.map.state === 'appended') out.repaired.push(`map pointer on #${parent}`)
+  } catch (e) {
+    out.map = { state: 'error', number: parent, error: e.message }
+    out.warnings.push(`the map pointer on #${parent} could not be written (${e.message})`)
+    journal('map_pointer_failed', { repo, map: parent, ticket, reason: e.message })
   }
 
   // --- 4. is the code IN? ----------------------------------------------------

--- a/daemon/test/fullloop.test.mjs
+++ b/daemon/test/fullloop.test.mjs
@@ -194,6 +194,72 @@ describe('the Test run as the installation acceptance (#882, #891)', () => {
     assert.equal(REHEARSAL_LABEL, 'rehearsal')
   })
 
+  test('a completed ticket with no map receipt repairs the map without redispatch and survives a restart', async () => {
+    const repairs = []
+    const repairMap = async (request) => { repairs.push(request); return { state: 'appended', number: MAP } }
+    loop = build({ repairMap })
+    await loop.start(gate())
+    await loop.settled()
+    cleanPass(j, tracker)
+    const receipt = j.rows.find((r) => r.type === 'ticket_resolved')
+    receipt.body = JSON.stringify({ ...JSON.parse(receipt.body), map: 'none' })
+    const before = loop.status()
+    assert.equal(before.failed.leg, 'map_update')
+    assert.match(before.failed.cause, /map.*none/i)
+    assert.doesNotMatch(before.failed.cause, /agent ended/)
+    await loop.retry()
+    await loop.settled()
+    assert.equal(repairs.length, 1)
+    assert.equal(repairs[0].ticket, T1)
+    assert.equal(repairs[0].map, MAP)
+    assert.equal(dispatched.filter((t) => t === `o/r#${T1}`).length, 1)
+    const restarted = build({ repairMap })
+    assert.equal(restarted.status().tickets[0].state, 'complete')
+    assert.equal(tracker.issues.get(T1).state, 'closed')
+  })
+
+  test('an unsuccessful map repair stays failed, and concurrent retries share one verified repair', async () => {
+    let calls = 0
+    let release
+    let fail = true
+    const repairMap = async () => {
+      calls++
+      if (fail) return { state: 'append-unverified', number: MAP }
+      await new Promise((resolve) => { release = resolve })
+      return { state: 'present', number: MAP }
+    }
+    loop = build({ repairMap })
+    await loop.start(gate())
+    await loop.settled()
+    cleanPass(j, tracker)
+    const receipt = j.rows.find((r) => r.type === 'ticket_resolved')
+    receipt.body = JSON.stringify({ ...JSON.parse(receipt.body), map: 'none' })
+    const failed = await loop.retry()
+    assert.equal(failed.failed.leg, 'map_update')
+    assert.match(failed.failed.cause, /append-unverified/)
+    assert.equal(j.rows.filter((r) => r.type === 'full_loop_map_repaired').length, 0)
+    fail = false
+    const a = loop.retry()
+    const b = loop.retry()
+    release()
+    await Promise.all([a, b])
+    await loop.settled()
+    assert.equal(calls, 2, 'one failed repair and one shared retry')
+    assert.equal(j.rows.filter((r) => r.type === 'full_loop_map_repaired').length, 1)
+    assert.equal(dispatched.filter((t) => t === `o/r#${T1}`).length, 1)
+  })
+
+  test('a map repair receipt for another ticket or resolution cannot satisfy this run', async () => {
+    await loop.start(gate())
+    await loop.settled()
+    cleanPass(j, tracker)
+    const receipt = j.rows.find((r) => r.type === 'ticket_resolved')
+    receipt.body = JSON.stringify({ ...JSON.parse(receipt.body), map: 'none' })
+    j.write('full_loop_map_repaired', { repo: 'o/r', ticket: T1, map: MAP, receipt_id: receipt.id - 1, state: 'appended' })
+    j.write('full_loop_map_repaired', { repo: 'o/r', ticket: T2, map: MAP, receipt_id: receipt.id, state: 'appended' })
+    assert.equal(loop.status().failed.leg, 'map_update')
+  })
+
   test('with no run there is nothing to report, and nothing is read from anywhere but the journal', () => {
     const s = loop.status()
     assert.equal(s.state, 'idle')

--- a/daemon/test/githubparent.test.mjs
+++ b/daemon/test/githubparent.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchIssue, parentNumberOf } from '../src/github.mjs'
+
+test('an App issue response without the parent field discovers its parent through the dedicated endpoint', async () => {
+  const calls = []
+  const request = async (args, opts) => {
+    calls.push([args, opts])
+    return JSON.stringify(args[1].endsWith('/parent') ? { number: 102 } : { number: 103, state: 'closed' })
+  }
+  const issue = await fetchIssue('seen-is/seen-site', 103, { request })
+  assert.equal(parentNumberOf(issue), 102)
+  assert.deepEqual(calls.map(([args]) => args[1]), ['repos/seen-is/seen-site/issues/103', 'repos/seen-is/seen-site/issues/103/parent'])
+  assert.ok(calls.every(([, opts]) => opts.repo === 'seen-is/seen-site'))
+})
+
+test('a missing parent is distinct from a failed parent read', async () => {
+  for (const code of [404, 403, 429, 500]) {
+    const request = async (args) => {
+      if (!args[1].endsWith('/parent')) return JSON.stringify({ number: 103 })
+      throw new Error(`gh: request failed (HTTP ${code})`)
+    }
+    if (code === 404) assert.equal(parentNumberOf(await fetchIssue('o/r', 103, { request })), null)
+    else await assert.rejects(fetchIssue('o/r', 103, { request }), new RegExp(`HTTP ${code}`))
+  }
+})

--- a/daemon/test/mapdispatch.test.mjs
+++ b/daemon/test/mapdispatch.test.mjs
@@ -95,6 +95,30 @@ async function waitFor(cond, timeoutMs = 10_000) {
   throw new Error('timed out waiting for a condition')
 }
 
+test('map-only recovery refuses open or reparented tickets and repairs a closed ticket without dispatching it', async () => {
+  let state = 'open'
+  let parent = 147
+  let body = '## Decisions so far\n\n## Not yet specified\n'
+  let writes = 0
+  const d = makeDispatcher({
+    fetchIssue: async (_, n) => Number(n) === 42
+      ? { number: 42, title: 'Done', state, parent_issue_url: `https://api.github.com/repos/o/r/issues/${parent}` }
+      : { number: n, labels: [{ name: 'wayfinder:map' }], body },
+    setIssueBody: async (_, n, next) => { assert.equal(n, 147); body = next; writes++ },
+  })
+  const request = { repo: 'o/r', ticket: 42, map: 147, summary: 'Merged' }
+  await assert.rejects(d.repairTicketMap(request), /closed ticket/)
+  state = 'closed'
+  parent = 148
+  await assert.rejects(d.repairTicketMap(request), /no longer belongs/)
+  assert.equal(writes, 0)
+  parent = 147
+  assert.equal((await d.repairTicketMap(request)).state, 'appended')
+  assert.equal((await d.repairTicketMap(request)).state, 'present')
+  assert.equal(writes, 1)
+  assert.deepEqual(calls, [], 'no claim, comment, close, or dispatch work')
+})
+
 function makeDispatcher(deps = {}, { issue = MAP_ISSUE, routing = ROUTING } = {}) {
   const root = path.join(tmp, 'work')
   const dataDir = path.join(tmp, 'data')

--- a/daemon/test/resolve.test.mjs
+++ b/daemon/test/resolve.test.mjs
@@ -11,7 +11,7 @@ import { test, describe, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   sectionBounds, pointerLine, mapPointerFor, insertMapPointer,
-  fallbackResolutionComment, nonCleanComment, reportProse, prBody, resolveAndLand, summariseOutcome,
+  fallbackResolutionComment, nonCleanComment, reportProse, prBody, resolveAndLand, repairMapPointer, summariseOutcome,
   landBranch, prLinkComment, DECISIONS_HEADING, MACHINE_MARKER,
 } from '../src/resolve.mjs'
 
@@ -221,6 +221,24 @@ const TICKET = { number: 42, title: 'a ticket', state: 'closed', html_url: 'http
 const MAP_ISSUE = { number: 1, title: 'the map', state: 'open', labels: [{ name: 'wayfinder:map' }], body: MAP_BODY }
 
 beforeEach(() => { journalled = []; calls = [] })
+
+test('map-only repair verifies the expected parent and appends once without touching the ticket or PR', async () => {
+  const issue = { ...TICKET, parent_issue_url: 'https://api.github.com/repos/o/r/issues/1' }
+  let body = MAP_BODY
+  let writes = 0
+  const args = { repo: 'o/r', ticket: 42, issue, expectedMap: 1, result: { summary: 'done' },
+    deps: {
+      fetchIssue: async () => ({ ...MAP_ISSUE, body }),
+      setIssueBody: async (_, n, next) => { assert.equal(n, 1); body = next; writes++ },
+    },
+    journal: () => {}, withMapLock: async (key, fn) => { assert.equal(key, 'o/r#1'); return fn() },
+  }
+  await assert.rejects(repairMapPointer({ ...args, expectedMap: 2 }), /no longer belongs/)
+  assert.equal(writes, 0)
+  assert.equal((await repairMapPointer(args)).state, 'appended')
+  assert.equal((await repairMapPointer(args)).state, 'present')
+  assert.equal(writes, 1)
+})
 
 describe('resolveAndLand: the agent did everything right', () => {
   test('nothing is repaired; the branch is pushed, a PR opened, and the ticket gets the link', async () => {

--- a/docs/operator/integration-setup.md
+++ b/docs/operator/integration-setup.md
@@ -432,7 +432,8 @@ A run fails when a write to GitHub fails while the map is made, when the ticket 
 
 - **Frontier discovery** fails when Curia couldn't create the map or a ticket, when the frontier can't be read, or when the ticket isn't listed as takeable. Check the GitHub card and the repository, then select **Try again**. The retry creates what is missing on the same map and reads the frontier again.
 - **Dispatch** fails when the dispatcher refuses the ticket, for example over a clone an earlier agent left on disk, or a missing model credential. The cause is the dispatcher's own sentence. Fix what it names, then select **Try again**. The retry dispatches the same ticket again.
-- **Every later ticket leg** fails when the agent ends before that leg: it exited, died, or was cancelled. Read the ticket's thread in the command channel, fix what stopped the agent, then select **Try again**. The retry dispatches the same ticket again, and only the new dispatch's legs count.
+- **Escalation through ticket resolution** fails when the agent ends before that leg: it exited, died, or was cancelled. Read the ticket's thread in the command channel, fix what stopped the agent, then select **Try again**. The retry dispatches the same ticket again, and only the new dispatch's legs count.
+- **Map update** can fail after the ticket was merged and closed. Select **Try again** to repair only the map pointer. Curia checks that the closed ticket still belongs to this map, appends the pointer if missing, and verifies it before advancing. The completed ticket isn't reopened or dispatched again. A failed repair names its error and leaves the run failed; retrying doesn't duplicate a pointer already written.
 - **Map closed** fails when you answer **Keep map open**. Close the map on GitHub, then select **Try again**. The retry reads the map again.
 
 A rejected review is not a failure. The agent takes your feedback, commits again, and asks for review again on the same pull request.


### PR DESCRIPTION
## Cause

The live installation-token issue response for seen-is/seen-site#103 omitted parent_issue_url, while the dedicated parent endpoint returned map #102. Dispatch and resolution both interpreted the missing field as no map. Resolution recorded map: none after a successful merge and closure, and Test run recovery tried to redispatch the closed ticket.

## Change

- Normalize missing issue parents through the dedicated GitHub endpoint. Non-404 lookup failures propagate instead of silently removing map context.
- Share the verified, locked map-pointer update between normal resolution and map-only recovery.
- Recover a completed Test run ticket without reopening, commenting, merging, or redispatching it. Require the original successful receipt and a freshly verified closed ticket with the expected parent.
- Bind verified recovery evidence to the original receipt and replay it after restart. Concurrent retries share one repair; existing pointers remain idempotent.
- Explain the missing map receipt instead of blaming a normal agent exit.

## Verification

- Regression tests cover missing parent fields, lookup failures, map-only repair, moved or open tickets, failed verification, concurrency, receipt binding, and restart replay.
- 93 focused parent/resolve/Test run tests and 114 dispatcher tests passed.
- Full daemon suite: 4546 passed, 0 failed, 0 cancelled, 1 skipped.
- Read-only live check using the corrected lookup and the installed GitHub App credential returned parent #102 for ticket #103.

Release level: patch. No production files, tickets, map bodies, or running services were changed. The existing failed run still needs the packaged fix and an operator retry.

Supports #894.